### PR TITLE
fix(cli): add missing generator dependencies and improve error messages

### DIFF
--- a/.changeset/fix-cli-generator-dependencies.md
+++ b/.changeset/fix-cli-generator-dependencies.md
@@ -1,0 +1,11 @@
+---
+"@drzl/cli": patch
+---
+
+Fix missing generator dependencies and improve error messages
+
+- Add all generator packages (@drzl/generator-zod, @drzl/generator-service, @drzl/generator-valibot, @drzl/generator-arktype) as dependencies in CLI package.json
+- Update error handling to provide clearer installation instructions when generators are missing
+- Separate error details for better readability
+
+This resolves the "Cannot find package" errors when using generators other than ORPC.


### PR DESCRIPTION
## Summary

- Add all generator packages as dependencies in CLI package.json to fix "Cannot find package" errors
- Update error handling to provide clearer installation instructions when generators are missing
- Separate error details for better readability

## Test plan

- [x] Verified CLI builds successfully with new dependencies
- [x] Error messages now provide clear installation instructions
- [x] All generator dependencies are properly declared

Fixes the issue where users get "Cannot find package" errors when using generators other than ORPC.