### PR TITLE
fix(cli): correct config types and update readme

### DIFF
--- a/.changeset/bumpy-geckos-yawn.md
+++ b/.changeset/bumpy-geckos-yawn.md
@@ -1,0 +1,5 @@
+---
+'@drzl/cli': minor
+---
+
+fix(cli): correct config types and update readme

--- a/README.md
+++ b/README.md
@@ -30,16 +30,17 @@ Zero‑friction codegen for Drizzle ORM. Analyze your schema. Generate validatio
 
 ## Install & Use
 
-- Init a config
+- Install the CLI and init a config
 
 ```bash
-pnpm dlx drzl init
+pnpm add @drzl/cli -D
+pnpm drzl init
 ```
 
 - Generate code
 
 ```bash
-pnpm dlx drzl generate -c drzl.config.ts
+pnpm drzl generate -c drzl.config.ts
 ```
 
 Minimal config

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,15 +8,21 @@
     "drzl": "dist/cli.js"
   },
   "main": "dist/cli.js",
+  "types": "dist/config.d.ts",
   "exports": {
-    ".": "./dist/cli.js",
-    "./config": "./dist/config.js"
+    ".": {
+      "import": "./dist/cli.js"
+    },
+    "./config": {
+      "import": "./dist/config.js",
+      "types": "./dist/config.d.ts"
+    }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/cli.ts src/config.ts --format esm,cjs --sourcemap",
+    "build": "tsup src/cli.ts src/config.ts --format esm,cjs --sourcemap --dts",
     "dev": "node --loader ts-node/esm src/cli.ts --help",
     "lint": "eslint . --ext .ts",
     "test": "vitest run"


### PR DESCRIPTION
## Summary

This PR addresses a few issues with the CLI package:

- Corrects the type definitions for `@drzl/cli/config` to fix a module declaration error.
- Makes the `analyzer` properties in `defineConfig` optional to prevent a TypeScript error when `includeHeuristicRelations` is not provided.
- Updates the `README.md` to recommend local installation of the CLI.

Fixes #5

## Type of change

- [x] fix: bug fix
- [x] docs: documentation only

## Checklist

- [x] I read the docs and [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I searched existing [Issues](../issues) and [Discussions](../discussions)
- [x] I’m on the latest version of DRZL packages
- [ ] I added/updated tests
- [x] I updated docs/readmes where appropriate
- [x] I ran `pnpm -r test` locally
- [x] I ran `pnpm lint` locally and fixed any issues
- [x] I linked related issues (Fixes/Closes #5)
- [x] I have starred the repository ⭐
- [ ] I’m willing to sponsor this work 💖 (optional)

## Breaking changes

- [x] No