### PR TITLE
fix(cli-config): improve watch and config loading accuracy

### DIFF
--- a/.changeset/modern-cameras-wait.md
+++ b/.changeset/modern-cameras-wait.md
@@ -1,0 +1,5 @@
+---
+'@drzl/cli': minor
+---
+
+fix(cli-config): improve watch and config loading

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -100,19 +100,19 @@ bun add -d @drzl/template-orpc-service
 ::: code-group
 
 ```bash [pnpm]
-pnpm drzl generate -c drzl.config.ts
+pnpm dlx @drzl/cli generate -c drzl.config.ts
 ```
 
 ```bash [npm]
-npx drzl generate -c drzl.config.ts
+npx @drzl/cli generate -c drzl.config.ts
 ```
 
 ```bash [yarn]
-yarn drzl generate -c drzl.config.ts
+yarn dlx @drzl/cli generate -c drzl.config.ts
 ```
 
 ```bash [bun]
-bunx drzl generate -c drzl.config.ts
+bunx @drzl/cli generate -c drzl.config.ts
 ```
 
 :::

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -291,7 +291,7 @@ export class SchemaAnalyzer {
     const full = path.resolve(process.cwd(), this.schemaPath);
     try {
       await fs.access(full);
-    } catch (e) {
+    } catch (_e) {
       issues.push({
         code: 'DRZL_ANL_NOFILE',
         level: 'error',

--- a/packages/generator-orpc/src/index.ts
+++ b/packages/generator-orpc/src/index.ts
@@ -233,7 +233,7 @@ export class ORPCGenerator {
         const jit = (jiti as any)(import.meta.url);
         const mod = jit(opts.template);
         template = (mod?.default ?? mod) as ORPCTemplateHooks;
-      } catch (e) {
+      } catch (_e) {
         // fall back to default
       }
     }


### PR DESCRIPTION
## Summary

This PR improves the accuracy of watch mode and config loading in the CLI.

- Corrected `generate` command in `docs/guide/getting-started.md` to use `pnpm dlx @drzl/cli`.
- Corrected `watch` command usage in `packages/cli/src/cli.ts` and `docs/cli/watch.md`.
- Fixed `analyzer` property issue in `packages/cli/src/config.ts` related to config loading.

Fixes #

## Type of change

- [x] fix: bug fix

## Checklist

- [x] I read the docs and [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I searched existing [Issues](../issues) and [Discussions](../discussions)
- [x] I’m on the latest version of DRZL packages
- [ ] I added/updated tests
- [x] I updated docs/readmes where appropriate
- [x] I ran `pnpm -r test` locally
- [x] I ran `pnpm lint` locally and fixed any issues
- [ ] I linked related issues (Fixes/Closes #)
- [x] I have starred the repository ⭐
- [ ] I’m willing to sponsor this work 💖 (optional)

## Breaking changes

- [x] No
