### PR TITLE
fix: array and structured columns, measured against the official validators

### DIFF
--- a/.changeset/structured-and-array-columns.md
+++ b/.changeset/structured-and-array-columns.md
@@ -1,0 +1,84 @@
+---
+'@drzl/generator-arktype': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-typebox': minor
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+'@drzl/analyzer': minor
+'@drzl/cli': minor
+---
+
+Array and structured columns, and a measured parity gate against the official validators.
+
+A differential harness now generates schemas for a 39 column Postgres table with DRZL and with
+`drizzle-orm/{zod,valibot,arktype}`, then pushes the same pool of values through both, column by
+column. It found DRZL weaker on **15 of 39 columns**. All 15 are fixed, and the harness runs in
+CI as part of `verify:packed` so a new divergence fails the build rather than being noticed later.
+
+### Columns whose schema rejected every row
+
+- **Arrays were collapsed to their element.** Drizzle gives an array no class of its own:
+  `text().array()` is still a `PgText`, separated from a scalar only by `dimensions`. Reading the
+  class alone produced `z.string()`, which rejected `['a']` and accepted `'a'`.
+- **`point`, `line` and `geometry` were mapped to strings.** They arrive as `[number, number]`.
+- **`serial` was lower-bounded at 1.** Postgres serial is an ordinary integer column that defaults
+  from a sequence; the sequence starts at 1, the column does not, and inserting `0` or a negative
+  is how backfills and sentinel rows get written.
+- **ArkType output containing a binary column could not be imported at all.** `'Uint8Array'` is
+  not an ArkType keyword, so the emitted module threw `'Uint8Array' is unresolvable` at import and
+  took its importer with it. The keyword is `TypedArray.Uint8`.
+
+### Columns whose schema accepted anything
+
+`bytea`, `bit` and `vector` emitted `z.unknown()`, which accepts `null` on a NOT NULL column.
+`json` and `jsonb` emitted `z.any()`, which accepts `undefined`, `NaN`, `Infinity`, bigints, Dates
+and Buffers, none of which survive the round trip. `real`, `double precision` and
+`numeric({ mode: 'number' })` were unbounded.
+
+| Column | Before | Now |
+| --- | --- | --- |
+| `text().array()` | `z.string()` | `z.array(z.string())` |
+| `point()` | `z.string()` | `z.tuple([z.number(), z.number()])` |
+| `vector({ dimensions: 3 })` | `z.unknown()` | `z.array(z.number()).length(3)` |
+| `bit({ dimensions: 3 })` | `z.unknown()` | `z.string().regex(/^[01]*$/).length(3)` |
+| `bytea()` | `z.unknown()` | `z.instanceof(Uint8Array)` |
+| `jsonb()` | `z.any()` | `z.json()` |
+| `real()` | `z.number()` | `z.number().gte(-8388608).lte(8388607)` |
+| `serial()` | `.gte(1)` | `.gte(-2147483648)` |
+
+All four generators handle all of it, and the harness also checks the four against each other, so
+`bytea` validates identically whichever validator you pick.
+
+### Two bugs found only by running the output
+
+- **Every ArkType `integer()` column accepted `1.5`.** The generator preferred the range on the
+  theory that an integer range implied integrality. ArkType parses
+  `-2147483648 <= number.integer <= 2147483647` perfectly well and rejects the fraction.
+- **`v.tuple` ignores extra items**, so a valibot `point` accepted `[1, 2, 3]`. `v.strictTuple`
+  holds the arity. `drizzle-orm/valibot` uses the plain form and accepts the third element.
+
+### Reading the type from Drizzle rather than guessing at it
+
+Drizzle v1 stamps every column with a `dataType` of the form `"number int32"`, `"object buffer"`,
+`"array point"`, plus a `codec` naming the SQL side. The analyzer now reads those. It used to
+match on the constructor name against a list running to dozens of entries per dialect, with a
+regex fallback that guessed from the name when it missed, which is how `PgBinaryVector` came out
+as a vector when it is a bit string. The class-name path is still there for Drizzle 0.4x, which
+carries no `codec`.
+
+`Column` gains `arrayDimensions`, `shape`, and `integer`. That last one exists because the
+generators each inferred "is an integer" from "declares both bounds", which was true only while
+integers were the only bounded type: bounding `real` made every float schema reject `1.5` until
+the flag replaced the inference.
+
+### Where DRZL deliberately differs
+
+- `bytea` accepts any `Uint8Array` where official demands a `Buffer`. A Buffer is a Uint8Array, so
+  nothing official accepts is turned away, and the wider check needs no `@types/node`, works in a
+  runtime with no `Buffer`, and makes a Postgres `bytea` and a SQLite `blob` behave the same.
+- valibot json rejects `Infinity` and class instances, which the official one accepts.
+- ArkType `bigint` carries no range. Its comparison operators take numeric literals, so a 64 bit
+  bound cannot be written in the string DSL this generator emits; official states it with a narrow
+  predicate built through the builder API.
+
+Each is listed in the harness with its reason, so it stays a decision rather than drift.

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ docs/.vitepress/cache
 packages/*/test/.e2e-tmp
 packages/*/test/.cmd-tmp
 packages/*/test/.tmp-run
+packages/*/test/.tmp-structured

--- a/docs/generators/arktype.md
+++ b/docs/generators/arktype.md
@@ -55,6 +55,39 @@ reads `(0 <= number <= 100 | null)`, which lets `null` through exactly as SQL do
 Only unambiguous comparisons are translated; see
 [Zod → CHECK constraints](/generators/zod#check-constraints) for what is skipped and why.
 
+## Arrays and structured columns
+
+A column declared with `.array()` becomes an array of the element type. The element is
+parenthesised, because `'a' | 'b'[]` parses as the literal `'a'` or an array of `'b'`, which is
+not what an enum array means:
+
+```ts
+tags:  "string[]",                      // text().array()
+moods: "('happy' | 'sad')[]",           // moodEnum().array()
+names: "(string <= 50)[]",              // varchar(50).array()
+```
+
+| Column                      | Emitted                                           |
+| --------------------------- | ------------------------------------------------- |
+| `point()`, `geometry()`     | `"number[] == 2"`                                 |
+| `line()`                    | `"number[] == 3"`                                 |
+| `vector({ dimensions: 3 })` | `"number[] == 3"`                                 |
+| `bit({ dimensions: 3 })`    | `"/^[01]*$/ & string == 3"`                       |
+| `bytea()`, SQLite `blob()`  | `"TypedArray.Uint8"`                              |
+| `json()`, `jsonb()`         | `"number \| object \| string \| boolean \| null"` |
+
+The tuple types are written as a length-constrained array rather than as `[number, number]`.
+ArkType does accept a real tuple, but only as a nested array in the definition object, and this
+generator emits one string per field. Both reject an array of the wrong length; the tuple form
+would additionally give a static type of `[number, number]` rather than `number[]`.
+
+### One thing ArkType cannot state here
+
+A `bigint({ mode: 'bigint' })` column is emitted as plain `bigint`, with no range. ArkType's
+comparison operators take numeric literals, so a 64 bit bound cannot be written in the string
+DSL at all; `drizzle-orm/arktype` states it through a narrow predicate built with the builder
+API instead. Every other column type is bounded here exactly as the official module bounds it.
+
 ## Custom names
 
 `Insert<Table>Schema` is the default, not the only option. The `affix` block renames the
@@ -73,9 +106,7 @@ export name so `users` becomes `Users` instead of being interpolated verbatim.
 ```
 
 ```ts
-export const InsertUsersSchema = type({
-  /* ... */
-});
+export const InsertUsersSchema = type({/* ... */});
 export type InsertUsersInput = (typeof InsertUsersSchema)['infer'];
 // Select's prefix and suffix are both empty, so the type is just the table name:
 export type Users = (typeof SelectUsersSchema)['infer'];

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -21,7 +21,7 @@ export const SelectpeopleSchema = Type.Object({
   id: Type.Integer({ minimum: -2147483648, maximum: 2147483647 }),
   age: Type.Integer({ minimum: 18, maximum: 2147483647 }),
   score: Type.Union([Type.Integer({ minimum: 0, maximum: 100 }), Type.Null()]),
-  tier: Type.Literal("gold"),
+  tier: Type.Literal('gold'),
   bio: Type.Union([Type.String(), Type.Null()]),
 });
 
@@ -32,12 +32,13 @@ export type SelectpeopleOutput = Static<typeof SelectpeopleSchema>;
 
 ## Column constraints
 
-| Column | Emitted |
-|---|---|
-| `varchar(255)` | `Type.String({ maxLength: 255 })` |
-| `uuid()` | `Type.String({ pattern: '...' })` |
-| `smallint()` | `Type.Integer({ minimum: -32768, maximum: 32767 })` |
-| `doublePrecision()` | `Type.Number()` |
+| Column              | Emitted                                                                |
+| ------------------- | ---------------------------------------------------------------------- |
+| `varchar(255)`      | `Type.String({ maxLength: 255 })`                                      |
+| `uuid()`            | `Type.String({ pattern: '...' })`                                      |
+| `smallint()`        | `Type.Integer({ minimum: -32768, maximum: 32767 })`                    |
+| `real()`            | `Type.Number({ minimum: -8388608, maximum: 8388607 })`                 |
+| `doublePrecision()` | `Type.Number({ minimum: -140737488355328, maximum: 140737488355327 })` |
 
 ### Why uuid is a pattern and not a format
 
@@ -50,12 +51,12 @@ valid uuid. A pattern needs no setup and behaves the same everywhere, so that is
 **No official Drizzle validator module enforces these**, in any library. TypeBox states them
 declaratively:
 
-| Constraint | Emitted |
-|---|---|
-| `CHECK (age >= 18)` | `minimum: 18` |
-| `CHECK (n > 0)` | `exclusiveMinimum: 0` |
+| Constraint                        | Emitted                    |
+| --------------------------------- | -------------------------- |
+| `CHECK (age >= 18)`               | `minimum: 18`              |
+| `CHECK (n > 0)`                   | `exclusiveMinimum: 0`      |
 | `CHECK (score BETWEEN 0 AND 100)` | `minimum: 0, maximum: 100` |
-| `CHECK (tier = 'gold')` | `Type.Literal("gold")` |
+| `CHECK (tier = 'gold')`           | `Type.Literal("gold")`     |
 
 An equality becomes `Type.Literal`, not a `const` option. TypeBox accepts a `const` option on
 `Type.String` and `Type.Integer` and then ignores it: `Type.String({ const: 'gold' })` validates
@@ -66,6 +67,29 @@ lets `null` through. That matches SQL, where a CHECK passes when it evaluates to
 
 Only unambiguous comparisons are translated; see
 [Zod → CHECK constraints](/generators/zod#check-constraints) for what is skipped and why.
+
+## Arrays and structured columns
+
+A column declared with `.array()` becomes `Type.Array` of the element, with the element's own
+constraints intact:
+
+```ts
+tags:   Type.Array(Type.String({ maxLength: 50 })),
+scores: Type.Array(Type.Integer({ minimum: -32768, maximum: 32767 })),
+```
+
+| Column                      | Emitted                                                           |
+| --------------------------- | ----------------------------------------------------------------- |
+| `point()`, `geometry()`     | `Type.Tuple([Type.Number(), Type.Number()])`                      |
+| `line()`                    | `Type.Tuple([...three...])`                                       |
+| `vector({ dimensions: 3 })` | `Type.Array(Type.Number(), { minItems: 3, maxItems: 3 })`         |
+| `bit({ dimensions: 3 })`    | `Type.String({ pattern: '^[01]*$', minLength: 3, maxLength: 3 })` |
+| `bytea()`                   | `Type.Uint8Array()`                                               |
+| `json()`, `jsonb()`         | a `Type.Recursive` `DrzlJsonValue`, declared once per file        |
+
+A `bigint` column carries its range as bigint literals, `Type.BigInt({ minimum: -9223372036854775808n, maximum: 9223372036854775807n })`.
+Written as plain numbers the bound would be wrong, since `9223372036854775807` rounds up the
+moment it becomes a JS number.
 
 ## `typedJson`
 

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -57,6 +57,38 @@ Only unambiguous comparisons are translated. Cross-column comparisons such as
 than guessed at, since a schema enforcing a guess rejects rows the database would accept. See
 [Zod → CHECK constraints](/generators/zod#check-constraints) for the full table.
 
+## Arrays and structured columns
+
+A column declared with `.array()` produces a schema for the array, keeping everything the element
+declares inside it:
+
+```ts
+tags:   v.array(v.pipe(v.string(), v.maxLength(50))),          // varchar(50).array()
+scores: v.array(v.pipe(v.number(), v.integer(), v.minValue(-32768), v.maxValue(32767))),
+```
+
+The structured Postgres columns each get the shape their runtime value actually has:
+
+| Column                      | Emitted                                               |
+| --------------------------- | ----------------------------------------------------- |
+| `point()`, `geometry()`     | `v.strictTuple([v.number(), v.number()])`             |
+| `line()`                    | `v.strictTuple([...three...])`                        |
+| `vector({ dimensions: 3 })` | `v.pipe(v.array(v.number()), v.length(3))`            |
+| `bit({ dimensions: 3 })`    | `v.pipe(v.string(), v.regex(/^[01]*$/), v.length(3))` |
+| `bytea()`                   | `v.instance(Uint8Array)`                              |
+| `json()`, `jsonb()`         | a recursive `DrzlJsonValue`, declared once per file   |
+
+`strictTuple` rather than `tuple` is deliberate: valibot's plain `tuple` ignores extra items, so a
+schema built from it accepts `[1, 2, 3]` for a point. `drizzle-orm/valibot` uses the plain form.
+
+Valibot has no `json()` built-in, so a json column emits a recursive declaration at the top of the
+file. It is stricter than the official one in two ways, both of which reject values that cannot
+survive the round trip: `Infinity` is refused rather than written out as `null`, and a class
+instance such as a `Date` is refused rather than being rebuilt as an empty object.
+
+See [Zod → Structured columns](/generators/zod#structured-columns) for why `bytea` is typed as a
+`Uint8Array`.
+
 ## Custom names
 
 `Insert<Table>Schema` is the default, not the only option. The `affix` block renames the
@@ -75,9 +107,7 @@ export name so `users` becomes `Users` instead of being interpolated verbatim.
 ```
 
 ```ts
-export const InsertUsersSchema = v.object({
-  /* ... */
-});
+export const InsertUsersSchema = v.object({/* ... */});
 export type InsertUsersInput = InferInput<typeof InsertUsersSchema>;
 // Select's prefix and suffix are both empty, so the type is just the table name:
 export type Users = InferOutput<typeof SelectUsersSchema>;

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -45,6 +45,48 @@ Integer ranges follow the column width, and `bigint({ mode: 'number' })` is type
 with the JavaScript safe-integer bound rather than as a bigint, because that is what the value
 actually is.
 
+`real` and `double precision` are bounded too, at the point past which a float stops being able
+to represent consecutive integers. That is narrower than the column, which holds far larger
+values, but a number above it comes back out of the database as a _different_ number.
+`drizzle-orm/zod` draws the line in the same place.
+
+## Arrays
+
+A column declared with `.array()` produces a schema for the array, with everything the element
+declares kept inside it:
+
+```ts
+tags:   z.array(z.string().max(50)),                          // varchar(50).array()
+scores: z.array(z.number().int().gte(-32768).lte(32767)),     // smallint().array()
+moods:  z.array(z.enum(['happy', 'sad'] as const)),           // moodEnum().array()
+```
+
+Note that `.array(3)` is **not** an array. It sets a size rather than a dimension, and Drizzle
+itself treats the result as a scalar, so DRZL does too.
+
+## Structured columns
+
+Some Postgres columns do not arrive as scalars at all, and a schema that says otherwise rejects
+every row the database returns:
+
+| Column                      | Runtime value              | Emitted                                 |
+| --------------------------- | -------------------------- | --------------------------------------- |
+| `point()`                   | `[number, number]`         | `z.tuple([z.number(), z.number()])`     |
+| `line()`                    | `[number, number, number]` | `z.tuple([...])`                        |
+| `geometry()`                | `[number, number]`         | `z.tuple([z.number(), z.number()])`     |
+| `vector({ dimensions: 3 })` | `number[]`                 | `z.array(z.number()).length(3)`         |
+| `bit({ dimensions: 3 })`    | `'010'`                    | `z.string().regex(/^[01]*$/).length(3)` |
+| `bytea()`                   | `Buffer`                   | `z.instanceof(Uint8Array)`              |
+| `json()`, `jsonb()`         | any JSON value             | `z.json()`                              |
+
+`bytea` is typed as `Uint8Array` rather than `Buffer`, which is the one place the output is
+deliberately wider than `drizzle-orm/zod`. A Buffer is a Uint8Array, so nothing official accepts
+is turned away; the wider check needs no `@types/node`, survives a runtime where `Buffer` is not
+defined, and makes a Postgres `bytea` and a SQLite `blob` validate the same way.
+
+A CHECK constraint naming an array or a structured column is skipped rather than folded in, since
+the comparison is against a scalar literal and describes neither.
+
 ## CHECK constraints
 
 A `check()` in your schema becomes a refinement. **No official Drizzle validator module does
@@ -69,14 +111,14 @@ a nullable column would make the schema stricter than the database.
 
 **Only unambiguous constraints are translated.** These are skipped rather than guessed at:
 
-| Skipped | Why |
-|---|---|
-| `start_date < end_date` | A statement about the row, not about either field |
+| Skipped                   | Why                                                        |
+| ------------------------- | ---------------------------------------------------------- |
+| `start_date < end_date`   | A statement about the row, not about either field          |
 | `age >= 18 AND age <= 65` | Compound; getting its scope wrong changes what is enforced |
-| `length(name) > 3` | Function call |
-| `email ~ '^[a-z]+$'` | Postgres `~` is POSIX ERE, not JavaScript's regex dialect |
+| `length(name) > 3`        | Function call                                              |
+| `email ~ '^[a-z]+$'`      | Postgres `~` is POSIX ERE, not JavaScript's regex dialect  |
 
-A schema that quietly enforces a *guess* at your constraint is worse than one enforcing nothing,
+A schema that quietly enforces a _guess_ at your constraint is worse than one enforcing nothing,
 because it rejects rows the database would have accepted.
 
 ## `typedJson`
@@ -99,7 +141,7 @@ runtime-derived validator is blind to it. `drizzle-orm/zod` types a json column 
 `Json` whatever you wrote.
 
 DRZL does not try to reconstruct the type either. It references
-`typeof settings.$inferSelect['prefs']`, which *is* the declared type, resolved by TypeScript at
+`typeof settings.$inferSelect['prefs']`, which _is_ the declared type, resolved by TypeScript at
 the point of use. That is why generics, unions and imported interfaces all work, where an
 approach that parses your source and rebuilds the type would fail on them.
 
@@ -128,9 +170,7 @@ export name so `users` becomes `Users` instead of being interpolated verbatim.
 ```
 
 ```ts
-export const InsertUsersSchema = z.object({
-  /* ... */
-});
+export const InsertUsersSchema = z.object({/* ... */});
 export type InsertUsersInput = z.input<typeof InsertUsersSchema>;
 // Select's prefix and suffix are both empty, so the type is just the table name:
 export type Users = z.output<typeof SelectUsersSchema>;

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -3,14 +3,7 @@
  * stays here so an analysis of a 0.4x schema still names what it found.
  */
 export type Dialect =
-  | 'sqlite'
-  | 'postgres'
-  | 'mysql'
-  | 'singlestore'
-  | 'mssql'
-  | 'cockroach'
-  | 'gel'
-  | 'unknown';
+  'sqlite' | 'postgres' | 'mysql' | 'singlestore' | 'mssql' | 'cockroach' | 'gel' | 'unknown';
 
 export interface Issue {
   code: string;
@@ -63,9 +56,53 @@ export interface Column {
   min?: string;
   max?: string;
 
+  /**
+   * Whether a numeric column holds whole numbers only.
+   *
+   * Stated rather than inferred. Generators used to read "has both bounds" as "is an integer",
+   * which held only while integers were the sole bounded type; bounding `real` and `double
+   * precision` promptly made every float schema reject `1.5`. Absent on a pre-1.7 analysis, and
+   * generators fall back to the old inference there.
+   */
+  integer?: boolean;
+
   /** A string column with a known shape, currently only `uuid`. */
   format?: 'uuid';
+
+  /**
+   * Array depth for a column declared with `.array()`, absent when the column is a scalar.
+   *
+   * Drizzle does not give an array its own column class: `text().array()` is still a `PgText`,
+   * distinguished only by `dimensions`. Reading the class alone therefore produced a schema for
+   * the *element*, which rejected every row the database returned and accepted a bare string in
+   * its place.
+   *
+   * `.array(3)` sets a size rather than a dimension and Drizzle itself treats the result as a
+   * scalar, so it is deliberately not an array here either.
+   */
+  arrayDimensions?: number;
+
+  /**
+   * A structured value that cannot be expressed as a scalar plus constraints.
+   *
+   * These all used to fall through to `any`/`unknown` or, worse, to `string`. A `point` really
+   * arrives as `[number, number]`, so a string schema rejected every row; a `bytea` typed as
+   * `unknown` accepted `null` on a NOT NULL column.
+   */
+  shape?: ColumnShape;
 }
+
+export type ColumnShape =
+  /** `bytea`, `blob`: a binary payload, carried as a Buffer/Uint8Array. */
+  | { kind: 'buffer' }
+  /** `json`, `jsonb`: any value that survives a JSON round trip, checked recursively. */
+  | { kind: 'json' }
+  /** `point`, `line`, `geometry`: a fixed-length tuple of numbers. */
+  | { kind: 'tuple'; length: number }
+  /** `vector`, `halfvec`: a numeric vector, with a fixed length where one is declared. */
+  | { kind: 'numberVector'; length?: number }
+  /** `bit`: a string of `0`/`1`, with a fixed length where one is declared. */
+  | { kind: 'bitstring'; length?: number };
 
 export interface Key {
   name?: string;
@@ -144,6 +181,172 @@ function renderSqlLiteral(v: unknown): string {
   if (v instanceof Date) return `'${v.toISOString()}'`;
   if (Array.isArray(v)) return `(${v.map(renderSqlLiteral).join(', ')})`;
   return `'${String(v).replace(/'/g, "''")}'`;
+}
+
+/**
+ * Bounds `drizzle-orm/zod` puts on the inexact numeric types, matched deliberately.
+ *
+ * They are narrower than the column: Postgres `real` holds values up to ~3.4e38. The bound is
+ * the point past which a float can no longer represent consecutive integers, so a value above
+ * it round-trips through the database as a *different* number. Drizzle chose to reject that
+ * rather than lose it silently, and a generated schema that disagreed with the first-party one
+ * about the same column would be the more surprising outcome.
+ */
+const V1_FLOAT_BOUNDS: Record<string, [string, string]> = {
+  float: ['-8388608', '8388607'], // real / float4, 2^23
+  double: ['-140737488355328', '140737488355327'], // double precision / float8, 2^47
+};
+
+/**
+ * Everything Drizzle v1 states about a column outright, or `null` on an older Drizzle.
+ *
+ * v1 stamps each column with a `dataType` of the form `"<js type> <semantic>"` (`"number
+ * int32"`, `"object buffer"`, `"array point"`) alongside a `codec` naming the SQL side. That
+ * is a far better key than the constructor name the analyzer used to match on: the class list
+ * ran to dozens of names per dialect, drifted between releases, and a miss fell through to a
+ * regex that guessed from the name. `PgBinaryVector`, for one, is a bit string and not a
+ * vector at all.
+ *
+ * Gated on `codec`, which 0.4x columns do not carry, so an older schema keeps the class-name
+ * path below untouched.
+ */
+export function describeV1Column(column: any): Partial<Column> | null {
+  const codec = column?.codec;
+  const dataType = column?.dataType;
+  if (typeof codec !== 'string' || typeof dataType !== 'string') return null;
+
+  const [js, semantic = ''] = dataType.split(' ');
+  const out: Partial<Column> = {};
+
+  switch (semantic) {
+    case 'int16':
+    case 'int32':
+    case 'int53':
+    case 'int64': {
+      const range = {
+        int16: ['-32768', '32767'],
+        int32: ['-2147483648', '2147483647'],
+        int53: ['-9007199254740991', '9007199254740991'],
+        int64: ['-9223372036854775808', '9223372036854775807'],
+      }[semantic]!;
+      [out.min, out.max] = range;
+      out.integer = true;
+      out.tsType = js === 'bigint' ? 'bigint' : 'number';
+      out.dbType = semantic === 'int16' ? 'SMALLINT' : semantic === 'int32' ? 'INTEGER' : 'BIGINT';
+      break;
+    }
+    case 'float':
+    case 'double': {
+      [out.min, out.max] = V1_FLOAT_BOUNDS[semantic]!;
+      out.integer = false;
+      out.tsType = 'number';
+      out.dbType = semantic === 'float' ? 'REAL' : 'DOUBLE';
+      break;
+    }
+    case 'uuid':
+      out.tsType = 'string';
+      out.dbType = 'UUID';
+      out.format = 'uuid';
+      break;
+    case 'numeric':
+      // Returned as a string: a JS number cannot hold arbitrary precision.
+      out.tsType = 'string';
+      out.dbType = 'NUMERIC';
+      break;
+    case 'json':
+      out.tsType = 'any';
+      out.dbType = codec === 'jsonb' ? 'JSONB' : 'JSON';
+      out.shape = { kind: 'json' };
+      break;
+    case 'buffer':
+      out.tsType = 'Buffer';
+      out.dbType = 'BYTEA';
+      out.shape = { kind: 'buffer' };
+      break;
+    case 'date':
+      // `date`/`timestamp` in `{ mode: 'string' }` report a js type of string.
+      out.tsType = js === 'string' ? 'string' : 'Date';
+      out.dbType = codec.startsWith('timestamp') ? 'TIMESTAMP' : 'DATE';
+      break;
+    case 'timestamp':
+      out.tsType = js === 'string' ? 'string' : 'Date';
+      out.dbType = 'TIMESTAMP';
+      break;
+    case 'time':
+      out.tsType = 'string';
+      out.dbType = 'TIME';
+      break;
+    case 'interval':
+      out.tsType = 'string';
+      out.dbType = 'INTERVAL';
+      break;
+    case 'inet':
+    case 'cidr':
+    case 'macaddr':
+      out.tsType = 'string';
+      out.dbType = semantic.toUpperCase();
+      break;
+    case 'binary':
+      // `bit(n)`. Named "binary" by the dataType and `PgBinaryVector` by the class, but the
+      // value is a string of '0' and '1' rather than anything vector shaped.
+      out.tsType = 'string';
+      out.dbType = 'BIT';
+      out.shape = { kind: 'bitstring', length: declaredLength(column) };
+      break;
+    case 'point':
+    case 'geometry':
+      out.tsType = '[number, number]';
+      out.dbType = semantic.toUpperCase();
+      out.shape = { kind: 'tuple', length: 2 };
+      break;
+    case 'line':
+      out.tsType = '[number, number, number]';
+      out.dbType = 'LINE';
+      out.shape = { kind: 'tuple', length: 3 };
+      break;
+    case 'vector':
+      out.tsType = 'number[]';
+      out.dbType = 'VECTOR';
+      out.shape = { kind: 'numberVector', length: declaredLength(column) };
+      break;
+    case 'enum':
+      out.tsType = 'string';
+      out.dbType = 'TEXT';
+      break;
+    default:
+      // No semantic half: a plain string, boolean, or the number mode of `numeric`.
+      if (js === 'boolean') {
+        out.tsType = 'boolean';
+        out.dbType = 'BOOLEAN';
+      } else if (js === 'number') {
+        out.tsType = 'number';
+        out.dbType = 'NUMERIC';
+        out.integer = false;
+        [out.min, out.max] = ['-9007199254740991', '9007199254740991'];
+      } else if (js === 'string') {
+        out.tsType = 'string';
+        out.dbType = codec === 'varchar' ? 'VARCHAR' : codec === 'char' ? 'CHAR' : 'TEXT';
+      } else {
+        // Something this release added that is not modelled yet. Falling back to the class
+        // name beats inventing a type: a wrong scalar rejects rows, `unknown` only fails to
+        // catch them.
+        return null;
+      }
+  }
+
+  // `.array()` leaves the column class alone and only raises `dimensions`, so this is the one
+  // signal that a value arrives as a list. `.array(3)` sets a size instead and Drizzle itself
+  // treats that as a scalar, which is why only a positive dimension counts.
+  const dims = column?.dimensions;
+  if (typeof dims === 'number' && dims >= 1) out.arrayDimensions = dims;
+
+  return out;
+}
+
+/** A declared width, from `vector({ dimensions: 3 })` or `bit({ dimensions: 3 })`. */
+function declaredLength(column: any): number | undefined {
+  const n = column?.length ?? column?.config?.length ?? column?.config?.dimensions;
+  return typeof n === 'number' && Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
 export class SchemaAnalyzer {
@@ -399,24 +602,28 @@ export class SchemaAnalyzer {
     SQLiteInteger: ['-9223372036854775808', '9223372036854775807'],
     // 16 bit
     PgSmallInt: ['-32768', '32767'],
-    PgSmallSerial: ['1', '32767'],
+    // A serial is an ordinary integer column that happens to default from a sequence. The
+    // sequence starts at 1, the column does not: `INSERT ... (id) VALUES (-5)` is accepted by
+    // Postgres and is how backfills and sentinel rows get written. Lower-bounding these at 1
+    // rejected valid rows, and `drizzle-orm/zod` bounds them by the integer width too.
+    PgSmallSerial: ['-32768', '32767'],
     MySqlSmallInt: ['-32768', '32767'],
     SingleStoreSmallInt: ['-32768', '32767'],
     // 24 bit
     MySqlMediumInt: ['-8388608', '8388607'],
     // 32 bit
     PgInteger: ['-2147483648', '2147483647'],
-    PgSerial: ['1', '2147483647'],
+    PgSerial: ['-2147483648', '2147483647'],
     MySqlInt: ['-2147483648', '2147483647'],
     SingleStoreInt: ['-2147483648', '2147483647'],
     // 53 bit, the JS safe-integer ceiling rather than the column's
     PgBigInt53: ['-9007199254740991', '9007199254740991'],
-    PgBigSerial53: ['1', '9007199254740991'],
+    PgBigSerial53: ['-9007199254740991', '9007199254740991'],
     MySqlBigInt53: ['-9007199254740991', '9007199254740991'],
     SingleStoreBigInt53: ['-9007199254740991', '9007199254740991'],
     // 64 bit, representable because the value is a bigint
     PgBigInt64: ['-9223372036854775808', '9223372036854775807'],
-    PgBigSerial64: ['1', '9223372036854775807'],
+    PgBigSerial64: ['-9223372036854775808', '9223372036854775807'],
     MySqlBigInt64: ['-9223372036854775808', '9223372036854775807'],
     SingleStoreBigInt64: ['-9223372036854775808', '9223372036854775807'],
   };
@@ -427,9 +634,11 @@ export class SchemaAnalyzer {
    * Everything here is read off Drizzle's own column instance, so it states what the schema
    * states. Nothing is inferred from a name or guessed from a type.
    */
-  private columnConstraints(column: any): Pick<Column, 'maxLength' | 'min' | 'max' | 'format'> {
+  private columnConstraints(
+    column: any
+  ): Pick<Column, 'maxLength' | 'min' | 'max' | 'format' | 'integer'> {
     const ctor = column?.constructor?.name ?? '';
-    const out: Pick<Column, 'maxLength' | 'min' | 'max' | 'format'> = {};
+    const out: Pick<Column, 'maxLength' | 'min' | 'max' | 'format' | 'integer'> = {};
 
     // `length` is set by varchar/char across every dialect, and by SQLite's `text({length})`.
     const length = column?.length ?? column?.config?.length;
@@ -440,6 +649,7 @@ export class SchemaAnalyzer {
     const range = SchemaAnalyzer.INT_RANGES[ctor];
     if (range) {
       [out.min, out.max] = range;
+      out.integer = true;
     }
 
     if (/^(Pg)?UUID$/i.test(ctor) || /Uuid$/i.test(ctor)) out.format = 'uuid';
@@ -527,7 +737,8 @@ export class SchemaAnalyzer {
           if (/Point|Line/i.test(ctor)) return { tsType: 'string', dbType: 'TEXT' };
 
           // Temporal
-          if (/TimestampString|DateString/i.test(ctor)) return { tsType: 'string', dbType: 'TIMESTAMP' };
+          if (/TimestampString|DateString/i.test(ctor))
+            return { tsType: 'string', dbType: 'TIMESTAMP' };
           if (/Timestamptz/i.test(ctor)) return { tsType: 'Date', dbType: 'TIMESTAMPTZ' };
           if (/Timestamp/i.test(ctor)) return { tsType: 'Date', dbType: 'TIMESTAMP' };
           if (/Date/i.test(ctor)) return { tsType: 'Date', dbType: 'TIMESTAMP' };
@@ -542,10 +753,12 @@ export class SchemaAnalyzer {
           if (/Bool/i.test(ctor)) return { tsType: 'boolean', dbType: 'BOOLEAN' };
 
           // JSON
-          if (/Jsonb?/i.test(ctor)) return { tsType: 'any', dbType: /Jsonb/i.test(ctor) ? 'JSONB' : 'JSON' };
+          if (/Jsonb?/i.test(ctor))
+            return { tsType: 'any', dbType: /Jsonb/i.test(ctor) ? 'JSONB' : 'JSON' };
 
           // Numbers
-          if (/Numeric|Float|Double|Real/i.test(ctor)) return { tsType: 'number', dbType: 'NUMERIC' };
+          if (/Numeric|Float|Double|Real/i.test(ctor))
+            return { tsType: 'number', dbType: 'NUMERIC' };
         }
         // coarse inference for MySQL types by name
         if (/^MySql/i.test(ctor)) {
@@ -644,7 +857,8 @@ export class SchemaAnalyzer {
           if (/TimestampTz/i.test(ctor)) return { tsType: 'Date', dbType: 'TIMESTAMPTZ' };
           if (/Timestamp/i.test(ctor)) return { tsType: 'string', dbType: 'TIMESTAMP' };
           if (/LocalDateString|LocalTime/i.test(ctor)) return { tsType: 'string', dbType: 'TEXT' };
-          if (/DateDuration|RelDuration|Duration/i.test(ctor)) return { tsType: 'string', dbType: 'TEXT' };
+          if (/DateDuration|RelDuration|Duration/i.test(ctor))
+            return { tsType: 'string', dbType: 'TEXT' };
         }
         return { tsType: 'unknown', dbType: 'UNKNOWN' };
     }
@@ -696,6 +910,16 @@ export class SchemaAnalyzer {
         uniqueGroups.set(uName, arr);
       }
 
+      // Drizzle v1 states the type outright; the class-name mapping is the fallback for 0.4x.
+      // v1 goes last so it wins, and only where it actually has an opinion: it leaves
+      // `maxLength` to `columnConstraints`, which reads the declared `length`.
+      const v1 = describeV1Column(col);
+      // ...except on a shaped column, where `length` is the vector width or the bit count
+      // rather than a character limit. Left in place it emitted a string length check on a
+      // `number[]`.
+      const constraints = this.columnConstraints(col);
+      if (v1?.shape) delete constraints.maxLength;
+
       columns.push({
         name: colName,
         tsType,
@@ -706,7 +930,8 @@ export class SchemaAnalyzer {
         defaultExpression: undefined,
         references,
         enumValues: Array.isArray(ev) ? ev : undefined,
-        ...this.columnConstraints(col),
+        ...constraints,
+        ...(v1 ?? {}),
       });
     }
 

--- a/packages/analyzer/test/v1-column-types.spec.ts
+++ b/packages/analyzer/test/v1-column-types.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * The Drizzle v1 column description, read from `dataType` and `codec`.
+ *
+ * v1 stamps every column with a `dataType` of the form `"<js type> <semantic>"` and a `codec`
+ * naming the SQL side. Both are read here instead of the constructor name, which the analyzer
+ * matched on before: the class list ran to dozens of names per dialect, drifted between releases,
+ * and a miss fell through to a regex that guessed from the name. `PgBinaryVector` is the clearest
+ * case against guessing, since it is a bit string and not a vector.
+ *
+ * Every pair below was taken from a real drizzle-orm 1.0.0-rc.4 column rather than invented, and
+ * the parity stage in `scripts/verify-packed.sh` re-measures them against the real thing.
+ */
+import { describe, it, expect } from 'vitest';
+import { describeV1Column } from '../src/index';
+
+/** A column as v1 presents one. `dimensions: 0` is what a scalar carries. */
+const col = (dataType: string, codec: string, extra: Record<string, unknown> = {}) => ({
+  dataType,
+  codec,
+  dimensions: 0,
+  ...extra,
+});
+
+describe('numbers', () => {
+  it('bounds each integer width', () => {
+    expect(describeV1Column(col('number int16', 'smallint'))).toMatchObject({
+      tsType: 'number',
+      integer: true,
+      min: '-32768',
+      max: '32767',
+    });
+    expect(describeV1Column(col('number int32', 'int'))).toMatchObject({
+      min: '-2147483648',
+      max: '2147483647',
+    });
+  });
+
+  it('keeps bigint mode number a number, and bigint mode bigint a bigint', () => {
+    // Drizzle names these `PgBigInt53` and `PgBigInt64`. The number mode really does return a JS
+    // number, so a schema demanding a bigint there rejects every row.
+    expect(describeV1Column(col('number int53', 'bigint:number'))).toMatchObject({
+      tsType: 'number',
+      max: '9007199254740991',
+    });
+    expect(describeV1Column(col('bigint int64', 'bigint'))).toMatchObject({
+      tsType: 'bigint',
+      max: '9223372036854775807',
+    });
+  });
+
+  it('marks the inexact types as non-integers even though they carry bounds', () => {
+    // The generators used to read "declares both bounds" as "is an integer". That held only while
+    // integers were the sole bounded type, so stating it outright is the whole point of the flag.
+    for (const [dt, codec] of [
+      ['number float', 'float4'],
+      ['number double', 'float8'],
+      ['number', 'numeric:number'],
+    ] as const) {
+      expect(describeV1Column(col(dt, codec))?.integer, `${dt} should not be an integer`).toBe(
+        false
+      );
+    }
+  });
+
+  it('leaves numeric a string, since a JS number cannot hold arbitrary precision', () => {
+    expect(describeV1Column(col('string numeric', 'numeric'))).toMatchObject({
+      tsType: 'string',
+      dbType: 'NUMERIC',
+    });
+  });
+});
+
+describe('structured values', () => {
+  it('describes the tuple types by their real arity', () => {
+    // These arrive as `[number, number]`. Mapped to a string, as they were, the select schema
+    // rejected every row the database returned.
+    expect(describeV1Column(col('array point', 'point:tuple'))?.shape).toEqual({
+      kind: 'tuple',
+      length: 2,
+    });
+    expect(describeV1Column(col('array line', 'line:tuple'))?.shape).toEqual({
+      kind: 'tuple',
+      length: 3,
+    });
+    expect(describeV1Column(col('array geometry', 'geometry(point):tuple'))?.shape).toEqual({
+      kind: 'tuple',
+      length: 2,
+    });
+  });
+
+  it('carries the declared width of a vector and a bit string', () => {
+    expect(describeV1Column(col('array vector', 'vector', { length: 3 }))?.shape).toEqual({
+      kind: 'numberVector',
+      length: 3,
+    });
+    // `bit(3)`, which the dataType calls "binary" and the class calls `PgBinaryVector`, is a
+    // string of '0' and '1' rather than anything vector shaped.
+    expect(describeV1Column(col('string binary', 'bit', { length: 3 }))).toMatchObject({
+      tsType: 'string',
+      shape: { kind: 'bitstring', length: 3 },
+    });
+  });
+
+  it('describes json and bytea by shape rather than as any/unknown', () => {
+    expect(describeV1Column(col('object json', 'jsonb'))).toMatchObject({
+      dbType: 'JSONB',
+      shape: { kind: 'json' },
+    });
+    expect(describeV1Column(col('object buffer', 'bytea'))?.shape).toEqual({ kind: 'buffer' });
+  });
+});
+
+describe('arrays', () => {
+  it('reads a positive dimension as an array of the element type', () => {
+    // Drizzle gives an array no class of its own: `text().array()` is still a `PgText`, and only
+    // `dimensions` distinguishes it. The element description has to survive.
+    const d = describeV1Column(col('number int32', 'int', { dimensions: 1 }));
+    expect(d).toMatchObject({ tsType: 'number', arrayDimensions: 1, min: '-2147483648' });
+  });
+
+  it('does not treat a sized array as an array', () => {
+    // `.array(3)` sets a size rather than a dimension, and Drizzle itself treats the result as a
+    // scalar: `drizzle-orm/zod` emits `number` for it, not `number[]`.
+    expect(
+      describeV1Column(col('number int32', 'int', { dimensions: null }))?.arrayDimensions
+    ).toBe(undefined);
+    expect(describeV1Column(col('number int32', 'int'))?.arrayDimensions).toBe(undefined);
+  });
+});
+
+describe('when it declines to answer', () => {
+  it('returns null on a 0.4x column, which carries no codec', () => {
+    // The class-name mapping stays in place for those, so an older schema is unaffected.
+    expect(describeV1Column({ dataType: 'string' })).toBe(null);
+    expect(describeV1Column({})).toBe(null);
+  });
+
+  it('returns null for a js type it does not model, rather than inventing one', () => {
+    // A wrong scalar rejects rows; falling back to the class name only risks failing to catch
+    // them, which is the safer of the two.
+    expect(describeV1Column(col('symbol whatever', 'newthing'))).toBe(null);
+  });
+});

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -7,6 +7,7 @@ import type {
 import type { ColumnCheck } from '@drzl/validation-core';
 import {
   insertColumns,
+  isIntegerColumn,
   parseCheck,
   updateColumns,
   selectColumns,
@@ -66,12 +67,47 @@ function atNarrowRange(
   return { lower, upper, equals };
 }
 
+/**
+ * A column whose value is structured rather than scalar, in ArkType's string DSL.
+ *
+ * Every form here was checked against ArkType itself, since an expression it cannot parse throws
+ * at import and takes the whole module with it. The tuple types are the reason for
+ * `number[] == n` rather than a literal `[number, number]`: ArkType does accept a real tuple, but
+ * only written as a nested array in the definition object, and this generator emits a string per
+ * field. Both reject a wrong-length array; the tuple form would additionally give a static type
+ * of `[number, number]` instead of `number[]`.
+ */
+function atShapeType(c: Column): string | undefined {
+  const s = c.shape;
+  if (!s) return undefined;
+  switch (s.kind) {
+    case 'json':
+      // Flat rather than recursive, matching what `drizzle-orm/arktype` builds. `object` covers
+      // both arrays and records, so nesting needs no separate arm.
+      return 'number | object | string | boolean | null';
+    case 'buffer':
+      return 'TypedArray.Uint8';
+    case 'tuple':
+      return `number[] == ${s.length}`;
+    case 'numberVector':
+      return s.length ? `number[] == ${s.length}` : 'number[]';
+    case 'bitstring':
+      return s.length ? `/^[01]*$/ & string == ${s.length}` : '/^[01]*$/';
+  }
+}
+
 function atTypeForColumn(
   c: Column,
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = []
 ): string {
+  const shaped = atShapeType(c);
+  if (shaped) return shaped;
+  // A parsed check compares the column to a scalar literal, which describes the array rather
+  // than an element. Folded in anyway, `CHECK (tags = 'x')` became `('x')[]`, demanding that
+  // every element equal 'x'.
+  if (c.arrayDimensions) checks = [];
   if (c.enumValues && c.enumValues.length) {
     return c.enumValues.map((v) => `'${v.replace(/'/g, "\\'")}'`).join(' | ');
   }
@@ -81,7 +117,9 @@ function atTypeForColumn(
     // because an expression it cannot parse throws at import and takes the router with it.
     case 'string': {
       // An equality check pins the value, which ArkType states as a literal type.
-      const eq = checks.find((k) => k.column === c.name && k.operator === '=' && k.kind === 'string');
+      const eq = checks.find(
+        (k) => k.column === c.name && k.operator === '=' && k.kind === 'string'
+      );
       if (eq) return `'${eq.value.replace(/'/g, "\\'")}'`;
       if (c.format === 'uuid') return 'string.uuid';
       return c.maxLength ? `string <= ${c.maxLength}` : 'string';
@@ -89,13 +127,14 @@ function atTypeForColumn(
     case 'number': {
       const { lower, upper, equals } = atNarrowRange(c, checks);
       if (equals !== undefined) return equals;
-      // `min <= number <= max` already implies an integer range here, and ArkType has no way to
-      // write both that and `number.integer` in one expression, so the bound is the stronger
-      // statement and is preferred where present.
-      if (lower && upper) return `${lower} number ${upper}`;
-      if (lower) return `${lower} number`;
-      if (upper) return `number ${upper}`;
-      return c.dbType === 'INTEGER' ? 'number.integer' : 'number';
+      // ArkType does accept both at once: `-2147483648 <= number.integer <= 2147483647` parses
+      // and rejects 1.5. Preferring the bound alone, on the theory that a range implied
+      // integrality, meant every `integer()` column accepted a fraction.
+      const num = isIntegerColumn(c) ? 'number.integer' : 'number';
+      if (lower && upper) return `${lower} ${num} ${upper}`;
+      if (lower) return `${lower} ${num}`;
+      if (upper) return `${num} ${upper}`;
+      return num;
     }
     case 'bigint':
       // ArkType compares bigints against bigint literals, and a 64 bit bound cannot be written
@@ -106,7 +145,10 @@ function atTypeForColumn(
     case 'Date':
       return atDateType(mode, coerceDates);
     case 'Uint8Array':
-      return 'Uint8Array';
+      // `'Uint8Array'` is not an ArkType keyword. It parses as an unresolvable alias and throws
+      // at import, so every emitted module holding a binary column was unloadable rather than
+      // merely wrong. `TypedArray.Uint8` is the keyword, and it accepts a Node Buffer too.
+      return 'TypedArray.Uint8';
     case 'any':
       return 'unknown';
     default:
@@ -121,6 +163,12 @@ function atField(
   checks: ColumnCheck[] = []
 ): string {
   let t = atTypeForColumn(c, mode, coerceDates, checks);
+  // The element is parenthesised whenever it is anything but a bare keyword, because `[]` binds
+  // tighter than every operator ArkType has: `'a' | 'b'[]` is the literal `'a'` or an array of
+  // `'b'`, not an array of either. A plain keyword needs no parentheses and reads better without,
+  // so `string[]` stays `string[]` while `('a' | 'b')[]` and `(string <= 255)[]` get them.
+  const bare = /^[A-Za-z_][A-Za-z0-9_.]*$/.test(t);
+  for (let i = 0; i < (c.arrayDimensions ?? 0); i++) t = bare && i === 0 ? `${t}[]` : `(${t})[]`;
   if (c.nullable) t = `(${t} | null)`;
   if (mode !== 'select') {
     if (mode === 'update' || c.nullable || c.hasDefault) t = `${t}?`;
@@ -135,7 +183,10 @@ function renderObjectShape(
   checks: ColumnCheck[] = []
 ) {
   return cols
-    .map((c) => `  ${JSON.stringify(c.name)}: ${JSON.stringify(atField(c, mode, coerceDates, checks))},`)
+    .map(
+      (c) =>
+        `  ${JSON.stringify(c.name)}: ${JSON.stringify(atField(c, mode, coerceDates, checks))},`
+    )
     .join('\n');
 }
 

--- a/packages/generator-arktype/test/checks.spec.ts
+++ b/packages/generator-arktype/test/checks.spec.ts
@@ -3,8 +3,12 @@
  *
  * ArkType states constraints inside its type expression rather than by chaining, so a check
  * folds into the range instead of becoming a separate assertion. That is not a workaround, it
- * is the better result: `18 <= number <= 32767` is one statement about the type rather than a
- * bound plus an opaque predicate.
+ * is the better result: `18 <= number.integer <= 32767` is one statement about the type rather
+ * than a bound plus an opaque predicate.
+ *
+ * The `.integer` is load bearing. These expectations previously read `18 <= number <= 32767`, on
+ * the theory that an integer range implied integrality; it does not, and every `integer()` column
+ * accepted `1.5` until ArkType was asked directly and turned out to parse both at once.
  *
  * Every emitted form is executed against arktype itself below. An expression it cannot parse
  * throws at import, which would take down whatever imported the schema, so "it looks right" is
@@ -51,7 +55,12 @@ async function typeOf(
   // Prettier drops the quotes around a key that is a valid identifier, so both forms occur.
   const line = block.split('\n').find((l) => new RegExp(`^\\s*"?${c.name}"?:`).test(l));
   expect(line, `no field ${c.name} in:\n${src}`).toBeTruthy();
-  return JSON.parse(line!.trim().replace(/^"?[A-Za-z0-9_]+"?:\s*/, '').replace(/,$/, ''));
+  return JSON.parse(
+    line!
+      .trim()
+      .replace(/^"?[A-Za-z0-9_]+"?:\s*/, '')
+      .replace(/,$/, '')
+  );
 }
 
 describe('folding a check into the range', () => {
@@ -59,26 +68,26 @@ describe('folding a check into the range', () => {
     const t = await typeOf(col('age', { min: '-32768', max: '32767' }), [
       { name: 'adult', expression: 'age >= 18' },
     ]);
-    expect(t).toBe('18 <= number <= 32767');
+    expect(t).toBe('18 <= number.integer <= 32767');
   });
 
   it('tightens the upper bound', async () => {
     const t = await typeOf(col('pct', { min: '-32768', max: '32767' }), [
       { expression: 'pct <= 100' },
     ]);
-    expect(t).toBe('-32768 <= number <= 100');
+    expect(t).toBe('-32768 <= number.integer <= 100');
   });
 
   it('turns BETWEEN into both bounds', async () => {
     const t = await typeOf(col('score', { min: '-32768', max: '32767' }), [
       { expression: 'score BETWEEN 0 AND 100' },
     ]);
-    expect(t).toBe('0 <= number <= 100');
+    expect(t).toBe('0 <= number.integer <= 100');
   });
 
   it('keeps an exclusive comparison exclusive', async () => {
     const t = await typeOf(col('n', { min: '-32768', max: '32767' }), [{ expression: 'n > 0' }]);
-    expect(t).toBe('0 < number <= 32767');
+    expect(t).toBe('0 < number.integer <= 32767');
   });
 
   it('pins an equality to a literal', async () => {
@@ -94,14 +103,14 @@ describe('what it leaves alone', () => {
     const t = await typeOf(col('age', { min: '-32768', max: '32767' }), [
       { expression: 'other >= 18' },
     ]);
-    expect(t).toBe('-32768 <= number <= 32767');
+    expect(t).toBe('-32768 <= number.integer <= 32767');
   });
 
   it('ignores a cross-column comparison, which is about the row', async () => {
     const t = await typeOf(col('age', { min: '-32768', max: '32767' }), [
       { expression: 'age > score' },
     ]);
-    expect(t).toBe('-32768 <= number <= 32767');
+    expect(t).toBe('-32768 <= number.integer <= 32767');
   });
 });
 
@@ -132,7 +141,8 @@ describe('the emitted expressions are ones arktype accepts', () => {
     expect(Object.keys(shape), `parsed nothing from:\n${body}`).toHaveLength(3);
     const { type } = await import('arktype');
     const T = type(shape as never);
-    const isErr = (r: unknown) => (r as { constructor?: { name?: string } })?.constructor?.name?.includes('Errors');
+    const isErr = (r: unknown) =>
+      (r as { constructor?: { name?: string } })?.constructor?.name?.includes('Errors');
 
     expect(isErr(T({ age: 30, score: 50, tier: 'gold' })), 'valid row').toBe(false);
     expect(isErr(T({ age: 5, score: 50, tier: 'gold' })), 'age below check').toBe(true);

--- a/packages/generator-arktype/test/structured-columns.spec.ts
+++ b/packages/generator-arktype/test/structured-columns.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Array and structured columns in ArkType output.
+ *
+ * ArkType parses its types at import, so an expression it cannot resolve throws and takes down
+ * whatever imported the schema. That makes running the emitted module the only test worth
+ * writing here, and it is how the worst defect in this generator was found: `'Uint8Array'` is not
+ * an ArkType keyword, so every emitted module holding a binary column threw
+ * `'Uint8Array' is unresolvable` on import. Asserting on the emitted text saw nothing wrong.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArkTypeGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { type } from 'arktype';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+async function schemasFor(columns: Column[], label: string): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-structured');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.arktype.ts'), file);
+  return await import(file);
+}
+
+const accepts = (schema: any, key: string, v: unknown) =>
+  !(schema.get(key)(v) instanceof type.errors);
+
+describe('binary columns', () => {
+  it('produces a module that imports at all', async () => {
+    // The regression guard. `'Uint8Array'` parsed as an unresolvable alias and threw here.
+    const m = await schemasFor([col('data', { tsType: 'Uint8Array', dbType: 'BLOB' })], 'blob');
+    expect(m.SelecttSchema).toBeDefined();
+    expect(accepts(m.SelecttSchema, 'data', new Uint8Array([1, 2]))).toBe(true);
+    expect(accepts(m.SelecttSchema, 'data', Buffer.from('ab')), 'a Buffer').toBe(true);
+    expect(accepts(m.SelecttSchema, 'data', 'abc'), 'a string').toBe(false);
+    expect(accepts(m.SelecttSchema, 'data', null), 'null on a NOT NULL column').toBe(false);
+  });
+
+  it('does the same for a bytea, which reaches it as a shape', async () => {
+    const m = await schemasFor(
+      [col('data', { tsType: 'Buffer', dbType: 'BYTEA', shape: { kind: 'buffer' } })],
+      'bytea'
+    );
+    expect(accepts(m.SelecttSchema, 'data', new Uint8Array([1]))).toBe(true);
+    expect(accepts(m.SelecttSchema, 'data', 5)).toBe(false);
+  });
+});
+
+describe('arrays', () => {
+  it('wraps the element rather than replacing it', async () => {
+    const m = await schemasFor([col('tags', { arrayDimensions: 1 })], 'tags');
+    expect(accepts(m.SelecttSchema, 'tags', ['a', 'b'])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'tags', 'a'), 'a bare string').toBe(false);
+  });
+
+  it('parenthesises an enum array, whose element is itself a union', async () => {
+    // `'a' | 'b'[]` would parse as the literal 'a' or an array of 'b'. The parentheses are what
+    // make it an array of either.
+    const m = await schemasFor(
+      [col('moods', { enumValues: ['happy', 'sad'], arrayDimensions: 1 })],
+      'moods'
+    );
+    expect(accepts(m.SelecttSchema, 'moods', ['happy', 'sad'])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'moods', ['nope'])).toBe(false);
+    expect(accepts(m.SelecttSchema, 'moods', 'happy'), 'a bare member').toBe(false);
+  });
+});
+
+describe('structured columns', () => {
+  it('holds a point to exactly two numbers', async () => {
+    const m = await schemasFor(
+      [
+        col('p', {
+          tsType: '[number, number]',
+          dbType: 'POINT',
+          shape: { kind: 'tuple', length: 2 },
+        }),
+      ],
+      'point'
+    );
+    expect(accepts(m.SelecttSchema, 'p', [1, 2])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'p', [1, 2, 3])).toBe(false);
+    expect(accepts(m.SelecttSchema, 'p', '(1,2)')).toBe(false);
+  });
+
+  it('holds a bit column to binary digits of the declared length', async () => {
+    const m = await schemasFor(
+      [col('b', { dbType: 'BIT', shape: { kind: 'bitstring', length: 3 } })],
+      'bit'
+    );
+    expect(accepts(m.SelecttSchema, 'b', '010')).toBe(true);
+    expect(accepts(m.SelecttSchema, 'b', '012')).toBe(false);
+    expect(accepts(m.SelecttSchema, 'b', '0101')).toBe(false);
+  });
+});
+
+describe('integer columns', () => {
+  it('rejects a fraction inside its range', async () => {
+    // These emitted `-32768 <= number <= 32767`, on the theory that an integer range implied
+    // integrality. ArkType parses `number.integer` inside a range perfectly well.
+    const m = await schemasFor(
+      [
+        col('n', {
+          tsType: 'number',
+          dbType: 'INTEGER',
+          integer: true,
+          min: '-32768',
+          max: '32767',
+        }),
+      ],
+      'int'
+    );
+    expect(accepts(m.SelecttSchema, 'n', 42)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'n', 1.5), 'a fraction').toBe(false);
+    expect(accepts(m.SelecttSchema, 'n', 40000), 'past the column width').toBe(false);
+  });
+
+  it('leaves a float free to be fractional', async () => {
+    const m = await schemasFor(
+      [
+        col('r', {
+          tsType: 'number',
+          dbType: 'REAL',
+          integer: false,
+          min: '-8388608',
+          max: '8388607',
+        }),
+      ],
+      'real'
+    );
+    expect(accepts(m.SelecttSchema, 'r', 1.5)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'r', 1e9), 'past the precision bound').toBe(false);
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -8,6 +8,7 @@ import type {
 import {
   formatCode,
   insertColumns,
+  isIntegerColumn,
   moduleFileName,
   moduleSpecifier,
   parseCheck,
@@ -103,6 +104,55 @@ function tbCheckOptions(c: Column, checks: ColumnCheck[]): Array<[string, string
   return out;
 }
 
+/** Name of the recursive JSON schema emitted into a file that has any json column. */
+const JSON_CONST = 'DrzlJsonValue';
+
+/**
+ * A recursive definition of the JSON value space, emitted once per file.
+ *
+ * `Type.Unknown()` accepted `undefined`, `NaN`, `Infinity`, bigints, Dates and Buffers, none of
+ * which survive a round trip through a json column. `Type.Recursive` is what lets the nested
+ * cases refer back to the whole, so a `{ a: { b: [1, 'x'] } }` is checked all the way down.
+ */
+const JSON_PREAMBLE = `const ${JSON_CONST} = Type.Recursive((This) =>
+  Type.Union([
+    Type.String(),
+    Type.Number(),
+    Type.Boolean(),
+    Type.Null(),
+    Type.Array(This),
+    Type.Record(Type.String(), This),
+  ])
+);
+`;
+
+/**
+ * A column whose value is structured rather than scalar.
+ *
+ * These used to land on `Type.Unknown()`, or for the tuple types on `Type.String()`, which
+ * rejected every row: a `point` really arrives as `[number, number]`.
+ */
+function tbShapeExpr(c: Column, typedJsonRef?: string): string | undefined {
+  const s = c.shape;
+  if (!s) return undefined;
+  switch (s.kind) {
+    case 'json':
+      // `typedJson` still wins, since the inferred type is narrower than "any JSON".
+      if (typedJsonRef) return `Type.Unsafe<${typedJsonRef}>(Type.Unknown())`;
+      return JSON_CONST;
+    case 'buffer':
+      return 'Type.Uint8Array()';
+    case 'tuple':
+      return `Type.Tuple([${Array.from({ length: s.length }, () => 'Type.Number()').join(', ')}])`;
+    case 'numberVector':
+      return `Type.Array(Type.Number()${s.length ? `, { minItems: ${s.length}, maxItems: ${s.length} }` : ''})`;
+    case 'bitstring':
+      // `pattern` rather than `format`, which TypeBox ignores unless the consuming project has
+      // registered it on `FormatRegistry` first.
+      return `Type.String({ pattern: '^[01]*$'${s.length ? `, minLength: ${s.length}, maxLength: ${s.length}` : ''} })`;
+  }
+}
+
 function tbExprForColumn(
   c: Column,
   mode: Mode,
@@ -110,6 +160,12 @@ function tbExprForColumn(
   checks: ColumnCheck[] = [],
   typedJsonRef?: string
 ): string {
+  const shaped = tbShapeExpr(c, typedJsonRef);
+  if (shaped) return shaped;
+  // A parsed check compares the column against a scalar literal, which describes an element
+  // rather than the array. Applied anyway, `CHECK (tags = 'x')` collapsed the whole column to
+  // `Type.Literal("x")`.
+  if (c.arrayDimensions) checks = [];
   if (c.enumValues && c.enumValues.length) {
     const vals = c.enumValues.map((v) => `Type.Literal(${JSON.stringify(v)})`).join(', ');
     return `Type.Union([${vals}])`;
@@ -130,24 +186,26 @@ function tbExprForColumn(
 
   switch (c.tsType) {
     case 'string': {
-      const base: Array<[string, string]> = c.format === 'uuid'
-        ? [['pattern', JSON.stringify(UUID_PATTERN)]]
-        : c.maxLength
-          ? [['maxLength', String(c.maxLength)]]
-          : [];
+      const base: Array<[string, string]> =
+        c.format === 'uuid'
+          ? [['pattern', JSON.stringify(UUID_PATTERN)]]
+          : c.maxLength
+            ? [['maxLength', String(c.maxLength)]]
+            : [];
       return `Type.String(${renderOptions(merged(base))})`;
     }
     case 'number': {
-      // An integer range is what marks the column as an integer; dbType alone misses
-      // `bigint({ mode: 'number' })`, whose value really is a JS number.
-      const isInt = c.dbType === 'INTEGER' || (c.min !== undefined && c.max !== undefined);
       const o = renderOptions(merged(tbBounds(c)));
-      return isInt ? `Type.Integer(${o})` : `Type.Number(${o})`;
+      return isIntegerColumn(c) ? `Type.Integer(${o})` : `Type.Number(${o})`;
     }
     case 'bigint':
-      // TypeBox compares bigints against bigint values, and a 64 bit bound cannot be written as
-      // a JSON Schema number without rounding, so the range is left unstated rather than wrong.
-      return 'Type.BigInt()';
+      // `minimum`/`maximum` do take bigint values here, verified by running the emitted schema:
+      // `Type.BigInt({ maximum: 100n })` rejects `1000n`. Writing the bound as a plain number
+      // would be the broken form, since 9223372036854775807 rounds up the moment it becomes one,
+      // so the literals are emitted with the `n` suffix and the bound stays exact.
+      return c.min !== undefined && c.max !== undefined
+        ? `Type.BigInt({ minimum: ${c.min}n, maximum: ${c.max}n })`
+        : 'Type.BigInt()';
     case 'boolean':
       return 'Type.Boolean()';
     case 'Date':
@@ -172,6 +230,9 @@ function tbField(
   typedJsonRef?: string
 ): string {
   let expr = tbExprForColumn(c, mode, coerceDates, checks, typedJsonRef);
+  // Drizzle keeps an array on the element's own column class, so everything above describes the
+  // element and the wrapping belongs out here, after its bounds are attached.
+  for (let i = 0; i < (c.arrayDimensions ?? 0); i++) expr = `Type.Array(${expr})`;
   // Nullability wraps the constrained type, so null skips the constraint. That reproduces SQL,
   // where a CHECK passes when it evaluates to TRUE or NULL.
   if (c.nullable) expr = `Type.Union([${expr}, Type.Null()])`;
@@ -233,9 +294,15 @@ function renderTableSchemas(
     ? `import type { ${T} } from '${typedJson.schemaSpecifier}';\n`
     : '';
 
+  // Emitted only where a json column exists, and not when `typedJson` has replaced it with the
+  // inferred type, so a file never carries an unused declaration.
+  const needsJson =
+    !typedJson &&
+    [...insertCols, ...updateCols, ...selectCols].some((c) => c.shape?.kind === 'json');
+
   return `import { Type } from '@sinclair/typebox';
 import type { Static } from '@sinclair/typebox';
-${schemaImport}
+${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}
 export const ${insertSchema} = Type.Object({
 ${bodyInsert}
 });

--- a/packages/generator-typebox/test/structured-columns.spec.ts
+++ b/packages/generator-typebox/test/structured-columns.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Array and structured columns in TypeBox output, checked by running the emitted schemas.
+ *
+ * Same reason as everywhere else in this package: TypeBox accepts an option it does not
+ * understand for a given type and then ignores it, so a schema can look right, compile, and
+ * validate nothing. The bigint bounds below are the case in point. They were left off because a
+ * 64 bit bound cannot be written as a JSON Schema number without rounding, which is true, but
+ * `minimum` and `maximum` take bigint values here and enforce them exactly.
+ */
+import { describe, it, expect } from 'vitest';
+import { TypeBoxGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { Value } from '@sinclair/typebox/value';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+async function schemasFor(columns: Column[], label: string): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-structured');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), file);
+  return await import(file);
+}
+
+const accepts = (schema: any, key: string, x: unknown) => Value.Check(schema.properties[key], x);
+
+describe('arrays', () => {
+  it('wraps the element rather than replacing it', async () => {
+    const m = await schemasFor([col('tags', { arrayDimensions: 1 })], 'tags');
+    expect(accepts(m.SelecttSchema, 'tags', ['a', 'b'])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'tags', 'a'), 'a bare string').toBe(false);
+  });
+
+  it('keeps the element constraints inside the array', async () => {
+    const m = await schemasFor(
+      [
+        col('scores', {
+          tsType: 'number',
+          dbType: 'INTEGER',
+          integer: true,
+          min: '-32768',
+          max: '32767',
+          arrayDimensions: 1,
+        }),
+      ],
+      'scores'
+    );
+    expect(accepts(m.SelecttSchema, 'scores', [1, 2])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'scores', [40000])).toBe(false);
+    expect(accepts(m.SelecttSchema, 'scores', [1.5])).toBe(false);
+  });
+});
+
+describe('structured columns', () => {
+  it('holds a point to exactly two numbers', async () => {
+    const m = await schemasFor(
+      [
+        col('p', {
+          tsType: '[number, number]',
+          dbType: 'POINT',
+          shape: { kind: 'tuple', length: 2 },
+        }),
+      ],
+      'point'
+    );
+    expect(accepts(m.SelecttSchema, 'p', [1, 2])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'p', [1, 2, 3])).toBe(false);
+    expect(accepts(m.SelecttSchema, 'p', '(1,2)')).toBe(false);
+  });
+
+  it('holds a vector to its declared width', async () => {
+    const m = await schemasFor(
+      [
+        col('vec', {
+          tsType: 'number[]',
+          dbType: 'VECTOR',
+          shape: { kind: 'numberVector', length: 3 },
+        }),
+      ],
+      'vector'
+    );
+    expect(accepts(m.SelecttSchema, 'vec', [1, 2, 3])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'vec', [1, 2])).toBe(false);
+  });
+
+  it('holds a bit column to binary digits of the declared length', async () => {
+    const m = await schemasFor(
+      [col('b', { dbType: 'BIT', shape: { kind: 'bitstring', length: 3 } })],
+      'bit'
+    );
+    expect(accepts(m.SelecttSchema, 'b', '010')).toBe(true);
+    expect(accepts(m.SelecttSchema, 'b', '012')).toBe(false);
+    expect(accepts(m.SelecttSchema, 'b', '0101')).toBe(false);
+  });
+
+  it('rejects null on a NOT NULL binary column', async () => {
+    const m = await schemasFor(
+      [col('data', { tsType: 'Buffer', dbType: 'BYTEA', shape: { kind: 'buffer' } })],
+      'bytea'
+    );
+    expect(accepts(m.SelecttSchema, 'data', new Uint8Array([1]))).toBe(true);
+    expect(accepts(m.SelecttSchema, 'data', null)).toBe(false);
+  });
+
+  it('holds a json column to values that survive a round trip', async () => {
+    const m = await schemasFor(
+      [col('doc', { tsType: 'any', dbType: 'JSONB', shape: { kind: 'json' } })],
+      'json'
+    );
+    const s = m.SelecttSchema;
+    expect(accepts(s, 'doc', { a: [1, 'x', null] }), 'a nested json value').toBe(true);
+    expect(accepts(s, 'doc', undefined)).toBe(false);
+    expect(accepts(s, 'doc', NaN)).toBe(false);
+    expect(accepts(s, 'doc', 1n)).toBe(false);
+    expect(accepts(s, 'doc', new Date())).toBe(false);
+  });
+});
+
+describe('bigint bounds', () => {
+  it('enforces a 64 bit range exactly', async () => {
+    // The literals are emitted with the `n` suffix. Written as plain numbers,
+    // 9223372036854775807 rounds up the moment it becomes one and the bound would be wrong.
+    const m = await schemasFor(
+      [
+        col('big', {
+          tsType: 'bigint',
+          dbType: 'BIGINT',
+          min: '-9223372036854775808',
+          max: '9223372036854775807',
+        }),
+      ],
+      'bigint'
+    );
+    expect(accepts(m.SelecttSchema, 'big', 1n)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'big', 9223372036854775807n), 'the exact maximum').toBe(true);
+    expect(accepts(m.SelecttSchema, 'big', 2n ** 70n), 'past the column width').toBe(false);
+  });
+});

--- a/packages/generator-valibot/package.json
+++ b/packages/generator-valibot/package.json
@@ -21,7 +21,8 @@
   },
   "devDependencies": {
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "valibot": "^1.1.0"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -7,6 +7,7 @@ import type {
 import type { ColumnCheck } from '@drzl/validation-core';
 import {
   insertColumns,
+  isIntegerColumn,
   parseCheck,
   updateColumns,
   selectColumns,
@@ -58,6 +59,11 @@ function vBounds(c: Column, literal: (v: string) => string): string[] {
  * that a CHECK passes on TRUE or NULL.
  */
 function vChecks(c: Column, checks: ColumnCheck[]): string[] {
+  // A parsed check compares this column against a scalar literal, which says nothing usable
+  // about an array or a tuple: `CHECK (tags = '{}')` would become a check no `string[]` can
+  // satisfy, rejecting every row.
+  if (c.arrayDimensions || c.shape) return [];
+
   const OPS: Record<ColumnCheck['operator'], string> = {
     '>=': '>=',
     '>': '>',
@@ -76,12 +82,84 @@ function vChecks(c: Column, checks: ColumnCheck[]): string[] {
     });
 }
 
+/** Name of the recursive JSON schema emitted into a file that has any json column. */
+const JSON_CONST = 'DrzlJsonValue';
+
+/**
+ * A recursive definition of the JSON value space, emitted once per file.
+ *
+ * Valibot has no `json()` built-in, and `v.any()` accepted `undefined`, `NaN`, bigints and every
+ * class instance, none of which survive the round trip through a json column. The shape mirrors
+ * what `drizzle-orm/valibot` builds, with one addition: `v.finite()`, so `Infinity` is rejected
+ * rather than written out as `null`.
+ */
+const JSON_PREAMBLE = `type ${JSON_CONST}Type =
+  | string
+  | number
+  | boolean
+  | null
+  | ${JSON_CONST}Type[]
+  | { [key: string]: ${JSON_CONST}Type };
+
+const ${JSON_CONST}: v.GenericSchema<${JSON_CONST}Type> = v.lazy(() =>
+  v.union([
+    v.string(),
+    v.pipe(v.number(), v.finite()),
+    v.boolean(),
+    v.null(),
+    v.array(${JSON_CONST}),
+    v.pipe(
+      // The plain-object test comes before the record, not after it. A valibot pipe passes the
+      // *output* of each step onward, and \`v.record\` outputs a freshly built object, so a check
+      // placed after it inspects that new object and reports every input as plain. A Date sailed
+      // through: it has no own enumerable keys, so the record accepted it and rebuilt it as \`{}\`.
+      v.custom<Record<string, ${JSON_CONST}Type>>((o) => {
+        if (typeof o !== 'object' || o === null || Array.isArray(o)) return false;
+        const p = Object.getPrototypeOf(o);
+        return p === Object.prototype || p === null;
+      }, 'not a plain object'),
+      v.record(v.string(), ${JSON_CONST})
+    ),
+  ])
+);
+`;
+
+/**
+ * A column whose value is structured rather than scalar.
+ *
+ * These used to fall through to `v.any()`/`v.unknown()`, or for the tuple types to `v.string()`,
+ * which rejected every row since a `point` really arrives as `[number, number]`.
+ */
+function vShapeExpr(c: Column): string | undefined {
+  const s = c.shape;
+  if (!s) return undefined;
+  switch (s.kind) {
+    case 'json':
+      return JSON_CONST;
+    case 'buffer':
+      // Matches the SQLite blob mapping, so binary validates the same way in either dialect.
+      return 'v.instance(Uint8Array)';
+    case 'tuple':
+      // `strictTuple`, not `tuple`: valibot's plain `tuple` ignores extra items, so a `point`
+      // schema built from it accepted `[1, 2, 3]`.
+      return `v.strictTuple([${Array.from({ length: s.length }, () => 'v.number()').join(', ')}])`;
+    case 'numberVector':
+      return s.length
+        ? `v.pipe(v.array(v.number()), v.length(${s.length}))`
+        : 'v.array(v.number())';
+    case 'bitstring':
+      return `v.pipe(v.string(), v.regex(/^[01]*$/)${s.length ? `, v.length(${s.length})` : ''})`;
+  }
+}
+
 function vExprForColumn(
   c: Column,
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = []
 ): string {
+  const shaped = vShapeExpr(c);
+  if (shaped) return shaped;
   const extra = vChecks(c, checks);
   /** Fold the constraint actions into whatever base this column maps to. */
   const piped = (base: string, actions: string[]) => {
@@ -100,14 +178,17 @@ function vExprForColumn(
       if (c.format === 'uuid') return piped('v.string()', ['v.uuid()']);
       return piped('v.string()', c.maxLength ? [`v.maxLength(${c.maxLength})`] : []);
     case 'number': {
-      // An integer range is what marks the column as an integer; dbType alone misses
-      // `bigint({ mode: 'number' })`, whose value is a JS number.
-      const isInt = c.dbType === 'INTEGER' || (c.min !== undefined && c.max !== undefined);
-      return piped('v.number()', [...(isInt ? ['v.integer()'] : []), ...vBounds(c, (v) => v)]);
+      return piped('v.number()', [
+        ...(isIntegerColumn(c) ? ['v.integer()'] : []),
+        ...vBounds(c, (v) => v),
+      ]);
     }
     case 'bigint': {
       // Bounds must be bigint literals: a 64 bit bound written as a number rounds.
-      return piped('v.bigint()', vBounds(c, (v) => `${v}n`));
+      return piped(
+        'v.bigint()',
+        vBounds(c, (v) => `${v}n`)
+      );
     }
     case 'boolean':
       return 'v.boolean()';
@@ -129,6 +210,9 @@ function vField(
   checks: ColumnCheck[] = []
 ): string {
   let expr = vExprForColumn(c, mode, coerceDates, checks);
+  // Drizzle keeps an array on the element's own column class, so everything above describes the
+  // element and the wrapping belongs out here, after the bounds and length limits are attached.
+  for (let i = 0; i < (c.arrayDimensions ?? 0); i++) expr = `v.array(${expr})`;
   if (c.nullable) expr = `v.nullable(${expr})`;
   if (mode !== 'select') {
     // optional for insert when nullable/hasDefault, and for all fields in update
@@ -172,9 +256,14 @@ function renderTableSchemas(
   const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks);
   const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks);
   const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks);
+  // Emitted only where a json column exists, so a file without one gains nothing unused.
+  const needsJson = [...insertCols, ...updateCols, ...selectCols].some(
+    (c) => c.shape?.kind === 'json'
+  );
+
   return `import * as v from 'valibot';
 import type { InferInput, InferOutput } from 'valibot';
-
+${needsJson ? `\n${JSON_PREAMBLE}` : ''}
 export const ${insertSchema} = v.object({
 ${bodyInsert}
 });

--- a/packages/generator-valibot/test/structured-columns.spec.ts
+++ b/packages/generator-valibot/test/structured-columns.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Array and structured columns in valibot output, checked by running the emitted schemas.
+ *
+ * Valibot has two traps that only show up when the schema is executed. `v.tuple` ignores extra
+ * items, so a `point` built from it accepted `[1, 2, 3]`; `v.strictTuple` is the one that holds
+ * the arity. And valibot has no `json()` built-in, so a json column used to fall through to
+ * `v.any()` and accept `undefined`, bigints and Dates.
+ */
+import { describe, it, expect } from 'vitest';
+import { ValibotGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import * as v from 'valibot';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+async function schemasFor(columns: Column[], label: string): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-structured');
+  await fs.mkdir(dir, { recursive: true });
+  await new ValibotGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.valibot.ts'), file);
+  return await import(file);
+}
+
+const accepts = (schema: any, key: string, x: unknown) =>
+  v.safeParse(schema.entries[key], x).success;
+
+describe('arrays', () => {
+  it('wraps the element rather than replacing it', async () => {
+    const m = await schemasFor([col('tags', { arrayDimensions: 1 })], 'tags');
+    expect(accepts(m.SelecttSchema, 'tags', ['a', 'b'])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'tags', 'a'), 'a bare string').toBe(false);
+  });
+
+  it('keeps the element constraints inside the array', async () => {
+    const m = await schemasFor(
+      [
+        col('scores', {
+          tsType: 'number',
+          dbType: 'INTEGER',
+          integer: true,
+          min: '-32768',
+          max: '32767',
+          arrayDimensions: 1,
+        }),
+      ],
+      'scores'
+    );
+    expect(accepts(m.SelecttSchema, 'scores', [1, 2])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'scores', [40000]), 'past the column width').toBe(false);
+    expect(accepts(m.SelecttSchema, 'scores', [1.5]), 'a fractional element').toBe(false);
+  });
+});
+
+describe('structured columns', () => {
+  it('holds a point to exactly two numbers', async () => {
+    // `v.tuple` would accept the third element. This is the reason for `v.strictTuple`.
+    const m = await schemasFor(
+      [
+        col('p', {
+          tsType: '[number, number]',
+          dbType: 'POINT',
+          shape: { kind: 'tuple', length: 2 },
+        }),
+      ],
+      'point'
+    );
+    expect(accepts(m.SelecttSchema, 'p', [1, 2])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'p', [1, 2, 3]), 'a third element').toBe(false);
+    expect(accepts(m.SelecttSchema, 'p', '(1,2)')).toBe(false);
+  });
+
+  it('holds a vector to its declared width', async () => {
+    const m = await schemasFor(
+      [
+        col('vec', {
+          tsType: 'number[]',
+          dbType: 'VECTOR',
+          shape: { kind: 'numberVector', length: 3 },
+        }),
+      ],
+      'vector'
+    );
+    expect(accepts(m.SelecttSchema, 'vec', [1, 2, 3])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'vec', [1, 2])).toBe(false);
+  });
+
+  it('rejects null on a NOT NULL binary column', async () => {
+    const m = await schemasFor(
+      [col('data', { tsType: 'Buffer', dbType: 'BYTEA', shape: { kind: 'buffer' } })],
+      'bytea'
+    );
+    expect(accepts(m.SelecttSchema, 'data', new Uint8Array([1]))).toBe(true);
+    expect(accepts(m.SelecttSchema, 'data', null)).toBe(false);
+  });
+
+  it('holds a json column to values that survive a round trip', async () => {
+    const m = await schemasFor(
+      [col('doc', { tsType: 'any', dbType: 'JSONB', shape: { kind: 'json' } })],
+      'json'
+    );
+    const s = m.SelecttSchema;
+    expect(accepts(s, 'doc', { a: [1, 'x', null] }), 'a nested json value').toBe(true);
+    expect(accepts(s, 'doc', undefined)).toBe(false);
+    expect(accepts(s, 'doc', NaN)).toBe(false);
+    expect(accepts(s, 'doc', 1n)).toBe(false);
+    // Stricter than `drizzle-orm/valibot`, which builds the object arm from a plain record and so
+    // lets both of these through.
+    expect(accepts(s, 'doc', Infinity), 'Infinity, which JSON cannot carry').toBe(false);
+    expect(accepts(s, 'doc', new Date()), 'a Date, which is not a plain object').toBe(false);
+  });
+
+  it('emits the json declaration only where a json column exists', async () => {
+    const dir = path.join(__dirname, '.tmp-structured');
+    await fs.mkdir(dir, { recursive: true });
+    const analysis = (columns: Column[]): Analysis =>
+      ({
+        dialect: 'postgres',
+        tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }],
+        enums: [],
+        relations: [],
+        issues: [],
+      }) as never;
+
+    await new ValibotGenerator(
+      analysis([col('doc', { tsType: 'any', shape: { kind: 'json' } })])
+    ).generate({ outDir: dir } as never);
+    expect(await fs.readFile(path.join(dir, 't.valibot.ts'), 'utf8')).toContain('DrzlJsonValue');
+
+    await new ValibotGenerator(analysis([col('name')])).generate({ outDir: dir } as never);
+    expect(await fs.readFile(path.join(dir, 't.valibot.ts'), 'utf8')).not.toContain(
+      'DrzlJsonValue'
+    );
+  });
+});

--- a/packages/generator-zod/package.json
+++ b/packages/generator-zod/package.json
@@ -21,7 +21,8 @@
   },
   "devDependencies": {
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "zod": "^4.1.13"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -10,6 +10,7 @@ import {
   parseCheck,
   resolveConfiguredImport,
   insertColumns,
+  isIntegerColumn,
   moduleFileName,
   moduleSpecifier,
   resolveAffix,
@@ -52,6 +53,12 @@ function numericBounds(c: Column, literal: (v: string) => string): string {
  * points at the thing in the schema that caused it.
  */
 function checkRefinements(c: Column, checks: ColumnCheck[]): string {
+  // A parsed check compares this column to a scalar literal, which says nothing usable about an
+  // array or a tuple. Emitting one anyway was actively harmful: `CHECK (tags = '{}')` became
+  // `.refine((v) => v === '{}')` against a `string[]`, which no value can satisfy, so the schema
+  // rejected every row.
+  if (c.arrayDimensions || c.shape) return '';
+
   const mine = checks.filter((k) => k.column === c.name);
   if (!mine.length) return '';
 
@@ -68,10 +75,46 @@ function checkRefinements(c: Column, checks: ColumnCheck[]): string {
     .map((k) => {
       const rhs = k.kind === 'string' ? JSON.stringify(k.value) : k.value;
       const label = k.name ? `${k.name}: ` : '';
-      const msg = JSON.stringify(`${label}${c.name} ${k.operator} ${k.kind === 'string' ? `'${k.value}'` : k.value}`);
+      const msg = JSON.stringify(
+        `${label}${c.name} ${k.operator} ${k.kind === 'string' ? `'${k.value}'` : k.value}`
+      );
       return `.refine((v) => v ${OPS[k.operator]} ${rhs}, { message: ${msg} })`;
     })
     .join('');
+}
+
+/**
+ * A column whose value is structured rather than scalar.
+ *
+ * Everything here used to land on `z.any()`, `z.unknown()` or, for the tuple types, `z.string()`.
+ * The string cases were the worst of the three: a `point` arrives as `[number, number]`, so the
+ * emitted select schema rejected every row the database returned.
+ */
+function shapeExpr(c: Column, typedJsonRef?: string): string | undefined {
+  const s = c.shape;
+  if (!s) return undefined;
+  switch (s.kind) {
+    case 'json':
+      // `typedJson` still wins: the type Drizzle inferred is narrower than "any JSON".
+      if (typedJsonRef) return `z.custom<${typedJsonRef}>()`;
+      // Zod's own JSON value space. `z.any()` accepted `undefined`, `NaN`, `Infinity`, bigints,
+      // Dates and Buffers, none of which survive the round trip through the column.
+      return 'z.json()';
+    case 'buffer':
+      // `Uint8Array` rather than `Buffer`, which is the one place the output is deliberately
+      // wider than `drizzle-orm/zod`. A Buffer is a Uint8Array, so everything official accepts
+      // is accepted here; the reverse is not true. Reasons for the wider check: it needs no
+      // `@types/node` and so survives an edge or browser build, `Buffer` is not defined in those
+      // runtimes at all and `v instanceof Buffer` would throw rather than fail, and it makes a
+      // Postgres `bytea` and a SQLite `blob` validate identically instead of by dialect.
+      return 'z.instanceof(Uint8Array)';
+    case 'tuple':
+      return `z.tuple([${Array.from({ length: s.length }, () => 'z.number()').join(', ')}])`;
+    case 'numberVector':
+      return `z.array(z.number())${s.length ? `.length(${s.length})` : ''}`;
+    case 'bitstring':
+      return `z.string().regex(/^[01]*$/)${s.length ? `.length(${s.length})` : ''}`;
+  }
 }
 
 function zodExprForColumn(
@@ -80,6 +123,8 @@ function zodExprForColumn(
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   typedJsonRef?: string
 ): string {
+  const shaped = shapeExpr(c, typedJsonRef);
+  if (shaped) return shaped;
   if (c.enumValues && c.enumValues.length) {
     const vals = c.enumValues.map((v) => `'${v.replace(/'/g, "\\'")}'`).join(', ');
     return `z.enum([${vals}] as const)`;
@@ -91,11 +136,7 @@ function zodExprForColumn(
       if (c.format === 'uuid') return 'z.uuid()';
       return c.maxLength ? `z.string().max(${c.maxLength})` : 'z.string()';
     case 'number': {
-      // The presence of an integer range is what marks a column as an integer, not `dbType`.
-      // Gating on `dbType === 'INTEGER'` missed `bigint({ mode: 'number' })`, whose dbType is
-      // BIGINT while its value really is a JS number.
-      const isInt = c.dbType === 'INTEGER' || (c.min !== undefined && c.max !== undefined);
-      const base = isInt ? 'z.number().int()' : 'z.number()';
+      const base = isIntegerColumn(c) ? 'z.number().int()' : 'z.number()';
       return base + numericBounds(c, (v) => v);
     }
     case 'bigint':
@@ -130,6 +171,10 @@ function zodField(
   typedJsonRef?: string
 ): string {
   let expr = zodExprForColumn(c, mode, coerceDates, typedJsonRef);
+  // `.array()` does not give the column its own class in Drizzle, so everything above describes
+  // the *element*. Length limits and integer bounds belong there, which is why the wrapping
+  // happens out here rather than inside.
+  for (let i = 0; i < (c.arrayDimensions ?? 0); i++) expr = `z.array(${expr})`;
   // Before nullability on purpose. A SQL CHECK passes when it evaluates to TRUE *or NULL*, so
   // wrapping the constrained type in `.nullable()` reproduces that exactly: null skips the
   // check, as the database does.

--- a/packages/generator-zod/test/structured-columns.spec.ts
+++ b/packages/generator-zod/test/structured-columns.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Array and structured columns, checked by running the emitted schemas.
+ *
+ * Drizzle gives an array no class of its own: `text().array()` is still a `PgText`, separated
+ * from a scalar only by `dimensions`. Reading the class alone produced a schema for the
+ * *element*, so the select schema rejected every row the database returned and accepted a bare
+ * string in its place. The tuple types failed the same way in the other direction: a `point`
+ * arrives as `[number, number]` and was mapped to a string.
+ *
+ * Every assertion here runs the emitted module rather than reading it, because source text
+ * cannot distinguish a schema that validates from one that merely parses.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+/** Emit a one-table module, write it inside this package, and import it. */
+async function schemasFor(columns: Column[]): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-structured');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  // Written in-package so `zod` resolves by the ordinary node_modules walk, and under a unique
+  // name so a rerun is never served from the module cache.
+  const file = path.join(dir, `t-${process.pid}-${columns.map((c) => c.name).join('')}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return await import(file);
+}
+
+const accepts = (schema: any, v: unknown) => schema.safeParse(v).success;
+
+describe('array columns', () => {
+  it('wraps the element rather than replacing it', async () => {
+    const m = await schemasFor([col('tags', { arrayDimensions: 1 })]);
+    const f = m.SelecttSchema.shape.tags;
+    expect(accepts(f, ['a', 'b']), 'an array of strings').toBe(true);
+    expect(accepts(f, []), 'an empty array').toBe(true);
+    // The bug this pins: the schema described the element, so a bare string passed and the real
+    // value did not.
+    expect(accepts(f, 'a'), 'a bare string').toBe(false);
+  });
+
+  it('keeps the element constraints inside the array', async () => {
+    const m = await schemasFor([
+      col('scores', {
+        tsType: 'number',
+        dbType: 'INTEGER',
+        integer: true,
+        min: '-32768',
+        max: '32767',
+        arrayDimensions: 1,
+      }),
+    ]);
+    const f = m.SelecttSchema.shape.scores;
+    expect(accepts(f, [1, 2]), 'in-range integers').toBe(true);
+    expect(accepts(f, [40000]), 'an element past the column width').toBe(false);
+    expect(accepts(f, [1.5]), 'a fractional element').toBe(false);
+  });
+
+  it('applies to an enum array too', async () => {
+    const m = await schemasFor([
+      col('moods', { enumValues: ['happy', 'sad'], arrayDimensions: 1 }),
+    ]);
+    const f = m.SelecttSchema.shape.moods;
+    expect(accepts(f, ['happy']), 'a list of members').toBe(true);
+    expect(accepts(f, ['nope']), 'a non-member').toBe(false);
+    expect(accepts(f, 'happy'), 'a bare member').toBe(false);
+  });
+});
+
+describe('structured columns', () => {
+  it('holds a point to exactly two numbers', async () => {
+    const m = await schemasFor([
+      col('p', {
+        tsType: '[number, number]',
+        dbType: 'POINT',
+        shape: { kind: 'tuple', length: 2 },
+      }),
+    ]);
+    const f = m.SelecttSchema.shape.p;
+    expect(accepts(f, [1, 2]), 'the real runtime value').toBe(true);
+    expect(accepts(f, [1, 2, 3]), 'a third element').toBe(false);
+    expect(accepts(f, '(1,2)'), 'the string form it used to be mapped to').toBe(false);
+  });
+
+  it('holds a vector to its declared width', async () => {
+    const m = await schemasFor([
+      col('v', {
+        tsType: 'number[]',
+        dbType: 'VECTOR',
+        shape: { kind: 'numberVector', length: 3 },
+      }),
+    ]);
+    const f = m.SelecttSchema.shape.v;
+    expect(accepts(f, [1, 2, 3])).toBe(true);
+    expect(accepts(f, [1, 2]), 'wrong width').toBe(false);
+  });
+
+  it('holds a bit column to binary digits of the declared length', async () => {
+    const m = await schemasFor([
+      col('b', { dbType: 'BIT', shape: { kind: 'bitstring', length: 3 } }),
+    ]);
+    const f = m.SelecttSchema.shape.b;
+    expect(accepts(f, '010')).toBe(true);
+    expect(accepts(f, '012'), 'a non-binary digit').toBe(false);
+    expect(accepts(f, '0101'), 'wrong length').toBe(false);
+  });
+
+  it('rejects null on a NOT NULL binary column', async () => {
+    // It used to emit `z.unknown()`, which accepts everything including null.
+    const m = await schemasFor([
+      col('data', { tsType: 'Buffer', dbType: 'BYTEA', shape: { kind: 'buffer' } }),
+    ]);
+    const f = m.SelecttSchema.shape.data;
+    expect(accepts(f, new Uint8Array([1, 2])), 'a byte array').toBe(true);
+    expect(accepts(f, Buffer.from('ab')), 'a Buffer, which is a Uint8Array').toBe(true);
+    expect(accepts(f, null), 'null on a NOT NULL column').toBe(false);
+    expect(accepts(f, 'abc'), 'a string').toBe(false);
+  });
+
+  it('holds a json column to values that survive a round trip', async () => {
+    // `z.any()` accepted all of the rejections below, none of which come back out of the column
+    // as they went in.
+    const m = await schemasFor([
+      col('doc', { tsType: 'any', dbType: 'JSONB', shape: { kind: 'json' } }),
+    ]);
+    const f = m.SelecttSchema.shape.doc;
+    expect(accepts(f, { a: [1, 'x', null] }), 'a nested json value').toBe(true);
+    expect(accepts(f, undefined)).toBe(false);
+    expect(accepts(f, NaN)).toBe(false);
+    expect(accepts(f, 1n)).toBe(false);
+    expect(accepts(f, new Date())).toBe(false);
+  });
+});
+
+describe('CHECK constraints on a structured column', () => {
+  it('are skipped rather than applied to the wrong thing', async () => {
+    // A parsed check compares the column to a scalar literal, which says nothing usable about an
+    // array. Emitted anyway, `CHECK (tags = '{}')` became a refinement no `string[]` can satisfy,
+    // so the schema rejected every row.
+    const analysis: Analysis = {
+      dialect: 'postgres',
+      tables: [
+        {
+          name: 't',
+          tsName: 't',
+          columns: [col('tags', { arrayDimensions: 1 })],
+          unique: [],
+          indexes: [],
+          checks: [{ name: 'empty', expression: "tags = '{}'" }],
+        },
+      ] as never,
+      enums: [],
+      relations: [],
+      issues: [],
+    };
+    const dir = path.join(__dirname, '.tmp-structured');
+    await fs.mkdir(dir, { recursive: true });
+    await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+    const src = await fs.readFile(path.join(dir, 't.zod.ts'), 'utf8');
+    expect(src).not.toContain('.refine(');
+  });
+});

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -105,6 +105,19 @@ export function isGeneratedColumn(c: Column, _primaryKeyColumns: string[] = []):
   return c.isGenerated;
 }
 
+/**
+ * Whether a numeric column accepts whole numbers only.
+ *
+ * The analyzer states this outright from Drizzle v1's `dataType`. The fallback is what the
+ * generators each used to do on their own: read "declares both bounds" as "is an integer". That
+ * was true only while integers were the sole bounded type, so it is kept strictly for an
+ * analysis produced before `Column.integer` existed, and never consulted when the flag is set.
+ */
+export function isIntegerColumn(c: Column): boolean {
+  if (typeof c.integer === 'boolean') return c.integer;
+  return c.dbType === 'INTEGER' || (c.min !== undefined && c.max !== undefined);
+}
+
 export function insertColumns(table: Table): Column[] {
   return table.columns.filter((c) => !isGeneratedColumn(c));
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      valibot:
+        specifier: ^1.1.0
+        version: 1.4.2(typescript@5.9.3)
 
   packages/generator-zod:
     dependencies:
@@ -229,6 +232,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      zod:
+        specifier: ^4.1.13
+        version: 4.4.3
 
   packages/template-orpc-service:
     dependencies:
@@ -2981,6 +2987,14 @@ packages:
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -5636,6 +5650,10 @@ snapshots:
       punycode: 2.3.1
 
   v8-compile-cache-lib@3.0.1: {}
+
+  valibot@1.4.2(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   vfile-message@4.0.3:
     dependencies:

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -351,5 +351,276 @@ if [ "$doc_failed" -ne 0 ]; then
 fi
 echo "    all $doc_total documented configs generate and typecheck"
 
+echo "==> differential parity against the official drizzle-orm validators"
+# The claim DRZL makes is that its generated schemas are at least as strict as the first-party
+# `drizzle-orm/{zod,valibot,arktype}` modules. That is a claim about behaviour, so it is measured
+# by behaviour: generate for the same table, then push the same pool of values through both
+# schemas column by column and compare the verdicts. Reading the emitted source cannot do this,
+# because a schema that parses and a schema that validates look identical as text.
+#
+# It runs here, against the packed tarballs, rather than as a unit test, because it needs
+# drizzle-orm v1 and the workspace is still on 0.4x. Installing v1 into this throwaway tree keeps
+# it out of the repo's own dependency graph.
+PARITY="$WORK/parity"
+mkdir -p "$PARITY/src"
+cd "$PARITY"
+echo '{ "name": "parity", "private": true, "type": "module" }' > package.json
+
+cat > src/schema.ts <<'PARITY_SCHEMA'
+import {
+  pgTable, pgEnum, text, varchar, char, uuid, integer, smallint, bigint, serial,
+  boolean, real, doublePrecision, numeric, decimal, json, jsonb, date, timestamp,
+  time, interval, bytea, inet, cidr, macaddr, point, line, geometry, bit, vector,
+} from 'drizzle-orm/pg-core';
+
+export const moodEnum = pgEnum('mood', ['happy', 'sad', 'neutral']);
+
+export const matrix = pgTable('matrix', {
+  c_text: text().notNull(),
+  c_varchar: varchar({ length: 255 }).notNull(),
+  c_char: char({ length: 4 }).notNull(),
+  c_uuid: uuid().notNull(),
+  c_text_enum: text({ enum: ['a', 'b', 'c'] }).notNull(),
+  c_varchar_enum: varchar({ length: 10, enum: ['x', 'y'] }).notNull(),
+  c_int: integer().notNull(),
+  c_smallint: smallint().notNull(),
+  c_bigint_n: bigint({ mode: 'number' }).notNull(),
+  c_bigint_b: bigint({ mode: 'bigint' }).notNull(),
+  c_serial: serial().notNull(),
+  c_real: real().notNull(),
+  c_double: doublePrecision().notNull(),
+  c_numeric: numeric({ precision: 10, scale: 2 }).notNull(),
+  c_numeric_n: numeric({ precision: 10, scale: 2, mode: 'number' }).notNull(),
+  c_decimal: decimal().notNull(),
+  c_bool: boolean().notNull(),
+  c_enum: moodEnum().notNull(),
+  c_json: json().notNull(),
+  c_jsonb: jsonb().notNull(),
+  c_jsonb_typed: jsonb().$type<{ a: string }>().notNull(),
+  c_date_d: date({ mode: 'date' }).notNull(),
+  c_date_s: date({ mode: 'string' }).notNull(),
+  c_ts_d: timestamp({ mode: 'date' }).notNull(),
+  c_ts_s: timestamp({ mode: 'string' }).notNull(),
+  c_time: time().notNull(),
+  c_interval: interval().notNull(),
+  c_text_arr: text().array().notNull(),
+  c_int_arr: integer().array().notNull(),
+  c_enum_arr: moodEnum().array().notNull(),
+  c_bytea: bytea().notNull(),
+  c_inet: inet().notNull(),
+  c_cidr: cidr().notNull(),
+  c_macaddr: macaddr().notNull(),
+  c_point: point().notNull(),
+  c_line: line().notNull(),
+  c_geometry: geometry().notNull(),
+  c_bit: bit({ dimensions: 3 }).notNull(),
+  c_vector: vector({ dimensions: 3 }).notNull(),
+});
+PARITY_SCHEMA
+
+cat > drzl.config.ts <<'PARITY_CONFIG'
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  schema: 'src/schema.ts',
+  outDir: 'src/gen',
+  generators: [
+    { kind: 'zod', path: 'src/gen/zod' },
+    { kind: 'valibot', path: 'src/gen/valibot' },
+    { kind: 'arktype', path: 'src/gen/arktype' },
+    { kind: 'typebox', path: 'src/gen/typebox' },
+  ],
+});
+PARITY_CONFIG
+
+cat > src/parity.ts <<'PARITY_HARNESS'
+/**
+ * Two passes:
+ *   1. every column, DRZL against `drizzle-orm/{zod,valibot,arktype}`
+ *   2. every column, DRZL's four generators against each other
+ *
+ * `drizzle-orm/typebox` is absent from pass 1 deliberately. At 1.0.0-rc.4 it declares a peer on
+ * `@sinclair/typebox` while its code imports `typebox`, and against the released `typebox` it
+ * throws `Class extends value undefined` on import. Pass 2 is what holds the typebox output.
+ */
+import { matrix } from './schema.js';
+import { createSelectSchema as zSel } from 'drizzle-orm/zod';
+import { createSelectSchema as vSel } from 'drizzle-orm/valibot';
+import { createSelectSchema as aSel } from 'drizzle-orm/arktype';
+import * as v from 'valibot';
+import { type } from 'arktype';
+import { Value } from '@sinclair/typebox/value';
+
+import { SelectmatrixSchema as dZod } from './gen/zod/matrix.zod.js';
+import { SelectmatrixSchema as dVal } from './gen/valibot/matrix.valibot.js';
+import { SelectmatrixSchema as dArk } from './gen/arktype/matrix.arktype.js';
+import { SelectmatrixSchema as dTb } from './gen/typebox/matrix.typebox.js';
+
+const POOL: [string, unknown][] = [
+  ['null', null], ['undefined', undefined], ['""', ''], ["'hello'", 'hello'],
+  ['300-char string', 'x'.repeat(300)], ['5-char string', 'xxxxx'], ["'not-a-uuid'", 'not-a-uuid'],
+  ['a real uuid', '3f2504e0-4f89-11d3-9a0c-0305e82c3301'], ["'zzz'", 'zzz'], ["'happy'", 'happy'],
+  ['0', 0], ['1.5', 1.5], ['-1', -1], ['40000', 40000], ['2147483648', 2147483648],
+  ['9007199254740993', 9007199254740993], ['NaN', NaN], ['Infinity', Infinity],
+  ['1n', 1n], ['2n**70n', 2n ** 70n], ['true', true],
+  ['Date', new Date('2020-01-01T00:00:00Z')], ["'2020-01-01'", '2020-01-01'],
+  ["'2020-01-01T00:00:00Z'", '2020-01-01T00:00:00Z'], ["'25:99:99'", '25:99:99'],
+  ['{}', {}], ["{a:'s'}", { a: 's' }], ['[]', []], ["['a']", ['a']], ['[1,2]', [1, 2]],
+  ["['happy']", ['happy']], ["['zzz']", ['zzz']], ['[1,2,3]', [1, 2, 3]],
+  ['Buffer', Buffer.from('ab')], ['Uint8Array', new Uint8Array([1, 2])],
+  ["'999.999.999.999'", '999.999.999.999'], ["'10.0.0.1'", '10.0.0.1'],
+  ['{x:1,y:2}', { x: 1, y: 2 }], ["'12.5'", '12.5'], ["'0101'", '0101'], ["'010'", '010'],
+];
+
+type Lib = { field: (s: any, k: string) => any; ok: (f: any, x: unknown) => boolean };
+
+const LIBS: Record<string, Lib> = {
+  zod: { field: (s, k) => s.shape[k], ok: (f, x) => f.safeParse(x).success },
+  valibot: { field: (s, k) => s.entries[k], ok: (f, x) => v.safeParse(f, x).success },
+  arktype: { field: (s, k) => s.get(k), ok: (f, x) => !(f(x) instanceof type.errors) },
+  typebox: { field: (s, k) => s.properties[k], ok: (f, x) => Value.Check(f, x) },
+};
+
+const safeOk = (lib: Lib, f: any, x: unknown) => {
+  try {
+    return lib.ok(f, x);
+  } catch {
+    return false;
+  }
+};
+
+const DRZL: Record<string, any> = { zod: dZod, valibot: dVal, arktype: dArk, typebox: dTb };
+const OFFICIAL: Record<string, any> = {
+  zod: zSel(matrix),
+  valibot: vSel(matrix),
+  arktype: aSel(matrix),
+};
+
+/**
+ * Divergences that are deliberate and reasoned. Anything not named here is a finding, so a new
+ * disagreement fails this script rather than quietly widening the list.
+ */
+const ALLOWED: Record<string, string> = {
+  'zod/c_bytea': 'accepts any Uint8Array where official demands a Buffer: portable to runtimes with no Buffer, and matches how a SQLite blob is validated',
+  'valibot/c_bytea': 'as zod/c_bytea',
+  'arktype/c_bytea': 'as zod/c_bytea',
+  'valibot/c_json': 'DRZL is stricter: rejects Infinity and non-plain objects, official accepts both',
+  'valibot/c_jsonb': 'as valibot/c_json',
+  'valibot/c_jsonb_typed': 'as valibot/c_json',
+  'valibot/c_point': 'DRZL is stricter: v.strictTuple rejects a third element, official v.tuple ignores extras',
+  'valibot/c_geometry': 'as valibot/c_point',
+  'arktype/c_bigint_b': 'official bounds bigints with a narrow predicate, which ArkType states through its builder rather than its string DSL; this generator emits strings',
+};
+
+/** Cross-generator gaps that follow from what each library can express, not from a defect. */
+const CROSS_ALLOWED = (k: string) => k.startsWith('c_json') || k === 'c_bigint_b';
+
+const cols = Object.keys(OFFICIAL.zod.shape);
+let findings = 0;
+
+for (const libName of ['zod', 'valibot', 'arktype']) {
+  const lib = LIBS[libName];
+  const rows: string[] = [];
+  let diverged = 0;
+
+  for (const key of cols) {
+    let o: any, d: any;
+    try {
+      o = lib.field(OFFICIAL[libName], key);
+      d = lib.field(DRZL[libName], key);
+    } catch {
+      continue;
+    }
+    if (!d) {
+      rows.push(`      ${key}: missing from the DRZL output entirely`);
+      findings++;
+      continue;
+    }
+    const looser: string[] = [];
+    const tighter: string[] = [];
+    for (const [label, x] of POOL) {
+      const a = safeOk(lib, o, x);
+      const b = safeOk(lib, d, x);
+      if (a !== b) (b ? looser : tighter).push(label);
+    }
+    if (!looser.length && !tighter.length) continue;
+    if (ALLOWED[`${libName}/${key}`]) {
+      diverged++;
+      continue;
+    }
+    findings++;
+    rows.push(
+      `      ${key}:` +
+        (looser.length ? `\n        DRZL accepts, official rejects: ${looser.join(', ')}` : '') +
+        (tighter.length ? `\n        DRZL rejects, official accepts: ${tighter.join(', ')}` : '')
+    );
+  }
+  console.log(
+    `    ${libName.padEnd(8)} ${cols.length} columns, ${rows.length ? 'DIFFERS' : 'parity'}` +
+      `${diverged ? ` (${diverged} allowed divergence${diverged > 1 ? 's' : ''})` : ''}`
+  );
+  if (rows.length) console.log(rows.join('\n'));
+}
+
+const disagreements: string[] = [];
+for (const key of cols) {
+  if (CROSS_ALLOWED(key)) continue;
+  const fields: Record<string, any> = {};
+  for (const [n, s] of Object.entries(DRZL)) {
+    try {
+      fields[n] = LIBS[n].field(s, key);
+    } catch {
+      fields[n] = undefined;
+    }
+  }
+  const absent = Object.entries(fields).filter(([, f]) => !f).map(([n]) => n);
+  if (absent.length) {
+    disagreements.push(`      ${key}: missing from ${absent.join(', ')}`);
+    continue;
+  }
+  for (const [label, x] of POOL) {
+    const verdicts = Object.entries(fields).map(([n, f]) => [n, safeOk(LIBS[n], f, x)] as const);
+    const yes = verdicts.filter(([, r]) => r).map(([n]) => n);
+    const no = verdicts.filter(([, r]) => !r).map(([n]) => n);
+    if (yes.length && no.length) {
+      disagreements.push(`      ${key} on ${label}: ${yes.join('/')} accept, ${no.join('/')} reject`);
+    }
+  }
+}
+if (disagreements.length) {
+  console.log('    the four generators disagree with each other:');
+  console.log(disagreements.join('\n'));
+  findings += disagreements.length;
+} else {
+  console.log(`    all four generators agree with each other on every column and value`);
+}
+
+if (findings) {
+  console.error(`FAIL: ${findings} parity finding(s). A generated schema that is looser than the`);
+  console.error('      first-party module accepts rows the database will reject.');
+  process.exit(1);
+}
+PARITY_HARNESS
+
+# drizzle-orm is pinned: the parity target is a specific release, and a floating one would turn
+# an upstream change into a mysterious failure here rather than a deliberate re-measurement.
+npm install --no-audit --no-fund --loglevel=error \
+  "$TARS"/*.tgz drizzle-orm@1.0.0-rc.4 zod valibot arktype @sinclair/typebox tsx >/dev/null
+
+npx drzl generate >/dev/null
+for kind in zod valibot arktype typebox; do
+  if [ ! -e "src/gen/$kind/matrix.$kind.ts" ]; then
+    echo "FAIL: the $kind generator produced no file for the parity matrix." >&2
+    exit 1
+  fi
+done
+
+if ! npx tsx src/parity.ts; then
+  echo "FAIL: DRZL's generated schemas diverge from the official drizzle-orm validators." >&2
+  exit 1
+fi
+cd "$APP"
+
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
-echo "    typechecks under bundler, node16 and nodenext."
+echo "    typechecks under bundler, node16 and nodenext, and validates at least as strictly as"
+echo "    the first-party drizzle-orm validator modules."


### PR DESCRIPTION
A differential harness generates schemas for a 39 column Postgres table with DRZL and with `drizzle-orm/{zod,valibot,arktype}`, then pushes the same pool of values through both, column by column. It found DRZL weaker on **15 of 39 columns**. All 15 are fixed, and the harness now runs in `verify:packed` so a new divergence fails the build.

```
zod      39 columns, parity (1 allowed divergence)
valibot  39 columns, parity (6 allowed divergences)
arktype  39 columns, parity (2 allowed divergences)
all four generators agree with each other on every column and value
```

## Columns whose schema rejected every row

- **Arrays were collapsed to their element.** Drizzle gives an array no class of its own: `text().array()` is still a `PgText`, separated from a scalar only by `dimensions`. Reading the class alone produced `z.string()`, which rejected `['a']` and accepted `'a'`.
- **`point`, `line` and `geometry` were mapped to strings.** They arrive as `[number, number]`.
- **`serial` was lower-bounded at 1.** Postgres serial is an ordinary integer column that defaults from a sequence. The sequence starts at 1, the column does not, and inserting `0` or a negative is how backfills and sentinel rows get written.
- **ArkType output holding a binary column could not be imported at all.** `'Uint8Array'` is not an ArkType keyword, so the emitted module threw `'Uint8Array' is unresolvable` at import and took its importer with it. The keyword is `TypedArray.Uint8`.

## Columns whose schema accepted anything

`bytea`, `bit` and `vector` emitted `z.unknown()`, which accepts `null` on a NOT NULL column. `json` and `jsonb` emitted `z.any()`, which accepts `undefined`, `NaN`, `Infinity`, bigints, Dates and Buffers. `real`, `double precision` and `numeric({ mode: 'number' })` were unbounded.

| Column | Before | Now |
| --- | --- | --- |
| `text().array()` | `z.string()` | `z.array(z.string())` |
| `point()` | `z.string()` | `z.tuple([z.number(), z.number()])` |
| `vector({ dimensions: 3 })` | `z.unknown()` | `z.array(z.number()).length(3)` |
| `bit({ dimensions: 3 })` | `z.unknown()` | `z.string().regex(/^[01]*$/).length(3)` |
| `bytea()` | `z.unknown()` | `z.instanceof(Uint8Array)` |
| `jsonb()` | `z.any()` | `z.json()` |
| `real()` | `z.number()` | `z.number().gte(-8388608).lte(8388607)` |
| `serial()` | `.gte(1)` | `.gte(-2147483648)` |

All four generators handle all of it.

## Two bugs found only by running the output

- **Every ArkType `integer()` column accepted `1.5`.** The generator preferred the range on the theory that an integer range implied integrality. ArkType parses `-2147483648 <= number.integer <= 2147483647` perfectly well and rejects the fraction.
- **`v.tuple` ignores extra items**, so a valibot `point` accepted `[1, 2, 3]`. `v.strictTuple` holds the arity.

Both are the reason the new tests write the emitted module to disk and import it. Source text cannot distinguish a schema that validates from one that merely parses, and in the ArkType case it could not even tell that the module was unloadable.

## Reading the type from Drizzle rather than guessing at it

Drizzle v1 stamps every column with a `dataType` of the form `"number int32"`, `"object buffer"`, `"array point"`, plus a `codec` naming the SQL side. The analyzer now reads those. It used to match on the constructor name against a list running to dozens of entries per dialect, with a regex fallback that guessed from the name when it missed, which is how `PgBinaryVector` came out as a vector when it is a bit string. The class-name path stays for Drizzle 0.4x, which carries no `codec`.

`Column` gains `arrayDimensions`, `shape` and `integer`. That last one exists because the generators each inferred "is an integer" from "declares both bounds", which was true only while integers were the only bounded type: bounding `real` made every float schema reject `1.5` until the flag replaced the inference.

## Where DRZL deliberately differs

Each is listed in the harness with its reason, so it stays a decision rather than drift:

- `bytea` accepts any `Uint8Array` where official demands a `Buffer`. A Buffer is a Uint8Array, so nothing official accepts is turned away, and the wider check needs no `@types/node`, works where `Buffer` is undefined, and makes a Postgres `bytea` and a SQLite `blob` behave the same.
- valibot json rejects `Infinity` and class instances, which the official one accepts.
- ArkType `bigint` carries no range: its comparison operators take numeric literals, so a 64 bit bound cannot be written in the string DSL this generator emits.

## Also worth knowing

`drizzle-orm/typebox` at 1.0.0-rc.4 cannot be imported at all. It declares a peer on `@sinclair/typebox` while its code imports `typebox`, and against the released `typebox` it throws `Class extends value undefined`. That is why pass 1 covers three libraries and pass 2 cross-checks all four against each other.

## Verification

- 421 tests across 54 files, including 28 new ones that import and execute the emitted schemas
- `verify:packed` green: 11 packages packed, installed with npm into an empty project, generated, typechecked under bundler/node16/nodenext, all 9 documented configs, plus the new parity stage
- the gate was checked by breaking array detection on purpose: it exits 1 and names the columns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PostgreSQL array and structured columns across generated Zod, Valibot, ArkType, and TypeBox schemas.
  * Improved validation for JSON, binary, tuples, vectors, bit strings, numeric values, integers, and bigint ranges.
  * Added accurate handling for array dimensions, fixed-length values, and recursive JSON structures.
* **Documentation**
  * Expanded generator documentation with array, structured-column, mapping, and validation details.
* **Bug Fixes**
  * Corrected binary schema output, integer bounds, array constraints, and incompatible CHECK constraint handling.
* **Tests**
  * Added comprehensive runtime validation and cross-generator parity coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->