### PR TITLE
feat: typedColumns, taking every column's static type from Drizzle

### DIFF
--- a/.changeset/typed-columns.md
+++ b/.changeset/typed-columns.md
@@ -1,0 +1,33 @@
+---
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+'@drzl/cli': minor
+---
+
+`typedColumns`: take every column's static type from Drizzle, not just the untyped ones.
+
+`.$type<T>()` is a compile-time cast on **any** column, not just json. Drizzle's implementation is
+literally `$type() { return this }`, so `text().$type<'admin' | 'member'>()` is an ordinary string
+to anything reading the column at runtime, and `drizzle-orm/zod` and DRZL alike emitted a plain
+`z.string()` with the narrowing lost.
+
+```ts
+{ kind: 'zod', path: 'src/validators/zod', typedColumns: true }
+```
+
+```ts
+role: z.string().max(50).pipe(z.custom<(typeof users.$inferSelect)['role']>()),
+```
+
+The runtime schema is untouched. The reference is appended rather than substituted, so a
+`varchar(50)` keeps its length check and only its _type_ narrows, and a typo in
+`if (user.role === 'admni')` becomes a compile error rather than dead code. Nothing narrows it at
+runtime, because the cast leaves no trace there.
+
+Appending happens after the nullable and optional wrappers, checked against zod rather than
+assumed: `.pipe()` keeps a key optional both when parsing and in the inferred type. A json or
+custom column still has its schema _replaced_ rather than appended to, since it has no runtime
+type worth keeping.
+
+Implies `typedJson`, since both need the schema imported back. Off by default: it adds a `.pipe()`
+to every field, which is noise unless you use `.$type<T>()`.

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ packages/*/test/.tmp-run
 packages/*/test/.tmp-structured
 packages/*/test/.tmp-dates
 packages/*/test/.tmp-custom-*
+packages/*/test/.tmp-typedcols-*

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -207,6 +207,31 @@ Off by default because it adds an `import type` of your schema module to the gen
 That import is erased at build time, so it adds no runtime dependency and cannot create a runtime
 cycle, but the coupling should be a choice.
 
+## `typedColumns`
+
+`.$type<T>()` is a compile-time cast on **any** column, not just json. Drizzle's implementation is
+literally `$type() { return this }`, so `text().$type<'admin' | 'member'>()` is an ordinary string
+to anything reading the column at runtime, and both `drizzle-orm/zod` and DRZL emit a plain
+`z.string()`. The narrowing is lost.
+
+```ts
+{ kind: 'zod', path: 'src/validators/zod', typedColumns: true }
+```
+
+```ts
+role: z.string().max(50).pipe(z.custom<(typeof users.$inferSelect)['role']>()),
+```
+
+The runtime schema is untouched: the length check is still there, and the reference is appended
+rather than substituted. Only the static type changes, from `string` to the union you declared, so
+a typo in `if (user.role === 'admni')` becomes a compile error instead of dead code.
+
+Nothing narrows it at _runtime_, because the cast leaves no trace there. If you want the value
+checked against the union as well, declare it as an enum column, which DRZL emits as `z.enum`.
+
+Implies `typedJson`, since both need the schema imported back. Off by default: it adds a `.pipe()`
+to every field, which is noise unless you use `.$type<T>()`.
+
 ## `customType` columns
 
 A `customType` column has nothing checkable at runtime, and DRZL does not pretend otherwise:

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -176,6 +176,7 @@ program
               // Drizzle inferred for a json column.
               schemaPath: cfg.schema,
               typedJson: g.typedJson,
+              typedColumns: g.typedColumns,
             });
             progress.stop();
             ora().succeed(chalk.green(`Generated (zod): ${files.length} files`));
@@ -276,15 +277,17 @@ program
         await restoreSnapshot(driftBefore, after);
 
         if (drift.length) {
-          console.error(
-            chalk.red(`\nGenerated output is out of date (${drift.length} file(s)):`)
-          );
+          console.error(chalk.red(`\nGenerated output is out of date (${drift.length} file(s)):`));
           for (const d of drift) {
             const mark = d.status === 'added' ? '+' : d.status === 'removed' ? '-' : '~';
-            console.error(`  ${mark} ${chalk.yellow(d.status.padEnd(8))} ${path.relative(process.cwd(), d.file)}`);
+            console.error(
+              `  ${mark} ${chalk.yellow(d.status.padEnd(8))} ${path.relative(process.cwd(), d.file)}`
+            );
           }
           console.error(
-            chalk.dim('\nRun `drzl generate` and commit the result. Nothing was written by this check.')
+            chalk.dim(
+              '\nRun `drzl generate` and commit the result. Nothing was written by this check.'
+            )
           );
           process.exit(1);
         }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -91,6 +91,8 @@ export const GeneratorSchema = z.object({
    * type-only import that disappears at build time.
    */
   typedJson: z.boolean().optional(),
+  // The wider form: every column's static type comes from Drizzle, not just the untyped ones.
+  typedColumns: z.boolean().optional(),
   naming: NamingSchema.optional(),
   outputHeader: z
     .object({

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -188,7 +188,15 @@ function zodField(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  typedJsonRef?: string
+  typedJsonRef?: string,
+  /**
+   * A reference to Drizzle's inferred type for a column that already has a runtime schema.
+   *
+   * Distinct from `typedJsonRef`, which *replaces* the schema for a column that has no runtime
+   * type worth checking. This one is appended, so the checks stay and only the static type
+   * narrows.
+   */
+  narrowRef?: string
 ): string {
   let expr = zodExprForColumn(c, mode, coerceDates, typedJsonRef);
   // `.array()` does not give the column its own class in Drizzle, so everything above describes
@@ -211,6 +219,10 @@ function zodField(
     // All update fields are optional; preserve nullability
     expr = `${expr}.optional()`;
   }
+  // Last, and after the optional wrapper on purpose. `.pipe()` keeps a key optional in both the
+  // parsed result and the inferred type, checked against zod rather than assumed, so the runtime
+  // schema is untouched and only the static type narrows.
+  if (narrowRef) expr = `${expr}.pipe(z.custom<${narrowRef}>())`;
   return expr;
 }
 
@@ -219,16 +231,19 @@ function renderObjectShape(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  typedJson?: { table: string; mode: 'insert' | 'select' }
+  typedJson?: { table: string; mode: 'insert' | 'select'; allColumns?: boolean }
 ) {
   return cols
     .map((c) => {
-      // Only json-ish columns get a reference; everything else already has a real type.
-      const ref =
-        typedJson && (c.tsType === 'any' || c.shape?.kind === 'custom')
-          ? `typeof ${typedJson.table}.$infer${typedJson.mode === 'insert' ? 'Insert' : 'Select'}[${JSON.stringify(c.name)}]`
-          : undefined;
-      return `  ${JSON.stringify(c.name)}: ${zodField(c, mode, coerceDates, checks, ref)},`;
+      const refFor = (t: { table: string; mode: 'insert' | 'select' }) =>
+        `typeof ${t.table}.$infer${t.mode === 'insert' ? 'Insert' : 'Select'}[${JSON.stringify(c.name)}]`;
+      // A json or custom column has no runtime type worth checking, so the reference replaces the
+      // schema outright. Every other column already has one, so the reference is appended instead
+      // and narrows only the static type.
+      const replaces = c.tsType === 'any' || c.shape?.kind === 'custom';
+      const ref = typedJson && replaces ? refFor(typedJson) : undefined;
+      const narrow = typedJson?.allColumns && !replaces ? refFor(typedJson) : undefined;
+      return `  ${JSON.stringify(c.name)}: ${zodField(c, mode, coerceDates, checks, ref, narrow)},`;
     })
     .join('\n');
 }
@@ -237,7 +252,7 @@ function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
-  typedJson?: { schemaSpecifier: string }
+  typedJson?: { schemaSpecifier: string; allColumns?: boolean }
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -257,8 +272,12 @@ function renderTableSchemas(
   });
   // Insert and select can disagree: a json column with a default is optional on insert, so its
   // inferred type differs. Each shape therefore references the matching inference.
-  const tj = typedJson ? { table: table.tsName, mode: 'select' as const } : undefined;
-  const tjInsert = typedJson ? { table: table.tsName, mode: 'insert' as const } : undefined;
+  const tj = typedJson
+    ? { table: table.tsName, mode: 'select' as const, allColumns: typedJson.allColumns }
+    : undefined;
+  const tjInsert = typedJson
+    ? { table: table.tsName, mode: 'insert' as const, allColumns: typedJson.allColumns }
+    : undefined;
   const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks, tjInsert);
   const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks, tjInsert);
   const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks, tj);
@@ -306,8 +325,11 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
     const fileSuffix = opts.fileSuffix ?? DEFAULT_FILE_SUFFIX;
     // `typedJson` needs to import the schema back, so it is only possible when the schema path
     // is known. Silently doing nothing would be worse than saying why.
+    // `typedColumns` is the wider form of the same idea and implies it: both need the schema
+    // imported back in order to reference what Drizzle inferred.
+    const wantsTypes = opts.typedJson || opts.typedColumns;
     const typedJson =
-      opts.typedJson && opts.schemaPath
+      wantsTypes && opts.schemaPath
         ? {
             schemaSpecifier: resolveConfiguredImport(
               opts.schemaPath,
@@ -315,9 +337,10 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
               process.cwd(),
               opts.importExtension
             ),
+            allColumns: !!opts.typedColumns,
           }
         : undefined;
-    if (opts.typedJson && !opts.schemaPath) {
+    if (wantsTypes && !opts.schemaPath) {
       console.warn(
         '[drzl] typedJson was requested but the schema path is unknown, so json columns keep their wide type.'
       );

--- a/packages/generator-zod/test/typed-columns.spec.ts
+++ b/packages/generator-zod/test/typed-columns.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * `typedColumns`, which takes every column's static type from Drizzle's inference.
+ *
+ * `.$type<T>()` is a compile-time cast on *any* column, not just json: Drizzle's implementation is
+ * literally `$type() { return this }`, so `text().$type<'admin' | 'member'>()` is an ordinary
+ * string to anything reading the column at runtime. `drizzle-orm/zod` emits a plain `z.string()`
+ * and the narrowing is lost; so did DRZL.
+ *
+ * The reference is appended rather than substituted, so the runtime schema is untouched and only
+ * the type narrows. Nothing can narrow it at runtime, because the cast leaves no trace there.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+async function emit(columns: Column[], opts: Record<string, unknown>): Promise<string> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = await fs.mkdtemp(path.join(__dirname, '.tmp-typedcols-'));
+  await new ZodGenerator(analysis).generate({
+    outDir: dir,
+    schemaPath: path.join(dir, '..', 'db', 'schema.ts'),
+    ...opts,
+  } as never);
+  const src = await fs.readFile(path.join(dir, 't.zod.ts'), 'utf8');
+  await fs.rm(dir, { recursive: true, force: true });
+  return src;
+}
+
+/** The select field for one column, collapsed to a single line. */
+const selectField = (src: string, name: string) => {
+  const block = src.match(/SelecttSchema = z\.object\(\{([\s\S]*?)\n\}\)/)?.[1] ?? '';
+  const flat = block.replace(/\s+/g, ' ');
+  const at = flat.indexOf(`${name}: `);
+  if (at === -1) return '';
+  let i = at + `${name}: `.length;
+  let depth = 0;
+  const from = i;
+  for (; i < flat.length; i++) {
+    const ch = flat[i];
+    if ('([{'.includes(ch)) depth++;
+    else if (')]}'.includes(ch)) depth--;
+    else if (ch === ',' && depth === 0) break;
+  }
+  return flat.slice(from, i).trim();
+};
+
+describe('off by default', () => {
+  it('adds nothing when neither option is set', async () => {
+    const src = await emit([col('role', { maxLength: 50 })], {});
+    expect(src).not.toContain('.pipe(');
+    expect(src).not.toContain('import type');
+  });
+
+  it('is not turned on by typedJson, which covers only the untyped columns', async () => {
+    const src = await emit([col('role', { maxLength: 50 })], { typedJson: true });
+    expect(selectField(src, 'role')).toBe('z.string().max(50)');
+  });
+});
+
+describe('with typedColumns', () => {
+  it('keeps the runtime schema and appends the type', async () => {
+    const src = await emit([col('role', { maxLength: 50 })], { typedColumns: true });
+    // The length check survives; only the static type changes.
+    expect(selectField(src, 'role')).toMatch(
+      /^z\.string\(\)\.max\(50\)\.pipe\(z\.custom<\(typeof t\.\$inferSelect\)\[['"]role['"]\]>\(\)\)$/
+    );
+  });
+
+  it('appends after the nullable and optional wrappers, so both survive', async () => {
+    // Checked against zod rather than assumed: piping after `.optional()` keeps the key optional
+    // both when parsing and in the inferred type.
+    const src = await emit([col('note', { nullable: true })], { typedColumns: true });
+    const insert = src.match(/InserttSchema[\s\S]*?\n\}\)/)![0].replace(/\s+/g, ' ');
+    expect(insert).toContain('.nullable().optional().pipe(');
+  });
+
+  it('still substitutes rather than appends for a column with no runtime type', async () => {
+    // A json column has nothing worth checking, so the reference replaces the schema outright.
+    const src = await emit([col('doc', { tsType: 'any', shape: { kind: 'json' } })], {
+      typedColumns: true,
+    });
+    expect(selectField(src, 'doc')).toMatch(
+      /^z\.custom<\(typeof t\.\$inferSelect\)\[['"]doc['"]\]>\(\)$/
+    );
+    expect(selectField(src, 'doc')).not.toContain('.pipe(');
+  });
+
+  it('implies typedJson, since both need the schema imported back', async () => {
+    const src = await emit([col('doc', { tsType: 'any', shape: { kind: 'json' } })], {
+      typedColumns: true,
+    });
+    expect(src).toMatch(/import type \{ t \} from/);
+  });
+
+  it('warns rather than silently doing nothing when the schema path is unknown', async () => {
+    const analysis: Analysis = {
+      dialect: 'postgres',
+      tables: [
+        { name: 't', tsName: 't', columns: [col('role')], unique: [], indexes: [], checks: [] },
+      ] as never,
+      enums: [],
+      relations: [],
+      issues: [],
+    };
+    const dir = await fs.mkdtemp(path.join(__dirname, '.tmp-typedcols-'));
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (m: string) => warnings.push(String(m));
+    try {
+      await new ZodGenerator(analysis).generate({ outDir: dir, typedColumns: true } as never);
+    } finally {
+      console.warn = original;
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+    expect(warnings.join('\n')).toMatch(/schema path is unknown/);
+  });
+});

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -49,6 +49,23 @@ export interface ValidationGenerateOptions {
    * should be a choice rather than a surprise.
    */
   typedJson?: boolean;
+  /**
+   * Take every column's static type from Drizzle's inference, not just the untyped ones.
+   *
+   * `typedJson` covers the columns that have no runtime type worth checking. This covers the
+   * rest, and exists for `.$type<T>()`, which is a compile-time cast on any column at all:
+   * `text().$type<'admin' | 'member'>()` is a `string` to every runtime-derived validator, so
+   * `drizzle-orm/zod` and DRZL alike emitted a plain `z.string()` and the narrowing was lost.
+   *
+   * The runtime schema is untouched. The reference is appended with `.pipe()` rather than
+   * replacing anything, so a `varchar(50)` keeps its length check and only its *type* narrows
+   * from `string` to the union you declared. Nothing can narrow it at runtime, since the cast
+   * leaves no trace there.
+   *
+   * Implies `typedJson`, since both need the schema imported back. Off by default: it adds a
+   * `.pipe()` to every field, which is noise unless you use `.$type<T>()`.
+   */
+  typedColumns?: boolean;
   format?: FormatOptions;
   /**
    * What every generated file is called after the Drizzle export name, e.g. `.zod.ts`


### PR DESCRIPTION
`.$type<T>()` is a compile-time cast on **any** column, not just json. Drizzle's implementation is literally `$type() { return this }`, so `text().$type<'admin' | 'member'>()` is an ordinary string to anything reading the column at runtime. `drizzle-orm/zod` emits a plain `z.string()` and the narrowing is lost; so did DRZL.

```ts
{ kind: 'zod', path: 'src/validators/zod', typedColumns: true }
```

```ts
role: z.string().max(50).pipe(z.custom<(typeof users.$inferSelect)['role']>()),
```

The runtime schema is **untouched**. The reference is appended rather than substituted, so a `varchar(50)` keeps its length check and only its type narrows, from `string` to the union you declared. That turns a typo in `if (user.role === 'admni')` into a compile error instead of dead code.

Nothing narrows it at *runtime*, because the cast leaves no trace there. If you want the value checked against the union too, declare it as an enum column, which DRZL already emits as `z.enum`.

## Why `.pipe()` and why last

Appending happens after the nullable and optional wrappers. That ordering was checked against zod rather than assumed, because it is the part that could quietly break: `.pipe()` keeps a key optional both when parsing (`{}` still passes) and in the inferred type (`const x: Input = {}` still compiles). A `ZodPipe` is not a `ZodOptional`, so it was entirely plausible that wrapping would make the key required.

A json or custom column still has its schema **replaced** rather than appended to, since it has no runtime type worth keeping. `typedColumns` implies `typedJson` for that reason: both need the schema imported back.

Off by default. It adds a `.pipe()` to every field, which is noise unless you use `.$type<T>()`.

## Verification

Compiled the emitted module rather than asserting on its text:

```ts
const role: Out['role'] = 'admin';
// @ts-expect-error narrowed by .$type<'admin' | 'member'>()
const bad: Out['role'] = 'nope';
```

tsc reports nothing, which means the `@ts-expect-error` is consumed rather than unused: the type really is narrow. At runtime `role` still accepts any string and `status` still enforces its integer bounds.

448 tests across 58 files, 7 new. `verify:packed` green across all 15 dialect/library/mode combinations.