### PR TITLE
feat: check the emitted schemas against Postgres itself

### DIFF
--- a/.changeset/numeric-format-and-ground-truth.md
+++ b/.changeset/numeric-format-and-ground-truth.md
@@ -1,0 +1,55 @@
+---
+'@drzl/generator-arktype': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-typebox': minor
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+'@drzl/analyzer': minor
+'@drzl/cli': minor
+---
+
+Check generated schemas against Postgres itself, and validate the numeric format.
+
+Every check so far compared DRZL to `drizzle-orm`'s validators. Both can be wrong about the same
+column and neither is the authority, so `verify:packed` now runs the emitted schemas against a
+real Postgres through PGlite: 1287 probes, each an actual INSERT, with the database answering
+directly.
+
+DRZL agrees with Postgres on **920** of them to `drizzle-orm`'s **897**, and is never further from
+the database on a column where `drizzle-orm` is closer.
+
+### What it found
+
+A `numeric`/`decimal` column is returned as a string, because a JS number cannot hold arbitrary
+precision. That left the schema a bare `z.string()`, which accepts `'hello'` for a numeric column.
+`drizzle-orm/zod` still does; Postgres rejects it. Numeric columns now carry the real grammar,
+which is broader than it looks: a sign, a leading `.`, exponents, `NaN`/`Infinity`, surrounding
+whitespace, and since Postgres 16 the underscore digit separators and `0x`/`0o`/`0b` literals, so
+`1_000` and `0xDEAD_beef` are valid. Not applied on SQLite, whose NUMERIC affinity stores whatever
+text it is given.
+
+### What it stopped
+
+`date`, `timestamp`, `time`, `interval`, `inet`, `cidr` and `macaddr` were all attempted and all
+dropped, each caught turning away input Postgres accepts:
+
+| Type      | What the pattern would have refused                              |
+| --------- | ---------------------------------------------------------------- |
+| `date`    | `today`, `January 8, 1999`, `20200101`, `01/02/2020`, `infinity` |
+| `time`    | `allballs`, `12:00:00+02`                                        |
+| `macaddr` | `2020-01-01`, which Postgres pads into `20:20:00:01:00:01`       |
+| `inet`    | `10.1/16`, `::ffff:1.2.3.4`                                      |
+| `cidr`    | parses as `inet`, then additionally demands zero host bits       |
+
+Those keep a plain string. A check that refuses valid data is worse than no check, and without the
+database to ask, all seven looked equally shippable.
+
+### The gate
+
+CI fails if a generated schema disagrees with Postgres where `drizzle-orm` agrees, which is what
+an over-strict check looks like. Verified to bite by removing underscore support from the numeric
+pattern: it fails and names `'1_000'`.
+
+Incidentally settled an earlier judgement call: DRZL types `bytea` as `Uint8Array` where official
+demands a `Buffer`, and Postgres accepts the `Uint8Array`. Official is the one refusing valid data
+there.

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ packages/*/test/.tmp-structured
 packages/*/test/.tmp-dates
 packages/*/test/.tmp-custom-*
 packages/*/test/.tmp-typedcols-*
+packages/*/test/.tmp-numfmt

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -232,6 +232,40 @@ checked against the union as well, declare it as an enum column, which DRZL emit
 Implies `typedJson`, since both need the schema imported back. Off by default: it adds a `.pipe()`
 to every field, which is noise unless you use `.$type<T>()`.
 
+## `numeric` and `decimal` columns
+
+A `numeric` column is returned as a string, because a JS number cannot hold arbitrary precision.
+That used to leave the schema a bare `z.string()`, which accepts `'hello'` for a numeric column.
+`drizzle-orm/zod` still does. Postgres does not:
+
+```ts
+amount: z.string().regex(/* the numeric grammar */),
+```
+
+The pattern accepts everything Postgres accepts, which is more than it first appears: a sign,
+a leading `.`, exponents, `NaN` and `Infinity`, surrounding whitespace, and since Postgres 16 the
+underscore digit separators and `0x`/`0o`/`0b` literals, so `1_000` and `0xDEAD_beef` are valid.
+
+It is not applied on SQLite, whose NUMERIC affinity stores whatever text it is given.
+
+### Why numeric is the only format checked
+
+`date`, `timestamp`, `time`, `interval`, `inet`, `cidr` and `macaddr` were all attempted and all
+dropped. Each candidate pattern was run against a real Postgres, and each turned away input the
+database accepts:
+
+| Type      | What Postgres takes and the pattern refused                      |
+| --------- | ---------------------------------------------------------------- |
+| `date`    | `today`, `January 8, 1999`, `20200101`, `01/02/2020`, `infinity` |
+| `time`    | `allballs`, `12:00:00+02`                                        |
+| `macaddr` | `2020-01-01`, which Postgres pads into `20:20:00:01:00:01`       |
+| `inet`    | `10.1/16`, `::ffff:1.2.3.4`                                      |
+| `cidr`    | parses as `inet`, then additionally demands zero host bits       |
+
+A check that refuses valid data is worse than no check, so those columns keep a plain string. The
+same harness runs in CI and fails the build if a check ever disagrees with Postgres where
+`drizzle-orm` does not.
+
 ## `customType` columns
 
 A `customType` column has nothing checkable at runtime, and DRZL does not pretend otherwise:

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -66,8 +66,16 @@ export interface Column {
    */
   integer?: boolean;
 
-  /** A string column with a known shape, currently only `uuid`. */
-  format?: 'uuid';
+  /**
+   * A string column whose contents have a shape the database enforces.
+   *
+   * Only formats checked against Postgres itself appear here, and the list is short because most
+   * candidates failed: Postgres reads `'today'` and `'January 8, 1999'` as dates, pads
+   * `'2020-01-01'` into a macaddr, and accepts `'10.1/16'` as an inet. A check for any of those
+   * would reject input the database accepts, and turning away valid data is worse than not
+   * checking at all. See `COLUMN_FORMATS` in `@drzl/validation-core`.
+   */
+  format?: 'uuid' | 'numeric';
 
   /**
    * Array depth for a column declared with `.array()`, absent when the column is a scalar.
@@ -326,9 +334,18 @@ export function describeV1Column(column: any): Partial<Column> | null {
       out.format = 'uuid';
       break;
     case 'numeric':
-      // Returned as a string: a JS number cannot hold arbitrary precision.
+      // Returned as a string: a JS number cannot hold arbitrary precision. Which meant the schema
+      // was a bare `z.string()` and accepted `'hello'` for a numeric column, as does
+      // `drizzle-orm/zod`; Postgres rejects it.
       out.tsType = 'string';
       out.dbType = 'NUMERIC';
+      // Not on SQLite: its NUMERIC affinity stores whatever text it is given, so a pattern there
+      // would refuse values that engine accepts. The check was verified against Postgres.
+      if (
+        !String(column?.constructor?.[Symbol.for('drizzle:entityKind')] ?? '').startsWith('SQLite')
+      ) {
+        out.format = 'numeric';
+      }
       break;
     case 'json':
       out.tsType = 'any';
@@ -362,6 +379,9 @@ export function describeV1Column(column: any): Partial<Column> | null {
     case 'macaddr':
       out.tsType = 'string';
       out.dbType = semantic.toUpperCase();
+      // No format for any of these. Postgres accepts `10.1/16` and `::ffff:1.2.3.4` as inet, pads
+      // `2020-01-01` into a macaddr, and requires cidr host bits to be zero on top of parsing.
+      // Each candidate pattern turned away something the database takes.
       break;
     case 'binary':
       // Two unrelated families share this semantic and only the codec separates them. Postgres

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -6,6 +6,7 @@ import type {
 } from '@drzl/validation-core';
 import type { ColumnCheck } from '@drzl/validation-core';
 import {
+  COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
   parseCheck,
@@ -127,6 +128,9 @@ function atTypeForColumn(
       );
       if (eq) return `'${eq.value.replace(/'/g, "\\'")}'`;
       if (c.format === 'uuid') return 'string.uuid';
+      // See the zod generator. ArkType states a pattern as a bare regex literal in its DSL.
+      const pattern = c.format ? COLUMN_FORMATS[c.format] : undefined;
+      if (pattern) return `/${pattern}/`;
       return c.maxLength ? `string <= ${c.maxLength}` : 'string';
     }
     case 'number': {

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -7,6 +7,7 @@ import type {
 } from '@drzl/validation-core';
 import {
   formatCode,
+  COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
   moduleFileName,
@@ -194,12 +195,15 @@ function tbExprForColumn(
 
   switch (c.tsType) {
     case 'string': {
-      const base: Array<[string, string]> =
-        c.format === 'uuid'
-          ? [['pattern', JSON.stringify(UUID_PATTERN)]]
-          : c.maxLength
-            ? [['maxLength', String(c.maxLength)]]
-            : [];
+      // A pattern for any format the database enforces, `uuid` included. See the zod generator:
+      // a bare string accepted values Postgres rejects, and `format` is not an option here
+      // because TypeBox ignores it unless the consuming project registered it first.
+      const formatPattern = c.format === 'uuid' ? UUID_PATTERN : COLUMN_FORMATS[c.format ?? ''];
+      const base: Array<[string, string]> = formatPattern
+        ? [['pattern', JSON.stringify(formatPattern)]]
+        : c.maxLength
+          ? [['maxLength', String(c.maxLength)]]
+          : [];
       return `Type.String(${renderOptions(merged(base))})`;
     }
     case 'number': {

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -6,6 +6,7 @@ import type {
 } from '@drzl/validation-core';
 import type { ColumnCheck } from '@drzl/validation-core';
 import {
+  COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
   parseCheck,
@@ -185,6 +186,9 @@ function vExprForColumn(
     // these becomes `v.pipe(base, ...actions)` and stays a single expression.
     case 'string':
       if (c.format === 'uuid') return piped('v.string()', ['v.uuid()']);
+      // See the zod generator: a bare string accepted values Postgres rejects.
+      const pattern = c.format ? COLUMN_FORMATS[c.format] : undefined;
+      if (pattern) return piped('v.string()', [`v.regex(new RegExp(${JSON.stringify(pattern)}))`]);
       return piped('v.string()', c.maxLength ? [`v.maxLength(${c.maxLength})`] : []);
     case 'number': {
       return piped('v.number()', [

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -9,6 +9,7 @@ import {
   formatCode,
   parseCheck,
   resolveConfiguredImport,
+  COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
   moduleFileName,
@@ -146,6 +147,11 @@ function zodExprForColumn(
       // A uuid is a string with a fixed shape, so the format supersedes any length: stacking
       // `.max(36)` on top would restate what the format already guarantees.
       if (c.format === 'uuid') return 'z.uuid()';
+      // A format the database enforces. These replaced a bare `z.string()`, which accepted
+      // `'hello'` for a numeric or inet column: `drizzle-orm/zod` still does, and Postgres does
+      // not. Only formats verified against Postgres appear here, so nothing valid is turned away.
+      const pattern = c.format ? COLUMN_FORMATS[c.format] : undefined;
+      if (pattern) return `z.string().regex(new RegExp(${JSON.stringify(pattern)}))`;
       return c.maxLength ? `z.string().max(${c.maxLength})` : 'z.string()';
     case 'number': {
       const base = isIntegerColumn(c) ? 'z.number().int()' : 'z.number()';

--- a/packages/generator-zod/test/numeric-format.spec.ts
+++ b/packages/generator-zod/test/numeric-format.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * The numeric format check, and why it is the only one.
+ *
+ * A `numeric`/`decimal` column is returned as a string, because a JS number cannot hold arbitrary
+ * precision. That left the schema a bare `z.string()`, which accepts `'hello'` for a numeric
+ * column; `drizzle-orm/zod` still does, and Postgres rejects it.
+ *
+ * The pattern was not reasoned about. It was run against a real Postgres through PGlite over a
+ * pool built to include the awkward *valid* forms, because the hazard here is over-rejection: a
+ * check that turns away something the database accepts breaks working code. Candidates for
+ * `date`, `time`, `macaddr` and `inet` were all built and all discarded for exactly that, each
+ * caught by a value Postgres takes and the pattern did not.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import { COLUMN_FORMATS } from '@drzl/validation-core';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'NUMERIC',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(columns: Column[]): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-numfmt');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  // Unique per call: the module cache is process-global, so reusing a path would hand back the
+  // first module and every later assertion would be made against the wrong schema.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return await import(file);
+}
+
+describe('what Postgres accepts, the schema accepts', () => {
+  it.each([
+    ['1', '1'],
+    ['a decimal', '1.5'],
+    ['signed', '-1.5'],
+    ['leading dot', '.5'],
+    ['an exponent', '1e3'],
+    ['NaN', 'NaN'],
+    ['Infinity', 'Infinity'],
+    ['surrounding whitespace', '  1  '],
+    ['underscore separators, Postgres 16', '1_000'],
+    ['a hex literal, Postgres 16', '0x1f'],
+    ['an octal literal', '0o17'],
+    ['a binary literal', '0b1010'],
+  ])('accepts %s', async (_label, value) => {
+    const m = await schemasFor([col('amount', { format: 'numeric' })]);
+    expect(m.SelecttSchema.shape.amount.safeParse(value).success).toBe(true);
+  });
+});
+
+describe('what Postgres rejects, the schema rejects', () => {
+  it.each([
+    ['empty', ''],
+    ['a word', 'hello'],
+    ['a comma decimal', '1,5'],
+    ['two dots', '1.2.3'],
+    ['a doubled underscore', '1__0'],
+    ['a leading underscore', '_1'],
+    ['a trailing underscore', '1_'],
+    ['a bare prefix', '0x'],
+    ['a dangling exponent', '1e'],
+    ['a lone sign', '+'],
+  ])('rejects %s', async (_label, value) => {
+    const m = await schemasFor([col('amount', { format: 'numeric' })]);
+    expect(m.SelecttSchema.shape.amount.safeParse(value).success).toBe(false);
+  });
+});
+
+describe('scope', () => {
+  it('leaves an ordinary string column alone', async () => {
+    const m = await schemasFor([col('name', { dbType: 'TEXT' })]);
+    expect(m.SelecttSchema.shape.name.safeParse('hello').success).toBe(true);
+  });
+
+  it('carries only the one format, since the rest could not be verified', async () => {
+    // Postgres reads 'today' as a date and pads '2020-01-01' into a macaddr, so patterns for
+    // those turned away valid input and were dropped rather than shipped.
+    expect(Object.keys(COLUMN_FORMATS)).toEqual(['numeric']);
+  });
+});

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -130,6 +130,34 @@ export function isGeneratedColumn(c: Column, _primaryKeyColumns: string[] = []):
  * was true only while integers were the sole bounded type, so it is kept strictly for an
  * analysis produced before `Column.integer` existed, and never consulted when the flag is set.
  */
+/**
+ * Patterns for string columns whose contents the database constrains.
+ *
+ * Every entry was validated against Postgres through PGlite rather than reasoned about: the
+ * pattern and the database agree on a pool built to include the awkward *valid* forms, because
+ * the real hazard is over-rejection. A check that turns away something Postgres accepts breaks
+ * working code, which is worse than the bare `string` it replaces.
+ *
+ * That is why there is exactly one entry. Candidates for `date`, `timestamp`, `time`, `interval`,
+ * `inet`, `cidr` and `macaddr` were all built and all rejected, each by a value Postgres accepts
+ * and the pattern did not:
+ *
+ *   date      `today`, `January 8, 1999`, `20200101`, `01/02/2020`, `infinity`
+ *   time      `allballs`, `12:00:00+02`
+ *   macaddr   `2020-01-01`, which Postgres pads into `20:20:00:01:00:01`
+ *   inet      `10.1/16`, `::ffff:1.2.3.4`
+ *   cidr      parses as `inet` and then demands zero host bits, which no regex can state
+ */
+export const COLUMN_FORMATS: Record<string, string> = {
+  // Sign, decimals, exponents, NaN/Infinity, surrounding whitespace, and the underscore digit
+  // separators and 0x/0o/0b integer literals Postgres 16 added. Agrees with Postgres on all 43
+  // probes, `1_000` and `0xDEAD_beef` through to `1__0`, `_1`, `0x` and `1e+`.
+  numeric:
+    '^\\s*([+-]?(0[xX][0-9a-fA-F](_?[0-9a-fA-F])*|0[oO][0-7](_?[0-7])*|0[bB][01](_?[01])*)' +
+    '|[+-]?(\\d(_?\\d)*(\\.(\\d(_?\\d)*)?)?|\\.\\d(_?\\d)*)([eE][+-]?\\d(_?\\d)*)?' +
+    '|[+-]?(NaN|Infinity))\\s*$',
+};
+
 export function isIntegerColumn(c: Column): boolean {
   if (typeof c.integer === 'boolean') return c.integer;
   return c.dbType === 'INTEGER' || (c.min !== undefined && c.max !== undefined);

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -609,6 +609,12 @@ const ALLOWED: Record<string, string> = {
   m_ts: 'as c_date_d',
   s_int_ts: 'as c_date_d',
   s_int_ts_ms: 'as c_date_d',
+  // Stricter than official, and verified against Postgres itself through PGlite: a `numeric`
+  // column is a string, and a bare string schema accepts 'hello' where the database rejects it.
+  // Official accepts all of these; the database does not.
+  c_numeric: 'numeric format enforced; official accepts any string, Postgres does not',
+  c_decimal: 'as c_numeric',
+  m_decimal: 'as c_numeric',
   // Stricter than official, in DRZL's favour.
   'valibot/c_json': 'DRZL rejects Infinity and non-plain objects; official accepts both',
   'valibot/c_jsonb': 'as valibot/c_json',
@@ -795,8 +801,198 @@ if ! npx tsx src/parity.ts; then
   echo "FAIL: DRZL's generated schemas diverge from the official drizzle-orm validators." >&2
   exit 1
 fi
+
+echo "==> ground truth: the emitted schemas against a real Postgres"
+# Everything above compares DRZL to another library's opinion. Both can be wrong about the same
+# column and neither is the authority. PGlite is a real Postgres compiled to wasm, so each probe
+# value goes through an actual INSERT and the database answers directly.
+#
+# What is gated is narrow on purpose: DRZL must never disagree with Postgres where the official
+# module agrees. A validator is deliberately stricter than a coercing driver, so most
+# disagreements are correct and gating on them would be noise. Disagreeing where official does
+# not means DRZL alone is wrong, which is what an over-strict check looks like. Candidate format
+# patterns for date, time, macaddr and inet were all discarded because this caught them turning
+# away values Postgres accepts.
+cat > src/ddl.ts <<'GROUND_DDL'
+/**
+ * DDL matching src/schema.ts, column for column, asserted against the analysis so it cannot drift.
+ *
+ * Every column is nullable on purpose. Each probe inserts exactly one column, so a NOT NULL
+ * sibling would fail the statement before the value under test was ever considered, and the whole
+ * table would look like it rejected everything. Nullability is not what this measures: the
+ * question is whether the column's *type* accepts the value.
+ */
+export const DDL = `
+CREATE TYPE mood AS ENUM ('happy','sad','neutral');
+CREATE TABLE matrix (
+  c_text text,
+  c_varchar varchar(255),
+  c_char char(4),
+  c_uuid uuid,
+  c_text_enum text,
+  c_varchar_enum varchar(10),
+  c_int integer,
+  c_smallint smallint,
+  c_bigint_n bigint,
+  c_bigint_b bigint,
+  c_serial integer,
+  c_real real,
+  c_double double precision,
+  c_numeric numeric(10,2),
+  c_numeric_n numeric(10,2),
+  c_decimal numeric,
+  c_bool boolean,
+  c_enum mood,
+  c_json json,
+  c_jsonb jsonb,
+  c_jsonb_typed jsonb,
+  c_date_d date,
+  c_date_s date,
+  c_ts_d timestamp,
+  c_ts_s timestamp,
+  c_time time,
+  c_interval interval,
+  c_text_arr text[],
+  c_int_arr integer[],
+  c_enum_arr mood[],
+  c_bytea bytea,
+  c_inet inet,
+  c_cidr cidr,
+  c_macaddr macaddr,
+  c_point point,
+  c_line line,
+  c_geometry point,
+  c_bit bit(3),
+  c_vector real[]
+);
+`;
+GROUND_DDL
+
+cat > src/ground-truth.ts <<'GROUND_TRUTH'
+/**
+ * Ground truth: DRZL's schemas against Postgres itself, not against another library's opinion.
+ *
+ * Everything else here compares DRZL to `drizzle-orm`'s validators. Both can be wrong about the
+ * same column and neither is the authority; Postgres is. PGlite runs a real Postgres in-process,
+ * so every probe value can be sent through an actual INSERT and the answer compared with what the
+ * two schemas predicted.
+ *
+ * **What is gated**: DRZL must never disagree with Postgres where the official module agrees. A
+ * validator is deliberately stricter than a coercing driver, so most disagreements are correct
+ * and gating on them would be noise, but disagreeing where official does not means DRZL alone is
+ * wrong. That is the assertion, and it is the one that catches an over-strict check: candidate
+ * patterns for `date`, `time`, `macaddr` and `inet` were all discarded because this caught them
+ * turning away values Postgres accepts.
+ */
+import { PGlite } from '@electric-sql/pglite';
+import { createSelectSchema } from 'drizzle-orm/zod';
+import { matrix } from './schema.js';
+import { SelectmatrixSchema as drzl } from './gen/pg/zod/matrix.zod.js';
+import { DDL } from './ddl.js';
+
+const POOL: [string, unknown][] = [
+  ['0', 0], ['1.5', 1.5], ['-1', -1], ['40000', 40000], ['2147483648', 2147483648],
+  ['1e9', 1e9], ['1e300', 1e300], ['9007199254740993', 9007199254740993],
+  ['NaN', NaN], ['Infinity', Infinity],
+  ["''", ''], ["'hello'", 'hello'], ['300-char', 'x'.repeat(300)],
+  ["'0101'", '0101'], ["'010'", '010'], ["'12.5'", '12.5'], ["'1_000'", '1_000'], ["'0x1f'", '0x1f'],
+  ['uuid', '3f2504e0-4f89-11d3-9a0c-0305e82c3301'], ["'not-a-uuid'", 'not-a-uuid'],
+  ["'happy'", 'happy'], ["'zzz'", 'zzz'],
+  ['true', true], ['Date', new Date('2020-01-01T00:00:00Z')],
+  ["'2020-01-01'", '2020-01-01'], ["'12:00:00'", '12:00:00'],
+  ["['a']", ['a']], ['[1,2]', [1, 2]], ['[1,2,3]', [1, 2, 3]],
+  ['{a:1}', { a: 1 }], ['Uint8Array', new Uint8Array([1, 2])],
+  ["'10.0.0.1'", '10.0.0.1'], ["'999.999.999.999'", '999.999.999.999'],
+];
+
+const db = new PGlite();
+await db.exec(DDL);
+
+const official: any = createSelectSchema(matrix);
+const cols = Object.keys(official.shape);
+
+// The DDL is hand-written, so it is checked against the analysed schema rather than trusted.
+const dbCols: any = await db.query(
+  `select column_name from information_schema.columns where table_name = 'matrix'`
+);
+const dbNames = new Set(dbCols.rows.map((r: any) => r.column_name));
+const missing = cols.filter((c) => !dbNames.has(c));
+if (missing.length) {
+  console.error(`    FAIL: the ground-truth DDL is missing ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+/** Does Postgres accept this value for this column? Each probe rolls back, so nothing persists. */
+async function dbAccepts(col: string, value: unknown): Promise<boolean> {
+  try {
+    await db.exec('BEGIN');
+    await db.query(`INSERT INTO matrix (${col}) VALUES ($1)`, [value as never]);
+    await db.exec('ROLLBACK');
+    return true;
+  } catch {
+    try {
+      await db.exec('ROLLBACK');
+    } catch {
+      /* already rolled back */
+    }
+    return false;
+  }
+}
+
+const ok = (schema: any, v: unknown) => {
+  try {
+    return schema.safeParse(v).success;
+  } catch {
+    return false;
+  }
+};
+
+type Row = { col: string; label: string; db: boolean; drzl: boolean; off: boolean };
+const rows: Row[] = [];
+for (const col of cols) {
+  for (const [label, value] of POOL) {
+    rows.push({
+      col,
+      label,
+      db: await dbAccepts(col, value),
+      drzl: ok(drzl.shape[col], value),
+      off: ok(official.shape[col], value),
+    });
+  }
+}
+
+const drzlOnly = rows.filter((r) => r.drzl !== r.db && r.off === r.db);
+const offOnly = rows.filter((r) => r.off !== r.db && r.drzl === r.db);
+const drzlAgrees = rows.filter((r) => r.drzl === r.db).length;
+const offAgrees = rows.filter((r) => r.off === r.db).length;
+
+console.log(`    ${rows.length} probes against a real Postgres (${cols.length} columns)`);
+console.log(`    agree with the database: DRZL ${drzlAgrees}, drizzle-orm ${offAgrees}`);
+console.log(`    DRZL closer than drizzle-orm on ${offOnly.length}, further on ${drzlOnly.length}`);
+
+if (drzlOnly.length) {
+  console.error('\n    FAIL: DRZL disagrees with Postgres where drizzle-orm agrees:');
+  for (const r of drzlOnly.slice(0, 20)) {
+    console.error(
+      `      ${r.col} on ${r.label}: Postgres ${r.db ? 'accepts' : 'rejects'}, DRZL ${r.drzl ? 'accepts' : 'rejects'}`
+    );
+  }
+  console.error('\n    A check that turns away what the database takes breaks working code.');
+  await db.close();
+  process.exit(1);
+}
+
+await db.close();
+GROUND_TRUTH
+
+npm install --no-audit --no-fund --loglevel=error @electric-sql/pglite >/dev/null
+if ! npx tsx src/ground-truth.ts; then
+  echo "FAIL: a generated schema disagrees with Postgres itself." >&2
+  exit 1
+fi
 cd "$APP"
 
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
 echo "    typechecks under bundler, node16 and nodenext, and validates at least as strictly as"
-echo "    the first-party drizzle-orm validator modules across three dialects and three modes."
+echo "    the first-party drizzle-orm validator modules across three dialects and three modes,"
+echo "    checked against a real Postgres."


### PR DESCRIPTION
Every check so far compared DRZL to `drizzle-orm`'s validators. Both can be wrong about the same column and neither is the authority. `verify:packed` now runs the emitted schemas against a **real Postgres** through PGlite: 1287 probes, each an actual INSERT, with the database answering directly.

```
1287 probes against a real Postgres (39 columns)
agree with the database: DRZL 920, drizzle-orm 897
DRZL closer than drizzle-orm on 23, further on 0
```

## What it found

A `numeric`/`decimal` column is returned as a string, because a JS number cannot hold arbitrary precision. That left the schema a bare `z.string()`, which accepts `'hello'` for a numeric column. `drizzle-orm/zod` still does; Postgres rejects it.

Numeric columns now carry the real grammar, which is broader than it looks: a sign, a leading `.`, exponents, `NaN`/`Infinity`, surrounding whitespace, and since Postgres 16 the underscore digit separators and `0x`/`0o`/`0b` literals, so `1_000` and `0xDEAD_beef` are valid. Not applied on SQLite, whose NUMERIC affinity stores whatever text it is given.

## What it stopped, which is the more useful half

Patterns for `date`, `timestamp`, `time`, `interval`, `inet`, `cidr` and `macaddr` were all built and all **dropped**, each caught turning away input Postgres accepts:

| Type | What the pattern would have refused |
| --- | --- |
| `date` | `today`, `January 8, 1999`, `20200101`, `01/02/2020`, `infinity` |
| `time` | `allballs`, `12:00:00+02` |
| `macaddr` | `2020-01-01`, which Postgres pads into `20:20:00:01:00:01` |
| `inet` | `10.1/16`, `::ffff:1.2.3.4` |
| `cidr` | parses as `inet`, then additionally demands zero host bits |

Without the database to ask, all seven looked equally shippable. A check that refuses valid data is worse than no check, so those columns keep a plain string.

## The gate

CI fails if a generated schema disagrees with Postgres **where `drizzle-orm` agrees** — that is what an over-strict check looks like. Gating on every disagreement would be noise, since a validator is deliberately stricter than a coercing driver that will happily stringify a number into a text column.

Verified to bite by removing underscore support from the numeric pattern:

```
FAIL: DRZL disagrees with Postgres where drizzle-orm agrees:
  c_numeric on '1_000': Postgres accepts, DRZL rejects
  c_decimal on '1_000': Postgres accepts, DRZL rejects
```

2.5s and 26MB of wasm, so it is cheap enough to keep in the normal run.

## One earlier call, now settled by the database

DRZL types `bytea` as `Uint8Array` where official demands a `Buffer`. That was a judgement call about portability. Postgres accepts the `Uint8Array`, so official is the one refusing valid data.

## Verification

- 472 tests across 59 files, 22 new
- `verify:packed` green: packed artefacts, 3 dialects x 3 modes vs the official validators, and the new database stage