### PR TITLE
feat: CHECK constraints for IN lists and conjunctions

### DIFF
--- a/.changeset/check-conjunctions-and-in-lists.md
+++ b/.changeset/check-conjunctions-and-in-lists.md
@@ -1,0 +1,53 @@
+---
+'@drzl/generator-arktype': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-typebox': minor
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+'@drzl/cli': minor
+---
+
+CHECK constraints: `IN` lists and conjunctions.
+
+The two most common shapes a CHECK is written in were both skipped. No official Drizzle validator
+module enforces any CHECK at all, so these are added to a list that already had no competition.
+
+### `IN` lists become enums
+
+```ts
+// check('status_valid', sql`${t.status} IN ('active', 'archived')`)
+status: z.enum(['active', 'archived'] as const),
+```
+
+A set constraint is what an enum is, so it takes the enum's shape in each library rather than
+becoming an opaque predicate, and the static type narrows with it: `v.picklist` for valibot,
+`'active' | 'archived'` for ArkType, `Type.Union([Type.Literal(...)])` for TypeBox.
+
+### Conjunctions split into one check per part
+
+```ts
+// check('n_bounds', sql`${t.n} > 0 AND ${t.n} < 10 AND ${t.n} <> 5`)
+n: z.number().int()
+  .refine((v) => v > 0, { message: 'n_bounds: n > 0' })
+  .refine((v) => v < 10, { message: 'n_bounds: n < 10' })
+  .refine((v) => v !== 5, { message: 'n_bounds: n <> 5' }),
+```
+
+Every part of an `AND` has to hold on its own, which is exactly what a list of refinements means.
+
+The split walks the expression rather than splitting on the text, so the `AND` inside `BETWEEN 1
+AND 10` and the one inside `'A AND B'` are both left alone. Lifting `BETWEEN` above the split was
+necessary for that: taking the naive order silently turned every `BETWEEN` into an unparseable
+pair and dropped a constraint that had been enforced since the feature shipped.
+
+### What is still refused, and why it grew
+
+`OR` and `NOT` anywhere in the expression disqualify it. A conjunction is safe to break apart
+because each part holds independently; a disjunction is not, and separating them inside a mixed
+expression needs a real parser. A conjunction where any single part is not understood is refused
+whole rather than partially applied, since enforcing half of a constraint is enforcing a different
+constraint.
+
+Verified against a real Postgres through PGlite: for `CHECK (status IN ('active','archived'))`,
+`CHECK (age >= 18 AND age <= 65)` and `CHECK (n > 0 AND n < 10 AND n <> 5)`, the emitted schema and
+the database agree on all 19 probes, NULL included.

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -164,14 +164,41 @@ Note the ordering on `score`: the refinement sits inside `.nullable()`, so `null
 is deliberate, because a SQL CHECK passes when it evaluates to TRUE **or NULL**. Enforcing it on
 a nullable column would make the schema stricter than the database.
 
+### `IN` lists become enums
+
+```ts
+// check('status_valid', sql`${t.status} IN ('active', 'archived')`)
+status: z.enum(["active", "archived"] as const),
+```
+
+A set constraint is what an enum is, so it takes the enum's shape rather than becoming a
+predicate, and the static type narrows with it.
+
+### Conjunctions split
+
+```ts
+// check('n_bounds', sql`${t.n} > 0 AND ${t.n} < 10 AND ${t.n} <> 5`)
+n: z.number().int()
+  .refine((v) => v > 0, { message: "n_bounds: n > 0" })
+  .refine((v) => v < 10, { message: "n_bounds: n < 10" })
+  .refine((v) => v !== 5, { message: "n_bounds: n <> 5" }),
+```
+
+Every part of an `AND` has to hold on its own, which is exactly what a list of refinements means.
+The split walks the expression rather than splitting on the text, so the `AND` inside a `BETWEEN`
+and the one inside `'A AND B'` are both left alone. If any single part is not understood, the
+whole constraint is skipped: enforcing half of a constraint is enforcing a different one.
+
 **Only unambiguous constraints are translated.** These are skipped rather than guessed at:
 
-| Skipped                   | Why                                                        |
-| ------------------------- | ---------------------------------------------------------- |
-| `start_date < end_date`   | A statement about the row, not about either field          |
-| `age >= 18 AND age <= 65` | Compound; getting its scope wrong changes what is enforced |
-| `length(name) > 3`        | Function call                                              |
-| `email ~ '^[a-z]+$'`      | Postgres `~` is POSIX ERE, not JavaScript's regex dialect  |
+| Skipped                       | Why                                                       |
+| ----------------------------- | --------------------------------------------------------- |
+| `start_date < end_date`       | A statement about the row, not about either field         |
+| `age >= 18 OR age <= 65`      | A disjunction cannot be split the way a conjunction can   |
+| `NOT (age >= 18)`             | Same: negation changes the scope of everything inside it  |
+| `age >= 18 AND length(n) > 3` | One part is not understood, so neither is enforced        |
+| `length(name) > 3`            | Function call                                             |
+| `email ~ '^[a-z]+$'`          | Postgres `~` is POSIX ERE, not JavaScript's regex dialect |
 
 A schema that quietly enforces a _guess_ at your constraint is worse than one enforcing nothing,
 because it rejects rows the database would have accepted.

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -4,7 +4,7 @@ import type {
   ValidationRenderer,
   ValidationGenerateOptions,
 } from '@drzl/validation-core';
-import type { ColumnCheck } from '@drzl/validation-core';
+import type { ColumnCheck, ColumnSet } from '@drzl/validation-core';
 import {
   COLUMN_FORMATS,
   insertColumns,
@@ -106,10 +106,18 @@ function atTypeForColumn(
   c: Column,
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
-  checks: ColumnCheck[] = []
+  checks: ColumnCheck[] = [],
+  sets: ColumnSet[] = []
 ): string {
   const shaped = atShapeType(c);
   if (shaped) return shaped;
+  // `CHECK (status IN ('a', 'b'))` is a literal union, which is exactly how ArkType states a set.
+  const set = sets.find((x) => x.column === c.name);
+  if (set) {
+    return set.kind === 'string'
+      ? set.values.map((v) => `'${v.replace(/'/g, "\\'")}'`).join(' | ')
+      : set.values.join(' | ');
+  }
   // A parsed check compares the column to a scalar literal, which describes the array rather
   // than an element. Folded in anyway, `CHECK (tags = 'x')` became `('x')[]`, demanding that
   // every element equal 'x'.
@@ -169,9 +177,10 @@ function atField(
   c: Column,
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
-  checks: ColumnCheck[] = []
+  checks: ColumnCheck[] = [],
+  sets: ColumnSet[] = []
 ): string {
-  let t = atTypeForColumn(c, mode, coerceDates, checks);
+  let t = atTypeForColumn(c, mode, coerceDates, checks, sets);
   // The element is parenthesised whenever it is anything but a bare keyword, because `[]` binds
   // tighter than every operator ArkType has: `'a' | 'b'[]` is the literal `'a'` or an array of
   // `'b'`, not an array of either. A plain keyword needs no parentheses and reads better without,
@@ -189,12 +198,13 @@ function renderObjectShape(
   cols: Column[],
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
-  checks: ColumnCheck[] = []
+  checks: ColumnCheck[] = [],
+  sets: ColumnSet[] = []
 ) {
   return cols
     .map(
       (c) =>
-        `  ${JSON.stringify(c.name)}: ${JSON.stringify(atField(c, mode, coerceDates, checks))},`
+        `  ${JSON.stringify(c.name)}: ${JSON.stringify(atField(c, mode, coerceDates, checks, sets))},`
     )
     .join('\n');
 }
@@ -214,13 +224,12 @@ function renderTableSchemas(
   const insertCols = insertColumns(table);
   const updateCols = updateColumns(table);
   const selectCols = selectColumns(table);
-  const checks = (table.checks ?? []).flatMap((k) => {
-    const parsed = parseCheck(k.expression, k.name);
-    return parsed.ok ? parsed.checks : [];
-  });
-  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks);
-  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks);
-  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks);
+  const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
+  const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
+  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks, sets);
+  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks, sets);
+  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks, sets);
   return `import { type } from 'arktype';
 
 export const ${insertSchema} = type({

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -1,6 +1,7 @@
 import type { Analysis, Table, Column } from '@drzl/analyzer';
 import type {
   ColumnCheck,
+  ColumnSet,
   ResolvedAffix,
   ValidationRenderer,
   ValidationGenerateOptions,
@@ -167,10 +168,20 @@ function tbExprForColumn(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  typedJsonRef?: string
+  typedJsonRef?: string,
+  sets: ColumnSet[] = []
 ): string {
   const shaped = tbShapeExpr(c, typedJsonRef);
   if (shaped) return shaped;
+  // `CHECK (status IN ('a', 'b'))` is a union of literals. `Type.Literal` is the only form
+  // TypeBox enforces: a `const` option parses and then accepts anything.
+  const set = sets.find((x) => x.column === c.name);
+  if (set) {
+    const lits = set.values.map((v) =>
+      set.kind === 'string' ? `Type.Literal(${JSON.stringify(v)})` : `Type.Literal(${v})`
+    );
+    return `Type.Union([${lits.join(', ')}])`;
+  }
   // A parsed check compares the column against a scalar literal, which describes an element
   // rather than the array. Applied anyway, `CHECK (tags = 'x')` collapsed the whole column to
   // `Type.Literal("x")`.
@@ -239,9 +250,10 @@ function tbField(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  typedJsonRef?: string
+  typedJsonRef?: string,
+  sets: ColumnSet[] = []
 ): string {
-  let expr = tbExprForColumn(c, mode, coerceDates, checks, typedJsonRef);
+  let expr = tbExprForColumn(c, mode, coerceDates, checks, typedJsonRef, sets);
   // Drizzle keeps an array on the element's own column class, so everything above describes the
   // element and the wrapping belongs out here, after its bounds are attached.
   for (let i = 0; i < (c.arrayDimensions ?? 0); i++) expr = `Type.Array(${expr})`;
@@ -259,7 +271,8 @@ function renderObjectShape(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  typedJson?: { table: string; mode: 'insert' | 'select' }
+  typedJson?: { table: string; mode: 'insert' | 'select' },
+  sets: ColumnSet[] = []
 ) {
   return cols
     .map((c) => {
@@ -267,7 +280,7 @@ function renderObjectShape(
         typedJson && (c.tsType === 'any' || c.shape?.kind === 'custom')
           ? `(typeof ${typedJson.table}.$infer${typedJson.mode === 'insert' ? 'Insert' : 'Select'})[${JSON.stringify(c.name)}]`
           : undefined;
-      return `  ${JSON.stringify(c.name)}: ${tbField(c, mode, coerceDates, checks, ref)},`;
+      return `  ${JSON.stringify(c.name)}: ${tbField(c, mode, coerceDates, checks, ref, sets)},`;
     })
     .join('\n');
 }
@@ -291,16 +304,15 @@ function renderTableSchemas(
 
   // Only checks the shared parser understands with certainty. Ambiguous ones are skipped rather
   // than guessed at, identically to the other validation generators.
-  const checks = (table.checks ?? []).flatMap((k) => {
-    const parsed = parseCheck(k.expression, k.name);
-    return parsed.ok ? parsed.checks : [];
-  });
+  const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
+  const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
 
   const tj = typedJson ? { table: T, mode: 'select' as const } : undefined;
   const tjInsert = typedJson ? { table: T, mode: 'insert' as const } : undefined;
-  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks, tjInsert);
-  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks, tjInsert);
-  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks, tj);
+  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks, tjInsert, sets);
+  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks, tjInsert, sets);
+  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks, tj, sets);
 
   const schemaImport = typedJson
     ? `import type { ${T} } from '${typedJson.schemaSpecifier}';\n`

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -4,7 +4,7 @@ import type {
   ValidationRenderer,
   ValidationGenerateOptions,
 } from '@drzl/validation-core';
-import type { ColumnCheck } from '@drzl/validation-core';
+import type { ColumnCheck, ColumnSet } from '@drzl/validation-core';
 import {
   COLUMN_FORMATS,
   insertColumns,
@@ -166,10 +166,18 @@ function vExprForColumn(
   c: Column,
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
-  checks: ColumnCheck[] = []
+  checks: ColumnCheck[] = [],
+  sets: ColumnSet[] = []
 ): string {
   const shaped = vShapeExpr(c);
   if (shaped) return shaped;
+  // `CHECK (status IN ('a', 'b'))` constrains the column to a set, which is what a picklist is.
+  const set = sets.find((x) => x.column === c.name);
+  if (set) {
+    return set.kind === 'string'
+      ? `v.picklist([${set.values.map((v) => JSON.stringify(v)).join(', ')}] as const)`
+      : `v.union([${set.values.map((v) => `v.literal(${v})`).join(', ')}])`;
+  }
   const extra = vChecks(c, checks);
   /** Fold the constraint actions into whatever base this column maps to. */
   const piped = (base: string, actions: string[]) => {
@@ -220,9 +228,10 @@ function vField(
   c: Column,
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
-  checks: ColumnCheck[] = []
+  checks: ColumnCheck[] = [],
+  sets: ColumnSet[] = []
 ): string {
-  let expr = vExprForColumn(c, mode, coerceDates, checks);
+  let expr = vExprForColumn(c, mode, coerceDates, checks, sets);
   // Drizzle keeps an array on the element's own column class, so everything above describes the
   // element and the wrapping belongs out here, after the bounds and length limits are attached.
   for (let i = 0; i < (c.arrayDimensions ?? 0); i++) expr = `v.array(${expr})`;
@@ -238,10 +247,11 @@ function renderObjectShape(
   cols: Column[],
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
-  checks: ColumnCheck[] = []
+  checks: ColumnCheck[] = [],
+  sets: ColumnSet[] = []
 ) {
   return cols
-    .map((c) => `  ${JSON.stringify(c.name)}: ${vField(c, mode, coerceDates, checks)},`)
+    .map((c) => `  ${JSON.stringify(c.name)}: ${vField(c, mode, coerceDates, checks, sets)},`)
     .join('\n');
 }
 
@@ -262,13 +272,12 @@ function renderTableSchemas(
   const selectCols = selectColumns(table);
   // Only checks the shared parser understands with certainty; the rest are skipped rather
   // than guessed at, exactly as in the Zod generator.
-  const checks = (table.checks ?? []).flatMap((k) => {
-    const parsed = parseCheck(k.expression, k.name);
-    return parsed.ok ? parsed.checks : [];
-  });
-  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks);
-  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks);
-  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks);
+  const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
+  const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
+  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks, sets);
+  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks, sets);
+  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks, sets);
   // Emitted only where a json column exists, so a file without one gains nothing unused.
   const needsJson = [...insertCols, ...updateCols, ...selectCols].some(
     (c) => c.shape?.kind === 'json'

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -4,7 +4,7 @@ import type {
   ValidationGenerateOptions,
   ValidationRenderer,
 } from '@drzl/validation-core';
-import type { ColumnCheck } from '@drzl/validation-core';
+import type { ColumnCheck, ColumnSet } from '@drzl/validation-core';
 import {
   formatCode,
   parseCheck,
@@ -134,10 +134,20 @@ function zodExprForColumn(
   c: Column,
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
-  typedJsonRef?: string
+  typedJsonRef?: string,
+  sets: ColumnSet[] = []
 ): string {
   const shaped = shapeExpr(c, typedJsonRef);
   if (shaped) return shaped;
+  // `CHECK (status IN ('a', 'b'))` constrains the column to a set, which is what an enum is. It
+  // takes the same shape here as a declared enum rather than becoming a predicate, so the static
+  // type narrows too. No official validator module enforces it at all.
+  const set = sets.find((x) => x.column === c.name);
+  if (set) {
+    return set.kind === 'string'
+      ? `z.enum([${set.values.map((v) => JSON.stringify(v)).join(', ')}] as const)`
+      : `z.union([${set.values.map((v) => `z.literal(${v})`).join(', ')}])`;
+  }
   if (c.enumValues && c.enumValues.length) {
     const vals = c.enumValues.map((v) => `'${v.replace(/'/g, "\\'")}'`).join(', ');
     return `z.enum([${vals}] as const)`;
@@ -195,6 +205,7 @@ function zodField(
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
   typedJsonRef?: string,
+  sets: ColumnSet[] = [],
   /**
    * A reference to Drizzle's inferred type for a column that already has a runtime schema.
    *
@@ -204,7 +215,7 @@ function zodField(
    */
   narrowRef?: string
 ): string {
-  let expr = zodExprForColumn(c, mode, coerceDates, typedJsonRef);
+  let expr = zodExprForColumn(c, mode, coerceDates, typedJsonRef, sets);
   // `.array()` does not give the column its own class in Drizzle, so everything above describes
   // the *element*. Length limits and integer bounds belong there, which is why the wrapping
   // happens out here rather than inside.
@@ -237,7 +248,8 @@ function renderObjectShape(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  typedJson?: { table: string; mode: 'insert' | 'select'; allColumns?: boolean }
+  typedJson?: { table: string; mode: 'insert' | 'select'; allColumns?: boolean },
+  sets: ColumnSet[] = []
 ) {
   return cols
     .map((c) => {
@@ -249,7 +261,7 @@ function renderObjectShape(
       const replaces = c.tsType === 'any' || c.shape?.kind === 'custom';
       const ref = typedJson && replaces ? refFor(typedJson) : undefined;
       const narrow = typedJson?.allColumns && !replaces ? refFor(typedJson) : undefined;
-      return `  ${JSON.stringify(c.name)}: ${zodField(c, mode, coerceDates, checks, ref, narrow)},`;
+      return `  ${JSON.stringify(c.name)}: ${zodField(c, mode, coerceDates, checks, ref, sets, narrow)},`;
     })
     .join('\n');
 }
@@ -272,10 +284,9 @@ function renderTableSchemas(
   const selectCols = selectColumns(table);
   // Only the checks this version can translate with certainty. The parser skips anything
   // ambiguous, since a schema that enforces a guess rejects rows the database would accept.
-  const checks = (table.checks ?? []).flatMap((k) => {
-    const parsed = parseCheck(k.expression, k.name);
-    return parsed.ok ? parsed.checks : [];
-  });
+  const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
+  const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
   // Insert and select can disagree: a json column with a default is optional on insert, so its
   // inferred type differs. Each shape therefore references the matching inference.
   const tj = typedJson
@@ -284,9 +295,9 @@ function renderTableSchemas(
   const tjInsert = typedJson
     ? { table: table.tsName, mode: 'insert' as const, allColumns: typedJson.allColumns }
     : undefined;
-  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks, tjInsert);
-  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks, tjInsert);
-  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks, tj);
+  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks, tjInsert, sets);
+  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks, tjInsert, sets);
+  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks, tj, sets);
   // A type-only import: it disappears at build time, so this adds no runtime dependency on the
   // schema module and cannot create an import cycle at runtime.
   const schemaImport = typedJson

--- a/packages/validation-core/src/checks.ts
+++ b/packages/validation-core/src/checks.ts
@@ -33,12 +33,126 @@ export interface ColumnCheck {
   name?: string;
 }
 
+/**
+ * A column constrained to a set of literals, from `col IN ('a', 'b')`.
+ *
+ * Kept separate from `ColumnCheck` rather than folded into it as another operator, so the
+ * existing shape is unchanged for anything already consuming it.
+ */
+export interface ColumnSet {
+  column: string;
+  values: string[];
+  kind: 'number' | 'string';
+  name?: string;
+}
+
 /** A check that was understood, or the reason it was not. */
 export type ParsedCheck =
-  | { ok: true; checks: ColumnCheck[] }
-  | { ok: false; reason: string };
+  { ok: true; checks: ColumnCheck[]; sets?: ColumnSet[] } | { ok: false; reason: string };
 
 const COMPARISON = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(>=|<=|<>|!=|>|<|=)\s*(.+?)\s*$/;
+const IN_LIST = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s+IN\s*\((.+)\)\s*$/i;
+
+/**
+ * Split on `AND`s that are at the top level, outside parentheses and outside quotes.
+ *
+ * A naive `split(/AND/i)` would cut through `'A AND B'` as a string literal and through the
+ * `AND` inside a `BETWEEN`, which is why this walks the expression instead. Returns a single
+ * element when there is nothing to split.
+ */
+function splitTopLevelAnd(expr: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let start = 0;
+  for (let i = 0; i < expr.length; i++) {
+    const c = expr[i];
+    if (inString) {
+      // SQL escapes a quote by doubling it, so `''` inside a string is not the end of it.
+      if (c === "'") {
+        if (expr[i + 1] === "'") i++;
+        else inString = false;
+      }
+      continue;
+    }
+    if (c === "'") {
+      inString = true;
+      continue;
+    }
+    if (c === '(') depth++;
+    else if (c === ')') depth--;
+    else if (depth === 0 && /\s/.test(c)) {
+      const m = /^\s+AND\s+/i.exec(expr.slice(i));
+      if (m) {
+        parts.push(expr.slice(start, i));
+        i += m[0].length - 1;
+        start = i + 1;
+      }
+    }
+  }
+  parts.push(expr.slice(start));
+  return parts;
+}
+
+/** Strip one layer of parentheses wrapping the whole expression, as many times as it is wrapped. */
+function unwrap(expr: string): string {
+  let e = expr.trim();
+  while (e.startsWith('(') && e.endsWith(')')) {
+    let depth = 0;
+    let inString = false;
+    let wrapsWhole = true;
+    for (let i = 0; i < e.length; i++) {
+      const c = e[i];
+      if (inString) {
+        if (c === "'") {
+          if (e[i + 1] === "'") i++;
+          else inString = false;
+        }
+        continue;
+      }
+      if (c === "'") inString = true;
+      else if (c === '(') depth++;
+      else if (c === ')') {
+        depth--;
+        // Closed before the end, so the outer parens are not wrapping everything: `(a) AND (b)`.
+        if (depth === 0 && i < e.length - 1) {
+          wrapsWhole = false;
+          break;
+        }
+      }
+    }
+    if (!wrapsWhole) break;
+    e = e.slice(1, -1).trim();
+  }
+  return e;
+}
+
+/** Top-level commas, for an `IN` list. Same walk as the `AND` split. */
+function splitTopLevelCommas(list: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let start = 0;
+  for (let i = 0; i < list.length; i++) {
+    const c = list[i];
+    if (inString) {
+      if (c === "'") {
+        if (list[i + 1] === "'") i++;
+        else inString = false;
+      }
+      continue;
+    }
+    if (c === "'") inString = true;
+    else if (c === '(') depth++;
+    else if (c === ')') depth--;
+    else if (c === ',' && depth === 0) {
+      parts.push(list.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(list.slice(start));
+  return parts;
+}
 const BETWEEN = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s+BETWEEN\s+(.+?)\s+AND\s+(.+?)\s*$/i;
 
 function literal(raw: string): { value: string; kind: 'number' | 'string' } | undefined {
@@ -58,10 +172,20 @@ function literal(raw: string): { value: string; kind: 'number' | 'string' } | un
  * silently change what is enforced.
  */
 export function parseCheck(expression: string | undefined, name?: string): ParsedCheck {
-  const expr = (expression ?? '').trim();
+  const expr = unwrap((expression ?? '').trim());
   if (!expr) return { ok: false, reason: 'empty expression' };
   if (expr.includes('?')) return { ok: false, reason: 'expression contains an unresolved value' };
 
+  // `OR` anywhere disqualifies the whole expression. Conjunction is safe to split because every
+  // part has to hold independently; disjunction is not, and telling the two apart in a mixed
+  // expression needs a real parser. Refusing is the behaviour that cannot silently enforce the
+  // wrong thing.
+  if (/(^|[\s)])OR($|[\s(])/i.test(expr)) return { ok: false, reason: 'contains OR' };
+  if (/(^|[\s(])NOT($|[\s(])/i.test(expr)) return { ok: false, reason: 'contains NOT' };
+
+  // Before the AND split, because the `AND` in `x BETWEEN 1 AND 10` belongs to the operator
+  // rather than joining two predicates. Splitting first turned every BETWEEN into an
+  // unparseable pair and silently dropped a constraint that used to be enforced.
   const between = expr.match(BETWEEN);
   if (between) {
     const lo = literal(between[2]);
@@ -77,6 +201,47 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
     };
   }
 
+  // A conjunction: every part must hold, so each becomes its own check. Any part this parser
+  // cannot read disqualifies the whole expression rather than being dropped, since enforcing
+  // half of a constraint is enforcing a different constraint.
+  const parts = splitTopLevelAnd(expr);
+  if (parts.length > 1) {
+    const checks: ColumnCheck[] = [];
+    const sets: ColumnSet[] = [];
+    for (const part of parts) {
+      const parsed = parseCheck(part, name);
+      if (!parsed.ok)
+        return { ok: false, reason: `part of an AND was not understood: ${parsed.reason}` };
+      checks.push(...parsed.checks);
+      if (parsed.sets) sets.push(...parsed.sets);
+    }
+    return sets.length ? { ok: true, checks, sets } : { ok: true, checks };
+  }
+
+  // `col IN (a, b, c)`: a set of literals, which is the constraint most often written as a CHECK
+  // and which no official validator module enforces.
+  const inList = expr.match(IN_LIST);
+  if (inList) {
+    const raw = splitTopLevelCommas(inList[2]);
+    const parsedValues = raw.map((r) => literal(r));
+    if (parsedValues.some((v) => !v)) return { ok: false, reason: 'IN list holds a non-literal' };
+    const kinds = new Set(parsedValues.map((v) => v!.kind));
+    if (kinds.size > 1) return { ok: false, reason: 'IN list mixes types' };
+    if (!parsedValues.length) return { ok: false, reason: 'IN list is empty' };
+    return {
+      ok: true,
+      checks: [],
+      sets: [
+        {
+          column: inList[1],
+          values: parsedValues.map((v) => v!.value),
+          kind: parsedValues[0]!.kind,
+          name,
+        },
+      ],
+    };
+  }
+
   const cmp = expr.match(COMPARISON);
   if (!cmp) return { ok: false, reason: 'not a single comparison this version understands' };
 
@@ -88,5 +253,19 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
   }
 
   const op = cmp[2] === '!=' ? '<>' : (cmp[2] as ColumnCheck['operator']);
-  return { ok: true, checks: [{ column: cmp[1], operator: op, value: value.value, kind: value.kind, name }] };
+  return {
+    ok: true,
+    checks: [{ column: cmp[1], operator: op, value: value.value, kind: value.kind, name }],
+  };
+}
+
+/**
+ * A human-readable rendering of a set constraint, for an error message.
+ *
+ * Values are re-quoted the way SQL wrote them, so the message reads like the constraint in the
+ * schema rather than like its JavaScript translation.
+ */
+export function describeSet(set: ColumnSet): string {
+  const shown = set.values.map((v) => (set.kind === 'string' ? `'${v}'` : v)).join(', ');
+  return `${set.name ? `${set.name}: ` : ''}${set.column} IN (${shown})`;
 }

--- a/packages/validation-core/test/checks.spec.ts
+++ b/packages/validation-core/test/checks.spec.ts
@@ -81,8 +81,18 @@ describe('what it refuses, and why that matters', () => {
     expect(rejected('age >= ?')).toMatch(/unresolved/);
   });
 
-  it('refuses a compound predicate rather than guessing its scope', () => {
-    expect(rejected('age >= 18 AND age <= 65')).toBeTruthy();
+  it('refuses a disjunction, whose scope cannot be split', () => {
+    // A conjunction is safe to break apart because every part has to hold on its own. A
+    // disjunction is not, and telling the two apart inside a mixed expression needs a real
+    // parser, so anything containing OR or NOT is refused outright.
+    expect(rejected('age >= 18 OR age <= 65')).toMatch(/OR/);
+    expect(rejected('NOT (age >= 18)')).toMatch(/NOT/);
+  });
+
+  it('refuses a whole conjunction when any one part is not understood', () => {
+    // Enforcing half of a constraint is enforcing a different constraint.
+    expect(rejected('age >= 18 AND length(name) > 3')).toMatch(/part of an AND/);
+    expect(rejected('age >= 18 AND start_date < end_date')).toMatch(/part of an AND/);
   });
 
   it('refuses a function call', () => {
@@ -103,5 +113,79 @@ describe('the constraint name', () => {
   it('is carried through so a failure can say which check failed', () => {
     const r = parseCheck('age >= 18', 'age_adult');
     expect(r.ok && r.checks[0].name).toBe('age_adult');
+  });
+});
+
+describe('conjunctions', () => {
+  // Every part of an AND has to hold independently, which is exactly what a list of checks means,
+  // so a conjunction can be split where a disjunction cannot. Verified against Postgres: a column
+  // with `CHECK (age >= 18 AND age <= 65)` accepts 18, 40 and 65, rejects 17 and 66, and accepts
+  // NULL, which is what the checks sitting inside `.nullable()` reproduces.
+  it('splits into one check per part', () => {
+    const r = parseCheck('age >= 18 AND age <= 65', 'age_range');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.checks).toHaveLength(2);
+    expect(r.checks.map((c) => `${c.operator}${c.value}`)).toEqual(['>=18', '<=65']);
+  });
+
+  it('handles more than two parts', () => {
+    const r = parseCheck('n > 0 AND n < 10 AND n <> 5');
+    expect(r.ok && r.checks).toHaveLength(3);
+  });
+
+  it('sees through parentheses wrapping the whole expression', () => {
+    const r = parseCheck('(age >= 18 AND age <= 65)');
+    expect(r.ok && r.checks).toHaveLength(2);
+  });
+
+  it('does not split the AND inside a BETWEEN', () => {
+    // That AND belongs to the operator. Splitting on it first turned every BETWEEN into an
+    // unparseable pair and silently dropped a constraint that had been enforced.
+    const r = parseCheck('x BETWEEN 1 AND 10');
+    expect(r.ok && r.checks.map((c) => `${c.operator}${c.value}`)).toEqual(['>=1', '<=10']);
+  });
+
+  it('does not split an AND inside a string literal', () => {
+    const r = parseCheck("label = 'A AND B'");
+    expect(r.ok && r.checks).toHaveLength(1);
+    expect(r.ok && r.checks[0].value).toBe('A AND B');
+  });
+});
+
+describe('IN lists', () => {
+  // The constraint most often written as a CHECK, and one no official validator module enforces.
+  it('reads a string set', () => {
+    const r = parseCheck("status IN ('active', 'archived')", 'status_valid');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.sets).toHaveLength(1);
+    expect(r.sets![0]).toMatchObject({
+      column: 'status',
+      values: ['active', 'archived'],
+      kind: 'string',
+    });
+  });
+
+  it('reads a numeric set', () => {
+    const r = parseCheck('level IN (1, 2, 3)');
+    expect(r.ok && r.sets![0]).toMatchObject({ values: ['1', '2', '3'], kind: 'number' });
+  });
+
+  it('combines with a comparison on another column', () => {
+    const r = parseCheck("status IN ('a', 'b') AND age > 0");
+    expect(r.ok && r.checks).toHaveLength(1);
+    expect(r.ok && r.sets).toHaveLength(1);
+  });
+
+  it('refuses a list that mixes types or holds a non-literal', () => {
+    expect(rejected("s IN ('a', 1)")).toMatch(/mixes types/);
+    expect(rejected('s IN (a, b)')).toBeTruthy();
+    expect(rejected('s IN (other_column)')).toBeTruthy();
+  });
+
+  it('keeps a quoted comma inside one value', () => {
+    const r = parseCheck("s IN ('a,b', 'c')");
+    expect(r.ok && r.sets![0].values).toEqual(['a,b', 'c']);
   });
 });


### PR DESCRIPTION
The two most common shapes a CHECK is written in were both skipped. No official Drizzle validator module enforces any CHECK at all, so this extends a list that already had no competition.

## `IN` lists become enums

```ts
// check('status_valid', sql`${t.status} IN ('active', 'archived')`)
status: z.enum(['active', 'archived'] as const),
```

A set constraint *is* an enum, so it takes the enum's shape in each library rather than becoming an opaque predicate, and the static type narrows with it:

| | |
|---|---|
| zod | `z.enum(["active", "archived"] as const)` |
| valibot | `v.picklist(["active", "archived"] as const)` |
| ArkType | `"'active' \| 'archived'"` |
| TypeBox | `Type.Union([Type.Literal("active"), Type.Literal("archived")])` |

## Conjunctions split into one check per part

```ts
// check('n_bounds', sql`${t.n} > 0 AND ${t.n} < 10 AND ${t.n} <> 5`)
n: z.number().int()
  .refine((v) => v > 0, { message: 'n_bounds: n > 0' })
  .refine((v) => v < 10, { message: 'n_bounds: n < 10' })
  .refine((v) => v !== 5, { message: 'n_bounds: n <> 5' }),
```

Every part of an `AND` has to hold on its own, which is exactly what a list of refinements means.

The split **walks** the expression rather than splitting on the text, so the `AND` inside `BETWEEN 1 AND 10` and the one inside `'A AND B'` are both left alone. Lifting `BETWEEN` above the split turned out to be necessary: taking the obvious order silently turned every `BETWEEN` into an unparseable pair and dropped a constraint that had been enforced since the feature shipped. The existing test suite caught it.

## What is still refused, and why that list grew

`OR` and `NOT` anywhere disqualify the expression. A conjunction is safe to break apart because each part holds independently; a disjunction is not, and separating them inside a mixed expression needs a real parser.

A conjunction where any single part is not understood is refused **whole** rather than partially applied. Enforcing half of a constraint is enforcing a different constraint, and the half that survives would reject rows the database accepts.

| Skipped | Why |
|---|---|
| `age >= 18 OR age <= 65` | A disjunction cannot be split the way a conjunction can |
| `NOT (age >= 18)` | Negation changes the scope of everything inside it |
| `age >= 18 AND length(n) > 3` | One part is not understood, so neither is enforced |
| `start_date < end_date` | A statement about the row, not about either field |

## Verification

Against a real Postgres through PGlite, for `status IN ('active','archived')`, `age >= 18 AND age <= 65` and `n > 0 AND n < 10 AND n <> 5`:

```
19 probes, 0 disagreements
```

including NULL, which passes every CHECK in SQL and which the refinements reproduce by sitting inside `.nullable()`.

483 tests across 59 files, 11 new. `verify:packed` green: packed artefacts, 3 dialects x 3 modes against the official validators, and the database stage.