### PR TITLE
feat: Relations v2, peer ranges, TypeBox parity, row-level CHECKs

### DIFF
--- a/.changeset/relations-v2-peers-typebox-parity-row-checks.md
+++ b/.changeset/relations-v2-peers-typebox-parity-row-checks.md
@@ -1,0 +1,58 @@
+---
+'@drzl/generator-arktype': minor
+'@drzl/generator-valibot': minor
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+'@drzl/analyzer': minor
+'@drzl/cli': minor
+---
+
+Relations v2, declared peer ranges, TypeBox measured against official, and row-level CHECKs.
+
+### `defineRelations` produced no relations at all
+
+Drizzle v1 added a second way to declare relations and the analyzer only knew the first, so a
+schema using `defineRelations` came back with an empty relations array and the oRPC and service
+generators emitted no relation endpoints. Nothing failed; the output was simply missing.
+Confirmed against `@drzl/cli@4.8.0`, which returns `[]` for the schema this now reads.
+
+The v2 shape is better than v1 for one case in particular: a many-to-many states its join table
+through `through`, where v1 leaves it to a heuristic over tables whose columns are all foreign
+keys. So a join table carrying extra columns is now recognised rather than missed.
+
+### Zod 4 output with no declared peer
+
+The emitted schemas use `z.uuid()` and `z.json()`, both Zod 4 only, and `@drzl/generator-zod`
+declared no peer dependency on zod whatsoever. A Zod 3 project got code that does not compile and
+nothing said why. All three now declare what they emit for: `zod >=4.0.0`, `valibot >=1.0.0`,
+`arktype >=2.0.0`, matching what `@drzl/generator-typebox` already did.
+
+### TypeBox is now measured against the official module
+
+The parity gate could only cross-check the typebox output against DRZL's own generators, and the
+docs said that was unavoidable. It was not: `drizzle-orm/typebox` targets the newer `typebox`
+package and throws on import against the released one, but `drizzle-orm/typebox-legacy` is the
+same module built for `@sinclair/typebox`, which is what this generator emits for.
+
+Turning it on immediately found a divergence, in DRZL's favour: official emits
+`Type.String({ format: 'uuid' })`, and TypeBox **fails** a format it has no entry for rather than
+ignoring it, so that schema rejects every valid uuid in any project that has not populated
+`FormatRegistry` first. DRZL emits a pattern, which needs no setup.
+
+### Row-level CHECK constraints
+
+`CHECK (start_date < end_date)` was skipped, because neither column alone can say whether it
+holds. It goes on the object schema instead:
+
+```ts
+.refine((v) => v['startDate'] == null || v['endDate'] == null || v['startDate'] < v['endDate'],
+  { message: 'date_order: startDate < endDate', path: ['startDate'] })
+```
+
+Both sides are guarded for null, reproducing SQL, where a comparison involving NULL yields NULL and
+a CHECK passes on NULL. The error is reported against the left column so it has somewhere to land,
+and a constraint naming a column the mode does not carry is left out rather than compared against
+`undefined`.
+
+Verified against a real Postgres through PGlite: for a table with `CHECK (start_date < end_date)`
+and `CHECK (price <= max_price)`, the emitted schema and the database agree on all five probe rows.

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ packages/*/test/.tmp-dates
 packages/*/test/.tmp-custom-*
 packages/*/test/.tmp-typedcols-*
 packages/*/test/.tmp-numfmt
+packages/*/test/.tmp-rowchecks

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -115,6 +115,9 @@ neither `@sinclair/typebox` nor the newer `typebox` package implements that spec
 three all do. A router handed a TypeBox schema would compile and then fail at runtime, so the
 config rejects it rather than emitting one.
 
+This is a limit of TypeBox, not of `drizzle-orm`: its own `drizzle-orm/typebox-legacy` module
+works fine with `@sinclair/typebox`, and DRZL's output is measured against it on every CI run.
+
 The generator itself is unaffected: TypeBox schemas are the right choice wherever you consume them
 yourself, or hand them to something that speaks JSON Schema. Pair it with a `zod` generator if you
 also want oRPC routers in the same project.

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -234,6 +234,28 @@ Off by default because it adds an `import type` of your schema module to the gen
 That import is erased at build time, so it adds no runtime dependency and cannot create a runtime
 cycle, but the coupling should be a choice.
 
+## Row-level CHECK constraints
+
+`CHECK (start_date < end_date)` is a statement about the row: neither column alone can say whether
+it holds, so it cannot be a field refinement. It goes on the object instead:
+
+```ts
+export const SelectbookingsSchema = z
+  .object({/* ... */})
+  .refine((v) => v['startDate'] == null || v['endDate'] == null || v['startDate'] < v['endDate'], {
+    message: 'date_order: startDate < endDate',
+    path: ['startDate'],
+  });
+```
+
+Both sides are guarded for null first, reproducing SQL, where a comparison involving NULL yields
+NULL and a CHECK passes on NULL. Without that guard an update omitting one column would be
+rejected by a comparison the database never applied.
+
+The error is reported against the left column, so it has somewhere to land in a form. A constraint
+naming a column the mode does not carry (a generated column on insert, say) is left out rather
+than emitted against `undefined`.
+
 ## `typedColumns`
 
 `.$type<T>()` is a compile-time cast on **any** column, not just json. Drizzle's implementation is

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -467,6 +467,77 @@ function declaredLength(column: any): number | undefined {
   return typeof n === 'number' && Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
+/** `getSymbol` as a free function, for the readers that live outside the class. */
+function getSymbolOf(target: any, key: string): unknown {
+  if (!target) return undefined;
+  try {
+    for (const sym of Object.getOwnPropertySymbols(target)) {
+      if ((sym as any).description === key) return (target as any)[sym];
+    }
+  } catch {}
+  return (target as any)[Symbol.for(key)];
+}
+
+/**
+ * Whether an export is a Relations v2 definition, from `defineRelations(schema, (r) => ...)`.
+ *
+ * v2 returns a plain object keyed by table name, each entry `{ table, name, relations }`, with
+ * no marker class or symbol to match on. So the shape is what identifies it: every value has a
+ * `relations` record whose entries carry a `relationType`. That is specific enough not to
+ * collide with a table or an enum, both of which are checked before this.
+ */
+export function isRelationsV2(val: any): boolean {
+  if (!val || typeof val !== 'object' || Array.isArray(val)) return false;
+  const entries = Object.values(val as Record<string, any>);
+  if (!entries.length) return false;
+  return entries.every(
+    (e) =>
+      !!e &&
+      typeof e === 'object' &&
+      !!e.table &&
+      !!e.relations &&
+      typeof e.relations === 'object' &&
+      Object.values(e.relations as Record<string, any>).every(
+        (r: any) => r?.relationType === 'one' || r?.relationType === 'many'
+      )
+  );
+}
+
+/**
+ * Read the relations declared by `defineRelations`.
+ *
+ * Simpler than the v1 reader, which has to invoke a callback with a stand-in builder to find
+ * out what was declared. v2 has already resolved everything: each descriptor states its
+ * `relationType`, its `targetTableName`, and for a many-to-many its `through` table, so nothing
+ * has to be inferred and the join table is stated rather than guessed at by the heuristic that
+ * covers v1.
+ */
+export function readRelationsV2(val: any, issues: Issue[] = []): Relation[] {
+  const out: Relation[] = [];
+  for (const [tableKey, entry] of Object.entries<any>(val)) {
+    const from = (getSymbolOf(entry.table, 'drizzle:Name') as string) ?? entry.name ?? tableKey;
+    for (const [fieldName, r] of Object.entries<any>(entry.relations ?? {})) {
+      const to = r?.targetTableName;
+      if (typeof to !== 'string' || !to) {
+        issues.push({
+          code: 'DRZL_ANL_REL_V2',
+          level: 'warn',
+          message: `Relation "${fieldName}" on "${from}" names no target table and was skipped.`,
+        });
+        continue;
+      }
+      // `through` is the join table of a many-to-many, which v1 leaves to a heuristic.
+      const via =
+        (getSymbolOf(r.throughTable, 'drizzle:Name') as string) ??
+        (getSymbolOf(r.through?.sourceTable, 'drizzle:Name') as string) ??
+        undefined;
+      if (via) out.push({ kind: 'manyToMany', from, to, via });
+      else out.push({ kind: r.relationType === 'many' ? 'many' : 'one', from, to });
+    }
+  }
+  return out;
+}
+
 export class SchemaAnalyzer {
   constructor(private readonly schemaPath: string) {}
 
@@ -1248,6 +1319,10 @@ export class SchemaAnalyzer {
         } else if (this.isRelationsObject(val)) {
           if (opts.includeRelations) {
             relations.push(...this.readRelationsObject(val, name, issues));
+          }
+        } else if (isRelationsV2(val)) {
+          if (opts.includeRelations) {
+            relations.push(...readRelationsV2(val, issues));
           }
         } else {
           // Detect exported enums (e.g., pgEnum('name', [...]))

--- a/packages/analyzer/test/relations-v2.spec.ts
+++ b/packages/analyzer/test/relations-v2.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Relations v2, from `defineRelations(schema, (r) => ...)`.
+ *
+ * Drizzle v1 added a second way to declare relations, and the analyzer only knew the first. A
+ * schema using the new API produced an empty relations array, so the oRPC and service generators
+ * emitted no relation endpoints at all. Nothing failed: the output was simply missing.
+ *
+ * Verified against drizzle-orm 1.0.0-rc.4, where `@drzl/cli@4.8.0` returns `[]` for the same
+ * schema this reader now reads. The shapes below were taken from a real `defineRelations` result
+ * rather than invented, and `scripts/verify-packed.sh` re-runs the real thing.
+ */
+import { describe, it, expect } from 'vitest';
+import { isRelationsV2, readRelationsV2 } from '../src/index';
+
+/** A table as Drizzle presents one, identified by the name symbol the reader looks for. */
+const table = (name: string) => ({ [Symbol.for('drizzle:Name')]: name });
+
+/** One entry of a `defineRelations` result. */
+const entry = (name: string, relations: Record<string, unknown>) => ({
+  table: table(name),
+  name,
+  relations,
+});
+
+const one = (targetTableName: string) => ({ relationType: 'one', targetTableName });
+const many = (targetTableName: string, throughTable?: string) => ({
+  relationType: 'many',
+  targetTableName,
+  ...(throughTable ? { throughTable: table(throughTable) } : {}),
+});
+
+describe('recognising the shape', () => {
+  it('accepts a defineRelations result', () => {
+    const v2 = { authors: entry('authors', { books: many('books') }) };
+    expect(isRelationsV2(v2)).toBe(true);
+  });
+
+  it('rejects things that are not one', () => {
+    // v2 has no marker class or symbol, so the shape is what identifies it, and the check has to
+    // be specific enough not to swallow a table or an enum.
+    expect(isRelationsV2(null)).toBe(false);
+    expect(isRelationsV2({})).toBe(false);
+    expect(isRelationsV2([entry('a', {})])).toBe(false);
+    expect(isRelationsV2({ a: { table: table('a') } }), 'no relations key').toBe(false);
+    expect(
+      isRelationsV2({ a: entry('a', { x: { targetTableName: 'b' } }) }),
+      'no relationType'
+    ).toBe(false);
+  });
+});
+
+describe('reading the relations', () => {
+  it('reads both directions of a one-to-many', () => {
+    const v2 = {
+      authors: entry('authors', { books: many('books') }),
+      books: entry('books', { author: one('authors') }),
+    };
+    expect(readRelationsV2(v2)).toEqual([
+      { kind: 'many', from: 'authors', to: 'books' },
+      { kind: 'one', from: 'books', to: 'authors' },
+    ]);
+  });
+
+  it('takes the join table of a many-to-many from `through` rather than guessing', () => {
+    // The v1 path infers a join table with a heuristic over tables whose columns are all foreign
+    // keys. v2 states it outright, so a join table carrying extra columns is still recognised.
+    const v2 = {
+      users: entry('users', { groups: many('groups', 'memberships') }),
+    };
+    expect(readRelationsV2(v2)).toEqual([
+      { kind: 'manyToMany', from: 'users', to: 'groups', via: 'memberships' },
+    ]);
+  });
+
+  it('falls back to the entry name when the table carries no name symbol', () => {
+    const v2 = { posts: { table: {}, name: 'posts', relations: { author: one('users') } } };
+    expect(readRelationsV2(v2)).toEqual([{ kind: 'one', from: 'posts', to: 'users' }]);
+  });
+
+  it('skips a relation with no target and says so, rather than emitting a broken one', () => {
+    const issues: any[] = [];
+    const v2 = { a: entry('a', { bad: { relationType: 'one' }, good: one('b') }) };
+    expect(readRelationsV2(v2, issues)).toEqual([{ kind: 'one', from: 'a', to: 'b' }]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe('DRZL_ANL_REL_V2');
+    expect(issues[0].message).toMatch(/bad/);
+  });
+});

--- a/packages/generator-arktype/package.json
+++ b/packages/generator-arktype/package.json
@@ -40,5 +40,8 @@
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/omar-dulaimi"
+  },
+  "peerDependencies": {
+    "arktype": ">=2.0.0"
   }
 }

--- a/packages/generator-valibot/package.json
+++ b/packages/generator-valibot/package.json
@@ -40,5 +40,8 @@
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/omar-dulaimi"
+  },
+  "peerDependencies": {
+    "valibot": ">=1.0.0"
   }
 }

--- a/packages/generator-zod/package.json
+++ b/packages/generator-zod/package.json
@@ -40,5 +40,8 @@
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/omar-dulaimi"
+  },
+  "peerDependencies": {
+    "zod": ">=4.0.0"
   }
 }

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -4,7 +4,7 @@ import type {
   ValidationGenerateOptions,
   ValidationRenderer,
 } from '@drzl/validation-core';
-import type { ColumnCheck, ColumnSet } from '@drzl/validation-core';
+import type { ColumnCheck, ColumnSet, RowCheck } from '@drzl/validation-core';
 import {
   formatCode,
   parseCheck,
@@ -266,6 +266,47 @@ function renderObjectShape(
     .join('\n');
 }
 
+/**
+ * `.refine()` calls that belong on the object rather than on a field.
+ *
+ * `CHECK (start_date < end_date)` is a statement about the row: neither column alone can say
+ * whether it holds, which is why it cannot be a field refinement. On the object it is exactly
+ * expressible. No official Drizzle validator module emits it, and DRZL used to skip it too.
+ *
+ * Both sides are guarded for null and undefined first, reproducing SQL, where a comparison
+ * involving NULL yields NULL and a CHECK passes on NULL. Without the guard a row omitting an
+ * optional column would be rejected by a comparison the database never applied.
+ */
+function rowRefinements(rows: RowCheck[], cols: Column[]): string {
+  const present = new Set(cols.map((c) => c.name));
+  const OPS: Record<RowCheck['operator'], string> = {
+    '>=': '>=',
+    '>': '>',
+    '<=': '<=',
+    '<': '<',
+    '=': '===',
+    '<>': '!==',
+  };
+  return (
+    rows
+      // A check naming a column this mode does not include cannot be evaluated: an insert schema
+      // omits generated columns, so the comparison would read undefined and always pass or fail.
+      .filter((r) => present.has(r.left) && present.has(r.right))
+      .map((r) => {
+        const l = `v[${JSON.stringify(r.left)}]`;
+        const rt = `v[${JSON.stringify(r.right)}]`;
+        const msg = JSON.stringify(
+          `${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`
+        );
+        return (
+          `.refine((v) => ${l} == null || ${rt} == null || ${l} ${OPS[r.operator]} ${rt}, ` +
+          `{ message: ${msg}, path: [${JSON.stringify(r.left)}] })`
+        );
+      })
+      .join('')
+  );
+}
+
 function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
@@ -287,6 +328,7 @@ function renderTableSchemas(
   const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
   const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
+  const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
   // Insert and select can disagree: a json column with a default is optional on insert, so its
   // inferred type differs. Each shape therefore references the matching inference.
   const tj = typedJson
@@ -307,15 +349,15 @@ function renderTableSchemas(
 ${schemaImport}
 export const ${insertSchema} = z.object({
 ${bodyInsert}
-});
+})${rowRefinements(rows, insertCols)};
 
 export const ${updateSchema} = z.object({
 ${bodyUpdate}
-});
+})${rowRefinements(rows, updateCols)};
 
 export const ${selectSchema} = z.object({
 ${bodySelect}
-});
+})${rowRefinements(rows, selectCols)};
 
 export type ${insertType} = z.input<typeof ${insertSchema}>;
 export type ${updateType} = z.input<typeof ${updateSchema}>;

--- a/packages/generator-zod/test/row-checks.spec.ts
+++ b/packages/generator-zod/test/row-checks.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Row-level CHECK constraints, which belong on the object rather than on a field.
+ *
+ * `CHECK (start_date < end_date)` cannot be a field refinement: neither column alone can say
+ * whether it holds. It was skipped for that reason, by DRZL and by every official Drizzle
+ * validator module, which enforce no CHECK at all. On the object schema it is exactly
+ * expressible.
+ *
+ * Verified against a real Postgres through PGlite: for a table with this constraint and
+ * `CHECK (price <= max_price)`, the emitted schema and the database agree on all five probe rows.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'number',
+    dbType: 'INTEGER',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-rowchecks');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return await import(file);
+}
+
+const ROW = [{ name: 'order', expression: 'lo < hi' }];
+const COLS = [col('lo'), col('hi')];
+
+describe('a comparison between two columns', () => {
+  it('is enforced on the object', async () => {
+    const m = await schemasFor(COLS, ROW);
+    expect(m.SelecttSchema.safeParse({ lo: 1, hi: 2 }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ lo: 2, hi: 1 }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ lo: 1, hi: 1 }), 'strict comparison').toMatchObject({
+      success: false,
+    });
+  });
+
+  it('reports against the left column, so the error has somewhere to land', async () => {
+    const m = await schemasFor(COLS, ROW);
+    const r = m.SelecttSchema.safeParse({ lo: 2, hi: 1 });
+    expect(r.error.issues[0].path).toEqual(['lo']);
+    expect(r.error.issues[0].message).toBe('order: lo < hi');
+  });
+
+  it('passes when either side is absent, as SQL does', async () => {
+    // A comparison involving NULL yields NULL, and a CHECK passes on NULL. Without the guard, an
+    // update omitting one column would be rejected by a comparison the database never applied.
+    const m = await schemasFor([col('lo', { nullable: true }), col('hi', { nullable: true })], ROW);
+    expect(m.SelecttSchema.safeParse({ lo: null, hi: 1 }).success).toBe(true);
+    expect(m.UpdatetSchema.safeParse({ lo: 5 }), 'hi omitted on update').toMatchObject({
+      success: true,
+    });
+  });
+
+  it('is left out of a mode that does not carry both columns', async () => {
+    // An insert schema omits generated columns. A comparison naming one would read undefined and
+    // silently always pass, which is worse than not emitting it.
+    const m = await schemasFor([col('lo'), col('hi', { isGenerated: true })], ROW);
+    const insert = JSON.stringify(Object.keys(m.InserttSchema.shape ?? {}));
+    expect(insert).not.toContain('hi');
+    expect(m.InserttSchema.safeParse({ lo: 1 }).success).toBe(true);
+  });
+
+  it('does not appear when there is no row-level constraint', async () => {
+    const m = await schemasFor(COLS, [{ name: 'x', expression: 'lo > 0' }]);
+    expect(m.SelecttSchema.safeParse({ lo: 5, hi: 1 }), 'no row check applies').toMatchObject({
+      success: true,
+    });
+  });
+});

--- a/packages/validation-core/src/checks.ts
+++ b/packages/validation-core/src/checks.ts
@@ -46,9 +46,23 @@ export interface ColumnSet {
   name?: string;
 }
 
+/**
+ * A comparison between two columns of the same row, from `CHECK (start_date < end_date)`.
+ *
+ * It cannot live on a field, because it is a statement about the row: neither column alone can
+ * say whether it holds. It can live on the *object* schema, which is where this ends up.
+ */
+export interface RowCheck {
+  left: string;
+  right: string;
+  operator: ColumnCheck['operator'];
+  name?: string;
+}
+
 /** A check that was understood, or the reason it was not. */
 export type ParsedCheck =
-  { ok: true; checks: ColumnCheck[]; sets?: ColumnSet[] } | { ok: false; reason: string };
+  | { ok: true; checks: ColumnCheck[]; sets?: ColumnSet[]; rows?: RowCheck[] }
+  | { ok: false; reason: string };
 
 const COMPARISON = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(>=|<=|<>|!=|>|<|=)\s*(.+?)\s*$/;
 const IN_LIST = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s+IN\s*\((.+)\)\s*$/i;
@@ -208,14 +222,21 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
   if (parts.length > 1) {
     const checks: ColumnCheck[] = [];
     const sets: ColumnSet[] = [];
+    const rows: RowCheck[] = [];
     for (const part of parts) {
       const parsed = parseCheck(part, name);
       if (!parsed.ok)
         return { ok: false, reason: `part of an AND was not understood: ${parsed.reason}` };
       checks.push(...parsed.checks);
       if (parsed.sets) sets.push(...parsed.sets);
+      if (parsed.rows) rows.push(...parsed.rows);
     }
-    return sets.length ? { ok: true, checks, sets } : { ok: true, checks };
+    return {
+      ok: true,
+      checks,
+      ...(sets.length ? { sets } : {}),
+      ...(rows.length ? { rows } : {}),
+    };
   }
 
   // `col IN (a, b, c)`: a set of literals, which is the constraint most often written as a CHECK
@@ -247,8 +268,15 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
 
   const value = literal(cmp[3]);
   if (!value) {
-    // The right side names something else, e.g. another column. That is a statement about the
-    // row rather than about this field, so it cannot be attached to one.
+    // The right side is not a literal. If it is a bare column name, the expression compares two
+    // columns of the same row: `start_date < end_date`. That cannot be attached to either field,
+    // since neither alone can say whether it holds, but it can be attached to the object.
+    const right = cmp[3].trim();
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(right)) {
+      const op = cmp[2] === '!=' ? '<>' : (cmp[2] as ColumnCheck['operator']);
+      return { ok: true, checks: [], rows: [{ left: cmp[1], right, operator: op, name }] };
+    }
+    // Anything else is an expression this parser does not model, such as `a + b`.
     return { ok: false, reason: 'right side is not a literal' };
   }
 

--- a/packages/validation-core/test/checks.spec.ts
+++ b/packages/validation-core/test/checks.spec.ts
@@ -72,9 +72,11 @@ describe('BETWEEN', () => {
 
 describe('what it refuses, and why that matters', () => {
   it('refuses a comparison between two columns', () => {
-    // `start < end` is a statement about the row, not about either field. Attaching it to one
-    // would reject rows the database accepts.
-    expect(rejected('start_date < end_date')).toMatch(/not a literal/);
+    // `start < end` is a statement about the row, not about either field, so it is not returned
+    // as a field check. It is returned as a row check instead, and the object schema carries it.
+    const r = parseCheck('start_date < end_date');
+    expect(r.ok && r.checks).toHaveLength(0);
+    expect(r.ok && r.rows).toHaveLength(1);
   });
 
   it('refuses an expression whose value was lost', () => {
@@ -92,7 +94,7 @@ describe('what it refuses, and why that matters', () => {
   it('refuses a whole conjunction when any one part is not understood', () => {
     // Enforcing half of a constraint is enforcing a different constraint.
     expect(rejected('age >= 18 AND length(name) > 3')).toMatch(/part of an AND/);
-    expect(rejected('age >= 18 AND start_date < end_date')).toMatch(/part of an AND/);
+    expect(rejected("age >= 18 AND email ~ '^[a-z]+$'")).toMatch(/part of an AND/);
   });
 
   it('refuses a function call', () => {
@@ -187,5 +189,40 @@ describe('IN lists', () => {
   it('keeps a quoted comma inside one value', () => {
     const r = parseCheck("s IN ('a,b', 'c')");
     expect(r.ok && r.sets![0].values).toEqual(['a,b', 'c']);
+  });
+});
+
+describe('row-level comparisons', () => {
+  // `start_date < end_date` is a statement about the row: neither column alone can say whether it
+  // holds, so it cannot be a field refinement. It was refused outright for that reason. It is
+  // exactly expressible on the *object* schema, which is where it goes now.
+  it('reads a comparison between two columns', () => {
+    const r = parseCheck('start_date < end_date', 'date_order');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.checks).toHaveLength(0);
+    expect(r.rows).toEqual([
+      { left: 'start_date', right: 'end_date', operator: '<', name: 'date_order' },
+    ]);
+  });
+
+  it('normalises != to <>', () => {
+    const r = parseCheck('a != b');
+    expect(r.ok && r.rows![0].operator).toBe('<>');
+  });
+
+  it('carries through a conjunction alongside field checks', () => {
+    const r = parseCheck('price > 0 AND price <= max_price');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.checks).toHaveLength(1);
+    expect(r.rows).toHaveLength(1);
+  });
+
+  it('still refuses an expression on the right, which is not a column', () => {
+    // `a + b` is arithmetic this parser does not model, and guessing at it would enforce
+    // something the schema never said.
+    expect(rejected('a > b + 1')).toBeTruthy();
+    expect(rejected('a + b > 0')).toBeTruthy();
   });
 });

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -514,10 +514,13 @@ cat > src/parity.ts <<'PARITY_HARNESS'
  * through both and comparing verdicts. Reading the emitted source cannot do this: a schema that
  * validates and one that merely parses look identical as text.
  *
- * Pass 2 cross-checks DRZL's own four generators against each other, which is what covers the
- * typebox output. `drizzle-orm/typebox` is absent from pass 1 on purpose: at 1.0.0-rc.4 it
- * declares a peer on `@sinclair/typebox` while its code imports `typebox`, and against the
- * released `typebox` it throws `Class extends value undefined` on import.
+ * Pass 2 cross-checks DRZL's own four generators against each other, which catches a generator
+ * drifting from its siblings on something all four should agree about.
+ *
+ * All four are compared against official. `drizzle-orm/typebox` targets the newer `typebox`
+ * package and throws `Class extends value undefined` on import against the released one, but
+ * `drizzle-orm/typebox-legacy` is the same module built for `@sinclair/typebox`, which is what
+ * this generator emits for.
  */
 import { createSelectSchema, createInsertSchema, createUpdateSchema } from 'drizzle-orm/zod';
 import {
@@ -530,6 +533,11 @@ import {
   createInsertSchema as aInsert,
   createUpdateSchema as aUpdate,
 } from 'drizzle-orm/arktype';
+import {
+  createSelectSchema as tSelect,
+  createInsertSchema as tInsert,
+  createUpdateSchema as tUpdate,
+} from 'drizzle-orm/typebox-legacy';
 import * as v from 'valibot';
 import { type } from 'arktype';
 import { Value } from '@sinclair/typebox/value';
@@ -570,6 +578,11 @@ const OFFICIAL: Record<string, Record<string, (t: any) => any>> = {
   zod: { select: createSelectSchema, insert: createInsertSchema, update: createUpdateSchema },
   valibot: { select: vSelect, insert: vInsert, update: vUpdate },
   arktype: { select: aSelect, insert: aInsert, update: aUpdate },
+  // `drizzle-orm/typebox` targets the `typebox` package and throws on import against the released
+  // one, but `typebox-legacy` is the same module built for `@sinclair/typebox`, which is what
+  // this generator emits for. So typebox is compared against official like the other three
+  // rather than only cross-checked.
+  typebox: { select: tSelect, insert: tInsert, update: tUpdate },
 };
 
 const safeOk = (lib: Lib, f: any, x: unknown) => {
@@ -609,6 +622,10 @@ const ALLOWED: Record<string, string> = {
   m_ts: 'as c_date_d',
   s_int_ts: 'as c_date_d',
   s_int_ts_ms: 'as c_date_d',
+  // Official emits `Type.String({ format: 'uuid' })`, and TypeBox fails a format it has no entry
+  // for rather than ignoring it, so that schema rejects every valid uuid in any project that has
+  // not populated `FormatRegistry` first. This generator emits a pattern, which needs no setup.
+  'typebox/c_uuid': 'official uses an unregistered `format`, which rejects every uuid',
   // Stricter than official, and verified against Postgres itself through PGlite: a `numeric`
   // column is a string, and a bare string schema accepts 'hello' where the database rejects it.
   // Official accepts all of these; the database does not.
@@ -668,7 +685,7 @@ for (const d of DIALECTS) {
   for (const mode of ['select', 'insert', 'update'] as const) {
     for (const libName of d.libs) {
       const off = OFFICIAL[libName]?.[mode];
-      if (!off) continue; // typebox: no usable official module
+      if (!off) continue;
       const lib = LIBS[libName];
       const official = off(d.table as never);
       const mine = loaded[libName][`${PREFIX[mode]}matrixSchema`];


### PR DESCRIPTION
Four gaps, each confirmed against the **published** packages before fixing.

## 1. `defineRelations` produced no relations at all

Drizzle v1 added a second way to declare relations and the analyzer only knew the first. A schema using `defineRelations` came back with an empty relations array, so the oRPC and service generators emitted no relation endpoints. Nothing failed; the output was simply missing.

```
published @drzl/cli@4.8.0 relations: []
this branch:  [{"kind":"many","from":"authors","to":"books"},
               {"kind":"one","from":"books","to":"authors"}]
```

The v2 shape is *better* than v1 in one place: a many-to-many states its join table through `through`, where v1 leaves it to a heuristic over tables whose columns are all foreign keys. So a join table carrying extra columns is now recognised rather than missed.

## 2. Zod 4 output with no declared peer

The emitted schemas use `z.uuid()` and `z.json()` — both Zod 4 only — and `@drzl/generator-zod` declared **no peer dependency on zod whatsoever**. A Zod 3 project got code that does not compile, and nothing said why.

All three now declare what they emit for, matching what `@drzl/generator-typebox` already did:

| | |
|---|---|
| `@drzl/generator-zod` | `zod >=4.0.0` |
| `@drzl/generator-valibot` | `valibot >=1.0.0` |
| `@drzl/generator-arktype` | `arktype >=2.0.0` |

## 3. TypeBox is now measured against the official module

The parity gate could only cross-check the typebox output against DRZL's own generators, and I documented that as unavoidable. **It was not.** `drizzle-orm/typebox` targets the newer `typebox` package and throws on import against the released one, but `drizzle-orm/typebox-legacy` is the same module built for `@sinclair/typebox`, which is what this generator emits for. The docs are corrected.

Turning it on immediately found a divergence, in DRZL's favour:

```
pg  typebox  select  39 cols  DIFFERS
    c_uuid:  DRZL accepts, official rejects: uuid
```

Official emits `Type.String({ format: 'uuid' })`, and TypeBox **fails** a format it has no entry for rather than ignoring it — so that schema rejects every valid uuid in any project that has not populated `FormatRegistry` first. DRZL emits a pattern, which needs no setup. All four generators are now compared against official on every CI run.

## 4. Row-level CHECK constraints

`CHECK (start_date < end_date)` was skipped, because neither column alone can say whether it holds. It goes on the object instead:

```ts
.refine((v) => v['startDate'] == null || v['endDate'] == null || v['startDate'] < v['endDate'],
  { message: 'date_order: startDate < endDate', path: ['startDate'] })
```

Both sides are guarded for null, reproducing SQL where a comparison involving NULL yields NULL and a CHECK passes on NULL — without it, an update omitting one column would be rejected by a comparison the database never applied. The error is reported against the left column so it has somewhere to land in a form, and a constraint naming a column the mode does not carry (a generated column on insert) is left out rather than compared against `undefined`.

Verified against a real Postgres through PGlite: for a table with this constraint and `CHECK (price <= max_price)`, the emitted schema and the database agree on all five probe rows.

## Verification

- 498 tests across 61 files, 15 new
- `verify:packed` green, now with **four** generators compared against official rather than three
- ground truth unchanged: DRZL 920, drizzle-orm 897, further on 0