### PR TITLE
feat: applyDefaults for every generator, typedColumns for TypeBox

### DIFF
--- a/.changeset/apply-defaults-all-generators.md
+++ b/.changeset/apply-defaults-all-generators.md
@@ -1,0 +1,57 @@
+---
+'@drzl/generator-arktype': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-typebox': minor
+'@drzl/generator-zod': minor
+'@drzl/cli': minor
+---
+
+`applyDefaults` for every generator, `typedColumns` for TypeBox, and three options that silently
+did nothing.
+
+### `applyDefaults` everywhere
+
+It shipped for zod only. Each library states a default in its own way, and all four now do:
+
+```ts
+country: z.string().default("GB"),                        // zod
+country: v.optional(v.string(), "GB"),                    // valibot
+country: 'string = "GB"',                                 // arktype
+country: Type.Optional(Type.String({ default: "GB" })),   // typebox
+```
+
+All four parse `{ name: 'x' }` into `{ name: 'x', country: 'GB', count: 0, flag: true }`, which is
+the row Postgres writes for the same insert. Checked by running the emitted modules rather than by
+reading them.
+
+One difference worth knowing: TypeBox's `Value.Check` does **not** materialise a default, only
+`Value.Parse` and `Value.Default` do. It separates validating from defaulting where zod and valibot
+fold the two together.
+
+### `typedColumns` for TypeBox
+
+`Type.Unsafe<T>(schema)` wraps an existing schema, so every check it carries still runs and only
+the inferred type is replaced:
+
+```ts
+role: Type.Unsafe<(typeof users.$inferSelect)['role']>(Type.String({ maxLength: 50 })),
+```
+
+That leaves ArkType as the one generator that cannot do this, and it is not an oversight: it emits
+one string per field, and a TypeScript type reference has nowhere to live inside a string DSL.
+
+### Three documented options that did nothing
+
+Found while wiring the above, each confirmed by generating and reading the output rather than by
+inspecting the code:
+
+- **`typedJson` on a `typebox` generator was ignored.** The CLI never passed it, so a json column
+  emitted the generic `DrzlJsonValue` no matter what the config said.
+- **`coerceDates` was ignored by every generator.** It was documented on the zod generator, but the
+  config schema had no such key, so `coerceDates: 'none'` parsed and was dropped. The output kept
+  coercing.
+- **`applyDefaults` reached only zod**, for the same reason, until the other three branches were
+  given it.
+
+Each generator branch in the CLI built its own options object by hand, so an option added to one
+was simply absent from the others. All four now pass everything they support.

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ packages/*/test/.tmp-structured
 packages/*/test/.tmp-dates
 packages/*/test/.tmp-custom-*
 packages/*/test/.tmp-typedcols-*
+packages/*/test/.tmp-typedcols-run
 packages/*/test/.tmp-numfmt
 packages/*/test/.tmp-rowchecks
 packages/*/test/.tmp-defaults

--- a/docs/generators/arktype.md
+++ b/docs/generators/arktype.md
@@ -88,6 +88,25 @@ comparison operators take numeric literals, so a 64 bit bound cannot be written 
 DSL at all; `drizzle-orm/arktype` states it through a narrow predicate built with the builder
 API instead. Every other column type is bounded here exactly as the official module bounds it.
 
+## `applyDefaults`
+
+Drizzle knows what a column defaults to, and `drizzle-orm` reproduces none of them.
+
+```ts
+{ kind: 'arktype', path: 'src/validators/arktype', applyDefaults: true }
+```
+
+```ts
+country: "string = 'GB'",
+```
+
+Only **literal** defaults. `defaultNow()`, `defaultRandom()` and any `sql` default are evaluated
+by the database, and `$defaultFn` is called by Drizzle at insert time, so those stay optional: a
+schema guessing at them would produce a different value than the one actually stored.
+
+Insert only, and off by default, because it changes what parsing _returns_ rather than only what
+it accepts.
+
 ## Custom names
 
 `Insert<Table>Schema` is the default, not the only option. The `affix` block renames the

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -122,6 +122,45 @@ The generator itself is unaffected: TypeBox schemas are the right choice whereve
 yourself, or hand them to something that speaks JSON Schema. Pair it with a `zod` generator if you
 also want oRPC routers in the same project.
 
+## `applyDefaults`
+
+Drizzle knows what a column defaults to, and `drizzle-orm` reproduces none of them.
+
+```ts
+{ kind: 'typebox', path: 'src/validators/typebox', applyDefaults: true }
+```
+
+```ts
+country: Type.Optional(Type.String({ default: 'GB' })),
+```
+
+Only **literal** defaults. `defaultNow()`, `defaultRandom()` and any `sql` default are evaluated
+by the database, and `$defaultFn` is called by Drizzle at insert time, so those stay optional: a
+schema guessing at them would produce a different value than the one actually stored.
+
+Insert only, and off by default, because it changes what parsing _returns_ rather than only what
+it accepts.
+
+`Value.Check` deliberately does **not** materialise a default, only `Value.Parse` and
+`Value.Default` do: TypeBox separates validating from defaulting where zod and valibot fold the
+two together.
+
+## `typedColumns`
+
+`.$type<T>()` is a compile-time cast on any column, so `text().$type<'admin' | 'member'>()` is an
+ordinary string to anything reading it at runtime and the narrowing is lost.
+
+```ts
+{ kind: 'typebox', path: 'src/validators/typebox', typedColumns: true }
+```
+
+```ts
+role: Type.Unsafe<(typeof users.$inferSelect)['role']>(Type.String({ maxLength: 50 })),
+```
+
+`Type.Unsafe<T>` wraps the existing schema, so every check it carried still runs and only the
+inferred type is replaced. Implies `typedJson`. Off by default.
+
 ## Peer dependency
 
 `@sinclair/typebox` >= 0.32, which your project provides.

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -89,6 +89,25 @@ instance such as a `Date` is refused rather than being rebuilt as an empty objec
 See [Zod → Structured columns](/generators/zod#structured-columns) for why `bytea` is typed as a
 `Uint8Array`.
 
+## `applyDefaults`
+
+Drizzle knows what a column defaults to, and `drizzle-orm` reproduces none of them.
+
+```ts
+{ kind: 'valibot', path: 'src/validators/valibot', applyDefaults: true }
+```
+
+```ts
+country: v.optional(v.string(), 'GB'),
+```
+
+Only **literal** defaults. `defaultNow()`, `defaultRandom()` and any `sql` default are evaluated
+by the database, and `$defaultFn` is called by Drizzle at insert time, so those stay optional: a
+schema guessing at them would produce a different value than the one actually stored.
+
+Insert only, and off by default, because it changes what parsing _returns_ rather than only what
+it accepts.
+
 ## Custom names
 
 `Insert<Table>Schema` is the default, not the only option. The `affix` block renames the

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -178,6 +178,7 @@ program
               typedJson: g.typedJson,
               typedColumns: g.typedColumns,
               applyDefaults: g.applyDefaults,
+              coerceDates: g.coerceDates,
             });
             progress.stop();
             ora().succeed(chalk.green(`Generated (zod): ${files.length} files`));
@@ -204,6 +205,8 @@ program
               fileSuffix: g.fileSuffix,
               importExtension: g.importExtension,
               affix: g.affix,
+              applyDefaults: g.applyDefaults,
+              coerceDates: g.coerceDates,
             });
             progress.stop();
             ora().succeed(chalk.green(`Generated (valibot): ${files.length} files`));
@@ -230,6 +233,8 @@ program
               fileSuffix: g.fileSuffix,
               importExtension: g.importExtension,
               affix: g.affix,
+              applyDefaults: g.applyDefaults,
+              coerceDates: g.coerceDates,
             });
             progress.stop();
             ora().succeed(chalk.green(`Generated (arktype): ${files.length} files`));
@@ -256,6 +261,12 @@ program
               fileSuffix: g.fileSuffix,
               importExtension: g.importExtension,
               affix: g.affix,
+              coerceDates: g.coerceDates,
+              // Needed by typedJson, which imports the schema back to reference the type
+              schemaPath: cfg.schema,
+              typedJson: g.typedJson,
+              typedColumns: g.typedColumns,
+              applyDefaults: g.applyDefaults,
             });
             progress.stop();
             ora().succeed(chalk.green(`Generated (typebox): ${files.length} files`));

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -90,6 +90,10 @@ export const GeneratorSchema = z.object({
    * Off by default because it makes the generated file import your schema module, as a
    * type-only import that disappears at build time.
    */
+  // What a date column accepts. Documented on the zod generator and, until now, accepted by the
+  // config parser and then dropped on the floor: the generators default it to 'input' themselves,
+  // so setting it here changed nothing.
+  coerceDates: z.enum(['input', 'all', 'none']).optional(),
   typedJson: z.boolean().optional(),
   // The wider form: every column's static type comes from Drizzle, not just the untyped ones.
   typedColumns: z.boolean().optional(),

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -178,7 +178,8 @@ function atField(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  sets: ColumnSet[] = []
+  sets: ColumnSet[] = [],
+  applyDefault = false
 ): string {
   let t = atTypeForColumn(c, mode, coerceDates, checks, sets);
   // The element is parenthesised whenever it is anything but a bare keyword, because `[]` binds
@@ -189,7 +190,13 @@ function atField(
   for (let i = 0; i < (c.arrayDimensions ?? 0); i++) t = bare && i === 0 ? `${t}[]` : `(${t})[]`;
   if (c.nullable) t = `(${t} | null)`;
   if (mode !== 'select') {
-    if (mode === 'update' || c.nullable || c.hasDefault) t = `${t}?`;
+    // ArkType states a default in the DSL itself: `"string = 'GB'"`. That already makes the key
+    // optional, so it replaces the `?` suffix rather than combining with it.
+    if (mode === 'insert' && applyDefault && c.defaultValue !== undefined) {
+      t = `${t} = ${JSON.stringify(c.defaultValue)}`;
+    } else if (mode === 'update' || c.nullable || c.hasDefault) {
+      t = `${t}?`;
+    }
   }
   return t;
 }
@@ -199,12 +206,13 @@ function renderObjectShape(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  sets: ColumnSet[] = []
+  sets: ColumnSet[] = [],
+  applyDefaults = false
 ) {
   return cols
     .map(
       (c) =>
-        `  ${JSON.stringify(c.name)}: ${JSON.stringify(atField(c, mode, coerceDates, checks, sets))},`
+        `  ${JSON.stringify(c.name)}: ${JSON.stringify(atField(c, mode, coerceDates, checks, sets, applyDefaults))},`
     )
     .join('\n');
 }
@@ -212,7 +220,8 @@ function renderObjectShape(
 function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
-  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
+  applyDefaults = false
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -227,9 +236,30 @@ function renderTableSchemas(
   const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
   const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
-  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks, sets);
-  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks, sets);
-  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks, sets);
+  const bodyInsert = renderObjectShape(
+    insertCols,
+    'insert',
+    coerceDates,
+    checks,
+    sets,
+    applyDefaults
+  );
+  const bodyUpdate = renderObjectShape(
+    updateCols,
+    'update',
+    coerceDates,
+    checks,
+    sets,
+    applyDefaults
+  );
+  const bodySelect = renderObjectShape(
+    selectCols,
+    'select',
+    coerceDates,
+    checks,
+    sets,
+    applyDefaults
+  );
   return `import { type } from 'arktype';
 
 export const ${insertSchema} = type({
@@ -271,7 +301,7 @@ export class ArkTypeGenerator implements ValidationRenderer<ArkTypeGenerateOptio
     // rename identifiers, never modules, so the barrel and importPath keep resolving.
     for (const table of this.analysis.tables) {
       const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
-      const code = renderTableSchemas(table, affix, coerceDates);
+      const code = renderTableSchemas(table, affix, coerceDates, !!opts.applyDefaults);
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
         filePath,

--- a/packages/generator-arktype/test/apply-defaults.spec.ts
+++ b/packages/generator-arktype/test/apply-defaults.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * `applyDefaults` in the arktype generator.
+ *
+ * Each library states a default in its own way, so this checks the emitted module *runs* and
+ * fills the value in, rather than that it contains a particular string. `drizzle-orm` reproduces
+ * no defaults in any of its validator modules.
+ *
+ * Only literals: an SQL default (`defaultNow()`, `defaultRandom()`, any `sql`) is evaluated by
+ * the database and a `$defaultFn` is called by Drizzle at insert time, so both stay optional.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { ArkTypeGenerator } from '../src/index';
+import { type } from 'arktype';
+
+const RUN = (schema: any, input: unknown) => {
+  const out = schema(input);
+  if (out instanceof type.errors) throw new Error(out.summary);
+  return out;
+};
+const GEN = ArkTypeGenerator;
+const SUFFIX = '.arktype.ts';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(columns: Column[], applyDefaults: boolean): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-defaults');
+  await fs.mkdir(dir, { recursive: true });
+  await new GEN(analysis).generate({ outDir: dir, applyDefaults } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return await import(file);
+}
+
+const LITERAL = [
+  col('name'),
+  col('country', { hasDefault: true, defaultValue: 'GB' }),
+  col('count', { tsType: 'number', dbType: 'INTEGER', hasDefault: true, defaultValue: 0 }),
+  col('flag', { tsType: 'boolean', dbType: 'BOOLEAN', hasDefault: true, defaultValue: true }),
+];
+
+describe('off by default', () => {
+  it('leaves the fields merely optional', async () => {
+    const m = await schemasFor(LITERAL, false);
+    expect(RUN(m.InserttSchema, { name: 'x' })).toEqual({ name: 'x' });
+  });
+});
+
+describe('with applyDefaults', () => {
+  it('fills every literal in, including the falsy ones', async () => {
+    // `0` and `false` are the values a truthiness check would silently drop.
+    const m = await schemasFor(LITERAL, true);
+    expect(RUN(m.InserttSchema, { name: 'x' })).toEqual({
+      name: 'x',
+      country: 'GB',
+      count: 0,
+      flag: true,
+    });
+  });
+
+  it('leaves a supplied value alone', async () => {
+    const m = await schemasFor(LITERAL, true);
+    expect(RUN(m.InserttSchema, { name: 'x', country: 'FR' })).toMatchObject({ country: 'FR' });
+  });
+
+  it('leaves a column whose default the database evaluates alone', async () => {
+    // `defaultNow()` has `hasDefault` but no literal, so there is nothing to reproduce.
+    const m = await schemasFor([col('name'), col('createdAt', { hasDefault: true })], true);
+    expect(RUN(m.InserttSchema, { name: 'x' })).toEqual({ name: 'x' });
+  });
+
+  it('touches only the insert schema', async () => {
+    // A default applies when a row is created, not when it is updated.
+    const m = await schemasFor(LITERAL, true);
+    expect(RUN(m.UpdatetSchema, {})).toEqual({});
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -245,13 +245,37 @@ function tbExprForColumn(
   }
 }
 
+/**
+ * Attach a JSON Schema `default` to whatever schema expression this is.
+ *
+ * `Type.String()` renders with no options and `Type.String({ maxLength: 5 })` renders with some,
+ * so the annotation is added by re-opening the call rather than by string surgery on the options
+ * object, which would have to parse what is already there.
+ */
+function withDefault(expr: string, value: unknown): string {
+  const json = JSON.stringify(value);
+  const open = expr.lastIndexOf('(');
+  const close = expr.lastIndexOf(')');
+  // Only a bare `Type.X()` or `Type.X({...})` can take one. Anything composed, a union or a
+  // pipe, has no single place to put it, and guessing would attach it to the wrong member.
+  if (!/^Type\.[A-Za-z]+\(/.test(expr) || open === -1 || close !== expr.length - 1) return expr;
+  const inner = expr.slice(open + 1, close).trim();
+  if (!inner) return `${expr.slice(0, open)}({ default: ${json} })`;
+  if (inner.startsWith('{') && inner.endsWith('}')) {
+    return `${expr.slice(0, open)}({ ${inner.slice(1, -1).trim().replace(/,$/, '')}, default: ${json} })`;
+  }
+  return `${expr.slice(0, close)}, { default: ${json} })`;
+}
+
 function tbField(
   c: Column,
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
   typedJsonRef?: string,
-  sets: ColumnSet[] = []
+  sets: ColumnSet[] = [],
+  applyDefault = false,
+  narrowRef?: string
 ): string {
   let expr = tbExprForColumn(c, mode, coerceDates, checks, typedJsonRef, sets);
   // Drizzle keeps an array on the element's own column class, so everything above describes the
@@ -260,8 +284,19 @@ function tbField(
   // Nullability wraps the constrained type, so null skips the constraint. That reproduces SQL,
   // where a CHECK passes when it evaluates to TRUE or NULL.
   if (c.nullable) expr = `Type.Union([${expr}, Type.Null()])`;
+  // `typedColumns` narrows the static type without touching the runtime schema. `Type.Unsafe<T>`
+  // is TypeBox's own primitive for exactly that: it wraps an existing schema, so every check it
+  // carries still runs, and only the inferred type is replaced.
+  if (narrowRef) expr = `Type.Unsafe<${narrowRef}>(${expr})`;
   if (mode !== 'select') {
-    if (mode === 'update' || c.nullable || c.hasDefault) expr = `Type.Optional(${expr})`;
+    // A literal default becomes a JSON Schema `default` annotation. Note that `Value.Check` does
+    // not materialise it, only `Value.Parse` and `Value.Default` do: TypeBox separates validating
+    // from defaulting, where zod and valibot fold the two together.
+    if (mode === 'insert' && applyDefault && c.defaultValue !== undefined) {
+      expr = `Type.Optional(${withDefault(expr, c.defaultValue)})`;
+    } else if (mode === 'update' || c.nullable || c.hasDefault) {
+      expr = `Type.Optional(${expr})`;
+    }
   }
   return expr;
 }
@@ -271,16 +306,21 @@ function renderObjectShape(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  typedJson?: { table: string; mode: 'insert' | 'select' },
-  sets: ColumnSet[] = []
+  typedJson?: { table: string; mode: 'insert' | 'select'; allColumns?: boolean },
+  sets: ColumnSet[] = [],
+  applyDefaults = false
 ) {
   return cols
     .map((c) => {
+      const refFor = (t: { table: string; mode: 'insert' | 'select' }) =>
+        `(typeof ${t.table}.$infer${t.mode === 'insert' ? 'Insert' : 'Select'})[${JSON.stringify(c.name)}]`;
+      const replaces = c.tsType === 'any' || c.shape?.kind === 'custom';
+      const narrow = typedJson?.allColumns && !replaces ? refFor(typedJson) : undefined;
       const ref =
         typedJson && (c.tsType === 'any' || c.shape?.kind === 'custom')
           ? `(typeof ${typedJson.table}.$infer${typedJson.mode === 'insert' ? 'Insert' : 'Select'})[${JSON.stringify(c.name)}]`
           : undefined;
-      return `  ${JSON.stringify(c.name)}: ${tbField(c, mode, coerceDates, checks, ref, sets)},`;
+      return `  ${JSON.stringify(c.name)}: ${tbField(c, mode, coerceDates, checks, ref, sets, applyDefaults, narrow)},`;
     })
     .join('\n');
 }
@@ -289,7 +329,8 @@ function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
-  typedJson?: { schemaSpecifier: string }
+  typedJson?: { schemaSpecifier: string; allColumns?: boolean },
+  applyDefaults = false
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -308,11 +349,39 @@ function renderTableSchemas(
   const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
 
-  const tj = typedJson ? { table: T, mode: 'select' as const } : undefined;
-  const tjInsert = typedJson ? { table: T, mode: 'insert' as const } : undefined;
-  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks, tjInsert, sets);
-  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks, tjInsert, sets);
-  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks, tj, sets);
+  const tj = typedJson
+    ? { table: T, mode: 'select' as const, allColumns: typedJson.allColumns }
+    : undefined;
+  const tjInsert = typedJson
+    ? { table: T, mode: 'insert' as const, allColumns: typedJson.allColumns }
+    : undefined;
+  const bodyInsert = renderObjectShape(
+    insertCols,
+    'insert',
+    coerceDates,
+    checks,
+    tjInsert,
+    sets,
+    applyDefaults
+  );
+  const bodyUpdate = renderObjectShape(
+    updateCols,
+    'update',
+    coerceDates,
+    checks,
+    tjInsert,
+    sets,
+    applyDefaults
+  );
+  const bodySelect = renderObjectShape(
+    selectCols,
+    'select',
+    coerceDates,
+    checks,
+    tj,
+    sets,
+    applyDefaults
+  );
 
   const schemaImport = typedJson
     ? `import type { ${T} } from '${typedJson.schemaSpecifier}';\n`
@@ -363,8 +432,11 @@ export class TypeBoxGenerator implements ValidationRenderer<TypeBoxGenerateOptio
     const coerceDates = opts.coerceDates ?? 'input';
     const fileSuffix = opts.fileSuffix ?? DEFAULT_FILE_SUFFIX;
 
+    // `typedColumns` is the wider form of the same idea and implies it: both need the schema
+    // imported back in order to reference what Drizzle inferred.
+    const wantsTypes = opts.typedJson || opts.typedColumns;
     const typedJson =
-      opts.typedJson && opts.schemaPath
+      wantsTypes && opts.schemaPath
         ? {
             schemaSpecifier: resolveConfiguredImport(
               opts.schemaPath,
@@ -372,9 +444,10 @@ export class TypeBoxGenerator implements ValidationRenderer<TypeBoxGenerateOptio
               process.cwd(),
               opts.importExtension
             ),
+            allColumns: !!opts.typedColumns,
           }
         : undefined;
-    if (opts.typedJson && !opts.schemaPath) {
+    if (wantsTypes && !opts.schemaPath) {
       console.warn(
         '[drzl] typedJson was requested but the schema path is unknown, so json columns keep their wide type.'
       );
@@ -382,7 +455,7 @@ export class TypeBoxGenerator implements ValidationRenderer<TypeBoxGenerateOptio
 
     for (const table of this.analysis.tables) {
       const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
-      const code = renderTableSchemas(table, affix, coerceDates, typedJson);
+      const code = renderTableSchemas(table, affix, coerceDates, typedJson, !!opts.applyDefaults);
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
         filePath,
@@ -404,7 +477,13 @@ export class TypeBoxGenerator implements ValidationRenderer<TypeBoxGenerateOptio
   }
 
   renderTable(table: Table, opts?: TypeBoxGenerateOptions) {
-    return renderTableSchemas(table, resolveAffix(opts), opts?.coerceDates ?? 'input');
+    return renderTableSchemas(
+      table,
+      resolveAffix(opts),
+      opts?.coerceDates ?? 'input',
+      undefined,
+      !!opts?.applyDefaults
+    );
   }
 
   private defaultIndex(analysis: Analysis, opts: TypeBoxGenerateOptions) {

--- a/packages/generator-typebox/test/apply-defaults.spec.ts
+++ b/packages/generator-typebox/test/apply-defaults.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * `applyDefaults` in the typebox generator.
+ *
+ * Each library states a default in its own way, so this checks the emitted module *runs* and
+ * fills the value in, rather than that it contains a particular string. `drizzle-orm` reproduces
+ * no defaults in any of its validator modules.
+ *
+ * Only literals: an SQL default (`defaultNow()`, `defaultRandom()`, any `sql`) is evaluated by
+ * the database and a `$defaultFn` is called by Drizzle at insert time, so both stay optional.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { TypeBoxGenerator } from '../src/index';
+import { Value } from '@sinclair/typebox/value';
+
+// `Value.Check` deliberately does not materialise a default; only `Value.Parse` and
+// `Value.Default` do. TypeBox separates validating from defaulting where zod and valibot fold
+// the two together, so the assertion has to go through Parse.
+const RUN = (schema: any, input: unknown) => Value.Parse(schema, input);
+const GEN = TypeBoxGenerator;
+const SUFFIX = '.typebox.ts';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(columns: Column[], applyDefaults: boolean): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-defaults');
+  await fs.mkdir(dir, { recursive: true });
+  await new GEN(analysis).generate({ outDir: dir, applyDefaults } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return await import(file);
+}
+
+const LITERAL = [
+  col('name'),
+  col('country', { hasDefault: true, defaultValue: 'GB' }),
+  col('count', { tsType: 'number', dbType: 'INTEGER', hasDefault: true, defaultValue: 0 }),
+  col('flag', { tsType: 'boolean', dbType: 'BOOLEAN', hasDefault: true, defaultValue: true }),
+];
+
+describe('off by default', () => {
+  it('leaves the fields merely optional', async () => {
+    const m = await schemasFor(LITERAL, false);
+    expect(RUN(m.InserttSchema, { name: 'x' })).toEqual({ name: 'x' });
+  });
+});
+
+describe('with applyDefaults', () => {
+  it('fills every literal in, including the falsy ones', async () => {
+    // `0` and `false` are the values a truthiness check would silently drop.
+    const m = await schemasFor(LITERAL, true);
+    expect(RUN(m.InserttSchema, { name: 'x' })).toEqual({
+      name: 'x',
+      country: 'GB',
+      count: 0,
+      flag: true,
+    });
+  });
+
+  it('leaves a supplied value alone', async () => {
+    const m = await schemasFor(LITERAL, true);
+    expect(RUN(m.InserttSchema, { name: 'x', country: 'FR' })).toMatchObject({ country: 'FR' });
+  });
+
+  it('leaves a column whose default the database evaluates alone', async () => {
+    // `defaultNow()` has `hasDefault` but no literal, so there is nothing to reproduce.
+    const m = await schemasFor([col('name'), col('createdAt', { hasDefault: true })], true);
+    expect(RUN(m.InserttSchema, { name: 'x' })).toEqual({ name: 'x' });
+  });
+
+  it('touches only the insert schema', async () => {
+    // A default applies when a row is created, not when it is updated.
+    const m = await schemasFor(LITERAL, true);
+    expect(RUN(m.UpdatetSchema, {})).toEqual({});
+  });
+});

--- a/packages/generator-typebox/test/typed-columns.spec.ts
+++ b/packages/generator-typebox/test/typed-columns.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * `typedColumns` in the TypeBox generator.
+ *
+ * `.$type<T>()` is a compile-time cast on any column: `text().$type<'admin' | 'member'>()` is an
+ * ordinary string to anything reading the column at runtime, so `drizzle-orm/typebox` and DRZL
+ * alike emitted a plain `Type.String()` and the narrowing was lost.
+ *
+ * `Type.Unsafe<T>(schema)` is TypeBox's own primitive for this: it wraps an existing schema, so
+ * every check it carries still runs and only the inferred type is replaced. That is why this
+ * generator can do what the ArkType one cannot, since ArkType emits one string per field and a
+ * TypeScript type reference has nowhere to live inside a string DSL.
+ */
+import { describe, it, expect } from 'vitest';
+import { TypeBoxGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { Value } from '@sinclair/typebox/value';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function emit(columns: Column[], opts: Record<string, unknown>): Promise<string> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = await fs.mkdtemp(path.join(__dirname, '.tmp-typedcols-'));
+  await new TypeBoxGenerator(analysis).generate({
+    outDir: dir,
+    schemaPath: path.join(dir, '..', 'db', 'schema.ts'),
+    ...opts,
+  } as never);
+  const src = await fs.readFile(path.join(dir, 't.typebox.ts'), 'utf8');
+  await fs.rm(dir, { recursive: true, force: true });
+  return src;
+}
+
+async function schemasFor(columns: Column[], opts: Record<string, unknown>) {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-typedcols-run');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir, ...opts } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), file);
+  return await import(file);
+}
+
+describe('off by default', () => {
+  it('adds nothing when neither option is set', async () => {
+    const src = await emit([col('role', { maxLength: 50 })], {});
+    expect(src).not.toContain('Type.Unsafe');
+    expect(src).not.toContain('import type { t }');
+  });
+
+  it('is not turned on by typedJson, which covers only the untyped columns', async () => {
+    const src = await emit([col('role', { maxLength: 50 })], { typedJson: true });
+    expect(src).not.toContain('Type.Unsafe');
+  });
+});
+
+describe('with typedColumns', () => {
+  it('wraps the schema rather than replacing it', async () => {
+    const src = await emit([col('role', { maxLength: 50 })], { typedColumns: true });
+    expect(src).toMatch(
+      /Type\.Unsafe<\(typeof t\.\$inferSelect\)\[['"]role['"]\]>\(Type\.String\(\{ maxLength: 50 \}\)\)/
+    );
+  });
+
+  it('keeps every runtime check the wrapped schema carried', async () => {
+    // This is the whole point of `Type.Unsafe` over substitution: the checks still run.
+    const m = await schemasFor([col('role', { maxLength: 5 })], {
+      typedColumns: true,
+      schemaPath: path.join(__dirname, '..', 'db', 'schema.ts'),
+    });
+    const f = m.SelecttSchema.properties.role;
+    expect(Value.Check(f, 'admin'), 'within the limit').toBe(true);
+    expect(Value.Check(f, 'toolong'), 'past the limit').toBe(false);
+    expect(Value.Check(f, 5), 'wrong type').toBe(false);
+  });
+
+  it('still substitutes for a column with no runtime type', async () => {
+    // A json column has nothing worth checking, so the reference replaces the schema outright
+    // rather than wrapping a `Type.Unknown()` that says nothing.
+    const src = await emit([col('doc', { tsType: 'any', shape: { kind: 'json' } })], {
+      typedColumns: true,
+    });
+    expect(src).toMatch(
+      /Type\.Unsafe<\(typeof t\.\$inferSelect\)\[['"]doc['"]\]>\(Type\.Unknown\(\)\)/
+    );
+  });
+
+  it('implies typedJson, since both need the schema imported back', async () => {
+    const src = await emit([col('doc', { tsType: 'any', shape: { kind: 'json' } })], {
+      typedColumns: true,
+    });
+    expect(src).toMatch(/import type \{ t \} from/);
+  });
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -229,7 +229,8 @@ function vField(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  sets: ColumnSet[] = []
+  sets: ColumnSet[] = [],
+  applyDefault = false
 ): string {
   let expr = vExprForColumn(c, mode, coerceDates, checks, sets);
   // Drizzle keeps an array on the element's own column class, so everything above describes the
@@ -237,8 +238,15 @@ function vField(
   for (let i = 0; i < (c.arrayDimensions ?? 0); i++) expr = `v.array(${expr})`;
   if (c.nullable) expr = `v.nullable(${expr})`;
   if (mode !== 'select') {
-    // optional for insert when nullable/hasDefault, and for all fields in update
-    if (mode === 'update' || c.nullable || c.hasDefault) expr = `v.optional(${expr})`;
+    // A literal default is reproduced as valibot's second argument to `optional`, which is where
+    // it puts one. `v.optional(schema, value)` already makes the key optional, so this replaces
+    // the plain wrapper rather than nesting inside it.
+    if (mode === 'insert' && applyDefault && c.defaultValue !== undefined) {
+      expr = `v.optional(${expr}, ${JSON.stringify(c.defaultValue)})`;
+    } else if (mode === 'update' || c.nullable || c.hasDefault) {
+      // optional for insert when nullable/hasDefault, and for all fields in update
+      expr = `v.optional(${expr})`;
+    }
   }
   return expr;
 }
@@ -248,17 +256,22 @@ function renderObjectShape(
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  sets: ColumnSet[] = []
+  sets: ColumnSet[] = [],
+  applyDefaults = false
 ) {
   return cols
-    .map((c) => `  ${JSON.stringify(c.name)}: ${vField(c, mode, coerceDates, checks, sets)},`)
+    .map(
+      (c) =>
+        `  ${JSON.stringify(c.name)}: ${vField(c, mode, coerceDates, checks, sets, applyDefaults)},`
+    )
     .join('\n');
 }
 
 function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
-  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
+  applyDefaults = false
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -275,9 +288,30 @@ function renderTableSchemas(
   const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
   const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
-  const bodyInsert = renderObjectShape(insertCols, 'insert', coerceDates, checks, sets);
-  const bodyUpdate = renderObjectShape(updateCols, 'update', coerceDates, checks, sets);
-  const bodySelect = renderObjectShape(selectCols, 'select', coerceDates, checks, sets);
+  const bodyInsert = renderObjectShape(
+    insertCols,
+    'insert',
+    coerceDates,
+    checks,
+    sets,
+    applyDefaults
+  );
+  const bodyUpdate = renderObjectShape(
+    updateCols,
+    'update',
+    coerceDates,
+    checks,
+    sets,
+    applyDefaults
+  );
+  const bodySelect = renderObjectShape(
+    selectCols,
+    'select',
+    coerceDates,
+    checks,
+    sets,
+    applyDefaults
+  );
   // Emitted only where a json column exists, so a file without one gains nothing unused.
   const needsJson = [...insertCols, ...updateCols, ...selectCols].some(
     (c) => c.shape?.kind === 'json'
@@ -325,7 +359,7 @@ export class ValibotGenerator implements ValidationRenderer<ValibotGenerateOptio
     // rename identifiers, never modules, so the barrel and importPath keep resolving.
     for (const table of this.analysis.tables) {
       const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
-      const code = renderTableSchemas(table, affix, coerceDates);
+      const code = renderTableSchemas(table, affix, coerceDates, !!opts.applyDefaults);
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
         filePath,

--- a/packages/generator-valibot/test/apply-defaults.spec.ts
+++ b/packages/generator-valibot/test/apply-defaults.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * `applyDefaults` in the valibot generator.
+ *
+ * Each library states a default in its own way, so this checks the emitted module *runs* and
+ * fills the value in, rather than that it contains a particular string. `drizzle-orm` reproduces
+ * no defaults in any of its validator modules.
+ *
+ * Only literals: an SQL default (`defaultNow()`, `defaultRandom()`, any `sql`) is evaluated by
+ * the database and a `$defaultFn` is called by Drizzle at insert time, so both stay optional.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { ValibotGenerator } from '../src/index';
+import * as v from 'valibot';
+
+const RUN = (schema: any, input: unknown) => v.parse(schema, input);
+const GEN = ValibotGenerator;
+const SUFFIX = '.valibot.ts';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(columns: Column[], applyDefaults: boolean): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-defaults');
+  await fs.mkdir(dir, { recursive: true });
+  await new GEN(analysis).generate({ outDir: dir, applyDefaults } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return await import(file);
+}
+
+const LITERAL = [
+  col('name'),
+  col('country', { hasDefault: true, defaultValue: 'GB' }),
+  col('count', { tsType: 'number', dbType: 'INTEGER', hasDefault: true, defaultValue: 0 }),
+  col('flag', { tsType: 'boolean', dbType: 'BOOLEAN', hasDefault: true, defaultValue: true }),
+];
+
+describe('off by default', () => {
+  it('leaves the fields merely optional', async () => {
+    const m = await schemasFor(LITERAL, false);
+    expect(RUN(m.InserttSchema, { name: 'x' })).toEqual({ name: 'x' });
+  });
+});
+
+describe('with applyDefaults', () => {
+  it('fills every literal in, including the falsy ones', async () => {
+    // `0` and `false` are the values a truthiness check would silently drop.
+    const m = await schemasFor(LITERAL, true);
+    expect(RUN(m.InserttSchema, { name: 'x' })).toEqual({
+      name: 'x',
+      country: 'GB',
+      count: 0,
+      flag: true,
+    });
+  });
+
+  it('leaves a supplied value alone', async () => {
+    const m = await schemasFor(LITERAL, true);
+    expect(RUN(m.InserttSchema, { name: 'x', country: 'FR' })).toMatchObject({ country: 'FR' });
+  });
+
+  it('leaves a column whose default the database evaluates alone', async () => {
+    // `defaultNow()` has `hasDefault` but no literal, so there is nothing to reproduce.
+    const m = await schemasFor([col('name'), col('createdAt', { hasDefault: true })], true);
+    expect(RUN(m.InserttSchema, { name: 'x' })).toEqual({ name: 'x' });
+  });
+
+  it('touches only the insert schema', async () => {
+    // A default applies when a row is created, not when it is updated.
+    const m = await schemasFor(LITERAL, true);
+    expect(RUN(m.UpdatetSchema, {})).toEqual({});
+  });
+});


### PR DESCRIPTION
## `applyDefaults` everywhere

It shipped for zod only. Each library states a default in its own way, and all four now do:

```ts
country: z.string().default("GB"),                        // zod
country: v.optional(v.string(), "GB"),                    // valibot
country: 'string = "GB"',                                 // arktype
country: Type.Optional(Type.String({ default: "GB" })),   // typebox
```

All four parse `{ name: 'x' }` into `{ name: 'x', country: 'GB', count: 0, flag: true }` — the row Postgres writes for the same insert. Checked by **running** the emitted modules, not by reading them, which is what caught the ArkType case: I emit the literal with `JSON.stringify`, so the DSL string ends up `string = "GB"` with double quotes inside, and that had to be confirmed rather than assumed.

One difference worth knowing: TypeBox's `Value.Check` does **not** materialise a default — only `Value.Parse` and `Value.Default` do. It separates validating from defaulting where zod and valibot fold the two together.

## `typedColumns` for TypeBox

```ts
role: Type.Unsafe<(typeof users.$inferSelect)['role']>(Type.String({ maxLength: 50 })),
```

`Type.Unsafe<T>(schema)` wraps an existing schema, so every check it carried still runs and only the inferred type is replaced. Verified: `'admin'` passes, `'toolong'` fails on `maxLength`, `5` fails on type.

That leaves **ArkType as the one generator that cannot do this**, and it is not an oversight: it emits one string per field, and a TypeScript type reference has nowhere to live inside a string DSL.

## Three documented options that did nothing

Found while wiring the above. Each confirmed by generating and reading the output, not by inspecting the code:

| Option | What happened |
|---|---|
| `typedJson` on a `typebox` generator | CLI never passed it; a json column emitted the generic `DrzlJsonValue` regardless of config |
| `coerceDates` on **any** generator | Documented on zod, but the config schema had no such key, so `coerceDates: 'none'` parsed and was dropped. Output kept coercing |
| `applyDefaults` | Reached zod only, for the same reason |

The root cause is structural: each generator branch in the CLI builds its own options object by hand, so an option added to one is simply absent from the others. All four now pass everything they support.

```
before:  createdAt: z.preprocess(...)   // coerceDates: 'none' ignored
after:   createdAt: z.date().optional()
```

## Verification

- 526 tests across 66 files, 21 new, all of them importing and executing the emitted modules
- `verify:packed` green: packed artefacts, 3 dialects x 3 modes against all four official validators, and the database stage (DRZL 920, drizzle-orm 897, further on 0)