### PR TITLE
fix: a varchar(n) limit counts characters, not UTF-16 code units

### DIFF
--- a/.changeset/character-length.md
+++ b/.changeset/character-length.md
@@ -1,0 +1,38 @@
+---
+'@drzl/generator-valibot': minor
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+---
+
+A `varchar(n)` limit counts characters, not UTF-16 code units.
+
+Postgres and MySQL count `varchar(n)` in **characters**. Every JavaScript validator counts
+`.length`, which is UTF-16 code units. The two agree until the text leaves the basic plane, and
+then they do not.
+
+Measured against Postgres through PGlite for a `varchar(10)` column:
+
+| value               | database    | `.max(10)`  |
+| ------------------- | ----------- | ----------- |
+| 10 plain characters | accepts     | accepts     |
+| 8 emoji             | **accepts** | **refuses** |
+| 10 emoji            | **accepts** | **refuses** |
+| 11 emoji            | refuses     | refuses     |
+
+So the generated schema was turning away a bio, display name or message the column would have
+stored quite happily. `drizzle-orm/zod` emits `.max(n)` and does the same.
+
+The zod and valibot generators now count code points, which is what the database counts:
+
+```ts
+name: z.string().refine((v) => [...v].length <= 10, { message: 'at most 10 characters' }),
+```
+
+TypeBox and ArkType keep the UTF-16 form, and it is not an oversight: both state a length
+declaratively with no predicate to hook, so their output stays approximate for astral text. That
+is documented on each.
+
+The probe pool behind the ground-truth stage gained astral characters, since it had none and that
+is why the gate never saw this. It remains a class the gate cannot fail on by itself, because DRZL
+and `drizzle-orm` were wrong in exactly the same way and the gate only fires when DRZL is uniquely
+wrong. Finding it needed the pool to contain a value that tells the two counts apart.

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ packages/*/test/.tmp-custom-*
 packages/*/test/.tmp-typedcols-*
 packages/*/test/.tmp-typedcols-run
 packages/*/test/.tmp-numfmt
+packages/*/test/.tmp-charlen
 packages/*/test/.tmp-rowchecks
 packages/*/test/.tmp-defaults

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -50,6 +50,30 @@ to represent consecutive integers. That is narrower than the column, which holds
 values, but a number above it comes back out of the database as a _different_ number.
 `drizzle-orm/zod` draws the line in the same place.
 
+## Character limits count characters
+
+A `varchar(n)` limit is n **characters**. Every JavaScript validator counts `.length`, which is
+UTF-16 code units, and the two agree only until the text leaves the basic plane:
+
+```ts
+name: z.string().refine((v) => [...v].length <= 10, { message: 'at most 10 characters' }),
+```
+
+Measured against Postgres for a `varchar(10)` column:
+
+| value               | database    | `.max(10)`  | this    |
+| ------------------- | ----------- | ----------- | ------- |
+| 10 plain characters | accepts     | accepts     | accepts |
+| 8 emoji             | **accepts** | **refuses** | accepts |
+| 10 emoji            | **accepts** | **refuses** | accepts |
+| 11 emoji            | refuses     | refuses     | refuses |
+
+`drizzle-orm/zod` emits `.max(n)`, so it turns away a bio, display name or message that the column
+would have stored. The same applies to a `CHECK (length(x) <= n)`.
+
+TypeBox and ArkType keep the UTF-16 form: both state a length declaratively with no predicate to
+hook, so their output is approximate for astral text. The zod and valibot generators are exact.
+
 ## Arrays
 
 A column declared with `.array()` produces a schema for the array, with everything the element

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -197,7 +197,16 @@ function vExprForColumn(
       // See the zod generator: a bare string accepted values Postgres rejects.
       const pattern = c.format ? COLUMN_FORMATS[c.format] : undefined;
       if (pattern) return piped('v.string()', [`v.regex(new RegExp(${JSON.stringify(pattern)}))`]);
-      return piped('v.string()', c.maxLength ? [`v.maxLength(${c.maxLength})`] : []);
+      // Not `v.maxLength(n)`, which counts UTF-16 units where the column counts characters. See
+      // the zod generator and `CODEPOINT_LENGTH` in validation-core.
+      return piped(
+        'v.string()',
+        c.maxLength
+          ? [
+              `v.check((val) => [...val].length <= ${c.maxLength}, 'at most ${c.maxLength} characters')`,
+            ]
+          : []
+      );
     case 'number': {
       return piped('v.number()', [
         ...(isIntegerColumn(c) ? ['v.integer()'] : []),

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -162,7 +162,12 @@ function zodExprForColumn(
       // not. Only formats verified against Postgres appear here, so nothing valid is turned away.
       const pattern = c.format ? COLUMN_FORMATS[c.format] : undefined;
       if (pattern) return `z.string().regex(new RegExp(${JSON.stringify(pattern)}))`;
-      return c.maxLength ? `z.string().max(${c.maxLength})` : 'z.string()';
+      // Not `.max(n)`. A `varchar(n)` limit is n *characters*, and `.max` counts UTF-16 units, so
+      // it refuses eight emoji in a `varchar(10)` the database is happy with. See
+      // `CODEPOINT_LENGTH` in validation-core for the measurements.
+      return c.maxLength
+        ? `z.string().refine((v) => [...v].length <= ${c.maxLength}, { message: 'at most ${c.maxLength} characters' })`
+        : 'z.string()';
     case 'number': {
       const base = isIntegerColumn(c) ? 'z.number().int()' : 'z.number()';
       return base + numericBounds(c, (v) => v);

--- a/packages/generator-zod/test/character-length.spec.ts
+++ b/packages/generator-zod/test/character-length.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * A `varchar(n)` limit counts characters, not UTF-16 code units.
+ *
+ * Postgres and MySQL count `varchar(n)` in characters. Every JavaScript validator counts
+ * `.length`, which is UTF-16 code units. The two agree until the text leaves the basic plane, and
+ * then they do not, so `z.string().max(10)` refuses eight emoji that `varchar(10)` accepts.
+ *
+ * Measured against Postgres through PGlite, for `varchar(10)`:
+ *
+ *    3 emoji   db accepts    .max(10) accepts
+ *    8 emoji   db accepts    .max(10) REFUSES
+ *   10 emoji   db accepts    .max(10) REFUSES
+ *   11 emoji   db refuses    .max(10) refuses
+ *
+ * `[...v].length` counts code points, which is what the database counts, and agrees on all four.
+ * `drizzle-orm/zod` emits `.max(n)` and refuses the middle two.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const THUMB = '\u{1F44D}'; // one code point, two UTF-16 units
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(columns: Column[]): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-charlen');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return await import(file);
+}
+
+describe('a varchar(10) column', () => {
+  it('accepts what the database accepts, emoji included', async () => {
+    const m = await schemasFor([col('name', { maxLength: 10 })]);
+    const f = m.SelecttSchema.shape.name;
+
+    expect(f.safeParse('abcdefghij').success, 'ten plain characters').toBe(true);
+    expect(f.safeParse('abcdefghijk').success, 'eleven plain characters').toBe(false);
+
+    // The cases `.max(10)` gets wrong: eight emoji are eight characters to the database and
+    // sixteen UTF-16 units to JavaScript.
+    expect(f.safeParse(THUMB.repeat(8)).success, 'eight emoji, which the database accepts').toBe(
+      true
+    );
+    expect(f.safeParse(THUMB.repeat(10)).success, 'ten emoji, exactly at the limit').toBe(true);
+    expect(f.safeParse(THUMB.repeat(11)).success, 'eleven emoji, past the limit').toBe(false);
+  });
+
+  it('counts a combining sequence the way the database does', async () => {
+    // A family emoji is five code points joined by zero-width joiners. Postgres counts five.
+    const family = '\u{1F468}‍\u{1F469}‍\u{1F467}';
+    expect([...family].length, 'five code points').toBe(5);
+    expect(family.length, 'eight UTF-16 units').toBe(8);
+
+    const m = await schemasFor([col('name', { maxLength: 5 })]);
+    expect(m.SelecttSchema.shape.name.safeParse(family).success).toBe(true);
+  });
+
+  it('leaves an unbounded string alone', async () => {
+    const m = await schemasFor([col('bio')]);
+    expect(m.SelecttSchema.shape.bio.safeParse(THUMB.repeat(500)).success).toBe(true);
+  });
+});

--- a/packages/generator-zod/test/column-fidelity.spec.ts
+++ b/packages/generator-zod/test/column-fidelity.spec.ts
@@ -52,14 +52,34 @@ async function emit(columns: Column[]): Promise<string> {
 async function exprFor(over: Partial<Column>): Promise<string> {
   const src = await emit([col('x', over)]);
   const block = src.match(/SelecttSchema = z\.object\(\{([\s\S]*?)\n\}\)/)?.[1] ?? src;
-  const line = block.split('\n').find((l) => /^\s*x:/.test(l));
-  expect(line, `no field 'x' in:\n${src}`).toBeTruthy();
-  return line!.trim().replace(/^x:\s*/, '').replace(/,$/, '');
+  // Collapsed to one line first: prettier wraps a long expression across several, and a
+  // line-based match would silently return only its first fragment.
+  // Collapsed to one line, and the space prettier leaves before a wrapped `.` removed with
+  // it, so the expectation reads as the expression would be written by hand.
+  const flat = block.replace(/\s+/g, ' ').replace(/\s+\./g, '.').replace(/\(\s+/g, '(');
+  const at = flat.indexOf('x: ');
+  expect(at, `no field 'x' in:\n${src}`).toBeGreaterThanOrEqual(0);
+  let i = at + 3;
+  let depth = 0;
+  const from = i;
+  for (; i < flat.length; i++) {
+    const ch = flat[i];
+    if ('([{'.includes(ch)) depth++;
+    else if (')]}'.includes(ch)) depth--;
+    else if (ch === ',' && depth === 0) break;
+  }
+  // Whitespace is prettier's to decide, so it is normalised away entirely.
+  return flat.slice(from, i).trim();
 }
 
 describe('string length', () => {
-  it('enforces a varchar limit', async () => {
-    expect(await exprFor({ tsType: 'string', maxLength: 255 })).toBe('z.string().max(255)');
+  it('enforces a varchar limit, counting characters rather than UTF-16 units', async () => {
+    // Deliberately not `.max(255)`, which is what `drizzle-orm/zod` emits. A `varchar(n)` limit
+    // is n *characters*, and `.max` counts `.length`. Measured against Postgres for
+    // `varchar(10)`: the database accepts eight emoji and `.max(10)` refuses them.
+    expect(await exprFor({ tsType: 'string', maxLength: 255 })).toMatch(
+      /^z\.string\(\)\.refine\(\(v\) => \[\.\.\.v\]\.length <= 255, \{ message: ['"]at most 255 characters['"] \}\)$/
+    );
   });
 
   it('leaves an unbounded string alone', async () => {
@@ -81,9 +101,9 @@ describe('uuid', () => {
 
 describe('integer range', () => {
   it('bounds a smallint', async () => {
-    expect(await exprFor({ tsType: 'number', dbType: 'INTEGER', min: '-32768', max: '32767' })).toBe(
-      'z.number().int().gte(-32768).lte(32767)'
-    );
+    expect(
+      await exprFor({ tsType: 'number', dbType: 'INTEGER', min: '-32768', max: '32767' })
+    ).toBe('z.number().int().gte(-32768).lte(32767)');
   });
 
   it('bounds an integer', async () => {
@@ -123,7 +143,9 @@ describe('integer range', () => {
 describe('composition with the rest of the schema', () => {
   it('applies nullability after the constraint', async () => {
     const e = await exprFor({ tsType: 'string', maxLength: 10, nullable: true });
-    expect(e).toBe('z.string().max(10).nullable()');
+    expect(e).toMatch(
+      /^z\.string\(\)\.refine\(\(v\) => \[\.\.\.v\]\.length <= 10, \{ message: ['"]at most 10 characters['"] \}\)\.nullable\(\)$/
+    );
   });
 
   it('still parses as TypeScript', async () => {

--- a/packages/generator-zod/test/typed-columns.spec.ts
+++ b/packages/generator-zod/test/typed-columns.spec.ts
@@ -48,7 +48,9 @@ async function emit(columns: Column[], opts: Record<string, unknown>): Promise<s
 /** The select field for one column, collapsed to a single line. */
 const selectField = (src: string, name: string) => {
   const block = src.match(/SelecttSchema = z\.object\(\{([\s\S]*?)\n\}\)/)?.[1] ?? '';
-  const flat = block.replace(/\s+/g, ' ');
+  // Collapsed to one line, and the space prettier leaves before a wrapped `.` removed with
+  // it, so the expectation reads as the expression would be written by hand.
+  const flat = block.replace(/\s+/g, ' ').replace(/\s+\./g, '.').replace(/\(\s+/g, '(');
   const at = flat.indexOf(`${name}: `);
   if (at === -1) return '';
   let i = at + `${name}: `.length;
@@ -72,7 +74,11 @@ describe('off by default', () => {
 
   it('is not turned on by typedJson, which covers only the untyped columns', async () => {
     const src = await emit([col('role', { maxLength: 50 })], { typedJson: true });
-    expect(selectField(src, 'role')).toBe('z.string().max(50)');
+    // Quote style is prettier's to decide, and it resolves a different config depending on where
+    // the file is written, so the assertion accepts either.
+    expect(selectField(src, 'role')).toMatch(
+      /^z\.string\(\)\.refine\(\(v\) => \[\.\.\.v\]\.length <= 50, \{ message: ['"]at most 50 characters['"] \}\)$/
+    );
   });
 });
 
@@ -81,7 +87,7 @@ describe('with typedColumns', () => {
     const src = await emit([col('role', { maxLength: 50 })], { typedColumns: true });
     // The length check survives; only the static type changes.
     expect(selectField(src, 'role')).toMatch(
-      /^z\.string\(\)\.max\(50\)\.pipe\(z\.custom<\(typeof t\.\$inferSelect\)\[['"]role['"]\]>\(\)\)$/
+      /^z\.string\(\)\.refine\(.*\)\.pipe\(z\.custom<\(typeof t\.\$inferSelect\)\[['"]role['"]\]>\(\)\)$/
     );
   });
 

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -173,6 +173,29 @@ export const COLUMN_FORMATS: Record<string, string> = {
     '|[+-]?(NaN|Infinity))\\s*$',
 };
 
+/**
+ * Why a character limit is not `.max(n)`.
+ *
+ * Postgres and MySQL count `varchar(n)` in **characters**; every JavaScript validator counts
+ * `.length`, which is UTF-16 code units. They agree until the text leaves the basic plane, and
+ * then they do not: `varchar(10)` accepts ten emoji, and `.max(10)` refuses eight of them.
+ *
+ * Verified against Postgres through PGlite, for `varchar(10)`:
+ *
+ *   3 emoji   db accepts   .max(10) accepts
+ *   8 emoji   db accepts   .max(10) REFUSES
+ *  10 emoji   db accepts   .max(10) REFUSES
+ *  11 emoji   db refuses   .max(10) refuses
+ *
+ * `[...v].length` counts code points, which is what the database counts, and matches on all four.
+ * Refusing a user's emoji is the failure mode this avoids, and it is the same rule applied
+ * everywhere else here: never reject what the database accepts.
+ *
+ * `@sinclair/typebox` and ArkType cannot express it. Both state a length declaratively with no
+ * predicate to hook, so they keep the UTF-16 form and are documented as approximate.
+ */
+export const CODEPOINT_LENGTH = '[...v].length';
+
 export function isIntegerColumn(c: Column): boolean {
   if (typeof c.integer === 'boolean') return c.integer;
   return c.dbType === 'INTEGER' || (c.min !== undefined && c.max !== undefined);

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -549,6 +549,11 @@ import { matrix as sqTable } from './schema-sqlite.js';
 const POOL: [string, unknown][] = [
   ['null', null], ['undefined', undefined], ['""', ''], ["'hello'", 'hello'],
   ['300-char', 'x'.repeat(300)], ['70k-char', 'x'.repeat(70000)], ['5-char', 'xxxxx'],
+  // Astral-plane characters, where a code-point count and a UTF-16 `.length` disagree.
+  // Postgres counts characters for `varchar(n)`, so a 3-emoji string fits in a varchar(5)
+  // that every library's `.max(5)` refuses.
+  ['3 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}'],
+  ['5 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}'],
   ["'not-a-uuid'", 'not-a-uuid'], ['uuid', '3f2504e0-4f89-11d3-9a0c-0305e82c3301'],
   ["'zzz'", 'zzz'], ["'a'", 'a'], ["'happy'", 'happy'],
   ['0', 0], ['1', 1], ['1.5', 1.5], ['-1', -1], ['200', 200], ['40000', 40000],
@@ -626,6 +631,10 @@ const ALLOWED: Record<string, string> = {
   // for rather than ignoring it, so that schema rejects every valid uuid in any project that has
   // not populated `FormatRegistry` first. This generator emits a pattern, which needs no setup.
   'typebox/c_uuid': 'official uses an unregistered `format`, which rejects every uuid',
+  // A character limit counts *characters*; official counts `.length`, which is UTF-16 units, so
+  // it refuses three emoji in a `char(4)` the database accepts. Measured against Postgres.
+  c_char: 'character limit counts code points; official counts UTF-16 units',
+  m_char: 'as c_char',
   // Stricter than official, and verified against Postgres itself through PGlite: a `numeric`
   // column is a string, and a bare string schema accepts 'hello' where the database rejects it.
   // Official accepts all of these; the database does not.
@@ -647,7 +656,14 @@ const ALLOWED: Record<string, string> = {
 const allowed = (lib: string, col: string) => ALLOWED[`${lib}/${col}`] ?? ALLOWED[col];
 
 /** Cross-generator gaps that follow from what each library can express, not from a defect. */
-const CROSS_ALLOWED = (k: string) => k.startsWith('c_json') || k.startsWith('c_jsonb') || /bigint_b|blob_bigint/.test(k);
+const CROSS_ALLOWED = (k: string) =>
+  k.startsWith('c_json') ||
+  k.startsWith('c_jsonb') ||
+  /bigint_b|blob_bigint/.test(k) ||
+  // zod and valibot count code points for a character limit; TypeBox and ArkType state a length
+  // declaratively with no predicate to hook, so they keep the UTF-16 form and stay approximate for
+  // astral text. A capability difference between the libraries, not a defect in one generator.
+  k === 'c_char';
 
 const DIALECTS = [
   {
@@ -912,6 +928,11 @@ const POOL: [string, unknown][] = [
   ['1e9', 1e9], ['1e300', 1e300], ['9007199254740993', 9007199254740993],
   ['NaN', NaN], ['Infinity', Infinity],
   ["''", ''], ["'hello'", 'hello'], ['300-char', 'x'.repeat(300)],
+  // Astral-plane characters, where a code-point count and a UTF-16 `.length` disagree. Postgres
+  // counts *characters* for `varchar(n)`, so a 3-emoji string fits in a `varchar(5)` that every
+  // library's `.max(5)` refuses. Without these in the pool the gate cannot see that.
+  ['3 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}'],
+  ['5 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}'],
   ["'0101'", '0101'], ["'010'", '010'], ["'12.5'", '12.5'], ["'1_000'", '1_000'], ["'0x1f'", '0x1f'],
   ['uuid', '3f2504e0-4f89-11d3-9a0c-0305e82c3301'], ["'not-a-uuid'", 'not-a-uuid'],
   ["'happy'", 'happy'], ["'zzz'", 'zzz'],


### PR DESCRIPTION
Postgres and MySQL count `varchar(n)` in **characters**. Every JavaScript validator counts `.length`, which is UTF-16 code units. The two agree until the text leaves the basic plane, and then they do not.

Measured against Postgres through PGlite, for a `varchar(10)` column:

| value | database | `.max(10)` | now |
| --- | --- | --- | --- |
| 10 plain characters | accepts | accepts | accepts |
| 8 emoji | **accepts** | **refuses** | accepts |
| 10 emoji | **accepts** | **refuses** | accepts |
| 11 emoji | refuses | refuses | refuses |

The generated schema was turning away a bio, display name or message the column would have stored quite happily. `drizzle-orm/zod` emits `.max(n)` and does exactly the same.

```ts
name: z.string().refine((v) => [...v].length <= 10, { message: 'at most 10 characters' }),
```

## Why only zod and valibot

TypeBox and ArkType keep the UTF-16 form. That is not an oversight: both state a length declaratively with no predicate to hook, so there is nowhere to put a code-point count. Their output stays approximate for astral text, and it is documented on each. All four libraries' built-in length checks were verified to use `.length`, so none of them could express this natively.

## What this says about the gate

The ground-truth stage did not catch it, and could not have: DRZL and `drizzle-orm` were wrong in **exactly the same way**, and the gate only fires when DRZL is uniquely wrong. That is the documented limitation, working as designed.

What was missing was the probe pool, which had no astral characters at all, so no value in it could tell a code-point count from a UTF-16 one. The pool now carries them, which is the actual regression guard here.

```
before:  1287 probes, DRZL 920, drizzle-orm 897, closer on 23
after:   1365 probes, DRZL 974, drizzle-orm 946, closer on 28
```

## Verification

- 529 tests across 67 files, 3 new, asserting the emoji cases behaviourally rather than on emitted text
- `verify:packed` green across all four generators, three dialects, three modes, and the database stage