### PR TITLE
feat: enforce CHECK (length(col)), counted in characters

### DIFF
--- a/.changeset/length-checks.md
+++ b/.changeset/length-checks.md
@@ -1,0 +1,32 @@
+---
+'@drzl/generator-valibot': minor
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+---
+
+`CHECK (length(col) <op> n)` is now enforced, counted in characters.
+
+The one function call the check parser reads, because the mapping is exact:
+
+```ts
+// check('name_len', sql`length(${t.name}) >= 3 AND length(${t.name}) <= 8`)
+name: z.string()
+  .refine((v) => [...v].length >= 3, { message: 'name_len: length(name) >= 3' })
+  .refine((v) => [...v].length <= 8, { message: 'name_len: length(name) <= 8' }),
+```
+
+`char_length` is the same function in Postgres and is read too. Counted in code points, for the
+same reason a `varchar(n)` limit is: Postgres counts characters and `.length` counts UTF-16 units.
+Verified against Postgres for `CHECK (length(name) >= 3 AND length(name) <= 8)`, which agrees on
+all eight probes including three, eight and nine emoji.
+
+`octet_length` is deliberately **not** read: it counts bytes, which depends on the encoding and
+cannot be derived from a JavaScript string without choosing one. Nor is `lower`, which would need
+a locale to be faithful. The rule is unchanged, only its reach: read what maps exactly, refuse the
+rest rather than guess.
+
+TypeBox and ArkType do not carry these, for the same reason they carry an approximate `varchar(n)`:
+both state constraints declaratively with no predicate to hook. Each generator's docs say so.
+
+The parity probe pool gained astral characters as well, so a cross-generator disagreement about
+character counting is visible rather than invisible.

--- a/docs/generators/arktype.md
+++ b/docs/generators/arktype.md
@@ -88,6 +88,19 @@ comparison operators take numeric literals, so a 64 bit bound cannot be written 
 DSL at all; `drizzle-orm/arktype` states it through a narrow predicate built with the builder
 API instead. Every other column type is bounded here exactly as the official module bounds it.
 
+## Character limits are approximate
+
+A `varchar(n)` limit is n **characters**, and ArkType's `string <= n` counts `.length`, which is
+UTF-16 code units. The two agree until the text leaves the basic plane: a `varchar(10)` column
+accepts ten emoji, and `string <= 10` refuses eight of them.
+
+ArkType states a length declaratively and this generator emits one string per field, so there is
+nowhere to put a code-point count. The zod and valibot generators are exact here; pair one of them
+with this generator if your columns hold emoji or other astral-plane text near their limit.
+
+See [Zod, character limits](/generators/zod#character-limits-count-characters) for the
+measurements against Postgres.
+
 ## `applyDefaults`
 
 Drizzle knows what a column defaults to, and `drizzle-orm` reproduces none of them.

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -122,6 +122,19 @@ The generator itself is unaffected: TypeBox schemas are the right choice whereve
 yourself, or hand them to something that speaks JSON Schema. Pair it with a `zod` generator if you
 also want oRPC routers in the same project.
 
+## Character limits are approximate
+
+A `varchar(n)` limit is n **characters**, and TypeBox's `maxLength` counts `.length`, which is
+UTF-16 code units. The two agree until the text leaves the basic plane: a `varchar(10)` column
+accepts ten emoji, and `maxLength: 10` refuses eight of them.
+
+JSON Schema defines `maxLength` in code points, so this is TypeBox's implementation rather than
+the spec, and there is no predicate to hook in a declarative schema. The zod and valibot
+generators are exact here.
+
+See [Zod, character limits](/generators/zod#character-limits-count-characters) for the
+measurements against Postgres.
+
 ## `applyDefaults`
 
 Drizzle knows what a column defaults to, and `drizzle-orm` reproduces none of them.

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -89,6 +89,18 @@ instance such as a `Date` is refused rather than being rebuilt as an empty objec
 See [Zod → Structured columns](/generators/zod#structured-columns) for why `bytea` is typed as a
 `Uint8Array`.
 
+## Character limits count characters
+
+A `varchar(n)` limit is n **characters**, and `v.maxLength` counts `.length`, which is UTF-16 code
+units. This generator emits a code-point check instead, so it accepts the emoji the column does:
+
+```ts
+name: v.pipe(v.string(), v.check((val) => [...val].length <= 10, 'at most 10 characters')),
+```
+
+See [Zod, character limits](/generators/zod#character-limits-count-characters) for the
+measurements against Postgres.
+
 ## `applyDefaults`
 
 Drizzle knows what a column defaults to, and `drizzle-orm` reproduces none of them.

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -213,16 +213,32 @@ The split walks the expression rather than splitting on the text, so the `AND` i
 and the one inside `'A AND B'` are both left alone. If any single part is not understood, the
 whole constraint is skipped: enforcing half of a constraint is enforcing a different one.
 
+### `length()` becomes a character count
+
+```ts
+// check('name_len', sql`length(${t.name}) >= 3 AND length(${t.name}) <= 8`)
+name: z.string()
+  .refine((v) => [...v].length >= 3, { message: 'name_len: length(name) >= 3' })
+  .refine((v) => [...v].length <= 8, { message: 'name_len: length(name) <= 8' }),
+```
+
+The one function call the parser reads, because the mapping is exact. `char_length` is the same
+function and is read too. Counted in code points, so it agrees with the database on emoji.
+
+`octet_length` is **not** read: it counts bytes, which depends on the encoding and cannot be
+derived from a JavaScript string without choosing one. Neither is `lower`, which would need a
+locale to be faithful.
+
 **Only unambiguous constraints are translated.** These are skipped rather than guessed at:
 
-| Skipped                       | Why                                                       |
-| ----------------------------- | --------------------------------------------------------- |
-| `start_date < end_date`       | A statement about the row, not about either field         |
-| `age >= 18 OR age <= 65`      | A disjunction cannot be split the way a conjunction can   |
-| `NOT (age >= 18)`             | Same: negation changes the scope of everything inside it  |
-| `age >= 18 AND length(n) > 3` | One part is not understood, so neither is enforced        |
-| `length(name) > 3`            | Function call                                             |
-| `email ~ '^[a-z]+$'`          | Postgres `~` is POSIX ERE, not JavaScript's regex dialect |
+| Skipped                       | Why                                                      |
+| ----------------------------- | -------------------------------------------------------- |
+| `start_date < end_date`       | A statement about the row, not about either field        |
+| `age >= 18 OR age <= 65`      | A disjunction cannot be split the way a conjunction can  |
+| `NOT (age >= 18)`             | Same: negation changes the scope of everything inside it |
+| `age >= 18 AND length(n) > 3` | One part is not understood, so neither is enforced       |
+
+| `email ~ '^[a-z]+$'` | Postgres `~` is POSIX ERE, not JavaScript's regex dialect |
 
 A schema that quietly enforces a _guess_ at your constraint is worse than one enforcing nothing,
 because it rejects rows the database would have accepted.

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -4,7 +4,7 @@ import type {
   ValidationRenderer,
   ValidationGenerateOptions,
 } from '@drzl/validation-core';
-import type { ColumnCheck, ColumnSet } from '@drzl/validation-core';
+import type { ColumnCheck, ColumnSet, LengthCheck } from '@drzl/validation-core';
 import {
   COLUMN_FORMATS,
   insertColumns,
@@ -162,12 +162,38 @@ function vShapeExpr(c: Column): string | undefined {
   }
 }
 
+/**
+ * `v.check(...)` actions for the `length(col)` constraints naming this column.
+ *
+ * Code points, because Postgres counts characters. See the zod generator.
+ */
+function vLengthChecks(c: Column, lengths: LengthCheck[]): string[] {
+  if (c.arrayDimensions || c.shape) return [];
+  const OPS: Record<LengthCheck['operator'], string> = {
+    '>=': '>=',
+    '>': '>',
+    '<=': '<=',
+    '<': '<',
+    '=': '===',
+    '<>': '!==',
+  };
+  return lengths
+    .filter((k) => k.column === c.name)
+    .map((k) => {
+      const msg = JSON.stringify(
+        `${k.name ? `${k.name}: ` : ''}length(${c.name}) ${k.operator} ${k.value}`
+      );
+      return `v.check((val) => [...val].length ${OPS[k.operator]} ${k.value}, ${msg})`;
+    });
+}
+
 function vExprForColumn(
   c: Column,
   mode: Mode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
-  sets: ColumnSet[] = []
+  sets: ColumnSet[] = [],
+  lengths: LengthCheck[] = []
 ): string {
   const shaped = vShapeExpr(c);
   if (shaped) return shaped;
@@ -178,7 +204,7 @@ function vExprForColumn(
       ? `v.picklist([${set.values.map((v) => JSON.stringify(v)).join(', ')}] as const)`
       : `v.union([${set.values.map((v) => `v.literal(${v})`).join(', ')}])`;
   }
-  const extra = vChecks(c, checks);
+  const extra = [...vChecks(c, checks), ...vLengthChecks(c, lengths)];
   /** Fold the constraint actions into whatever base this column maps to. */
   const piped = (base: string, actions: string[]) => {
     const all = [...actions, ...extra];
@@ -239,9 +265,10 @@ function vField(
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
   sets: ColumnSet[] = [],
-  applyDefault = false
+  applyDefault = false,
+  lengths: LengthCheck[] = []
 ): string {
-  let expr = vExprForColumn(c, mode, coerceDates, checks, sets);
+  let expr = vExprForColumn(c, mode, coerceDates, checks, sets, lengths);
   // Drizzle keeps an array on the element's own column class, so everything above describes the
   // element and the wrapping belongs out here, after the bounds and length limits are attached.
   for (let i = 0; i < (c.arrayDimensions ?? 0); i++) expr = `v.array(${expr})`;
@@ -266,12 +293,13 @@ function renderObjectShape(
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   checks: ColumnCheck[] = [],
   sets: ColumnSet[] = [],
-  applyDefaults = false
+  applyDefaults = false,
+  lengths: LengthCheck[] = []
 ) {
   return cols
     .map(
       (c) =>
-        `  ${JSON.stringify(c.name)}: ${vField(c, mode, coerceDates, checks, sets, applyDefaults)},`
+        `  ${JSON.stringify(c.name)}: ${vField(c, mode, coerceDates, checks, sets, applyDefaults, lengths)},`
     )
     .join('\n');
 }
@@ -297,13 +325,15 @@ function renderTableSchemas(
   const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
   const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
+  const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
   const bodyInsert = renderObjectShape(
     insertCols,
     'insert',
     coerceDates,
     checks,
     sets,
-    applyDefaults
+    applyDefaults,
+    lengths
   );
   const bodyUpdate = renderObjectShape(
     updateCols,
@@ -311,7 +341,8 @@ function renderTableSchemas(
     coerceDates,
     checks,
     sets,
-    applyDefaults
+    applyDefaults,
+    lengths
   );
   const bodySelect = renderObjectShape(
     selectCols,
@@ -319,7 +350,8 @@ function renderTableSchemas(
     coerceDates,
     checks,
     sets,
-    applyDefaults
+    applyDefaults,
+    lengths
   );
   // Emitted only where a json column exists, so a file without one gains nothing unused.
   const needsJson = [...insertCols, ...updateCols, ...selectCols].some(

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -4,7 +4,7 @@ import type {
   ValidationGenerateOptions,
   ValidationRenderer,
 } from '@drzl/validation-core';
-import type { ColumnCheck, ColumnSet, RowCheck } from '@drzl/validation-core';
+import type { ColumnCheck, ColumnSet, LengthCheck, RowCheck } from '@drzl/validation-core';
 import {
   formatCode,
   parseCheck,
@@ -53,6 +53,33 @@ function numericBounds(c: Column, literal: (v: string) => string): string {
  * skipped by the parser rather than guessed at. The message names the constraint, so a failure
  * points at the thing in the schema that caused it.
  */
+/**
+ * `.refine()` calls for the `length(col)` constraints naming this column.
+ *
+ * Counted in code points, because Postgres counts characters. The same reason `varchar(n)` is not
+ * `.max(n)`: `.length` is UTF-16 units and would refuse text the database accepts.
+ */
+function lengthRefinements(c: Column, lengths: LengthCheck[]): string {
+  if (c.arrayDimensions || c.shape) return [].join('');
+  const OPS: Record<LengthCheck['operator'], string> = {
+    '>=': '>=',
+    '>': '>',
+    '<=': '<=',
+    '<': '<',
+    '=': '===',
+    '<>': '!==',
+  };
+  return lengths
+    .filter((k) => k.column === c.name)
+    .map((k) => {
+      const msg = JSON.stringify(
+        `${k.name ? `${k.name}: ` : ''}length(${c.name}) ${k.operator} ${k.value}`
+      );
+      return `.refine((v) => [...v].length ${OPS[k.operator]} ${k.value}, { message: ${msg} })`;
+    })
+    .join('');
+}
+
 function checkRefinements(c: Column, checks: ColumnCheck[]): string {
   // A parsed check compares this column to a scalar literal, which says nothing usable about an
   // array or a tuple. Emitting one anyway was actively harmful: `CHECK (tags = '{}')` became
@@ -212,6 +239,7 @@ function zodField(
   typedJsonRef?: string,
   sets: ColumnSet[] = [],
   applyDefault = false,
+  lengths: LengthCheck[] = [],
   /**
    * A reference to Drizzle's inferred type for a column that already has a runtime schema.
    *
@@ -230,6 +258,7 @@ function zodField(
   // wrapping the constrained type in `.nullable()` reproduces that exactly: null skips the
   // check, as the database does.
   expr += checkRefinements(c, checks);
+  expr += lengthRefinements(c, lengths);
   // For selects, nullable columns should allow null values
   if (c.nullable) {
     expr = `${expr}.nullable()`;
@@ -263,7 +292,8 @@ function renderObjectShape(
   checks: ColumnCheck[] = [],
   typedJson?: { table: string; mode: 'insert' | 'select'; allColumns?: boolean },
   sets: ColumnSet[] = [],
-  applyDefaults = false
+  applyDefaults = false,
+  lengths: LengthCheck[] = []
 ) {
   return cols
     .map((c) => {
@@ -275,7 +305,7 @@ function renderObjectShape(
       const replaces = c.tsType === 'any' || c.shape?.kind === 'custom';
       const ref = typedJson && replaces ? refFor(typedJson) : undefined;
       const narrow = typedJson?.allColumns && !replaces ? refFor(typedJson) : undefined;
-      return `  ${JSON.stringify(c.name)}: ${zodField(c, mode, coerceDates, checks, ref, sets, applyDefaults, narrow)},`;
+      return `  ${JSON.stringify(c.name)}: ${zodField(c, mode, coerceDates, checks, ref, sets, applyDefaults, lengths, narrow)},`;
     })
     .join('\n');
 }
@@ -344,6 +374,7 @@ function renderTableSchemas(
   const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
   const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
+  const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
   // Insert and select can disagree: a json column with a default is optional on insert, so its
   // inferred type differs. Each shape therefore references the matching inference.
   const tj = typedJson
@@ -359,7 +390,8 @@ function renderTableSchemas(
     checks,
     tjInsert,
     sets,
-    applyDefaults
+    applyDefaults,
+    lengths
   );
   const bodyUpdate = renderObjectShape(
     updateCols,
@@ -368,7 +400,8 @@ function renderTableSchemas(
     checks,
     tjInsert,
     sets,
-    applyDefaults
+    applyDefaults,
+    lengths
   );
   const bodySelect = renderObjectShape(
     selectCols,
@@ -377,7 +410,8 @@ function renderTableSchemas(
     checks,
     tj,
     sets,
-    applyDefaults
+    applyDefaults,
+    lengths
   );
   // A type-only import: it disappears at build time, so this adds no runtime dependency on the
   // schema module and cannot create an import cycle at runtime.

--- a/packages/generator-zod/test/character-length.spec.ts
+++ b/packages/generator-zod/test/character-length.spec.ts
@@ -84,3 +84,58 @@ describe('a varchar(10) column', () => {
     expect(m.SelecttSchema.shape.bio.safeParse(THUMB.repeat(500)).success).toBe(true);
   });
 });
+
+describe('a CHECK on length()', () => {
+  // The one function call the check parser reads, because a character count maps exactly. Counted
+  // in code points for the same reason `varchar(n)` is. Verified against Postgres for
+  // `CHECK (length(name) >= 3 AND length(name) <= 8)`: agrees on all eight probes, emoji included.
+  const withCheck = async (expression: string) => {
+    const analysis: Analysis = {
+      dialect: 'postgres',
+      tables: [
+        {
+          name: 't',
+          tsName: 't',
+          columns: [col('name')],
+          unique: [],
+          indexes: [],
+          checks: [{ name: 'name_len', expression }],
+        },
+      ] as never,
+      enums: [],
+      relations: [],
+      issues: [],
+    };
+    const dir = path.join(__dirname, '.tmp-charlen');
+    await fs.mkdir(dir, { recursive: true });
+    await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+    const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+    await fs.rename(path.join(dir, 't.zod.ts'), file);
+    return await import(file);
+  };
+
+  it('enforces the bound in characters', async () => {
+    const m = await withCheck('length(name) >= 3 AND length(name) <= 8');
+    const f = m.SelecttSchema.shape.name;
+    expect(f.safeParse('ab').success, 'two characters').toBe(false);
+    expect(f.safeParse('abc').success, 'three').toBe(true);
+    expect(f.safeParse('abcdefgh').success, 'eight').toBe(true);
+    expect(f.safeParse('abcdefghi').success, 'nine').toBe(false);
+  });
+
+  it('counts emoji as one character each, as the database does', async () => {
+    const m = await withCheck('length(name) >= 3 AND length(name) <= 8');
+    const f = m.SelecttSchema.shape.name;
+    expect(f.safeParse(THUMB.repeat(2)).success, 'two emoji').toBe(false);
+    expect(f.safeParse(THUMB.repeat(3)).success, 'three emoji').toBe(true);
+    // Sixteen UTF-16 units, which a `.max(8)` would have refused.
+    expect(f.safeParse(THUMB.repeat(8)).success, 'eight emoji').toBe(true);
+    expect(f.safeParse(THUMB.repeat(9)).success, 'nine emoji').toBe(false);
+  });
+
+  it('names the constraint in the message, so a failure points at the schema', async () => {
+    const m = await withCheck('length(name) >= 3');
+    const r = m.SelecttSchema.safeParse({ name: 'ab' });
+    expect(r.error.issues[0].message).toBe('name_len: length(name) >= 3');
+  });
+});

--- a/packages/validation-core/src/checks.ts
+++ b/packages/validation-core/src/checks.ts
@@ -59,13 +59,39 @@ export interface RowCheck {
   name?: string;
 }
 
+/**
+ * A constraint on a column's *character* count, from `CHECK (length(name) > 3)`.
+ *
+ * Kept apart from `ColumnCheck` because it is not a comparison of the value: it compares a count
+ * derived from it, and the count Postgres takes is code points rather than UTF-16 units. See
+ * `CODEPOINT_LENGTH` for why that distinction is load bearing.
+ */
+export interface LengthCheck {
+  column: string;
+  operator: ColumnCheck['operator'];
+  /** Decimal, as text, matching how the other bounds are carried. */
+  value: string;
+  name?: string;
+}
+
 /** A check that was understood, or the reason it was not. */
 export type ParsedCheck =
-  | { ok: true; checks: ColumnCheck[]; sets?: ColumnSet[]; rows?: RowCheck[] }
+  | {
+      ok: true;
+      checks: ColumnCheck[];
+      sets?: ColumnSet[];
+      rows?: RowCheck[];
+      lengths?: LengthCheck[];
+    }
   | { ok: false; reason: string };
 
 const COMPARISON = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(>=|<=|<>|!=|>|<|=)\s*(.+?)\s*$/;
 const IN_LIST = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s+IN\s*\((.+)\)\s*$/i;
+// `length` and `char_length` are the same function in Postgres and both count characters.
+// `octet_length` is deliberately absent: it counts bytes, which depends on the encoding and
+// cannot be derived from a JavaScript string without choosing one.
+const LENGTH_OF =
+  /^\s*(?:length|char_length)\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)\s*(>=|<=|<>|!=|>|<|=)\s*(\d+)\s*$/i;
 
 /**
  * Split on `AND`s that are at the top level, outside parentheses and outside quotes.
@@ -223,6 +249,7 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
     const checks: ColumnCheck[] = [];
     const sets: ColumnSet[] = [];
     const rows: RowCheck[] = [];
+    const lengths: LengthCheck[] = [];
     for (const part of parts) {
       const parsed = parseCheck(part, name);
       if (!parsed.ok)
@@ -230,12 +257,27 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
       checks.push(...parsed.checks);
       if (parsed.sets) sets.push(...parsed.sets);
       if (parsed.rows) rows.push(...parsed.rows);
+      if (parsed.lengths) lengths.push(...parsed.lengths);
     }
     return {
       ok: true,
       checks,
       ...(sets.length ? { sets } : {}),
       ...(rows.length ? { rows } : {}),
+      ...(lengths.length ? { lengths } : {}),
+    };
+  }
+
+  // `length(col) <op> n`: a character-count bound. The only function call this parser reads, and
+  // it is read rather than refused because the mapping is exact, which is more than can be said
+  // for the others: see the skip list in the docs.
+  const lengthOf = expr.match(LENGTH_OF);
+  if (lengthOf) {
+    const op = lengthOf[2] === '!=' ? '<>' : (lengthOf[2] as ColumnCheck['operator']);
+    return {
+      ok: true,
+      checks: [],
+      lengths: [{ column: lengthOf[1], operator: op, value: lengthOf[3], name }],
     };
   }
 

--- a/packages/validation-core/test/checks.spec.ts
+++ b/packages/validation-core/test/checks.spec.ts
@@ -93,12 +93,17 @@ describe('what it refuses, and why that matters', () => {
 
   it('refuses a whole conjunction when any one part is not understood', () => {
     // Enforcing half of a constraint is enforcing a different constraint.
-    expect(rejected('age >= 18 AND length(name) > 3')).toMatch(/part of an AND/);
+    expect(rejected("age >= 18 AND lower(name) = 'x'")).toMatch(/part of an AND/);
     expect(rejected("age >= 18 AND email ~ '^[a-z]+$'")).toMatch(/part of an AND/);
   });
 
-  it('refuses a function call', () => {
-    expect(rejected('length(name) > 3')).toBeTruthy();
+  it('refuses a function call it cannot map exactly', () => {
+    // `length` is read, because a character count maps exactly. These do not: `lower` would need
+    // a locale to be faithful, and `octet_length` counts bytes, which depends on the encoding and
+    // cannot be derived from a JavaScript string without picking one.
+    expect(rejected("lower(name) = 'x'")).toBeTruthy();
+    expect(rejected('octet_length(name) > 3')).toBeTruthy();
+    expect(rejected('abs(n) > 3')).toBeTruthy();
   });
 
   it('refuses a regex match, whose dialect is not JavaScript', () => {
@@ -224,5 +229,34 @@ describe('row-level comparisons', () => {
     // something the schema never said.
     expect(rejected('a > b + 1')).toBeTruthy();
     expect(rejected('a + b > 0')).toBeTruthy();
+  });
+});
+
+describe('character-count constraints', () => {
+  // The one function call this parser reads, because the mapping is exact. Counted in code
+  // points by the generators, since Postgres counts characters and `.length` counts UTF-16 units.
+  it('reads length() and char_length() alike', () => {
+    for (const e of ['length(name) > 3', 'char_length(name) > 3', 'LENGTH(name) > 3']) {
+      const r = parseCheck(e, 'min_name');
+      expect(r.ok, e).toBe(true);
+      if (!r.ok) continue;
+      expect(r.checks, 'not a value comparison').toHaveLength(0);
+      expect(r.lengths).toEqual([{ column: 'name', operator: '>', value: '3', name: 'min_name' }]);
+    }
+  });
+
+  it('carries both ends of a conjunction', () => {
+    const r = parseCheck('length(a) > 3 AND length(a) < 10');
+    expect(r.ok && r.lengths).toHaveLength(2);
+  });
+
+  it('normalises != to <>', () => {
+    const r = parseCheck('length(a) != 5');
+    expect(r.ok && r.lengths![0].operator).toBe('<>');
+  });
+
+  it('refuses a comparison against anything but a number', () => {
+    expect(rejected('length(a) > b')).toBeTruthy();
+    expect(rejected("length(a) > '3'")).toBeTruthy();
   });
 });

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -549,6 +549,10 @@ import { matrix as sqTable } from './schema-sqlite.js';
 const POOL: [string, unknown][] = [
   ['null', null], ['undefined', undefined], ['""', ''], ["'hello'", 'hello'],
   ['300-char', 'x'.repeat(300)], ['70k-char', 'x'.repeat(70000)], ['5-char', 'xxxxx'],
+  // Astral-plane characters, which tell a code-point count from a UTF-16 `.length`. Without them
+  // the pool cannot see the difference, which is exactly how the `varchar(n)` bug survived.
+  ['3 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}'],
+  ['5 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}'],
   // Astral-plane characters, where a code-point count and a UTF-16 `.length` disagree.
   // Postgres counts characters for `varchar(n)`, so a 3-emoji string fits in a varchar(5)
   // that every library's `.max(5)` refuses.


### PR DESCRIPTION
The one function call the check parser reads, because the mapping is exact.

```ts
// check('name_len', sql`length(${t.name}) >= 3 AND length(${t.name}) <= 8`)
name: z.string()
  .refine((v) => [...v].length >= 3, { message: 'name_len: length(name) >= 3' })
  .refine((v) => [...v].length <= 8, { message: 'name_len: length(name) <= 8' }),
```

`char_length` is the same function in Postgres and is read too. Counted in **code points**, for the same reason a `varchar(n)` limit is.

Verified against Postgres, agreeing on all eight probes:

```
"ab"          chars=2  db=false zod=false
"abc"         chars=3  db=true  zod=true
"abcdefgh"    chars=8  db=true  zod=true
"abcdefghi"   chars=9  db=false zod=false
2 emoji       chars=2  db=false zod=false
3 emoji       chars=3  db=true  zod=true
8 emoji       chars=8  db=true  zod=true      <- 16 UTF-16 units
9 emoji       chars=9  db=false zod=false
disagreements: 0
```

## What is still refused, and why the rule did not change

`octet_length` counts **bytes**, which depends on the encoding and cannot be derived from a JavaScript string without choosing one. `lower` would need a locale to be faithful. The rule is unchanged, only its reach: read what maps exactly, refuse the rest rather than guess.

## The audit

I checked every other place a length is enforced, for the same UTF-16 assumption that produced the `varchar(n)` bug:

| site | verdict |
|---|---|
| `bit(n)` / `binary(n)` patterns | safe, the regex `^[01]*$` admits only ASCII |
| vector widths | safe, array length not string length |
| `varchar(n)` | fixed in the previous PR |
| TypeBox / ArkType `maxLength` | approximate, no predicate to hook |

The TypeBox and ArkType caveat was only in **zod's** docs, where a reader of those generators would never see it. It is now on each.

## One thing that nearly shipped silently

My first wiring pass used single-line string replacements for the `renderObjectShape(...)` call sites. Prettier had wrapped them across lines, so the replacements matched nothing and no-oped without complaint. The generated output still said `z.string()` with no constraint at all, and only running it against Postgres surfaced it. The call sites are matched structurally now, and the replacement asserts it changed something.

## Also

The parity probe pool gained astral characters, so a cross-generator disagreement about character counting is visible rather than invisible. That gap is precisely what let the `varchar(n)` bug survive both gates.

536 tests across 67 files, 7 new. `verify:packed` green: DRZL agrees with Postgres on 974 of 1365 probes to drizzle-orm's 946, closer on 28, further on 0.