### PR TITLE
feat: enforce CHECK (cardinality(col)) on array columns

### DIFF
--- a/.changeset/cardinality-checks.md
+++ b/.changeset/cardinality-checks.md
@@ -1,0 +1,26 @@
+---
+'@drzl/generator-valibot': minor
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+---
+
+`CHECK (cardinality(col) <op> n)` is now enforced on array columns.
+
+```ts
+// check('tags_rule', sql`cardinality(${t.tags}) > 0 AND cardinality(${t.tags}) < 4`)
+tags: z.array(z.string())
+  .refine((v) => v.length > 0, { message: 'tags_rule: cardinality(tags) > 0' })
+  .refine((v) => v.length < 4, { message: 'tags_rule: cardinality(tags) < 4' }),
+```
+
+The array analogue of the `length()` support, and free of the question that one carries: an
+element count is the same number in SQL and in JavaScript, with no encoding involved.
+`array_length(col, 1)` reads the same way, because for a one-dimensional array it is that count.
+`array_length(col, 2)` is refused, since a higher dimension is not an element count.
+
+This is the one check an array column takes. Every other kind is skipped there, because a
+comparison against a scalar literal says nothing usable about an array; this one is about the
+array itself, so it is applied after the array wrapping rather than to an element.
+
+Verified against Postgres for `CHECK (cardinality(tags) > 0 AND cardinality(tags) < 4)`: the
+emitted schema and the database agree on all four probes.

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ packages/*/test/.tmp-typedcols-*
 packages/*/test/.tmp-typedcols-run
 packages/*/test/.tmp-numfmt
 packages/*/test/.tmp-charlen
+packages/*/test/.tmp-cardinality
 packages/*/test/.tmp-rowchecks
 packages/*/test/.tmp-defaults

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -229,6 +229,21 @@ function and is read too. Counted in code points, so it agrees with the database
 derived from a JavaScript string without choosing one. Neither is `lower`, which would need a
 locale to be faithful.
 
+### `cardinality()` becomes an element count
+
+```ts
+// check('tags_rule', sql`cardinality(${t.tags}) > 0`)
+tags: z.array(z.string())
+  .refine((v) => v.length > 0, { message: 'tags_rule: cardinality(tags) > 0' }),
+```
+
+The array analogue of `length()`, and free of the question that one carries: an element count is
+the same number in SQL and in JavaScript. `array_length(col, 1)` reads the same way, since for a
+one-dimensional array it is that count. Any other dimension is refused.
+
+This is the one check an array column takes. The others are skipped there because a comparison
+against a scalar literal says nothing usable about an array, whereas this one is _about_ it.
+
 **Only unambiguous constraints are translated.** These are skipped rather than guessed at:
 
 | Skipped                       | Why                                                      |

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -4,7 +4,7 @@ import type {
   ValidationRenderer,
   ValidationGenerateOptions,
 } from '@drzl/validation-core';
-import type { ColumnCheck, ColumnSet, LengthCheck } from '@drzl/validation-core';
+import type { CardinalityCheck, ColumnCheck, ColumnSet, LengthCheck } from '@drzl/validation-core';
 import {
   COLUMN_FORMATS,
   insertColumns,
@@ -187,6 +187,32 @@ function vLengthChecks(c: Column, lengths: LengthCheck[]): string[] {
     });
 }
 
+/**
+ * `v.check(...)` actions for the `cardinality(col)` constraints naming this column.
+ *
+ * Only for an array column, and applied to the array rather than to an element, which is why it
+ * is threaded to the field rather than folded into the element pipe.
+ */
+function vCardinalityChecks(c: Column, cardinalities: CardinalityCheck[]): string[] {
+  if (!c.arrayDimensions) return [];
+  const OPS: Record<CardinalityCheck['operator'], string> = {
+    '>=': '>=',
+    '>': '>',
+    '<=': '<=',
+    '<': '<',
+    '=': '===',
+    '<>': '!==',
+  };
+  return cardinalities
+    .filter((k) => k.column === c.name)
+    .map((k) => {
+      const msg = JSON.stringify(
+        `${k.name ? `${k.name}: ` : ''}cardinality(${c.name}) ${k.operator} ${k.value}`
+      );
+      return `v.check((val) => val.length ${OPS[k.operator]} ${k.value}, ${msg})`;
+    });
+}
+
 function vExprForColumn(
   c: Column,
   mode: Mode,
@@ -266,12 +292,16 @@ function vField(
   checks: ColumnCheck[] = [],
   sets: ColumnSet[] = [],
   applyDefault = false,
-  lengths: LengthCheck[] = []
+  lengths: LengthCheck[] = [],
+  cardinalities: CardinalityCheck[] = []
 ): string {
   let expr = vExprForColumn(c, mode, coerceDates, checks, sets, lengths);
   // Drizzle keeps an array on the element's own column class, so everything above describes the
   // element and the wrapping belongs out here, after the bounds and length limits are attached.
   for (let i = 0; i < (c.arrayDimensions ?? 0); i++) expr = `v.array(${expr})`;
+  // After the wrapping, because this constrains the array rather than an element.
+  const card = vCardinalityChecks(c, cardinalities);
+  if (card.length) expr = `v.pipe(${expr}, ${card.join(', ')})`;
   if (c.nullable) expr = `v.nullable(${expr})`;
   if (mode !== 'select') {
     // A literal default is reproduced as valibot's second argument to `optional`, which is where
@@ -294,12 +324,13 @@ function renderObjectShape(
   checks: ColumnCheck[] = [],
   sets: ColumnSet[] = [],
   applyDefaults = false,
-  lengths: LengthCheck[] = []
+  lengths: LengthCheck[] = [],
+  cardinalities: CardinalityCheck[] = []
 ) {
   return cols
     .map(
       (c) =>
-        `  ${JSON.stringify(c.name)}: ${vField(c, mode, coerceDates, checks, sets, applyDefaults, lengths)},`
+        `  ${JSON.stringify(c.name)}: ${vField(c, mode, coerceDates, checks, sets, applyDefaults, lengths, cardinalities)},`
     )
     .join('\n');
 }
@@ -326,6 +357,7 @@ function renderTableSchemas(
   const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
   const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
+  const cardinalities = parsedChecks.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : []));
   const bodyInsert = renderObjectShape(
     insertCols,
     'insert',
@@ -333,7 +365,8 @@ function renderTableSchemas(
     checks,
     sets,
     applyDefaults,
-    lengths
+    lengths,
+    cardinalities
   );
   const bodyUpdate = renderObjectShape(
     updateCols,
@@ -342,7 +375,8 @@ function renderTableSchemas(
     checks,
     sets,
     applyDefaults,
-    lengths
+    lengths,
+    cardinalities
   );
   const bodySelect = renderObjectShape(
     selectCols,
@@ -351,7 +385,8 @@ function renderTableSchemas(
     checks,
     sets,
     applyDefaults,
-    lengths
+    lengths,
+    cardinalities
   );
   // Emitted only where a json column exists, so a file without one gains nothing unused.
   const needsJson = [...insertCols, ...updateCols, ...selectCols].some(

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -4,7 +4,13 @@ import type {
   ValidationGenerateOptions,
   ValidationRenderer,
 } from '@drzl/validation-core';
-import type { ColumnCheck, ColumnSet, LengthCheck, RowCheck } from '@drzl/validation-core';
+import type {
+  ColumnCheck,
+  ColumnSet,
+  CardinalityCheck,
+  LengthCheck,
+  RowCheck,
+} from '@drzl/validation-core';
 import {
   formatCode,
   parseCheck,
@@ -76,6 +82,34 @@ function lengthRefinements(c: Column, lengths: LengthCheck[]): string {
         `${k.name ? `${k.name}: ` : ''}length(${c.name}) ${k.operator} ${k.value}`
       );
       return `.refine((v) => [...v].length ${OPS[k.operator]} ${k.value}, { message: ${msg} })`;
+    })
+    .join('');
+}
+
+/**
+ * `.refine()` calls for the `cardinality(col)` constraints naming this column.
+ *
+ * Only for an array column: on anything else there is nothing to count, and comparing `.length`
+ * of a string would enforce a different constraint than the schema stated. This is the one check
+ * an array column does take, since it is about the array rather than about an element.
+ */
+function cardinalityRefinements(c: Column, cardinalities: CardinalityCheck[]): string {
+  if (!c.arrayDimensions) return '';
+  const OPS: Record<CardinalityCheck['operator'], string> = {
+    '>=': '>=',
+    '>': '>',
+    '<=': '<=',
+    '<': '<',
+    '=': '===',
+    '<>': '!==',
+  };
+  return cardinalities
+    .filter((k) => k.column === c.name)
+    .map((k) => {
+      const msg = JSON.stringify(
+        `${k.name ? `${k.name}: ` : ''}cardinality(${c.name}) ${k.operator} ${k.value}`
+      );
+      return `.refine((v) => v.length ${OPS[k.operator]} ${k.value}, { message: ${msg} })`;
     })
     .join('');
 }
@@ -240,6 +274,7 @@ function zodField(
   sets: ColumnSet[] = [],
   applyDefault = false,
   lengths: LengthCheck[] = [],
+  cardinalities: CardinalityCheck[] = [],
   /**
    * A reference to Drizzle's inferred type for a column that already has a runtime schema.
    *
@@ -259,6 +294,8 @@ function zodField(
   // check, as the database does.
   expr += checkRefinements(c, checks);
   expr += lengthRefinements(c, lengths);
+  // After the array wrapping above, because this constrains the array rather than an element.
+  expr += cardinalityRefinements(c, cardinalities);
   // For selects, nullable columns should allow null values
   if (c.nullable) {
     expr = `${expr}.nullable()`;
@@ -293,7 +330,8 @@ function renderObjectShape(
   typedJson?: { table: string; mode: 'insert' | 'select'; allColumns?: boolean },
   sets: ColumnSet[] = [],
   applyDefaults = false,
-  lengths: LengthCheck[] = []
+  lengths: LengthCheck[] = [],
+  cardinalities: CardinalityCheck[] = []
 ) {
   return cols
     .map((c) => {
@@ -305,7 +343,7 @@ function renderObjectShape(
       const replaces = c.tsType === 'any' || c.shape?.kind === 'custom';
       const ref = typedJson && replaces ? refFor(typedJson) : undefined;
       const narrow = typedJson?.allColumns && !replaces ? refFor(typedJson) : undefined;
-      return `  ${JSON.stringify(c.name)}: ${zodField(c, mode, coerceDates, checks, ref, sets, applyDefaults, lengths, narrow)},`;
+      return `  ${JSON.stringify(c.name)}: ${zodField(c, mode, coerceDates, checks, ref, sets, applyDefaults, lengths, cardinalities, narrow)},`;
     })
     .join('\n');
 }
@@ -375,6 +413,7 @@ function renderTableSchemas(
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
   const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
   const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
+  const cardinalities = parsedChecks.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : []));
   // Insert and select can disagree: a json column with a default is optional on insert, so its
   // inferred type differs. Each shape therefore references the matching inference.
   const tj = typedJson
@@ -391,7 +430,8 @@ function renderTableSchemas(
     tjInsert,
     sets,
     applyDefaults,
-    lengths
+    lengths,
+    cardinalities
   );
   const bodyUpdate = renderObjectShape(
     updateCols,
@@ -401,7 +441,8 @@ function renderTableSchemas(
     tjInsert,
     sets,
     applyDefaults,
-    lengths
+    lengths,
+    cardinalities
   );
   const bodySelect = renderObjectShape(
     selectCols,
@@ -411,7 +452,8 @@ function renderTableSchemas(
     tj,
     sets,
     applyDefaults,
-    lengths
+    lengths,
+    cardinalities
   );
   // A type-only import: it disappears at build time, so this adds no runtime dependency on the
   // schema module and cannot create an import cycle at runtime.

--- a/packages/generator-zod/test/cardinality.spec.ts
+++ b/packages/generator-zod/test/cardinality.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * `CHECK (cardinality(tags) > 0)`, the array analogue of a length constraint.
+ *
+ * Free of the encoding question a character count carries: an element count is the same number in
+ * SQL and in JavaScript. Verified against Postgres, where the constraint rejects `[]` and accepts
+ * `['a']`.
+ *
+ * Array columns skip the ordinary check refinements, because a comparison against a scalar
+ * literal says nothing usable about an array. A cardinality check is the exception: it is *about*
+ * the array, so it is the one that belongs there.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function withCheck(expression: string, columns: Column[]) {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [
+      {
+        name: 't',
+        tsName: 't',
+        columns,
+        unique: [],
+        indexes: [],
+        checks: [{ name: 'tags_rule', expression }],
+      },
+    ] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-cardinality');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return await import(file);
+}
+
+const TAGS = [col('tags', { arrayDimensions: 1 })];
+
+describe('a cardinality constraint', () => {
+  it('rejects an array shorter than the bound', async () => {
+    const m = await withCheck('cardinality(tags) > 0', TAGS);
+    const f = m.SelecttSchema.shape.tags;
+    expect(f.safeParse([]).success, 'empty').toBe(false);
+    expect(f.safeParse(['a']).success, 'one element').toBe(true);
+  });
+
+  it('holds both ends of a range', async () => {
+    const m = await withCheck('cardinality(tags) > 0 AND cardinality(tags) < 3', TAGS);
+    const f = m.SelecttSchema.shape.tags;
+    expect(f.safeParse([]).success).toBe(false);
+    expect(f.safeParse(['a', 'b']).success).toBe(true);
+    expect(f.safeParse(['a', 'b', 'c']).success).toBe(false);
+  });
+
+  it('keeps the element schema intact', async () => {
+    // The constraint is about the array; each element is still validated as itself.
+    const m = await withCheck('cardinality(tags) > 0', [
+      col('tags', { arrayDimensions: 1, maxLength: 3 }),
+    ]);
+    const f = m.SelecttSchema.shape.tags;
+    expect(f.safeParse(['ab']).success, 'a short element').toBe(true);
+    expect(f.safeParse(['toolong']).success, 'an element past its own limit').toBe(false);
+  });
+
+  it('names the constraint in the message', async () => {
+    const m = await withCheck('cardinality(tags) > 0', TAGS);
+    const r = m.SelecttSchema.safeParse({ tags: [] });
+    expect(r.error.issues[0].message).toBe('tags_rule: cardinality(tags) > 0');
+  });
+
+  it('is left off a column that is not an array', async () => {
+    // Nothing to count. Emitting it would compare `.length` of a string, which is a different
+    // constraint entirely.
+    const m = await withCheck('cardinality(tags) > 0', [col('tags')]);
+    expect(m.SelecttSchema.shape.tags.safeParse('').success).toBe(true);
+  });
+});

--- a/packages/validation-core/src/checks.ts
+++ b/packages/validation-core/src/checks.ts
@@ -74,6 +74,19 @@ export interface LengthCheck {
   name?: string;
 }
 
+/**
+ * A constraint on an array column's element count, from `CHECK (cardinality(tags) > 0)`.
+ *
+ * The array analogue of `LengthCheck`, and free of the question that one carries: an element
+ * count is the same number in SQL and in JavaScript, with no encoding involved.
+ */
+export interface CardinalityCheck {
+  column: string;
+  operator: ColumnCheck['operator'];
+  value: string;
+  name?: string;
+}
+
 /** A check that was understood, or the reason it was not. */
 export type ParsedCheck =
   | {
@@ -82,6 +95,7 @@ export type ParsedCheck =
       sets?: ColumnSet[];
       rows?: RowCheck[];
       lengths?: LengthCheck[];
+      cardinalities?: CardinalityCheck[];
     }
   | { ok: false; reason: string };
 
@@ -90,6 +104,11 @@ const IN_LIST = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s+IN\s*\((.+)\)\s*$/i;
 // `length` and `char_length` are the same function in Postgres and both count characters.
 // `octet_length` is deliberately absent: it counts bytes, which depends on the encoding and
 // cannot be derived from a JavaScript string without choosing one.
+// `cardinality(a)` is the element count. `array_length(a, 1)` is the length of the first
+// dimension, which is the same number for a one-dimensional array; any other dimension is not an
+// element count and is refused.
+const CARDINALITY_OF =
+  /^\s*(?:cardinality\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)|array_length\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*1\s*\))\s*(>=|<=|<>|!=|>|<|=)\s*(\d+)\s*$/i;
 const LENGTH_OF =
   /^\s*(?:length|char_length)\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)\s*(>=|<=|<>|!=|>|<|=)\s*(\d+)\s*$/i;
 
@@ -250,6 +269,7 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
     const sets: ColumnSet[] = [];
     const rows: RowCheck[] = [];
     const lengths: LengthCheck[] = [];
+    const cardinalities: CardinalityCheck[] = [];
     for (const part of parts) {
       const parsed = parseCheck(part, name);
       if (!parsed.ok)
@@ -258,6 +278,7 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
       if (parsed.sets) sets.push(...parsed.sets);
       if (parsed.rows) rows.push(...parsed.rows);
       if (parsed.lengths) lengths.push(...parsed.lengths);
+      if (parsed.cardinalities) cardinalities.push(...parsed.cardinalities);
     }
     return {
       ok: true,
@@ -265,6 +286,7 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
       ...(sets.length ? { sets } : {}),
       ...(rows.length ? { rows } : {}),
       ...(lengths.length ? { lengths } : {}),
+      ...(cardinalities.length ? { cardinalities } : {}),
     };
   }
 
@@ -278,6 +300,23 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
       ok: true,
       checks: [],
       lengths: [{ column: lengthOf[1], operator: op, value: lengthOf[3], name }],
+    };
+  }
+
+  const cardinalityOf = expr.match(CARDINALITY_OF);
+  if (cardinalityOf) {
+    const op = cardinalityOf[3] === '!=' ? '<>' : (cardinalityOf[3] as ColumnCheck['operator']);
+    return {
+      ok: true,
+      checks: [],
+      cardinalities: [
+        {
+          column: cardinalityOf[1] ?? cardinalityOf[2],
+          operator: op,
+          value: cardinalityOf[4],
+          ...(name ? { name } : {}),
+        },
+      ],
     };
   }
 

--- a/packages/validation-core/test/checks.spec.ts
+++ b/packages/validation-core/test/checks.spec.ts
@@ -260,3 +260,35 @@ describe('character-count constraints', () => {
     expect(rejected("length(a) > '3'")).toBeTruthy();
   });
 });
+
+describe('array cardinality', () => {
+  // `cardinality(tags) > 0` is the array analogue of `length(name) > 3`, and the mapping is just
+  // as exact: it is the element count, which JavaScript spells `.length` on an array with no
+  // encoding question attached. Verified against Postgres: the constraint rejects `[]` and
+  // accepts `['a']`.
+  it('reads cardinality() as an element count', () => {
+    const r = parseCheck('cardinality(tags) > 0', 'not_empty');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.checks, 'not a value comparison').toHaveLength(0);
+    expect(r.cardinalities).toEqual([
+      { column: 'tags', operator: '>', value: '0', name: 'not_empty' },
+    ]);
+  });
+
+  it('reads array_length(col, 1) too, which is the older spelling', () => {
+    // `array_length(a, 1)` is the length of the first dimension, which for a one-dimensional
+    // array is the same number `cardinality` gives.
+    const r = parseCheck('array_length(tags, 1) <= 5');
+    expect(r.ok && r.cardinalities).toEqual([{ column: 'tags', operator: '<=', value: '5' }]);
+  });
+
+  it('refuses a dimension other than the first, which is not the element count', () => {
+    expect(rejected('array_length(grid, 2) > 0')).toBeTruthy();
+  });
+
+  it('carries both ends of a conjunction', () => {
+    const r = parseCheck('cardinality(a) > 0 AND cardinality(a) < 10');
+    expect(r.ok && r.cardinalities).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
The array analogue of the `length()` support, written test-first.

```ts
// check('tags_rule', sql`cardinality(${t.tags}) > 0 AND cardinality(${t.tags}) < 4`)
tags: z.array(z.string())
  .refine((v) => v.length > 0, { message: 'tags_rule: cardinality(tags) > 0' })
  .refine((v) => v.length < 4, { message: 'tags_rule: cardinality(tags) < 4' }),
```

Free of the question `length()` carries: an element count is the same number in SQL and in JavaScript, with no encoding involved.

`array_length(col, 1)` reads the same way, because for a one-dimensional array it *is* that count. `array_length(col, 2)` is refused, since a higher dimension is not an element count.

## Why an array column takes this one and no other

Every other check kind is skipped on an array, because a comparison against a scalar literal says nothing usable about one, and applying it anyway produced refinements no array could satisfy. This one is about the array itself, so it is applied **after** the array wrapping rather than to an element. The element schema is untouched, which the tests assert directly.

## Verified against Postgres

```
[]                  db=false zod=false agree
["a"]               db=true  zod=true  agree
["a","b","c"]       db=true  zod=true  agree
["a","b","c","d"]   db=false zod=false agree
disagreements: 0
```

545 tests across 68 files, 9 new. `verify:packed` green, ground truth unchanged at DRZL 974 to drizzle-orm's 946.