### PR TITLE
refactor: one options builder for every validation generator

### DIFF
--- a/.changeset/shared-validation-options.md
+++ b/.changeset/shared-validation-options.md
@@ -1,0 +1,35 @@
+---
+'@drzl/generator-typebox': patch
+'@drzl/cli': minor
+---
+
+One options builder for every validation generator, and a default that was being dropped.
+
+Each of the four generator branches in the CLI hand-built its own options object. Three documented
+options had already been found silently dead that way: `typedJson` never reached typebox, and
+`coerceDates` and `applyDefaults` never reached anything but zod. Fixing each instance did not
+address the shape of the problem, so the four now share one builder and an option added once
+reaches everything that can act on it.
+
+What stays per-generator is a real capability rather than an oversight, and it is named as one:
+ArkType does not receive the schema-import options, because it emits one string per field and a
+TypeScript type reference has nowhere to live inside a string DSL.
+
+### The default that was being dropped
+
+Auditing the result immediately turned up another: with `typedColumns` **and** `applyDefaults`
+both on, the typebox generator emitted no default at all.
+
+```ts
+// before
+country: Type.Optional(Type.Unsafe<(typeof users.$inferInsert)['country']>(Type.String())),
+// after
+country: Type.Optional(Type.Unsafe<(typeof users.$inferInsert)['country']>(Type.String({ default: 'GB' }))),
+```
+
+The default was being applied after the `Type.Unsafe` wrapper, where it lands on the wrapper
+rather than the schema, and the helper that attaches it declines anything that is not a bare
+`Type.X(...)`. So it returned the expression untouched and the default vanished without a word.
+It now goes on the schema before anything wraps it.
+
+Neither option is on by default, so this only affects a project that had turned both on.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import cliProgress from 'cli-progress';
 import { Command } from 'commander';
 import * as path from 'node:path';
 import ora from 'ora';
+import { validationOptions } from './validation-options';
 import {
   computeGeneratorOutputDirs,
   computeWatchTargets,
@@ -164,22 +165,9 @@ program
             const { ZodGenerator } = await import('@drzl/generator-zod');
             const gen = new ZodGenerator(analysis);
             const target = g.path ?? 'src/validators/zod';
-            const files = await gen.generate({
-              outDir: target,
-              outputHeader: g.outputHeader,
-              format: g.format,
-              schemaSuffix: g.schemaSuffix,
-              fileSuffix: g.fileSuffix,
-              importExtension: g.importExtension,
-              affix: g.affix,
-              // Needed by typedJson, which imports the schema back to reference the type
-              // Drizzle inferred for a json column.
-              schemaPath: cfg.schema,
-              typedJson: g.typedJson,
-              typedColumns: g.typedColumns,
-              applyDefaults: g.applyDefaults,
-              coerceDates: g.coerceDates,
-            });
+            const files = await gen.generate(
+              validationOptions(g, cfg, target, { schemaTypes: true }) as never
+            );
             progress.stop();
             ora().succeed(chalk.green(`Generated (zod): ${files.length} files`));
             files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
@@ -197,20 +185,9 @@ program
             const { ValibotGenerator } = await import('@drzl/generator-valibot');
             const gen = new ValibotGenerator(analysis);
             const target = g.path ?? 'src/validators/valibot';
-            const files = await gen.generate({
-              outDir: target,
-              outputHeader: g.outputHeader,
-              format: g.format,
-              schemaSuffix: g.schemaSuffix,
-              fileSuffix: g.fileSuffix,
-              importExtension: g.importExtension,
-              affix: g.affix,
-              applyDefaults: g.applyDefaults,
-              coerceDates: g.coerceDates,
-              // Needed by typedColumns, which imports the schema back to reference the type
-              schemaPath: cfg.schema,
-              typedColumns: g.typedColumns,
-            });
+            const files = await gen.generate(
+              validationOptions(g, cfg, target, { schemaTypes: true }) as never
+            );
             progress.stop();
             ora().succeed(chalk.green(`Generated (valibot): ${files.length} files`));
             files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
@@ -228,17 +205,9 @@ program
             const { ArkTypeGenerator } = await import('@drzl/generator-arktype');
             const gen = new ArkTypeGenerator(analysis);
             const target = g.path ?? 'src/validators/arktype';
-            const files = await gen.generate({
-              outDir: target,
-              outputHeader: g.outputHeader,
-              format: g.format,
-              schemaSuffix: g.schemaSuffix,
-              fileSuffix: g.fileSuffix,
-              importExtension: g.importExtension,
-              affix: g.affix,
-              applyDefaults: g.applyDefaults,
-              coerceDates: g.coerceDates,
-            });
+            const files = await gen.generate(
+              validationOptions(g, cfg, target, { schemaTypes: false }) as never
+            );
             progress.stop();
             ora().succeed(chalk.green(`Generated (arktype): ${files.length} files`));
             files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
@@ -256,21 +225,9 @@ program
             const { TypeBoxGenerator } = await import('@drzl/generator-typebox');
             const gen = new TypeBoxGenerator(analysis);
             const target = g.path ?? 'src/validators/typebox';
-            const files = await gen.generate({
-              outDir: target,
-              outputHeader: g.outputHeader,
-              format: g.format,
-              schemaSuffix: g.schemaSuffix,
-              fileSuffix: g.fileSuffix,
-              importExtension: g.importExtension,
-              affix: g.affix,
-              coerceDates: g.coerceDates,
-              // Needed by typedJson, which imports the schema back to reference the type
-              schemaPath: cfg.schema,
-              typedJson: g.typedJson,
-              typedColumns: g.typedColumns,
-              applyDefaults: g.applyDefaults,
-            });
+            const files = await gen.generate(
+              validationOptions(g, cfg, target, { schemaTypes: true }) as never
+            );
             progress.stop();
             ora().succeed(chalk.green(`Generated (typebox): ${files.length} files`));
             files.forEach((f: string) => console.log('  -', chalk.cyan(f)));

--- a/packages/cli/src/validation-options.ts
+++ b/packages/cli/src/validation-options.ts
@@ -1,0 +1,67 @@
+/**
+ * The options every validation generator receives, built in one place.
+ *
+ * Each of the four branches used to assemble this by hand, and three documented options were
+ * found silently dead as a result: `typedJson` never reached typebox, and `coerceDates` and
+ * `applyDefaults` never reached anything but zod. The config parsed them, the CLI dropped them,
+ * and the feature simply did nothing while nothing said so. Building it once removes the class
+ * rather than fixing each instance.
+ *
+ * What stays per-generator is a real capability rather than an oversight, which is why it is
+ * named as one.
+ */
+
+/** A generator entry from the config, loosely typed because the config schema owns its shape. */
+type GeneratorConfig = {
+  outputHeader?: unknown;
+  format?: unknown;
+  schemaSuffix?: unknown;
+  fileSuffix?: unknown;
+  importExtension?: unknown;
+  affix?: unknown;
+  coerceDates?: unknown;
+  applyDefaults?: unknown;
+  typedJson?: unknown;
+  typedColumns?: unknown;
+};
+
+export interface GeneratorCapabilities {
+  /**
+   * Whether the generator can reference a type from the schema module.
+   *
+   * `typedJson` and `typedColumns` both work by importing the table back and reading
+   * `typeof table.$inferSelect['col']`, so a generator that cannot embed a TypeScript type in its
+   * output cannot use either. ArkType is the case: it emits one string per field, and a type
+   * reference has nowhere to live inside a string DSL.
+   */
+  schemaTypes?: boolean;
+}
+
+export function validationOptions(
+  g: GeneratorConfig,
+  cfg: { schema?: unknown },
+  outDir: string,
+  caps: GeneratorCapabilities = {}
+): Record<string, unknown> {
+  return {
+    outDir,
+    outputHeader: g.outputHeader,
+    format: g.format,
+    schemaSuffix: g.schemaSuffix,
+    fileSuffix: g.fileSuffix,
+    importExtension: g.importExtension,
+    affix: g.affix,
+    coerceDates: g.coerceDates,
+    applyDefaults: g.applyDefaults,
+    // Only where the generator can act on them, so an unsupported option is absent rather than
+    // present and ignored.
+    ...(caps.schemaTypes
+      ? {
+          // Needed by both: the reference is resolved relative to the emitted file.
+          schemaPath: cfg.schema,
+          typedJson: g.typedJson,
+          typedColumns: g.typedColumns,
+        }
+      : {}),
+  };
+}

--- a/packages/cli/test/validation-options.spec.ts
+++ b/packages/cli/test/validation-options.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Every validation generator gets every option it supports.
+ *
+ * Each generator branch used to hand-build its own options object, and three documented options
+ * were found silently dead as a result: `typedJson` never reached typebox, and `coerceDates` and
+ * `applyDefaults` never reached anything but zod. The config parsed them and the CLI dropped them,
+ * so the feature simply did nothing and nothing said so.
+ *
+ * One builder now serves all four, which removes the class rather than testing for each instance.
+ * What remains per-generator is a capability: ArkType cannot reference a TypeScript type from
+ * inside its string DSL, so the schema-import options are not passed to it.
+ */
+import { describe, it, expect } from 'vitest';
+import { validationOptions } from '../src/validation-options';
+
+const generator = {
+  path: 'out',
+  outputHeader: { enabled: true },
+  format: { semi: false },
+  schemaSuffix: 'Schema',
+  fileSuffix: '.x.ts',
+  importExtension: 'js' as const,
+  affix: { tableCase: 'pascal' as const },
+  coerceDates: 'none' as const,
+  applyDefaults: true,
+  typedJson: true,
+  typedColumns: true,
+};
+const config = { schema: 'src/db/schema.ts' };
+
+describe('the shared options', () => {
+  it('carries everything a generator can act on', () => {
+    const o = validationOptions(generator, config, 'out', { schemaTypes: true });
+    // Named individually rather than snapshotted, so adding an option to the config without
+    // adding it here is a failing test rather than an updated snapshot.
+    expect(o).toMatchObject({
+      outDir: 'out',
+      outputHeader: generator.outputHeader,
+      format: generator.format,
+      schemaSuffix: 'Schema',
+      fileSuffix: '.x.ts',
+      importExtension: 'js',
+      affix: generator.affix,
+      coerceDates: 'none',
+      applyDefaults: true,
+      schemaPath: 'src/db/schema.ts',
+      typedJson: true,
+      typedColumns: true,
+    });
+  });
+
+  it('withholds the schema-import options from a generator that cannot use them', () => {
+    // ArkType emits one string per field; a TypeScript type reference has nowhere to live there.
+    // Passing them would be harmless but misleading, and the capability is the honest record.
+    const o = validationOptions(generator, config, 'out', { schemaTypes: false });
+    expect(o).not.toHaveProperty('schemaPath');
+    expect(o).not.toHaveProperty('typedJson');
+    expect(o).not.toHaveProperty('typedColumns');
+    // Everything else still arrives.
+    expect(o).toMatchObject({ coerceDates: 'none', applyDefaults: true, affix: generator.affix });
+  });
+
+  it('defaults the output directory when the generator names none', () => {
+    const o = validationOptions({}, config, 'src/validators/zod', {});
+    expect(o.outDir).toBe('src/validators/zod');
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -284,17 +284,23 @@ function tbField(
   // Nullability wraps the constrained type, so null skips the constraint. That reproduces SQL,
   // where a CHECK passes when it evaluates to TRUE or NULL.
   if (c.nullable) expr = `Type.Union([${expr}, Type.Null()])`;
+  // The default goes on the schema itself, before anything wraps it. Applied after the
+  // `Type.Unsafe` wrapper instead, it landed on the wrapper, where `withDefault` declines to
+  // touch it and the default was silently dropped: the field carried none at all and nothing
+  // said so.
+  //
+  // `Value.Check` does not materialise a default, only `Value.Parse` and `Value.Default` do:
+  // TypeBox separates validating from defaulting where zod and valibot fold the two together.
+  const wantsDefault = mode === 'insert' && applyDefault && c.defaultValue !== undefined;
+  if (wantsDefault) expr = withDefault(expr, c.defaultValue);
+
   // `typedColumns` narrows the static type without touching the runtime schema. `Type.Unsafe<T>`
   // is TypeBox's own primitive for exactly that: it wraps an existing schema, so every check it
   // carries still runs, and only the inferred type is replaced.
   if (narrowRef) expr = `Type.Unsafe<${narrowRef}>(${expr})`;
+
   if (mode !== 'select') {
-    // A literal default becomes a JSON Schema `default` annotation. Note that `Value.Check` does
-    // not materialise it, only `Value.Parse` and `Value.Default` do: TypeBox separates validating
-    // from defaulting, where zod and valibot fold the two together.
-    if (mode === 'insert' && applyDefault && c.defaultValue !== undefined) {
-      expr = `Type.Optional(${withDefault(expr, c.defaultValue)})`;
-    } else if (mode === 'update' || c.nullable || c.hasDefault) {
+    if (wantsDefault || mode === 'update' || c.nullable || c.hasDefault) {
       expr = `Type.Optional(${expr})`;
     }
   }

--- a/packages/generator-typebox/test/apply-defaults.spec.ts
+++ b/packages/generator-typebox/test/apply-defaults.spec.ts
@@ -35,7 +35,11 @@ const col = (name: string, over: Partial<Column> = {}): Column =>
 
 let seq = 0;
 
-async function schemasFor(columns: Column[], applyDefaults: boolean): Promise<Record<string, any>> {
+async function schemasFor(
+  columns: Column[],
+  applyDefaults: boolean,
+  extra: Record<string, unknown> = {}
+): Promise<Record<string, any>> {
   const analysis: Analysis = {
     dialect: 'postgres',
     tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
@@ -45,7 +49,7 @@ async function schemasFor(columns: Column[], applyDefaults: boolean): Promise<Re
   };
   const dir = path.join(__dirname, '.tmp-defaults');
   await fs.mkdir(dir, { recursive: true });
-  await new GEN(analysis).generate({ outDir: dir, applyDefaults } as never);
+  await new GEN(analysis).generate({ outDir: dir, applyDefaults, ...extra } as never);
   // Unique per call: the module cache is process-global.
   const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
   await fs.rename(path.join(dir, `t${SUFFIX}`), file);
@@ -93,5 +97,23 @@ describe('with applyDefaults', () => {
     // A default applies when a row is created, not when it is updated.
     const m = await schemasFor(LITERAL, true);
     expect(RUN(m.UpdatetSchema, {})).toEqual({});
+  });
+});
+
+describe('together with typedColumns', () => {
+  // `Type.Unsafe<T>(schema)` wraps the schema, and the default has to go on the schema it wraps.
+  // Applied to the wrapper instead, it was silently dropped: the emitted field carried no default
+  // at all and nothing said so. Found by generating with both options and reading the output.
+  it('keeps the default when the type is also narrowed', async () => {
+    const m = await schemasFor(LITERAL, true, {
+      typedColumns: true,
+      schemaPath: 'src/db/schema.ts',
+    });
+    expect(RUN(m.InserttSchema, { name: 'x' })).toEqual({
+      name: 'x',
+      country: 'GB',
+      count: 0,
+      flag: true,
+    });
   });
 });


### PR DESCRIPTION
Each of the four generator branches in the CLI hand-built its own options object. Three documented options had already been found silently dead that way: `typedJson` never reached typebox, and `coerceDates` and `applyDefaults` never reached anything but zod.

Fixing each instance did not address the shape of the problem. The four now share one builder, so an option added once reaches everything that can act on it.

What stays per-generator is a real **capability**, and it is named as one:

```ts
validationOptions(g, cfg, target, { schemaTypes: false })   // arktype
```

ArkType emits one string per field, and a TypeScript type reference has nowhere to live inside a string DSL, so it does not receive the schema-import options. Absent rather than present-and-ignored.

## The audit found another one immediately

With `typedColumns` **and** `applyDefaults` both on, the typebox generator emitted **no default at all**:

```ts
// before
country: Type.Optional(Type.Unsafe<(typeof users.$inferInsert)['country']>(Type.String())),
// after
country: Type.Optional(Type.Unsafe<(typeof users.$inferInsert)['country']>(Type.String({ default: 'GB' }))),
```

The default was applied *after* the `Type.Unsafe` wrapper, where it lands on the wrapper rather than the schema. The helper that attaches it declines anything that is not a bare `Type.X(...)`, so it returned the expression untouched and the default vanished without a word. It now goes on the schema before anything wraps it.

Neither option is on by default, so only a project with both enabled was affected.

## The audit, re-run through the real CLI

```
zod      applyDefaults: yes  coerceDates:none: yes  typedColumns: yes
valibot  applyDefaults: yes  coerceDates:none: yes  typedColumns: yes
arktype  applyDefaults: yes  coerceDates:none: yes  typedColumns: n/a
typebox  applyDefaults: yes  coerceDates:none: yes  typedColumns: yes
```

560 tests across 72 files, 4 new. `verify:packed` green.