### PR TITLE
feat(validation): enforce row-level CHECK constraints in every generator

### DIFF
--- a/.changeset/row-checks-everywhere.md
+++ b/.changeset/row-checks-everywhere.md
@@ -1,0 +1,23 @@
+---
+'@drzl/generator-arktype': minor
+'@drzl/generator-typebox': minor
+'@drzl/generator-valibot': minor
+---
+
+Enforce row-level CHECK constraints in the valibot, TypeBox and ArkType generators
+
+`CHECK (start_date < end_date)` compares two columns, so it cannot be a field constraint. Only the
+zod generator applied one; the other three parsed it and dropped it, so a row the database refuses
+validated clean. Each generator now states it in its own idiom: `v.check` on a pipe for valibot,
+`.narrow` for ArkType, and for TypeBox a registered kind intersected with the object, which both
+`Value.Check` and `TypeCompiler` honour. Serialising a TypeBox schema to JSON Schema keeps the
+constraint as a description, since JSON Schema cannot compare two fields.
+
+Both sides are guarded for null first, matching SQL, where a comparison involving NULL leaves the
+CHECK satisfied. A constraint naming a column a given mode does not carry is left out rather than
+emitted against an undefined value.
+
+Also fixes an ArkType crash this uncovered: a CHECK on a column with no declared width, which is
+every numeric type but the integers, emitted `0 < number`. ArkType rejects a left bound with no
+right bound, so the generated module threw the moment anything imported it. A lone bound is now
+written as `number > 0`.

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -2,8 +2,7 @@ import type { Analysis, Table, Column } from '@drzl/analyzer';
 import type {
   ResolvedAffix,
   ValidationRenderer,
-  ValidationGenerateOptions,
-} from '@drzl/validation-core';
+  ValidationGenerateOptions, RowCheck } from '@drzl/validation-core';
 import type { ColumnCheck, ColumnSet } from '@drzl/validation-core';
 import {
   COLUMN_FORMATS,
@@ -53,19 +52,38 @@ function atDateType(
 function atNarrowRange(
   c: Column,
   checks: ColumnCheck[]
-): { lower?: string; upper?: string; equals?: string } {
-  let lower = c.min !== undefined ? `${c.min} <=` : undefined;
-  let upper = c.max !== undefined ? `<= ${c.max}` : undefined;
+): { lower?: Bound; upper?: Bound; equals?: string } {
+  let lower: Bound | undefined = c.min !== undefined ? { op: '>=', value: c.min } : undefined;
+  let upper: Bound | undefined = c.max !== undefined ? { op: '<=', value: c.max } : undefined;
   let equals: string | undefined;
 
   for (const k of checks.filter((x) => x.column === c.name && x.kind === 'number')) {
-    if (k.operator === '>=') lower = `${k.value} <=`;
-    else if (k.operator === '>') lower = `${k.value} <`;
-    else if (k.operator === '<=') upper = `<= ${k.value}`;
-    else if (k.operator === '<') upper = `< ${k.value}`;
+    if (k.operator === '>=' || k.operator === '>') lower = { op: k.operator, value: k.value };
+    else if (k.operator === '<=' || k.operator === '<') upper = { op: k.operator, value: k.value };
     else if (k.operator === '=') equals = k.value;
   }
   return { lower, upper, equals };
+}
+
+/** One end of a range, kept as operator and value because the two ends render differently. */
+type Bound = { op: '>=' | '>' | '<=' | '<'; value: string };
+
+/** The flip of each comparison, for moving a bound from the left of the type to its right. */
+const MIRROR = { '>=': '<=', '>': '<', '<=': '>=', '<': '>' } as const;
+
+/**
+ * A range around a type, in the only forms ArkType parses.
+ *
+ * A bound may sit on the left only when the other end is on the right: `0 < number` is a parse
+ * error, "Left bounds are only valid when paired with right bounds". A lone bound therefore has
+ * to be mirrored onto the right, as `number > 0`. Every numeric column but the integers has no
+ * declared width, so this is the shape a CHECK on a `numeric` or `double precision` column takes,
+ * and it used to emit a module that threw the moment anything imported it.
+ */
+function atRange(num: string, lower?: Bound, upper?: Bound): string {
+  if (lower && upper) return `${lower.value} ${MIRROR[lower.op]} ${num} ${upper.op} ${upper.value}`;
+  const only = lower ?? upper;
+  return only ? `${num} ${only.op} ${only.value}` : num;
 }
 
 /**
@@ -147,11 +165,7 @@ function atTypeForColumn(
       // ArkType does accept both at once: `-2147483648 <= number.integer <= 2147483647` parses
       // and rejects 1.5. Preferring the bound alone, on the theory that a range implied
       // integrality, meant every `integer()` column accepted a fraction.
-      const num = isIntegerColumn(c) ? 'number.integer' : 'number';
-      if (lower && upper) return `${lower} ${num} ${upper}`;
-      if (lower) return `${lower} ${num}`;
-      if (upper) return `${num} ${upper}`;
-      return num;
+      return atRange(isIntegerColumn(c) ? 'number.integer' : 'number', lower, upper);
     }
     case 'bigint':
       // ArkType compares bigints against bigint literals, and a 64 bit bound cannot be written
@@ -217,6 +231,39 @@ function renderObjectShape(
     .join('\n');
 }
 
+/**
+ * `.narrow(...)` calls that belong on the object rather than on a field.
+ *
+ * `CHECK (start_date < end_date)` is a statement about the row. ArkType states one through
+ * `.narrow`, which is its builder rather than its string DSL, so unlike every other constraint
+ * this generator emits it appends to the `type({...})` call rather than living inside a field
+ * string.
+ *
+ * Both sides are guarded for null first, reproducing SQL, where a comparison involving NULL
+ * yields NULL and the CHECK passes.
+ */
+function atRowNarrows(rows: RowCheck[], cols: Column[]): string {
+  const present = new Set(cols.map((c) => c.name));
+  const OPS: Record<RowCheck['operator'], string> = {
+    '>=': '>=',
+    '>': '>',
+    '<=': '<=',
+    '<': '<',
+    '=': '===',
+    '<>': '!==',
+  };
+  return rows
+    // A check naming a column this mode does not carry cannot be evaluated.
+    .filter((r) => present.has(r.left) && present.has(r.right))
+    .map((r) => {
+      const l = `o[${JSON.stringify(r.left)}]`;
+      const rt = `o[${JSON.stringify(r.right)}]`;
+      const msg = JSON.stringify(`${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`);
+      return `.narrow((o, ctx) => ${l} == null || ${rt} == null || ${l} ${OPS[r.operator]} ${rt} || ctx.mustBe(${msg}))`;
+    })
+    .join('');
+}
+
 function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
@@ -236,6 +283,7 @@ function renderTableSchemas(
   const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
   const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
+  const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
   const bodyInsert = renderObjectShape(
     insertCols,
     'insert',
@@ -264,15 +312,15 @@ function renderTableSchemas(
 
 export const ${insertSchema} = type({
 ${bodyInsert}
-});
+})${atRowNarrows(rows, insertCols)};
 
 export const ${updateSchema} = type({
 ${bodyUpdate}
-});
+})${atRowNarrows(rows, updateCols)};
 
 export const ${selectSchema} = type({
 ${bodySelect}
-});
+})${atRowNarrows(rows, selectCols)};
 
 export type ${insertType} = typeof ${insertSchema}["infer"];
 export type ${updateType} = typeof ${updateSchema}["infer"];

--- a/packages/generator-arktype/test/checks.spec.ts
+++ b/packages/generator-arktype/test/checks.spec.ts
@@ -152,3 +152,30 @@ describe('the emitted expressions are ones arktype accepts', () => {
     expect(isErr(T({ age: 30, score: 50, tier: 'silver' })), 'wrong tier').toBe(true);
   });
 });
+
+describe('a bound with no opposite bound', () => {
+  // ArkType refuses `0 < number`: "Left bounds are only valid when paired with right bounds".
+  // So a CHECK on a column carrying no width, which is every numeric type but the integers,
+  // produced a module that threw at import. A lone bound has to be written on the right.
+  it('writes a lone lower bound on the right, where ArkType accepts it', async () => {
+    const t = await typeOf(col('n', { dbType: 'DOUBLE PRECISION' }), [
+      { name: 'positive', expression: 'n > 0' },
+    ]);
+    expect(t).toBe('number > 0');
+  });
+
+  it('writes a lone upper bound the same way', async () => {
+    const t = await typeOf(col('n', { dbType: 'DOUBLE PRECISION' }), [
+      { name: 'small', expression: 'n <= 10' },
+    ]);
+    expect(t).toBe('number <= 10');
+  });
+
+  it('still pairs them when both are present', async () => {
+    const t = await typeOf(col('n', { dbType: 'DOUBLE PRECISION' }), [
+      { expression: 'n > 0' },
+      { expression: 'n < 10' },
+    ]);
+    expect(t).toBe('0 < number < 10');
+  });
+});

--- a/packages/generator-arktype/test/row-checks.spec.ts
+++ b/packages/generator-arktype/test/row-checks.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Row-level CHECK constraints in the arktype generator.
+ *
+ * `CHECK (start_date < end_date)` is a statement about the row: neither column alone can say
+ * whether it holds, so it cannot be a field constraint. It goes on the object.
+ *
+ * Both sides are guarded for null first, reproducing SQL, where a comparison involving NULL
+ * yields NULL and a CHECK passes on NULL. Without the guard an update omitting one column would
+ * be rejected by a comparison the database never applied.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { ArkTypeGenerator } from '../src/index';
+import { type } from 'arktype';
+
+const GEN = ArkTypeGenerator;
+const SUFFIX = '.arktype.ts';
+const RUN = (schema: any, input: unknown) => !(schema(input) instanceof type.errors);
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'number',
+    dbType: 'INTEGER',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-rowchecks');
+  await fs.mkdir(dir, { recursive: true });
+  await new GEN(analysis).generate({ outDir: dir } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return await import(file);
+}
+
+const ROW = [{ name: 'order', expression: 'lo < hi' }];
+const COLS = [col('lo'), col('hi')];
+
+describe('a comparison between two columns', () => {
+  it('is enforced on the object', async () => {
+    const m = await schemasFor(COLS, ROW);
+    expect(RUN(m.SelecttSchema, { lo: 1, hi: 2 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { lo: 2, hi: 1 })).toBe(false);
+    expect(RUN(m.SelecttSchema, { lo: 1, hi: 1 }), 'strict comparison').toBe(false);
+  });
+
+  it('passes when either side is absent, as SQL does', async () => {
+    const m = await schemasFor([col('lo', { nullable: true }), col('hi', { nullable: true })], ROW);
+    expect(RUN(m.SelecttSchema, { lo: null, hi: 1 })).toBe(true);
+    expect(RUN(m.UpdatetSchema, { lo: 5 }), 'hi omitted on update').toBe(true);
+  });
+
+  it('is left out of a mode that does not carry both columns', async () => {
+    // An insert schema omits generated columns. A comparison naming one would read undefined and
+    // silently always pass, which is worse than not emitting it.
+    const m = await schemasFor([col('lo'), col('hi', { isGenerated: true })], ROW);
+    expect(RUN(m.InserttSchema, { lo: 1 })).toBe(true);
+  });
+
+  it('does not appear when there is no row-level constraint', async () => {
+    const m = await schemasFor(COLS, [{ name: 'x', expression: 'lo > 0' }]);
+    expect(RUN(m.SelecttSchema, { lo: 5, hi: 1 }), 'no row check applies').toBe(true);
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -3,6 +3,7 @@ import type {
   ColumnCheck,
   ColumnSet,
   ResolvedAffix,
+  RowCheck,
   ValidationRenderer,
   ValidationGenerateOptions,
 } from '@drzl/validation-core';
@@ -354,6 +355,7 @@ function renderTableSchemas(
   const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
   const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
+  const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
 
   const tj = typedJson
     ? { table: T, mode: 'select' as const, allColumns: typedJson.allColumns }
@@ -399,25 +401,79 @@ function renderTableSchemas(
     !typedJson &&
     [...insertCols, ...updateCols, ...selectCols].some((c) => c.shape?.kind === 'json');
 
-  return `import { Type } from '@sinclair/typebox';
+  const rowCols = [insertCols, updateCols, selectCols].map(
+    (cols) => new Set(cols.map((c) => c.name))
+  );
+  const needsRows = rows.some((r) => rowCols.some((s) => s.has(r.left) && s.has(r.right)));
+  const rowImport = needsRows ? `, Kind, TypeRegistry` : '';
+
+  return `import { Type${rowImport} } from '@sinclair/typebox';
 import type { Static } from '@sinclair/typebox';
-${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}
-export const ${insertSchema} = Type.Object({
-${bodyInsert}
-});
+${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}${needsRows ? `\n${ROW_PREAMBLE}` : ''}
+export const ${insertSchema} = ${tbWrapRows(`Type.Object({\n${bodyInsert}\n})`, rows, insertCols)};
 
-export const ${updateSchema} = Type.Object({
-${bodyUpdate}
-});
+export const ${updateSchema} = ${tbWrapRows(`Type.Object({\n${bodyUpdate}\n})`, rows, updateCols)};
 
-export const ${selectSchema} = Type.Object({
-${bodySelect}
-});
+export const ${selectSchema} = ${tbWrapRows(`Type.Object({\n${bodySelect}\n})`, rows, selectCols)};
 
 export type ${insertType} = Static<typeof ${insertSchema}>;
 export type ${updateType} = Static<typeof ${updateSchema}>;
 export type ${selectType} = Static<typeof ${selectSchema}>;
 `;
+}
+
+/**
+ * The registry entry a row-level check needs, emitted once per file that has one.
+ *
+ * TypeBox has no `.refine`. What it has is a type registry: a kind whose check function is looked
+ * up at validation time, honoured by both `Value.Check` and `TypeCompiler`. Registering is
+ * idempotent, so several generated modules in one process are fine.
+ */
+const ROW_PREAMBLE = `TypeRegistry.Set('DrzlRowCheck', (schema: any, value: any) =>
+  schema.assert(value)
+);
+`;
+
+/**
+ * A row-level CHECK as a branch of an intersection.
+ *
+ * Intersecting rather than setting the kind on the object itself is what keeps the properties
+ * checked. `{ ...Type.Object({...}), [Kind]: 'DrzlRowCheck' }` parses, validates the predicate,
+ * and quietly stops validating the fields, so `{ lo: 'x' }` passes.
+ *
+ * The branch carries no JSON Schema keywords, so `JSON.stringify` renders it as `{}` and the
+ * document stays valid: JSON Schema cannot compare two fields, and an empty branch says nothing
+ * rather than something wrong. `description` survives for a reader, and a failing validation
+ * reports it on `error.schema.description`.
+ */
+function tbWrapRows(objectExpr: string, rows: RowCheck[], cols: Column[]): string {
+  const present = new Set(cols.map((c) => c.name));
+  const OPS: Record<RowCheck['operator'], string> = {
+    '>=': '>=',
+    '>': '>',
+    '<=': '<=',
+    '<': '<',
+    '=': '===',
+    '<>': '!==',
+  };
+  const branches = rows
+    // A check naming a column this mode does not carry cannot be evaluated: an insert schema
+    // omits generated columns, so the comparison would read undefined and always pass or fail.
+    .filter((r) => present.has(r.left) && present.has(r.right))
+    .map((r) => {
+      const l = `o[${JSON.stringify(r.left)}]`;
+      const rt = `o[${JSON.stringify(r.right)}]`;
+      const msg = JSON.stringify(`${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`);
+      // Null on either side means SQL never applied the comparison, so neither does this.
+      return `Type.Unsafe<unknown>({
+    [Kind]: 'DrzlRowCheck',
+    description: ${msg},
+    assert: (o: any) => o == null || ${l} == null || ${rt} == null || ${l} ${OPS[r.operator]} ${rt},
+  })`;
+    });
+  return branches.length
+    ? `Type.Intersect([\n  ${objectExpr},\n  ${branches.join(',\n  ')},\n])`
+    : objectExpr;
 }
 
 export interface TypeBoxGenerateOptions extends ValidationGenerateOptions {

--- a/packages/generator-typebox/test/row-checks.spec.ts
+++ b/packages/generator-typebox/test/row-checks.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * Row-level CHECK constraints in the TypeBox generator.
+ *
+ * `CHECK (start_date < end_date)` is a statement about the row, so it cannot be a field
+ * constraint. TypeBox has no `.refine`, but it does have a type registry: a custom kind holds a
+ * predicate, and intersecting it with the object applies it after the properties are checked.
+ *
+ * The intersection is load bearing. Setting the kind on the object itself parses, and silently
+ * stops checking the properties: `{ lo: 'x' }` passes. That is the failure this file exists to
+ * pin down, so both the row check and an ordinary type error are asserted on every schema here.
+ *
+ * Both sides are guarded for null first, reproducing SQL, where a comparison involving NULL
+ * yields NULL and the CHECK passes.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { TypeBoxGenerator } from '../src/index';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'number',
+    dbType: 'INTEGER',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-rowchecks');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), file);
+  return await import(file);
+}
+
+const ROW = [{ name: 'order', expression: 'lo < hi' }];
+const COLS = [col('lo'), col('hi')];
+
+describe('a comparison between two columns', () => {
+  it('is enforced on the object', async () => {
+    const m = await schemasFor(COLS, ROW);
+    expect(Value.Check(m.SelecttSchema, { lo: 1, hi: 2 })).toBe(true);
+    expect(Value.Check(m.SelecttSchema, { lo: 2, hi: 1 })).toBe(false);
+    expect(Value.Check(m.SelecttSchema, { lo: 1, hi: 1 }), 'strict comparison').toBe(false);
+  });
+
+  it('still checks the property types, which setting the kind directly would not', async () => {
+    const m = await schemasFor(COLS, ROW);
+    expect(Value.Check(m.SelecttSchema, { lo: 'x', hi: 'y' })).toBe(false);
+    expect(Value.Check(m.SelecttSchema, { lo: 1 }), 'hi is required on select').toBe(false);
+  });
+
+  it('holds under the compiler, not only the dynamic checker', async () => {
+    // TypeCompiler is why most people reach for TypeBox. A predicate it cannot compile would be
+    // a schema that behaves one way in tests and another in production.
+    const m = await schemasFor(COLS, ROW);
+    const c = TypeCompiler.Compile(m.SelecttSchema);
+    expect(c.Check({ lo: 1, hi: 2 })).toBe(true);
+    expect(c.Check({ lo: 2, hi: 1 })).toBe(false);
+    expect(c.Check({ lo: 'x', hi: 'y' })).toBe(false);
+  });
+
+  it('passes when either side is absent, as SQL does', async () => {
+    const m = await schemasFor([col('lo', { nullable: true }), col('hi', { nullable: true })], ROW);
+    expect(Value.Check(m.SelecttSchema, { lo: null, hi: 1 })).toBe(true);
+    expect(Value.Check(m.UpdatetSchema, { lo: 5 }), 'hi omitted on update').toBe(true);
+  });
+
+  it('is left out of a mode that does not carry both columns', async () => {
+    // An insert schema omits generated columns. A comparison naming one would read undefined and
+    // silently always pass, which is worse than not emitting it.
+    const m = await schemasFor([col('lo'), col('hi', { isGenerated: true })], ROW);
+    expect(Value.Check(m.InserttSchema, { lo: 1 })).toBe(true);
+  });
+
+  it('does not appear when there is no row-level constraint', async () => {
+    const m = await schemasFor(COLS, [{ name: 'x', expression: 'lo > 0' }]);
+    expect(Value.Check(m.SelecttSchema, { lo: 5, hi: 1 }), 'no row check applies').toBe(true);
+  });
+
+  it('serialises to a JSON Schema that is still valid, having dropped the predicate', async () => {
+    // A function cannot survive JSON.stringify, and JSON Schema cannot express a comparison
+    // between two fields at all. The branch carries no keywords, so it serialises to a schema
+    // that accepts everything: the document stays correct and merely says less than the runtime
+    // does. What it keeps is the description, so a reader of the JSON still learns the rule.
+    const m = await schemasFor(COLS, ROW);
+    const json = JSON.parse(JSON.stringify(m.SelecttSchema));
+    expect(json.allOf?.[0]?.properties?.lo?.type).toBe('integer');
+    expect(Object.keys(json.allOf?.[1] ?? {})).toEqual(['description']);
+    expect(json.allOf[1].description).toBe('order: lo < hi');
+  });
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -3,6 +3,7 @@ import type {
   ResolvedAffix,
   ValidationRenderer,
   ValidationGenerateOptions,
+  RowCheck,
 } from '@drzl/validation-core';
 import type { CardinalityCheck, ColumnCheck, ColumnSet, LengthCheck } from '@drzl/validation-core';
 import {
@@ -361,6 +362,41 @@ function renderObjectShape(
     .join('\n');
 }
 
+/**
+ * `v.check(...)` actions that belong on the object rather than on a field.
+ *
+ * `CHECK (start_date < end_date)` is a statement about the row: neither column alone can say
+ * whether it holds. Both sides are guarded for null first, reproducing SQL, where a comparison
+ * involving NULL yields NULL and the CHECK passes.
+ */
+/** Wrap an object schema in its row-level checks, or leave it alone when there are none. */
+function wrapRows(objectExpr: string, rows: RowCheck[], cols: Column[]): string {
+  const checks = vRowChecks(rows, cols);
+  return checks.length ? `v.pipe(${objectExpr}, ${checks.join(', ')})` : objectExpr;
+}
+
+function vRowChecks(rows: RowCheck[], cols: Column[]): string[] {
+  const present = new Set(cols.map((c) => c.name));
+  const OPS: Record<RowCheck['operator'], string> = {
+    '>=': '>=',
+    '>': '>',
+    '<=': '<=',
+    '<': '<',
+    '=': '===',
+    '<>': '!==',
+  };
+  return rows
+    // A check naming a column this mode does not carry cannot be evaluated: an insert schema
+    // omits generated columns, so the comparison would read undefined and always pass or fail.
+    .filter((r) => present.has(r.left) && present.has(r.right))
+    .map((r) => {
+      const l = `o[${JSON.stringify(r.left)}]`;
+      const rt = `o[${JSON.stringify(r.right)}]`;
+      const msg = JSON.stringify(`${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`);
+      return `v.check((o) => ${l} == null || ${rt} == null || ${l} ${OPS[r.operator]} ${rt}, ${msg})`;
+    });
+}
+
 function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
@@ -383,6 +419,7 @@ function renderTableSchemas(
   const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
   const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
+  const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
   const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
   const cardinalities = parsedChecks.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : []));
   const tj = typedColumns ? { table: T, mode: 'select' as const } : undefined;
@@ -434,17 +471,11 @@ function renderTableSchemas(
   return `import * as v from 'valibot';
 import type { InferInput, InferOutput } from 'valibot';
 ${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}
-export const ${insertSchema} = v.object({
-${bodyInsert}
-});
+export const ${insertSchema} = ${wrapRows(`v.object({\n${bodyInsert}\n})`, rows, insertCols)};
 
-export const ${updateSchema} = v.object({
-${bodyUpdate}
-});
+export const ${updateSchema} = ${wrapRows(`v.object({\n${bodyUpdate}\n})`, rows, updateCols)};
 
-export const ${selectSchema} = v.object({
-${bodySelect}
-});
+export const ${selectSchema} = ${wrapRows(`v.object({\n${bodySelect}\n})`, rows, selectCols)};
 
 export type ${insertType} = InferInput<typeof ${insertSchema}>;
 export type ${updateType} = InferInput<typeof ${updateSchema}>;

--- a/packages/generator-valibot/test/row-checks.spec.ts
+++ b/packages/generator-valibot/test/row-checks.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Row-level CHECK constraints in the valibot generator.
+ *
+ * `CHECK (start_date < end_date)` is a statement about the row: neither column alone can say
+ * whether it holds, so it cannot be a field constraint. It goes on the object.
+ *
+ * Both sides are guarded for null first, reproducing SQL, where a comparison involving NULL
+ * yields NULL and a CHECK passes on NULL. Without the guard an update omitting one column would
+ * be rejected by a comparison the database never applied.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { ValibotGenerator } from '../src/index';
+import * as v from 'valibot';
+
+const GEN = ValibotGenerator;
+const SUFFIX = '.valibot.ts';
+const RUN = (schema: any, input: unknown) => v.safeParse(schema, input).success;
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'number',
+    dbType: 'INTEGER',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-rowchecks');
+  await fs.mkdir(dir, { recursive: true });
+  await new GEN(analysis).generate({ outDir: dir } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return await import(file);
+}
+
+const ROW = [{ name: 'order', expression: 'lo < hi' }];
+const COLS = [col('lo'), col('hi')];
+
+describe('a comparison between two columns', () => {
+  it('is enforced on the object', async () => {
+    const m = await schemasFor(COLS, ROW);
+    expect(RUN(m.SelecttSchema, { lo: 1, hi: 2 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { lo: 2, hi: 1 })).toBe(false);
+    expect(RUN(m.SelecttSchema, { lo: 1, hi: 1 }), 'strict comparison').toBe(false);
+  });
+
+  it('passes when either side is absent, as SQL does', async () => {
+    const m = await schemasFor([col('lo', { nullable: true }), col('hi', { nullable: true })], ROW);
+    expect(RUN(m.SelecttSchema, { lo: null, hi: 1 })).toBe(true);
+    expect(RUN(m.UpdatetSchema, { lo: 5 }), 'hi omitted on update').toBe(true);
+  });
+
+  it('is left out of a mode that does not carry both columns', async () => {
+    // An insert schema omits generated columns. A comparison naming one would read undefined and
+    // silently always pass, which is worse than not emitting it.
+    const m = await schemasFor([col('lo'), col('hi', { isGenerated: true })], ROW);
+    expect(RUN(m.InserttSchema, { lo: 1 })).toBe(true);
+  });
+
+  it('does not appear when there is no row-level constraint', async () => {
+    const m = await schemasFor(COLS, [{ name: 'x', expression: 'lo > 0' }]);
+    expect(RUN(m.SelecttSchema, { lo: 5, hi: 1 }), 'no row check applies').toBe(true);
+  });
+});


### PR DESCRIPTION
## What

`CHECK (start_date < end_date)` is a statement about the row: neither column alone can decide it.
All four validation generators parsed it. One applied it. valibot, TypeBox and ArkType dropped it
on the floor, so a row Postgres refuses validated clean.

Each generator now states it in its own idiom:

| generator | form |
| --- | --- |
| valibot | `v.pipe(v.object({...}), v.check(...))` |
| ArkType | `type({...}).narrow((o, ctx) => ...)` |
| TypeBox | `Type.Intersect([Type.Object({...}), <registered kind>])` |

## TypeBox has no `.refine`, and the obvious workaround is a trap

TypeBox has no refinement mechanism at all, but it has a type registry: a kind whose check
function is looked up during validation, honoured by both `Value.Check` and `TypeCompiler`.

The tempting way to attach it is to set the kind on the object:

```ts
{ ...Type.Object({ lo: Type.Number() }), [Kind]: 'DrzlRowCheck', assert }
```

That parses, enforces the predicate, and **silently stops checking the properties**: `{ lo: 'x' }`
passes. Intersecting instead keeps both. Every schema in the new test file is asserted against an
ordinary type error as well as the row check, so a regression to that form fails rather than
looking green.

`TypeCompiler.Compile` is covered too. It is the main reason people choose TypeBox, and a
predicate it could not compile would behave one way in tests and another in production.

Serialising to JSON Schema stays valid. JSON Schema cannot compare two fields, so the branch
carries no keywords and renders as a schema that accepts everything, keeping its `description` so
a reader of the document still learns the rule.

## SQL semantics

A comparison involving NULL yields NULL, and a CHECK passes on NULL. Both sides are therefore
guarded before comparing. Without that, an update omitting one column would be rejected by a
comparison the database never applied.

A constraint naming a column the mode does not carry, for example a generated column absent from
the insert schema, is left out rather than emitted against `undefined`, where it would silently
always pass or always fail.

## An ArkType crash found along the way

The last test of the four, the one asserting no row check appears when there is no row-level
constraint, failed with a `ParseError` rather than an assertion:

```
Left bounds are only valid when paired with right bounds (try ...>0)
```

`CHECK (n > 0)` on a column with no declared width, which is every numeric type except the
integers, emitted `0 < number`. ArkType refuses a left bound with no right bound, so the generated
module **threw the moment anything imported it**. A lone bound is now mirrored onto the right as
`number > 0`; a pair still renders as `0 < number < 10`. Three tests cover it.

## Verification

- 578 tests across 75 files, green
- `pnpm typecheck` and `pnpm lint` clean
- every emitted form is executed against the real library rather than string-matched, which is how
  both the TypeBox property-checking trap and the ArkType parse error surfaced
