### PR TITLE
feat(json-schema): generate JSON Schema and OpenAPI, and fix what it uncovered on drizzle 0.4x

### DIFF
--- a/.changeset/json-schema-generator.md
+++ b/.changeset/json-schema-generator.md
@@ -1,0 +1,33 @@
+---
+'@drzl/generator-json-schema': minor
+'@drzl/analyzer': patch
+'@drzl/cli': minor
+---
+
+Add a JSON Schema and OpenAPI generator, and fix two analyzer gaps it uncovered on drizzle-orm 0.4x
+
+`{ kind: 'json-schema' }` emits plain JSON Schema per table, with no runtime dependency at all.
+The other four generators each target one validation library, so the output only helps a
+TypeScript program that installs that library. JSON Schema is what OpenAPI documents, API
+gateways, form builders and validators in other languages already read, and nothing in the
+official Drizzle family emits it.
+
+`target` picks the dialect: `draft-2020-12` (default), `openapi-3.1`, or `openapi-3.0`. The last
+is genuinely different rather than older, spelling nullable as `nullable: true` and an exclusive
+bound as a boolean beside the bound. Since JSON Schema ignores unknown keywords rather than
+rejecting them, emitting the wrong dialect gives a document that validates and then accepts what
+the constraint exists to reject.
+
+Running the new generator through the real CLI surfaced two analyzer bugs affecting **every**
+generator on drizzle-orm 0.4x, the version the analyzer depends on:
+
+- **`.array()` columns came back `unknown`.** 0.4x wraps the column in a `PgArray` whose
+  `baseColumn` is the element; v1 leaves the class alone and raises `dimensions`. Only the v1
+  signal was read.
+- **`pgEnum` columns came back `unknown`.** The class map had no arm for `PgEnumColumn`, so the
+  values sat in `enumValues` with no type to attach to.
+
+Both produced schemas that accepted anything, in all five generators, with nothing reporting a
+problem. `verify-packed.sh` pins `drizzle-orm@1.0.0-rc.4`, so the whole verification ladder only
+ever ran on one major; it now runs a stage against 0.4x that fails on any column the analyzer
+cannot name. That stage found the enum bug the first time it ran.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Thanks for your interest in contributing! This guide explains how to set up your
 
 - `analyzer`: Drizzle schema analysis
 - `cli`: drzl CLI
-- `generator-*`: code generators (oRPC, service, zod, valibot, arktype, typebox)
+- `generator-*`: code generators (oRPC, service, zod, valibot, arktype, typebox, json-schema)
 - `template-*`: oRPC templates
 - `validation-core`: shared validation codegen helpers
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Zero‑friction codegen for Drizzle ORM. Analyze your schema. Generate validatio
 ## What’s Inside
 
 - Analyzer: turns Drizzle schemas into a normalized analysis model
-- Generators: Zod, Valibot, ArkType, TypeBox validation; typed CRUD services; router templates (oRPC)
+- Generators: Zod, Valibot, ArkType, TypeBox validation; JSON Schema and OpenAPI; typed CRUD services; router templates (oRPC)
 - Batteries: formatting, naming, reusable/shared schemas, relation support
 - Monorepo: pnpm workspace, lockstep releases with Changesets
 
@@ -82,6 +82,7 @@ Runtime
 - `packages/generator-valibot`: Valibot generator
 - `packages/generator-arktype`: ArkType generator
 - `packages/generator-typebox`: TypeBox generator
+- `packages/generator-json-schema`: JSON Schema and OpenAPI generator
 - `packages/validation-core`: shared validation utilities
 - `packages/template-orpc-service`: oRPC router template (service‑backed)
 - `packages/template-standard`: minimal oRPC router template

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -60,6 +60,7 @@ export default {
           { text: 'Valibot', link: '/generators/valibot' },
           { text: 'ArkType', link: '/generators/arktype' },
           { text: 'TypeBox', link: '/generators/typebox' },
+          { text: 'JSON Schema', link: '/generators/json-schema' },
           { text: 'Adapters (Overview)', link: '/adapters/overview' },
           { text: 'Router Adapters', link: '/adapters/router' },
         ],

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,3 +205,4 @@ See also:
   - [/generators/valibot](/generators/valibot)
   - [/generators/arktype](/generators/arktype)
   - [/generators/typebox](/generators/typebox)
+  - [/generators/json-schema](/generators/json-schema)

--- a/docs/generators/json-schema.md
+++ b/docs/generators/json-schema.md
@@ -1,0 +1,101 @@
+# JSON Schema Generator
+
+Generates plain [JSON Schema](https://json-schema.org) per table (insert/update/select) and an
+index barrel.
+
+```ts
+{ kind: 'json-schema', path: 'src/validators/json-schema' }
+```
+
+The other four generators each target one validation library, so the output is only useful to a
+TypeScript program that installs that library. JSON Schema is the format everything else already
+reads: OpenAPI documents, API gateways, form builders, contract tests, and validators in other
+languages.
+
+**There is no runtime dependency, not even an optional one.** The output is data.
+
+## Example output
+
+```ts
+export const SelectpeopleSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'people.select',
+  title: 'select people',
+  type: 'object',
+  properties: {
+    id: { type: 'integer', minimum: -2147483648, maximum: 2147483647 },
+    age: { type: 'integer', minimum: 18, maximum: 2147483647 },
+    score: { type: ['integer', 'null'], minimum: 0, maximum: 100 },
+    tier: { const: 'gold' },
+    tags: { type: 'array', items: { type: 'string' }, minItems: 2 },
+    bio: { type: ['string', 'null'] },
+  },
+  required: ['id', 'age', 'score', 'tier', 'tags', 'bio'],
+  additionalProperties: false,
+} as const;
+
+export type SelectpeopleOutput = typeof SelectpeopleSchema;
+```
+
+## Which dialect
+
+```ts
+{ kind: 'json-schema', target: 'openapi-3.0' }
+```
+
+| `target` | What it is |
+| --- | --- |
+| `draft-2020-12` (default) | The current draft, with a `$schema` declaration |
+| `openapi-3.1` | The same draft, with no `$schema`, which is how a schema appears inside an OpenAPI 3.1 document |
+| `openapi-3.0` | A different dialect, see below |
+
+OpenAPI 3.0 is not an older superset of 2020-12. It spells things differently:
+
+| | `draft-2020-12` | `openapi-3.0` |
+| --- | --- | --- |
+| nullable | `type: ['string', 'null']` | `type: 'string', nullable: true` |
+| exclusive bound | `exclusiveMinimum: 0` | `minimum: 0, exclusiveMinimum: true` |
+| positional array | `prefixItems: [...]` | no equivalent, falls back to a length |
+
+This matters more than a formatting preference, because **an unknown keyword is not an error in
+JSON Schema: it is ignored.** A 2020-12 `exclusiveMinimum: 0` dropped into a 3.0 document is read
+as the boolean form with no bound at all, or ignored outright. Either way the document still
+validates as OpenAPI, and the constraint that exists to reject `0` now accepts it. That is the
+reason this is an option rather than a note.
+
+## What it cannot say
+
+JSON Schema cannot compare one property against another. `if`/`then` and `dependentSchemas` can
+branch on whether a property is present or on a fixed value, and neither of those is `lo < hi`.
+
+So a row-level `CHECK (start_date < end_date)` is carried as the schema's `description` and
+nothing pretends to enforce it:
+
+```json
+{
+  "description": "Row constraints not expressible in JSON Schema: valid_range: start_date < end_date"
+}
+```
+
+The four validation generators do enforce these. See
+[the ArkType generator](/generators/arktype) or [the valibot generator](/generators/valibot).
+
+## Values as they survive JSON
+
+The schema describes the value **after** `JSON.stringify`, which is not always what the TypeScript
+type says:
+
+| Column | Schema |
+| --- | --- |
+| `bigint` | `{ type: 'string', pattern: '^-?\\d+$' }`, because `JSON.stringify` throws on a bigint |
+| `bytea`, `blob` | `{ type: 'string', contentEncoding: 'base64' }` |
+| `timestamp` | `{ type: 'string', format: 'date-time' }` |
+| `json`, `jsonb` | `{}`, which is how the format spells "any JSON value" |
+| `point` | `prefixItems` of two numbers, with `minItems` and `maxItems` |
+
+## Verification
+
+Every emitted schema in the test suite is compiled by [ajv](https://ajv.js.org) in **strict mode**,
+which rejects unknown keywords rather than ignoring them, and then asserted on which values it
+accepts. Nothing asserts on the shape of the emitted object, because a schema that looks right and
+means nothing is the failure this format makes easy.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -80,7 +80,8 @@ By default the validation generators name their exports `Insert<Table>Schema`,
 name from your Drizzle schema, used exactly as written, so `export const users = ...` gives
 `InsertusersSchema`.
 
-The `affix` option on a `zod`, `valibot`, `arktype` or `typebox` generator changes all of that. Leaving
+The `affix` option on a `zod`, `valibot`, `arktype`, `typebox` or `json-schema` generator changes all of
+that. Leaving
 it out keeps the names above unchanged.
 
 ```ts
@@ -171,10 +172,10 @@ compile.
 
 ## Naming generated files
 
-A `zod`, `valibot`, `arktype` or `typebox` generator writes one file per table, named after the
-Drizzle export name plus a suffix that defaults to `.zod.ts`, `.valibot.ts`, `.arktype.ts` or
-`.typebox.ts`, and an
-`index.ts` barrel that re-exports them. `fileSuffix` replaces that suffix.
+A `zod`, `valibot`, `arktype`, `typebox` or `json-schema` generator writes one file per table,
+named after the Drizzle export name plus a suffix that defaults to `.zod.ts`, `.valibot.ts`,
+`.arktype.ts`, `.typebox.ts` or `.schema.ts`, and an `index.ts` barrel that re-exports them.
+`fileSuffix` replaces that suffix.
 
 ```ts
 { kind: 'zod', path: 'src/validators/zod', fileSuffix: '.schema.ts' }

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -477,6 +477,28 @@ export function describeV1Column(column: any): Partial<Column> | null {
   return out;
 }
 
+/**
+ * The element of an array column, and how deeply it is nested.
+ *
+ * Drizzle changed how it models an array between majors. v1 leaves the column class alone and
+ * raises `dimensions` on it, which `describeV1Column` reads. 0.4x wraps the column in a `PgArray`
+ * whose `baseColumn` holds the element, and nothing read that at all: every `.array()` column on
+ * the version this package depends on came back `unknown`, in all five generators, because the
+ * class-name mapping had no arm for `PgArray` and no reason to look inside one.
+ *
+ * A no-op on v1, where there is no `baseColumn` to find.
+ */
+function unwrapArrayColumn(column: any): { element: any; dimensions: number } {
+  let element = column;
+  let dimensions = 0;
+  // `.array().array()` nests one PgArray inside another, so the depth is the walk length.
+  while (element?.baseColumn && String(element?.constructor?.name ?? '').endsWith('Array')) {
+    element = element.baseColumn;
+    dimensions++;
+  }
+  return { element, dimensions };
+}
+
 /** A declared width, from `vector({ dimensions: 3 })` or `bit({ dimensions: 3 })`. */
 function declaredLength(column: any): number | undefined {
   const n = column?.length ?? column?.config?.length ?? column?.config?.dimensions;
@@ -899,6 +921,11 @@ export class SchemaAnalyzer {
         return { tsType: 'string', dbType: 'NUMERIC' };
       case 'SQLiteBoolean':
         return { tsType: 'boolean', dbType: 'INTEGER' };
+      // 0.4x gives an enum its own class, which had no arm here at all, so an enum column came
+      // back `unknown` and every generator emitted a schema that accepted anything. The values
+      // were on the column the whole time, in `enumValues`, waiting for a type to attach to.
+      case 'PgEnumColumn':
+        return { tsType: 'string', dbType: 'TEXT' };
       case 'PgInteger':
       case 'PgSmallInt':
         return { tsType: 'number', dbType: 'INTEGER' };
@@ -1097,7 +1124,10 @@ export class SchemaAnalyzer {
     const pkCols: string[] = [];
     const uniqueGroups = new Map<string, string[]>();
 
-    for (const [colName, col] of Object.entries(columnsObj)) {
+    for (const [colName, outerCol] of Object.entries(columnsObj)) {
+      // Everything describing the *value* reads the element; everything describing the *column*
+      // (nullability, defaults, generated) stays on the outer one, which is where Drizzle keeps it.
+      const { element: col, dimensions: arrayDims } = unwrapArrayColumn(outerCol);
       let { tsType, dbType } = this.mapColumnType(col);
       if (tsType === 'unknown' && /At$/.test(colName)) {
         // Heuristic for timestamp fields
@@ -1105,7 +1135,7 @@ export class SchemaAnalyzer {
         dbType = 'INTEGER';
       }
       const ev = (col as any)?.enumValues as string[] | undefined;
-      const nullable = !(col as any)?.notNull && !(col as any)?.config?.notNull;
+      const nullable = !(outerCol as any)?.notNull && !(outerCol as any)?.config?.notNull;
       // What the database refuses to be given a value for, which is narrower than "the database
       // fills this in".
       //
@@ -1122,18 +1152,18 @@ export class SchemaAnalyzer {
       // A literal default, which a schema can reproduce. An SQL object carries `queryChunks` and
       // is evaluated by the database; a `$defaultFn` is called by Drizzle at insert time. Both
       // would change the value if a schema guessed at them, so neither is carried.
-      const rawDefault = (col as any)?.default;
+      const rawDefault = (outerCol as any)?.default;
       const defaultValue =
         rawDefault !== undefined &&
         !(rawDefault && typeof rawDefault === 'object' && 'queryChunks' in rawDefault)
           ? rawDefault
           : undefined;
 
-      const generatedIdentity = (col as any)?.generatedIdentity;
+      const generatedIdentity = (outerCol as any)?.generatedIdentity;
       const isGenerated = !!(
-        (col as any)?.generated ||
+        (outerCol as any)?.generated ||
         generatedIdentity?.type === 'always' ||
-        (col as any)?.isGenerated
+        (outerCol as any)?.isGenerated
       );
       // `col.hasDefault` is the property Drizzle actually sets, and it is the only thing that
       // separates a key the database fills in from one the caller must supply. Reading
@@ -1141,20 +1171,20 @@ export class SchemaAnalyzer {
       // reported false for every Postgres `serial`, every identity column and every SQLite
       // rowid alias, making them indistinguishable from a plain `integer('id').primaryKey()`.
       const hasDefault =
-        (col as any)?.hasDefault === true ||
-        (col as any)?.default !== undefined ||
-        (col as any)?.config?.default !== undefined ||
-        (col as any)?.defaultFn !== undefined ||
+        (outerCol as any)?.hasDefault === true ||
+        (outerCol as any)?.default !== undefined ||
+        (outerCol as any)?.config?.default !== undefined ||
+        (outerCol as any)?.defaultFn !== undefined ||
         isGenerated;
       // `col.references` does not exist on a Drizzle column; reading it always produced
       // undefined, so no foreign key was ever reported. The real data is collected from the
       // table's inline and table-level foreign keys below and attached afterwards.
       const references = undefined as Column['references'];
-      const isUnique = !!((col as any)?.isUnique || (col as any)?.config?.isUnique);
-      const isPk = !!((col as any)?.primary || (col as any)?.config?.primaryKey);
+      const isUnique = !!((outerCol as any)?.isUnique || (outerCol as any)?.config?.isUnique);
+      const isPk = !!((outerCol as any)?.primary || (outerCol as any)?.config?.primaryKey);
       if (isPk) pkCols.push(colName);
       if (isUnique) unique.push({ columns: [colName] });
-      const uName = (col as any)?.uniqueName || (col as any)?.config?.uniqueName;
+      const uName = (outerCol as any)?.uniqueName || (outerCol as any)?.config?.uniqueName;
       if (uName) {
         const arr = uniqueGroups.get(uName) ?? [];
         arr.push(colName);
@@ -1184,6 +1214,9 @@ export class SchemaAnalyzer {
         ...(defaultValue !== undefined ? { defaultValue } : {}),
         ...constraints,
         ...(v1 ?? {}),
+        // After the v1 spread, which sets its own `arrayDimensions` from `dimensions`. On 0.4x
+        // that spread has nothing to say and this is the only source.
+        ...(arrayDims ? { arrayDimensions: arrayDims } : {}),
       });
     }
 

--- a/packages/analyzer/test/arrays-0.4x.spec.ts
+++ b/packages/analyzer/test/arrays-0.4x.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * `.array()` columns on drizzle-orm 0.4x, which is the version this package depends on.
+ *
+ * Drizzle changed how it models an array between majors. v1 leaves the column class alone and
+ * raises `dimensions` on it; 0.4x wraps the column in a `PgArray` whose `baseColumn` is the
+ * element. The analyzer only ever read the v1 signal.
+ *
+ * That was invisible because the whole verification ladder, `verify-packed.sh` included, installs
+ * `drizzle-orm@1.0.0-rc.4`. The gate was green, `text().array()` was in the fixture, and on the
+ * version users actually have every array column came back `unknown` in all five generators.
+ *
+ * So these tests build against the installed 0.4x and assert the element type survives.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function columnsOf(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const a = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  return Object.fromEntries((a.tables[0]?.columns ?? []).map((c) => [c.name, c]));
+}
+
+describe('a postgres array column', () => {
+  it('reports the element type and one dimension', async () => {
+    const cols = await columnsOf(
+      'arr-pg',
+      `
+      import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', {
+        tags: text('tags').array(),
+        nums: integer('nums').array(),
+        plain: text('plain'),
+      });
+      `
+    );
+    expect(cols.tags).toMatchObject({ tsType: 'string', dbType: 'TEXT', arrayDimensions: 1 });
+    expect(cols.nums).toMatchObject({ tsType: 'number', dbType: 'INTEGER', arrayDimensions: 1 });
+    expect(cols.plain.arrayDimensions, 'a scalar is not an array').toBeUndefined();
+  });
+
+  it('counts nesting for an array of arrays', async () => {
+    const cols = await columnsOf(
+      'arr-pg-2d',
+      `
+      import { pgTable, text } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', { grid: text('grid').array().array() });
+      `
+    );
+    expect(cols.grid).toMatchObject({ tsType: 'string', arrayDimensions: 2 });
+  });
+
+  it('keeps the element bounds rather than the array getting them', async () => {
+    // `columnConstraints` reads the outer column. On an array that is the PgArray, which has no
+    // length and no integer range, so a `varchar(10)[]` silently lost its cap.
+    const cols = await columnsOf(
+      'arr-pg-bounds',
+      `
+      import { pgTable, varchar, integer } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', {
+        names: varchar('names', { length: 10 }).array(),
+        nums: integer('nums').array(),
+      });
+      `
+    );
+    expect(cols.names.maxLength, 'varchar(10)[] caps each element at 10').toBe(10);
+    expect(cols.nums.min, 'integer[] elements are still int32').toBe('-2147483648');
+  });
+
+  it('carries an enum array as the enum, not as unknown', async () => {
+    const cols = await columnsOf(
+      'arr-pg-enum',
+      `
+      import { pgTable, pgEnum } from 'drizzle-orm/pg-core';
+      export const mood = pgEnum('mood', ['sad', 'ok']);
+      export const t = pgTable('t', { moods: mood('moods').array() });
+      `
+    );
+    expect(cols.moods).toMatchObject({ arrayDimensions: 1 });
+    expect(cols.moods.enumValues).toEqual(['sad', 'ok']);
+  });
+
+  it('leaves nullability on the column itself', async () => {
+    const cols = await columnsOf(
+      'arr-pg-null',
+      `
+      import { pgTable, text } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', {
+        a: text('a').array(),
+        b: text('b').array().notNull(),
+      });
+      `
+    );
+    expect(cols.a.nullable).toBe(true);
+    expect(cols.b.nullable).toBe(false);
+  });
+});
+
+describe('a pgEnum column on 0.4x', () => {
+  // Found by the drizzle-orm 0.4x stage of `verify-packed.sh` the first time it ran. The
+  // class-name map had no arm for `PgEnumColumn`, so an enum column was `unknown` and every
+  // generator emitted a schema accepting anything, even though `enumValues` was right there.
+  it('is a string, so the enum values can be applied to it', async () => {
+    const cols = await columnsOf(
+      'enum-0.4x',
+      `
+      import { pgTable, pgEnum } from 'drizzle-orm/pg-core';
+      export const mood = pgEnum('mood', ['sad', 'ok', 'happy']);
+      export const t = pgTable('t', {
+        feeling: mood('feeling').notNull(),
+        moods: mood('moods').array().notNull(),
+      });
+      `
+    );
+    expect(cols.feeling.tsType).toBe('string');
+    expect(cols.feeling.dbType).not.toBe('UNKNOWN');
+    expect(cols.feeling.enumValues).toEqual(['sad', 'ok', 'happy']);
+
+    expect(cols.moods.tsType, 'the element type, with the array carried separately').toBe('string');
+    expect(cols.moods.dbType).not.toBe('UNKNOWN');
+    expect(cols.moods.arrayDimensions).toBe(1);
+    expect(cols.moods.enumValues).toEqual(['sad', 'ok', 'happy']);
+  });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@drzl/analyzer": "workspace:^",
     "@drzl/generator-arktype": "workspace:^",
+    "@drzl/generator-json-schema": "workspace:^",
     "@drzl/generator-orpc": "workspace:^",
     "@drzl/generator-service": "workspace:^",
     "@drzl/generator-typebox": "workspace:^",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -220,6 +220,28 @@ program
             console.error(chalk.gray('Error details:'), e?.message ?? e);
             process.exit(1);
           }
+        } else if (g.kind === 'json-schema') {
+          try {
+            const { JsonSchemaGenerator } = await import('@drzl/generator-json-schema');
+            const gen = new JsonSchemaGenerator(analysis);
+            const target = g.path ?? 'src/validators/json-schema';
+            const files = await gen.generate({
+              // JSON Schema is data, so nothing here references a type from the schema module.
+              ...(validationOptions(g, cfg, target, { schemaTypes: false }) as object),
+              target: g.target,
+            } as never);
+            progress.stop();
+            ora().succeed(chalk.green(`Generated (json-schema): ${files.length} files`));
+            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+          } catch (e: any) {
+            progress.stop();
+            console.error(
+              chalk.red('JSON Schema generator missing.'),
+              chalk.yellow('\nInstall with: npm install @drzl/generator-json-schema')
+            );
+            console.error(chalk.gray('Error details:'), e?.message ?? e);
+            process.exit(1);
+          }
         } else if (g.kind === 'typebox') {
           try {
             const { TypeBoxGenerator } = await import('@drzl/generator-typebox');
@@ -234,7 +256,7 @@ program
           } catch (e: any) {
             progress.stop();
             console.error(
-              chalk.red('ArkType generator missing.'),
+              chalk.red('TypeBox generator missing.'),
               chalk.yellow('\nInstall with: npm install @drzl/generator-typebox')
             );
             console.error(chalk.gray('Error details:'), e?.message ?? e);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -71,7 +71,7 @@ export const AffixSchema = z
 export const ImportExtensionSchema = z.enum(IMPORT_EXTENSIONS);
 
 export const GeneratorSchema = z.object({
-  kind: z.enum(['orpc', 'service', 'zod', 'valibot', 'arktype', 'typebox']),
+  kind: z.enum(['orpc', 'service', 'zod', 'valibot', 'arktype', 'typebox', 'json-schema']),
   /**
    * Overrides the top-level `importExtension` for this generator alone, for a project whose
    * generated directories are compiled by different tsconfigs.
@@ -113,6 +113,16 @@ export const GeneratorSchema = z.object({
       configPath: z.string().optional(),
     })
     .optional(),
+  /**
+   * Which spelling of JSON Schema the `json-schema` generator emits.
+   *
+   * OpenAPI 3.0 is not an older superset of the 2020-12 draft, it is a different dialect: a
+   * nullable type is `nullable: true` rather than a type array, and an exclusive bound is a
+   * boolean flag beside the bound rather than its own keyword. An unknown keyword is not an error
+   * in JSON Schema, it is ignored, so emitting the wrong dialect produces a document that
+   * validates and then accepts the values the constraints exist to reject.
+   */
+  target: z.enum(['draft-2020-12', 'openapi-3.1', 'openapi-3.0']).optional(),
   // service generator specific options
   path: z.string().optional(),
   dataAccess: z.enum(['stub', 'drizzle']).default('stub').optional(),
@@ -388,6 +398,7 @@ export function computeGeneratorOutputDirs(cfg: DrzlConfig, cwd = process.cwd())
     if (g.kind === 'valibot') dirs.add(abs(g.path ?? 'src/validators/valibot'));
     if (g.kind === 'arktype') dirs.add(abs(g.path ?? 'src/validators/arktype'));
     if (g.kind === 'typebox') dirs.add(abs(g.path ?? 'src/validators/typebox'));
+    if (g.kind === 'json-schema') dirs.add(abs(g.path ?? 'src/validators/json-schema'));
   }
   return [...dirs];
 }

--- a/packages/generator-json-schema/README.md
+++ b/packages/generator-json-schema/README.md
@@ -1,0 +1,87 @@
+<div align="center">
+
+# @drzl/generator-json-schema
+
+<div align="center">
+
+[![CI](https://github.com/use-drzl/drzl/actions/workflows/ci.yml/badge.svg)](https://github.com/use-drzl/drzl/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/%40drzl%2Fgenerator-json-schema)](https://www.npmjs.com/package/@drzl/generator-json-schema)
+
+</div>
+
+JSON Schema and OpenAPI schemas from your Drizzle analysis (insert / update / select).
+
+No runtime dependency. The output is data.
+
+</div>
+
+## 💚 Sponsor DRZL
+
+<div align="center">
+
+<strong>DRZL is crafted nights & weekends. Sponsorships keep the generators fast, tested, and free.</strong>
+
+[![Sponsor DRZL](https://img.shields.io/badge/GitHub%20Sponsors-Support%20the%20project-ff69b4?logo=github)](https://github.com/sponsors/omar-dulaimi)
+
+</div>
+
+- Every dollar speeds up CI hardware and offsets long test runs on my aging laptop.
+- Sponsors get roadmap input and priority responses in GitHub Issues.
+- Prefer a quick overview? Check `docs/sponsor.md` for the current goals and thank-yous.
+
+## Use
+
+Add to `drzl.config.ts`:
+
+```ts
+generators: [{ kind: 'json-schema', path: 'src/validators/json-schema' }];
+```
+
+## Output
+
+- `Insert<Table>Schema`, `Update<Table>Schema`, `Select<Table>Schema`, each a plain object
+  declared `as const`
+- Optional `index` barrel
+
+## Dialect
+
+```ts
+generators: [{ kind: 'json-schema', target: 'openapi-3.0' }];
+```
+
+`draft-2020-12` (default), `openapi-3.1`, or `openapi-3.0`. The last is a different dialect rather
+than an older version: nullable is `nullable: true` rather than a type array, and an exclusive
+bound is a boolean beside the bound rather than its own keyword. Since an unknown keyword is
+ignored rather than rejected in JSON Schema, emitting the wrong one produces a document that
+validates and then accepts what the constraint exists to reject.
+
+See [the full generator docs](https://use-drzl.github.io/drzl/generators/json-schema) for what the
+format cannot express and how each column type survives `JSON.stringify`.
+
+## Custom names
+
+`affix` renames the exported schemas and type aliases, and `tableCase: 'pascal'` upper-camels
+the Drizzle export name (`users` -> `Users`) instead of interpolating it verbatim. Omit it and
+the names above are unchanged.
+
+```ts
+generators: [
+  {
+    kind: 'json-schema',
+    path: 'src/validators/json-schema',
+    affix: {
+      tableCase: 'pascal',
+      schema: { suffix: 'Schema' },
+      type: {
+        prefix: { insert: 'Create', update: 'Edit', select: '' },
+        suffix: { insert: 'Input', update: 'Input', select: '' },
+      },
+    },
+  },
+];
+```
+
+Emits `InsertUsersSchema` / `UpdateUsersSchema` / `SelectUsersSchema` plus `CreateUsersInput`,
+`EditUsersInput` and a bare `Users`. Every prefix and suffix takes a string or a per-mode
+object keyed by `insert`, `update`, `select`. The legacy `schemaSuffix` still works and is the
+default for `affix.schema.suffix`.

--- a/packages/generator-json-schema/package.json
+++ b/packages/generator-json-schema/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@drzl/generator-json-schema",
+  "version": "0.1.0",
+  "private": false,
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "lint": "eslint . --ext .ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@drzl/analyzer": "workspace:^",
+    "@drzl/validation-core": "workspace:^"
+  },
+  "devDependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=18.17.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/use-drzl/drzl",
+    "directory": "packages/generator-json-schema"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/omar-dulaimi"
+  },
+  "description": "Generate JSON Schema and OpenAPI schemas from a Drizzle schema",
+  "keywords": [
+    "json-schema",
+    "openapi",
+    "drizzle"
+  ]
+}

--- a/packages/generator-json-schema/src/index.ts
+++ b/packages/generator-json-schema/src/index.ts
@@ -1,0 +1,443 @@
+/**
+ * JSON Schema and OpenAPI schemas from a Drizzle schema.
+ *
+ * The other four generators each target one validation library, which means the output is only
+ * useful to a TypeScript program that installs that library. JSON Schema is the format everything
+ * else already reads: OpenAPI documents, API gateways, form builders, contract tests, and
+ * validators in other languages. Nothing in the official Drizzle family emits it.
+ *
+ * There is no runtime dependency here, not even an optional one. The output is data.
+ *
+ * What JSON Schema cannot say is stated plainly rather than approximated. A comparison between
+ * two columns has no expression in the format at all, so it is carried as a `description` and
+ * nothing pretends to enforce it.
+ */
+import type { Analysis, Column, Table } from '@drzl/analyzer';
+import type {
+  CardinalityCheck,
+  ColumnCheck,
+  ColumnSet,
+  LengthCheck,
+  ResolvedAffix,
+  RowCheck,
+  ValidationGenerateOptions,
+} from '@drzl/validation-core';
+import {
+  COLUMN_FORMATS,
+  formatCode,
+  insertColumns,
+  isIntegerColumn,
+  moduleFileName,
+  moduleSpecifier,
+  parseCheck,
+  resolveAffix,
+  schemaName,
+  selectColumns,
+  typeName,
+  updateColumns,
+} from '@drzl/validation-core';
+
+type Mode = 'insert' | 'update' | 'select';
+
+/** A JSON Schema, as data. Deliberately loose: the output is checked by a validator, not by TS. */
+type Schema = Record<string, unknown>;
+
+const DEFAULT_FILE_SUFFIX = '.schema.ts';
+
+/**
+ * Which spelling of JSON Schema to emit.
+ *
+ * `draft-2020-12` is the current draft and the default. `openapi-3.1` is that same draft with the
+ * `$schema` key left off, which is how a schema appears inside an OpenAPI 3.1 document.
+ *
+ * `openapi-3.0` predates it and is not a superset: it spells a nullable type as `nullable: true`
+ * rather than a type array, an exclusive bound as a boolean flag beside the bound rather than as
+ * its own keyword, and has no `prefixItems`. Emitting 2020-12 into a 3.0 document produces a
+ * document that validates as OpenAPI and then quietly means something else, which is the reason
+ * this option exists rather than a note in the README.
+ */
+export type JsonSchemaTarget = 'draft-2020-12' | 'openapi-3.1' | 'openapi-3.0';
+
+const DRAFT = 'https://json-schema.org/draft/2020-12/schema';
+
+/** A uuid, as `format`. Unlike TypeBox, JSON Schema validators know this one without setup. */
+const UUID_FORMAT = 'uuid';
+
+/**
+ * The JSON Schema for one column, before nullability and defaults are applied.
+ *
+ * Every branch answers the same question: what does this value look like once it has been through
+ * `JSON.stringify`? That is not always what the TypeScript type says. A `bigint` cannot be
+ * serialised at all, so it travels as a string; a `Buffer` travels as base64.
+ */
+function baseSchema(
+  c: Column,
+  mode: Mode,
+  target: JsonSchemaTarget,
+  checks: ColumnCheck[],
+  sets: ColumnSet[],
+  lengths: LengthCheck[]
+): Schema {
+  const s = c.shape;
+  if (s) {
+    switch (s.kind) {
+      case 'json':
+        // Any JSON value. An empty schema is how the format spells "no constraint", and it is
+        // honest: a json column really does accept anything JSON can express.
+        return {};
+      case 'custom':
+        // Nothing is known about a custom type's runtime shape, so nothing is claimed.
+        return {};
+      case 'buffer':
+        // Binary cannot travel as JSON. `contentEncoding` is the keyword for saying how it did.
+        return { type: 'string', contentEncoding: 'base64' };
+      case 'tuple':
+        // `prefixItems` is 2020-12. OpenAPI 3.0 has no positional form at all, so it falls back
+        // to a homogeneous array of the right length, which is the closest true statement.
+        return target === 'openapi-3.0'
+          ? { type: 'array', items: { type: 'number' }, minItems: s.length, maxItems: s.length }
+          : {
+              type: 'array',
+              prefixItems: Array.from({ length: s.length }, () => ({ type: 'number' })),
+              minItems: s.length,
+              maxItems: s.length,
+            };
+      case 'numberVector':
+        return {
+          type: 'array',
+          items: { type: 'number' },
+          ...(s.length ? { minItems: s.length, maxItems: s.length } : {}),
+        };
+      case 'bitstring':
+        return {
+          type: 'string',
+          pattern: '^[01]*$',
+          ...(s.length ? (s.exact ? { minLength: s.length, maxLength: s.length } : { maxLength: s.length }) : {}),
+        };
+    }
+  }
+
+  // `CHECK (status IN ('a', 'b'))` is exactly what `enum` means.
+  const set = sets.find((x) => x.column === c.name);
+  if (set) return { enum: set.values.map((v) => (set.kind === 'string' ? v : Number(v))) };
+
+  if (c.enumValues && c.enumValues.length) return { enum: [...c.enumValues] };
+
+  const mine = c.arrayDimensions ? [] : checks.filter((k) => k.column === c.name);
+  const eq = mine.find((k) => k.operator === '=');
+  if (eq) return { const: eq.kind === 'string' ? eq.value : Number(eq.value) };
+
+  switch (c.tsType) {
+    case 'string': {
+      const out: Schema = { type: 'string' };
+      if (c.format === 'uuid') out.format = UUID_FORMAT;
+      else if (c.format && COLUMN_FORMATS[c.format]) out.pattern = COLUMN_FORMATS[c.format];
+      if (c.maxLength !== undefined) out.maxLength = c.maxLength;
+      applyLengths(out, c, lengths);
+      return out;
+    }
+    case 'number': {
+      const out: Schema = { type: isIntegerColumn(c) ? 'integer' : 'number' };
+      if (!c.arrayDimensions) applyNumericBounds(out, c, checks, target);
+      return out;
+    }
+    case 'bigint':
+      // `JSON.stringify` throws on a bigint, so in a JSON document this column is a string. The
+      // pattern is what makes that string still mean an integer.
+      return { type: 'string', pattern: '^-?\\d+$' };
+    case 'boolean':
+      return { type: 'boolean' };
+    case 'Date':
+      // Dates arrive as ISO strings once serialised, whatever `coerceDates` does in TypeScript.
+      return { type: 'string', format: 'date-time' };
+    case 'Uint8Array':
+      return { type: 'string', contentEncoding: 'base64' };
+    default:
+      return {};
+  }
+}
+
+/** `length(col) >= n` as `minLength` and `maxLength`, which count characters as SQL does. */
+function applyLengths(out: Schema, c: Column, lengths: LengthCheck[]) {
+  for (const k of lengths.filter((x) => x.column === c.name)) {
+    const n = Number(k.value);
+    if (k.operator === '>=') out.minLength = Math.max(Number(out.minLength ?? 0), n);
+    else if (k.operator === '>') out.minLength = Math.max(Number(out.minLength ?? 0), n + 1);
+    else if (k.operator === '<=') out.maxLength = Math.min(Number(out.maxLength ?? Infinity), n);
+    else if (k.operator === '<') out.maxLength = Math.min(Number(out.maxLength ?? Infinity), n - 1);
+    else if (k.operator === '=') {
+      out.minLength = n;
+      out.maxLength = n;
+    }
+  }
+}
+
+/**
+ * Declared range and CHECK comparisons as numeric keywords.
+ *
+ * 2020-12 spells an exclusive bound as its own keyword holding the bound. OpenAPI 3.0 spells it
+ * as a boolean beside `minimum`, which means the same thing and is written nowhere near the same
+ * way. Getting this wrong produces a schema that reads as inclusive, silently accepting the one
+ * value the constraint exists to exclude.
+ */
+function applyNumericBounds(
+  out: Schema,
+  c: Column,
+  checks: ColumnCheck[],
+  target: JsonSchemaTarget
+) {
+  let min: { value: number; exclusive: boolean } | undefined =
+    c.min !== undefined ? { value: Number(c.min), exclusive: false } : undefined;
+  let max: { value: number; exclusive: boolean } | undefined =
+    c.max !== undefined ? { value: Number(c.max), exclusive: false } : undefined;
+
+  for (const k of checks.filter((x) => x.column === c.name && x.kind === 'number')) {
+    if (k.operator === '>=') min = { value: Number(k.value), exclusive: false };
+    else if (k.operator === '>') min = { value: Number(k.value), exclusive: true };
+    else if (k.operator === '<=') max = { value: Number(k.value), exclusive: false };
+    else if (k.operator === '<') max = { value: Number(k.value), exclusive: true };
+  }
+
+  const old = target === 'openapi-3.0';
+  if (min) {
+    if (min.exclusive && !old) out.exclusiveMinimum = min.value;
+    else {
+      out.minimum = min.value;
+      if (min.exclusive) out.exclusiveMinimum = true;
+    }
+  }
+  if (max) {
+    if (max.exclusive && !old) out.exclusiveMaximum = max.value;
+    else {
+      out.maximum = max.value;
+      if (max.exclusive) out.exclusiveMaximum = true;
+    }
+  }
+}
+
+/** `cardinality(col) >= n` as array bounds. Exclusive becomes the next integer, which is exact. */
+function cardinalityBounds(c: Column, cardinalities: CardinalityCheck[]): Schema {
+  if (!c.arrayDimensions) return {};
+  const out: Schema = {};
+  for (const k of cardinalities.filter((x) => x.column === c.name)) {
+    const n = Number(k.value);
+    if (k.operator === '>=') out.minItems = n;
+    else if (k.operator === '>') out.minItems = n + 1;
+    else if (k.operator === '<=') out.maxItems = n;
+    else if (k.operator === '<') out.maxItems = n - 1;
+    else if (k.operator === '=') {
+      out.minItems = n;
+      out.maxItems = n;
+    }
+  }
+  return out;
+}
+
+/**
+ * A nullable schema, in whichever way the target spells it.
+ *
+ * 2020-12 has no `nullable` keyword: a value that may be null says so in its `type`. OpenAPI 3.0
+ * has no type array: it has `nullable: true`. A schema with no `type` at all, such as a json
+ * column, already accepts null in 2020-12 and needs nothing.
+ */
+function makeNullable(s: Schema, target: JsonSchemaTarget): Schema {
+  if (target === 'openapi-3.0') return { ...s, nullable: true };
+  if (s.type === undefined) {
+    // `const` and `enum` constrain the value directly, so null has to be added to them instead.
+    if (Array.isArray(s.enum)) return { ...s, enum: [...s.enum, null] };
+    if ('const' in s) {
+      const { const: k, ...rest } = s;
+      return { ...rest, enum: [k, null] };
+    }
+    return s;
+  }
+  return { ...s, type: [s.type as string, 'null'] };
+}
+
+function columnSchema(
+  c: Column,
+  mode: Mode,
+  target: JsonSchemaTarget,
+  checks: ColumnCheck[],
+  sets: ColumnSet[],
+  lengths: LengthCheck[],
+  cardinalities: CardinalityCheck[],
+  applyDefault: boolean
+): Schema {
+  let s = baseSchema(c, mode, target, checks, sets, lengths);
+  // Drizzle keeps an array on the element's own column class, so everything above describes the
+  // element and the wrapping belongs here.
+  const dims = c.arrayDimensions ?? 0;
+  for (let i = 0; i < dims; i++) {
+    s = { type: 'array', items: s, ...(i === dims - 1 ? cardinalityBounds(c, cardinalities) : {}) };
+  }
+  if (c.nullable) s = makeNullable(s, target);
+  if (mode === 'insert' && applyDefault && c.defaultValue !== undefined) {
+    s = { ...s, default: c.defaultValue };
+  }
+  return s;
+}
+
+/**
+ * Row-level checks, as prose.
+ *
+ * JSON Schema cannot compare one property against another. `dependentSchemas` and `if`/`then` can
+ * branch on a property's presence or on a fixed value, and neither can express `lo < hi`. Saying
+ * so in the description is the whole of what the format allows, and it beats emitting something
+ * that looks enforced and is not.
+ */
+function rowDescription(rows: RowCheck[], cols: Column[]): string | undefined {
+  const present = new Set(cols.map((c) => c.name));
+  const applicable = rows.filter((r) => present.has(r.left) && present.has(r.right));
+  if (!applicable.length) return undefined;
+  const list = applicable
+    .map((r) => `${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`)
+    .join('; ')
+  return `Row constraints not expressible in JSON Schema: ${list}`;
+}
+
+function tableSchema(
+  table: Table,
+  cols: Column[],
+  mode: Mode,
+  target: JsonSchemaTarget,
+  applyDefaults: boolean,
+  parsed: ReturnType<typeof collect>
+): Schema {
+  const properties: Schema = {};
+  const required: string[] = [];
+  for (const c of cols) {
+    properties[c.name] = columnSchema(
+      c,
+      mode,
+      target,
+      parsed.checks,
+      parsed.sets,
+      parsed.lengths,
+      parsed.cardinalities,
+      applyDefaults
+    );
+    // An update makes everything optional; elsewhere a column is required unless the database
+    // will supply it. A nullable column is still required: null is a value, and omitting the key
+    // is not the same as sending null.
+    const supplied = c.hasDefault || (mode === 'insert' && applyDefaults && c.defaultValue !== undefined);
+    if (mode !== 'update' && !supplied) required.push(c.name);
+  }
+  const desc = rowDescription(parsed.rows, cols);
+  return {
+    ...(target === 'draft-2020-12' ? { $schema: DRAFT } : {}),
+    $id: `${table.tsName}.${mode}`,
+    title: `${mode} ${table.tsName}`,
+    ...(desc ? { description: desc } : {}),
+    type: 'object',
+    properties,
+    ...(required.length ? { required } : {}),
+    additionalProperties: false,
+  };
+}
+
+function collect(table: Table) {
+  const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  return {
+    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
+    lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
+    cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),
+  };
+}
+
+/** The three schemas for one table, as data rather than as source. */
+export function tableSchemas(
+  table: Table,
+  opts: { target?: JsonSchemaTarget; applyDefaults?: boolean } = {}
+): Record<Mode, Schema> {
+  const target = opts.target ?? 'draft-2020-12';
+  const parsed = collect(table);
+  const build = (cols: Column[], mode: Mode) =>
+    tableSchema(table, cols, mode, target, !!opts.applyDefaults, parsed);
+  return {
+    insert: build(insertColumns(table), 'insert'),
+    update: build(updateColumns(table), 'update'),
+    select: build(selectColumns(table), 'select'),
+  };
+}
+
+function renderTableModule(
+  table: Table,
+  affix: ResolvedAffix,
+  target: JsonSchemaTarget,
+  applyDefaults: boolean
+): string {
+  const T = table.tsName;
+  const schemas = tableSchemas(table, { target, applyDefaults });
+  const decl = (mode: Mode) =>
+    `export const ${schemaName(mode, T, affix)} = ${JSON.stringify(schemas[mode], null, 2)} as const;
+
+export type ${typeName(mode, T, affix)} = typeof ${schemaName(mode, T, affix)};`;
+  return [decl('insert'), decl('update'), decl('select')].join('\n\n') + '\n';
+}
+
+export interface JsonSchemaGenerateOptions extends ValidationGenerateOptions {
+  outputHeader?: { enabled?: boolean; text?: string };
+  target?: JsonSchemaTarget;
+}
+
+export class JsonSchemaGenerator {
+  readonly library = 'json-schema' as const;
+  constructor(private analysis: Analysis) {}
+
+  async generate(opts: JsonSchemaGenerateOptions) {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const out = path.resolve(process.cwd(), opts.outDir);
+    const files: string[] = [];
+    await fs.mkdir(out, { recursive: true });
+    const affix = resolveAffix(opts);
+    const fileSuffix = opts.fileSuffix ?? DEFAULT_FILE_SUFFIX;
+    const target = opts.target ?? 'draft-2020-12';
+
+    for (const table of this.analysis.tables) {
+      const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
+      const code = renderTableModule(table, affix, target, !!opts.applyDefaults);
+      const formatted = await formatCode(
+        buildHeader(opts.outputHeader) + code,
+        filePath,
+        opts.format
+      );
+      await fs.writeFile(filePath, formatted, 'utf8');
+      files.push(filePath);
+    }
+
+    const indexPath = path.join(out, 'index.ts');
+    const index =
+      this.analysis.tables
+        .map((t) => `export * from '${moduleSpecifier(t.tsName, fileSuffix, opts.importExtension)}';`)
+        .join('\n') + '\n';
+    const indexFormatted = await formatCode(
+      buildHeader(opts.outputHeader) + index,
+      indexPath,
+      opts.format
+    );
+    await fs.writeFile(indexPath, indexFormatted, 'utf8');
+    files.push(indexPath);
+    return files;
+  }
+
+  renderTable(table: Table, opts?: JsonSchemaGenerateOptions) {
+    return renderTableModule(
+      table,
+      resolveAffix(opts),
+      opts?.target ?? 'draft-2020-12',
+      !!opts?.applyDefaults
+    );
+  }
+}
+
+export default JsonSchemaGenerator;
+
+function buildHeader(h?: { enabled?: boolean; text?: string }) {
+  if (h?.enabled === false) return '';
+  const text = h?.text ?? '// Generated by DRZL. Do not edit by hand.';
+  return `${text}\n\n`;
+}

--- a/packages/generator-json-schema/test/against-ajv.spec.ts
+++ b/packages/generator-json-schema/test/against-ajv.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * Emitted schemas, run through a real JSON Schema validator.
+ *
+ * A JSON Schema is data, which makes it very easy to emit something that looks right and means
+ * nothing: an unknown keyword is not an error in JSON Schema, it is ignored. `exclusiveMinimum`
+ * in the wrong spelling, `prefixItems` in a draft that has no such keyword, `nullable` in a draft
+ * that has no such keyword: every one of those produces a schema that validates as a schema and
+ * then accepts the value it exists to reject.
+ *
+ * So nothing here asserts on the shape of the emitted object. Every case compiles the schema with
+ * ajv in strict mode, which rejects unknown keywords outright, and then asserts which values it
+ * accepts.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import type { Column, Table } from '@drzl/analyzer';
+import { tableSchemas, type JsonSchemaTarget } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (columns: Column[], checks: { name?: string; expression?: string }[] = []): Table =>
+  ({ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }) as never;
+
+/**
+ * Compile with strict mode on, so an unknown or misspelled keyword fails here rather than being
+ * silently ignored the way the specification requires.
+ */
+function compile(schema: unknown) {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  addFormats(ajv as never);
+  return ajv.compile(schema as never);
+}
+
+const selectOf = (t: Table, target?: JsonSchemaTarget) =>
+  tableSchemas(t, { target }) .select;
+
+describe('the emitted schema is a schema', () => {
+  it('compiles under ajv strict mode, which rejects unknown keywords', () => {
+    const t = table([
+      col('id', { tsType: 'number', dbType: 'INTEGER', min: '-2147483648', max: '2147483647' }),
+      col('name', { maxLength: 10 }),
+      col('at', { tsType: 'Date', dbType: 'TIMESTAMP' }),
+      col('raw', { tsType: 'Uint8Array', dbType: 'BYTEA', shape: { kind: 'buffer' } as never }),
+      col('meta', { tsType: 'unknown', dbType: 'JSONB', shape: { kind: 'json' } as never }),
+      col('tags', { arrayDimensions: 1 }),
+      col('big', { tsType: 'bigint', dbType: 'BIGINT' }),
+      col('ok', { tsType: 'boolean', dbType: 'BOOLEAN' }),
+    ]);
+    expect(() => compile(selectOf(t))).not.toThrow();
+  });
+});
+
+describe('numeric bounds', () => {
+  const t = table([col('n', { tsType: 'number', dbType: 'INTEGER' })], [
+    { name: 'positive', expression: 'n > 0' },
+    { name: 'small', expression: 'n <= 10' },
+  ]);
+
+  it('excludes the bound itself for an exclusive comparison', () => {
+    const v = compile(selectOf(t));
+    expect(v({ n: 0 }), '0 is excluded by n > 0').toBe(false);
+    expect(v({ n: 1 })).toBe(true);
+    expect(v({ n: 10 }), '10 is included by n <= 10').toBe(true);
+    expect(v({ n: 11 })).toBe(false);
+  });
+
+  it('keeps the same meaning in the OpenAPI 3.0 spelling', () => {
+    // 3.0 writes an exclusive bound as a boolean beside the bound. Emitting the 2020-12 keyword
+    // into a 3.0 document would be read as an inclusive bound, accepting exactly the value the
+    // constraint exists to reject. ajv reads 3.0's spelling when told the draft is older, so
+    // this asserts the shape directly, which is the one place that is the right call.
+    const s = selectOf(t, 'openapi-3.0') as any;
+    expect(s.properties.n).toMatchObject({ minimum: 0, exclusiveMinimum: true, maximum: 10 });
+    expect(s.properties.n.exclusiveMaximum).toBeUndefined();
+  });
+
+  it('rejects a fraction in an integer column', () => {
+    const v = compile(selectOf(table([col('n', { tsType: 'number', dbType: 'INTEGER' })])));
+    expect(v({ n: 1.5 })).toBe(false);
+    expect(v({ n: 2 })).toBe(true);
+  });
+});
+
+describe('nullability', () => {
+  it('accepts null only where the column is nullable', () => {
+    const v = compile(
+      selectOf(table([col('a', { nullable: true }), col('b')]))
+    );
+    expect(v({ a: null, b: 'x' })).toBe(true);
+    expect(v({ a: 'x', b: null })).toBe(false);
+  });
+
+  it('keeps null out of a non-nullable enum and lets it into a nullable one', () => {
+    const strict = compile(selectOf(table([col('s', { enumValues: ['a', 'b'] as never })])));
+    expect(strict({ s: 'a' })).toBe(true);
+    expect(strict({ s: null })).toBe(false);
+    const loose = compile(
+      selectOf(table([col('s', { enumValues: ['a', 'b'] as never, nullable: true })]))
+    );
+    expect(loose({ s: null })).toBe(true);
+    expect(loose({ s: 'c' })).toBe(false);
+  });
+
+  it('uses the 3.0 keyword when targeting 3.0', () => {
+    const s = selectOf(table([col('a', { nullable: true })]), 'openapi-3.0') as any;
+    expect(s.properties.a).toMatchObject({ type: 'string', nullable: true });
+  });
+});
+
+describe('required keys', () => {
+  it('requires a column the database will not fill in', () => {
+    const v = compile(tableSchemas(table([col('a'), col('b', { hasDefault: true })])).insert);
+    expect(v({ a: 'x' }), 'b has a default').toBe(true);
+    expect(v({ b: 'x' }), 'a does not').toBe(false);
+  });
+
+  it('requires a nullable column, because null is not absence', () => {
+    const v = compile(tableSchemas(table([col('a', { nullable: true })])).insert);
+    expect(v({ a: null })).toBe(true);
+    expect(v({})).toBe(false);
+  });
+
+  it('requires nothing on update', () => {
+    const v = compile(tableSchemas(table([col('a'), col('b')])).update);
+    expect(v({})).toBe(true);
+    expect(v({ a: 1 }), 'still typed').toBe(false);
+  });
+});
+
+describe('constraints carried from CHECK', () => {
+  it('turns IN into an enum', () => {
+    const v = compile(
+      selectOf(table([col('s')], [{ expression: "s IN ('a', 'b')" }]))
+    );
+    expect(v({ s: 'a' })).toBe(true);
+    expect(v({ s: 'c' })).toBe(false);
+  });
+
+  it('turns length() into minLength', () => {
+    const v = compile(
+      selectOf(table([col('s')], [{ expression: 'length(s) >= 3' }]))
+    );
+    expect(v({ s: 'ab' })).toBe(false);
+    expect(v({ s: 'abc' })).toBe(true);
+  });
+
+  it('turns cardinality() into minItems on the array, not the element', () => {
+    const v = compile(
+      selectOf(table([col('tags', { arrayDimensions: 1 })], [{ expression: 'cardinality(tags) >= 2' }]))
+    );
+    expect(v({ tags: ['a'] })).toBe(false);
+    expect(v({ tags: ['a', 'b'] })).toBe(true);
+    expect(v({ tags: [1, 2] }), 'elements are still strings').toBe(false);
+  });
+
+  it('says in prose what it cannot enforce, rather than pretending', () => {
+    // A comparison between two columns has no expression in JSON Schema at all. Carrying it as a
+    // description is the whole of what the format allows.
+    const s = selectOf(
+      table([col('lo', { tsType: 'number' }), col('hi', { tsType: 'number' })], [
+        { name: 'order', expression: 'lo < hi' },
+      ])
+    ) as any;
+    expect(s.description).toContain('lo < hi');
+    const v = compile(s);
+    expect(v({ lo: 5, hi: 1 }), 'and does not claim to enforce it').toBe(true);
+  });
+});
+
+describe('values as they survive JSON', () => {
+  it('carries a bigint as a digit string, since JSON cannot hold one', () => {
+    const v = compile(selectOf(table([col('n', { tsType: 'bigint', dbType: 'BIGINT' })])));
+    expect(v({ n: '9007199254740993' })).toBe(true);
+    expect(v({ n: '1.5' })).toBe(false);
+    expect(v({ n: 1 })).toBe(false);
+  });
+
+  it('carries binary as base64', () => {
+    const v = compile(
+      selectOf(table([col('b', { tsType: 'Uint8Array', shape: { kind: 'buffer' } as never })]))
+    );
+    expect(v({ b: 'aGVsbG8=' })).toBe(true);
+    expect(v({ b: 1 })).toBe(false);
+  });
+
+  it('carries a Date as an ISO string', () => {
+    const v = compile(selectOf(table([col('at', { tsType: 'Date', dbType: 'TIMESTAMP' })])));
+    expect(v({ at: '2026-08-02T12:00:00Z' })).toBe(true);
+    expect(v({ at: 'yesterday' })).toBe(false);
+  });
+
+  it('accepts any JSON in a json column, and nothing outside JSON', () => {
+    const v = compile(selectOf(table([col('j', { shape: { kind: 'json' } as never })])));
+    expect(v({ j: { a: [1, 'x', null] } })).toBe(true);
+    expect(v({ j: 3 })).toBe(true);
+  });
+
+  it('describes a point positionally under 2020-12 and by length under 3.0', () => {
+    const t = table([col('p', { shape: { kind: 'tuple', length: 2 } as never })]);
+    const v = compile(selectOf(t));
+    expect(v({ p: [1, 2] })).toBe(true);
+    expect(v({ p: [1, 2, 3] })).toBe(false);
+    expect(v({ p: ['a', 'b'] })).toBe(false);
+    expect((selectOf(t, 'openapi-3.0') as any).properties.p.prefixItems).toBeUndefined();
+  });
+});
+
+describe('the target', () => {
+  it('declares the draft only where a draft is declared', () => {
+    const t = table([col('a')]);
+    expect((selectOf(t) as any).$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    // Inside an OpenAPI document the schema has no $schema of its own.
+    expect((selectOf(t, 'openapi-3.1') as any).$schema).toBeUndefined();
+    expect((selectOf(t, 'openapi-3.0') as any).$schema).toBeUndefined();
+  });
+});

--- a/packages/generator-json-schema/tsconfig.json
+++ b/packages/generator-json-schema/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@drzl/generator-arktype':
         specifier: workspace:^
         version: link:../generator-arktype
+      '@drzl/generator-json-schema':
+        specifier: workspace:^
+        version: link:../generator-json-schema
       '@drzl/generator-orpc':
         specifier: workspace:^
         version: link:../generator-orpc
@@ -137,6 +140,28 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.6)(supports-color@7.2.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/generator-json-schema:
+    dependencies:
+      '@drzl/analyzer':
+        specifier: workspace:^
+        version: link:../analyzer
+      '@drzl/validation-core':
+        specifier: workspace:^
+        version: link:../validation-core
+    devDependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(supports-color@7.2.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1130,19 +1155,9 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rollup/rollup-android-arm-eabi@4.50.0':
-    resolution: {integrity: sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.62.3':
     resolution: {integrity: sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.50.0':
-    resolution: {integrity: sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.62.3':
@@ -1150,19 +1165,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.50.0':
-    resolution: {integrity: sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.62.3':
     resolution: {integrity: sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.50.0':
-    resolution: {integrity: sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.62.3':
@@ -1170,19 +1175,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.50.0':
-    resolution: {integrity: sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.62.3':
     resolution: {integrity: sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.50.0':
-    resolution: {integrity: sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.62.3':
@@ -1190,23 +1185,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.50.0':
-    resolution: {integrity: sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.3':
     resolution: {integrity: sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.50.0':
-    resolution: {integrity: sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.3':
     resolution: {integrity: sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==}
@@ -1214,23 +1197,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.50.0':
-    resolution: {integrity: sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm64-gnu@4.62.3':
     resolution: {integrity: sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.50.0':
-    resolution: {integrity: sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.3':
     resolution: {integrity: sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==}
@@ -1250,18 +1221,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
-    resolution: {integrity: sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.50.0':
-    resolution: {integrity: sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.3':
     resolution: {integrity: sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==}
     cpu: [ppc64]
@@ -1274,23 +1233,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.50.0':
-    resolution: {integrity: sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.3':
     resolution: {integrity: sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.50.0':
-    resolution: {integrity: sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.3':
     resolution: {integrity: sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==}
@@ -1298,21 +1245,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.50.0':
-    resolution: {integrity: sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-s390x-gnu@4.62.3':
     resolution: {integrity: sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.50.0':
-    resolution: {integrity: sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1321,12 +1256,6 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-x64-musl@4.50.0':
-    resolution: {integrity: sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.3':
     resolution: {integrity: sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==}
@@ -1339,29 +1268,14 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.50.0':
-    resolution: {integrity: sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rollup/rollup-openharmony-arm64@4.62.3':
     resolution: {integrity: sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.50.0':
-    resolution: {integrity: sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.62.3':
     resolution: {integrity: sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.50.0':
-    resolution: {integrity: sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.62.3':
@@ -1371,11 +1285,6 @@ packages:
 
   '@rollup/rollup-win32-x64-gnu@4.62.3':
     resolution: {integrity: sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.50.0':
-    resolution: {integrity: sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==}
     cpu: [x64]
     os: [win32]
 
@@ -1437,9 +1346,6 @@ packages:
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -1800,8 +1706,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   algoliasearch@5.37.0:
     resolution: {integrity: sha512-y7gau/ZOQDqoInTQp0IwTOjkrHc4Aq4R8JgpmCleFwiLl+PbN2DMWoDUWZnrK8AhNJwT++dn28Bt4NZYNLAmuA==}
@@ -2180,6 +2097,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -2349,6 +2269,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2712,6 +2635,10 @@ packages:
   regex@6.0.1:
     resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -2730,11 +2657,6 @@ packages:
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rollup@4.50.0:
-    resolution: {integrity: sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   rollup@4.62.3:
@@ -3909,61 +3831,31 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/rollup-android-arm-eabi@4.50.0':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.62.3':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.50.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.62.3':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.50.0':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.62.3':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.50.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.62.3':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.50.0':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.62.3':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.50.0':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.50.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.3':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.50.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.50.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.62.3':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.50.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.62.3':
@@ -3975,43 +3867,22 @@ snapshots:
   '@rollup/rollup-linux-loong64-musl@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.50.0':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.3':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.50.0':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.3':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.50.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.50.0':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.50.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.62.3':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.50.0':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.62.3':
@@ -4020,28 +3891,16 @@ snapshots:
   '@rollup/rollup-openbsd-x64@4.62.3':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.50.0':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.62.3':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.50.0':
-    optional: true
-
   '@rollup/rollup-win32-arm64-msvc@4.62.3':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.50.0':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.62.3':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.62.3':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.50.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.3':
@@ -4111,8 +3970,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
-
-  '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
 
@@ -4455,12 +4312,23 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   algoliasearch@5.37.0:
     dependencies:
@@ -4776,6 +4644,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.5: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -4932,6 +4802,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -5248,6 +5120,8 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  require-from-string@2.0.2: {}
+
   resolve-from@5.0.0: {}
 
   restore-cursor@5.1.0:
@@ -5279,33 +5153,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.5
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
-
-  rollup@4.50.0:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.50.0
-      '@rollup/rollup-android-arm64': 4.50.0
-      '@rollup/rollup-darwin-arm64': 4.50.0
-      '@rollup/rollup-darwin-x64': 4.50.0
-      '@rollup/rollup-freebsd-arm64': 4.50.0
-      '@rollup/rollup-freebsd-x64': 4.50.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.50.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.50.0
-      '@rollup/rollup-linux-arm64-gnu': 4.50.0
-      '@rollup/rollup-linux-arm64-musl': 4.50.0
-      '@rollup/rollup-linux-loongarch64-gnu': 4.50.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.50.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.50.0
-      '@rollup/rollup-linux-riscv64-musl': 4.50.0
-      '@rollup/rollup-linux-s390x-gnu': 4.50.0
-      '@rollup/rollup-linux-x64-gnu': 4.50.0
-      '@rollup/rollup-linux-x64-musl': 4.50.0
-      '@rollup/rollup-openharmony-arm64': 4.50.0
-      '@rollup/rollup-win32-arm64-msvc': 4.50.0
-      '@rollup/rollup-win32-ia32-msvc': 4.50.0
-      '@rollup/rollup-win32-x64-msvc': 4.50.0
-      fsevents: 2.3.3
 
   rollup@4.62.3:
     dependencies:
@@ -5669,7 +5516,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
-      rollup: 4.50.0
+      rollup: 4.62.3
     optionalDependencies:
       '@types/node': 26.1.2
       fsevents: 2.3.3

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1034,7 +1034,114 @@ if ! npx tsx src/ground-truth.ts; then
 fi
 cd "$APP"
 
+# ---------------------------------------------------------------------------------------------
+# The other drizzle major.
+#
+# Everything above pins drizzle-orm@1.0.0-rc.4, and every generator's own tests build fake column
+# objects. Between them, nothing in this repository ever ran against 0.4x, which is the version
+# the analyzer itself depends on and the one nearly every user has installed.
+#
+# What that hid: 0.4x models `.array()` by wrapping the column in a `PgArray` whose `baseColumn`
+# is the element, while v1 leaves the class alone and raises `dimensions`. The analyzer read only
+# the v1 signal, so on 0.4x every array column came back `unknown` in all five generators. The
+# fixture above contains three array columns and the gate was green the whole time.
+#
+# This stage is deliberately narrow: it does not repeat parity or ground truth, it asserts that
+# the analyzer still has an opinion about every column. A type it cannot name is the shape that
+# failure takes.
+# ---------------------------------------------------------------------------------------------
+echo "==> generating against drizzle-orm 0.4x"
+OLD="$WORK/old-major"
+rm -rf "$OLD"; mkdir -p "$OLD/src"
+cd "$OLD"
+npm init -y >/dev/null 2>&1
+npm install --no-audit --no-fund --loglevel=error \
+  "$TARS"/*.tgz drizzle-orm@0.45.2 zod tsx >/dev/null
+
+cat > src/schema.ts <<'OLD_SCHEMA'
+import { pgTable, pgEnum, text, integer, varchar, timestamp, boolean } from 'drizzle-orm/pg-core';
+
+export const mood = pgEnum('mood', ['sad', 'ok', 'happy']);
+
+export const rows = pgTable('rows', {
+  id: integer('id').primaryKey(),
+  name: varchar('name', { length: 40 }).notNull(),
+  bio: text('bio'),
+  at: timestamp('at').notNull(),
+  live: boolean('live').notNull(),
+  feeling: mood('feeling').notNull(),
+  tags: text('tags').array().notNull(),
+  scores: integer('scores').array().notNull(),
+  moods: mood('moods').array().notNull(),
+  grid: text('grid').array().array().notNull(),
+});
+OLD_SCHEMA
+
+cat > drzl.config.ts <<'OLD_CONFIG'
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  schema: 'src/schema.ts',
+  outDir: 'src/gen',
+  generators: [{ kind: 'zod', path: 'src/gen/zod' }],
+});
+OLD_CONFIG
+
+npx drzl generate --config drzl.config.ts >/dev/null
+
+cat > check-old.ts <<'OLD_CHECK'
+import { SchemaAnalyzer } from '@drzl/analyzer';
+
+// `npm init -y` leaves the project CommonJS, where tsx refuses a top-level await.
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+
+async function main() {
+const a = await new SchemaAnalyzer('src/schema.ts').analyze({});
+const cols = a.tables.find((t) => t.name === 'rows')?.columns ?? [];
+if (!cols.length) {
+  console.error('FAIL: no columns analyzed on drizzle-orm 0.4x at all.');
+  process.exit(1);
+}
+
+// A column the analyzer cannot name is the shape this failure takes: nothing throws, the
+// generators emit `z.unknown()`, and every row validates.
+const vague = cols.filter((c) => c.tsType === 'unknown' || c.dbType === 'UNKNOWN');
+const arrays = cols.filter((c) => c.name.match(/^(tags|scores|moods|grid)$/));
+const notArrays = arrays.filter((c) => !c.arrayDimensions);
+
+console.log(`    ${cols.length} columns analyzed on drizzle-orm 0.4x, ${vague.length} unnamed`);
+
+let bad = 0;
+if (vague.length) {
+  console.error('    FAIL: analyzed as unknown on 0.4x:');
+  for (const c of vague) console.error(`      ${c.name} (${c.dbType})`);
+  bad++;
+}
+if (notArrays.length) {
+  console.error('    FAIL: an .array() column carries no dimension:');
+  for (const c of notArrays) console.error(`      ${c.name}`);
+  bad++;
+}
+const grid = cols.find((c) => c.name === 'grid');
+if (grid && grid.arrayDimensions !== 2) {
+  console.error(`    FAIL: text().array().array() reported ${grid.arrayDimensions} dimensions, not 2`);
+  bad++;
+}
+if (bad) process.exit(1);
+}
+OLD_CHECK
+
+if ! npx tsx check-old.ts; then
+  echo "FAIL: the analyzer loses column types on drizzle-orm 0.4x." >&2
+  exit 1
+fi
+cd "$APP"
+
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
 echo "    typechecks under bundler, node16 and nodenext, and validates at least as strictly as"
 echo "    the first-party drizzle-orm validator modules across three dialects and three modes,"
-echo "    checked against a real Postgres."
+echo "    checked against a real Postgres, and analyzed with no column left unnamed on both"
+echo "    drizzle-orm majors."


### PR DESCRIPTION
## A generator with no runtime dependency

`{ kind: 'json-schema', path: 'src/validators/json-schema' }`

The four validation generators each target one library, so their output is only useful to a
TypeScript program that installs that library. JSON Schema is the format everything else already
reads: OpenAPI documents, API gateways, form builders, contract tests, validators in other
languages. **No package in the official Drizzle family emits it.**

There is no runtime dependency here, not even an optional peer. The output is data.

```ts
export const SelectpeopleSchema = {
  $schema: 'https://json-schema.org/draft/2020-12/schema',
  type: 'object',
  properties: {
    age: { type: 'integer', minimum: 18, maximum: 2147483647 },
    tags: { type: ['array', 'null'], items: { type: 'string' }, minItems: 2 },
  },
  required: ['age', 'tags'],
  additionalProperties: false,
} as const;
```

Every constraint the other generators learned this week comes through: CHECK bounds, `IN` as
`enum`, `length()` as `minLength`, `cardinality()` as `minItems`.

## Dialects, which is not a formatting preference

`target` is `draft-2020-12` (default), `openapi-3.1`, or `openapi-3.0`.

| | 2020-12 | OpenAPI 3.0 |
| --- | --- | --- |
| nullable | `type: ['string','null']` | `nullable: true` |
| exclusive bound | `exclusiveMinimum: 0` | `minimum: 0, exclusiveMinimum: true` |
| positional array | `prefixItems` | no equivalent |

**JSON Schema ignores unknown keywords rather than rejecting them.** A 2020-12 `exclusiveMinimum`
dropped into a 3.0 document is read as the boolean form with no bound, or ignored outright. Either
way the document still validates and the constraint that exists to reject `0` now accepts it.

## Verified by running, not by reading

Every emitted schema is compiled by **ajv in strict mode**, which rejects unknown keywords instead
of ignoring them, then asserted on which values it accepts. Nothing asserts on the shape of the
emitted object, because a schema that looks right and means nothing is the failure this format
makes easy.

The suite went green on the first run, so I broke the generator twice to check it bites:

| sabotage | caught |
| --- | --- |
| exclusive lower bound emitted as inclusive | yes |
| 3.0's `nullable` keyword emitted into 2020-12 | yes |

## Then I ran the actual CLI, and it printed `tags: {}`

That was not this generator.

On **drizzle-orm 0.4x**, which `@drzl/analyzer` depends on and which nearly every user has
installed today, two column kinds were analyzed as `unknown` in **all five generators**:

| column | why |
| --- | --- |
| `text('tags').array()` | 0.4x wraps the column in a `PgArray` whose `baseColumn` is the element. v1 leaves the class alone and raises `dimensions`. Only the v1 signal was read. |
| `mood('feeling')` | the class-name map had no arm for `PgEnumColumn` at all, so the values sat in `enumValues` with no type to attach to |

Both emitted `z.unknown()`, `Type.Unknown()`, `unknown`, `{}`. Every row validated. Nothing
reported a problem.

### Why nothing caught it

`verify-packed.sh` pins `drizzle-orm@1.0.0-rc.4` at every rung, and the generators' own tests
build column objects by hand. Between them, **nothing in this repository had ever run against
0.4x**. The parity fixture contains three `.array()` columns and the gate was green throughout.

So this adds a stage that installs 0.4x, generates, and fails on any column the analyzer cannot
name, because a type it cannot name is the exact shape this failure takes.

It found the enum bug the first time it ran, after the array fix was already in:

```
    10 columns analyzed on drizzle-orm 0.4x, 2 unnamed
    FAIL: analyzed as unknown on 0.4x:
      feeling (UNKNOWN)
      moods (UNKNOWN)
```

and now:

```
    10 columns analyzed on drizzle-orm 0.4x, 0 unnamed
```

## Verification

- 630 tests across 80 files, green
- `pnpm typecheck` and `pnpm lint` clean
- full `verify-packed.sh` green, including 1365 probes against a real Postgres and the new 0.4x
  stage
- docs: new `/generators/json-schema` page, plus root README, CONTRIBUTING, `docs/cli.md`,
  configuration guide and VitePress nav
