### PR TITLE
test(verify): diff the analyzer across both drizzle majors, and correct an overstated changeset

### DIFF
--- a/.changeset/json-schema-generator.md
+++ b/.changeset/json-schema-generator.md
@@ -24,10 +24,12 @@ generator on drizzle-orm 0.4x, the version the analyzer depends on:
 - **`.array()` columns came back `unknown`.** 0.4x wraps the column in a `PgArray` whose
   `baseColumn` is the element; v1 leaves the class alone and raises `dimensions`. Only the v1
   signal was read.
-- **`pgEnum` columns came back `unknown`.** The class map had no arm for `PgEnumColumn`, so the
-  values sat in `enumValues` with no type to attach to.
+- **`pgEnum` columns came back `unknown`, on both majors.** The class map had no arm for
+  `PgEnumColumn` and `describeV1Column` does not read `dataType: 'string enum'` either. The
+  emitted schemas were still correct, because every generator reads `enumValues` ahead of
+  `tsType`, so this one was a gap in the analysis model rather than a validation hole.
 
-Both produced schemas that accepted anything, in all five generators, with nothing reporting a
-problem. `verify-packed.sh` pins `drizzle-orm@1.0.0-rc.4`, so the whole verification ladder only
-ever ran on one major; it now runs a stage against 0.4x that fails on any column the analyzer
-cannot name. That stage found the enum bug the first time it ran.
+The array bug did produce schemas that accepted anything, in all five generators, with nothing
+reporting a problem. `verify-packed.sh` pins `drizzle-orm@1.0.0-rc.4`, so the whole verification
+ladder only ever ran on one major; it now runs a stage against 0.4x that fails on any column the
+analyzer cannot name. That stage found the enum gap the first time it ran.

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1058,17 +1058,32 @@ npm init -y >/dev/null 2>&1
 npm install --no-audit --no-fund --loglevel=error \
   "$TARS"/*.tgz drizzle-orm@0.45.2 zod tsx >/dev/null
 
+# Written once and analyzed under both majors, so the comparison below is about the analyzer
+# rather than about two schemas that happen to differ. Every type here exists in both.
 cat > src/schema.ts <<'OLD_SCHEMA'
-import { pgTable, pgEnum, text, integer, varchar, timestamp, boolean } from 'drizzle-orm/pg-core';
+import {
+  pgTable, pgEnum, text, integer, smallint, bigint, varchar, char, timestamp, date,
+  boolean, numeric, doublePrecision, uuid, json, jsonb,
+} from 'drizzle-orm/pg-core';
 
 export const mood = pgEnum('mood', ['sad', 'ok', 'happy']);
 
 export const rows = pgTable('rows', {
   id: integer('id').primaryKey(),
+  small: smallint('small').notNull(),
+  big53: bigint('big53', { mode: 'number' }).notNull(),
+  big64: bigint('big64', { mode: 'bigint' }).notNull(),
   name: varchar('name', { length: 40 }).notNull(),
+  code: char('code', { length: 3 }).notNull(),
   bio: text('bio'),
   at: timestamp('at').notNull(),
+  day: date('day').notNull(),
   live: boolean('live').notNull(),
+  amount: numeric('amount').notNull(),
+  ratio: doublePrecision('ratio').notNull(),
+  ref: uuid('ref').notNull(),
+  blob: json('blob').notNull(),
+  blob2: jsonb('blob2').notNull(),
   feeling: mood('feeling').notNull(),
   tags: text('tags').array().notNull(),
   scores: integer('scores').array().notNull(),
@@ -1076,6 +1091,9 @@ export const rows = pgTable('rows', {
   grid: text('grid').array().array().notNull(),
 });
 OLD_SCHEMA
+
+# The same file, analyzed by the v1 project, so the two runs can be compared directly.
+cp src/schema.ts "$APP/src/cross-major.ts"
 
 cat > drzl.config.ts <<'OLD_CONFIG'
 import { defineConfig } from '@drzl/cli/config';
@@ -1088,6 +1106,101 @@ export default defineConfig({
 OLD_CONFIG
 
 npx drzl generate --config drzl.config.ts >/dev/null
+
+cat > describe-columns.ts <<'DESCRIBE'
+import { SchemaAnalyzer } from '@drzl/analyzer';
+
+// What the analyzer claims about each column, reduced to the facts every generator reads.
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+
+async function main() {
+  const file = process.argv[2];
+  const a = await new SchemaAnalyzer(file).analyze({});
+  const cols = a.tables.find((t) => t.name === 'rows')?.columns ?? [];
+  const out = cols.map((c) => ({
+    name: c.name,
+    tsType: c.tsType,
+    dbType: c.dbType,
+    nullable: c.nullable,
+    arrayDimensions: c.arrayDimensions ?? 0,
+    enumValues: c.enumValues ?? null,
+    maxLength: c.maxLength ?? null,
+    min: c.min ?? null,
+    max: c.max ?? null,
+    format: c.format ?? null,
+    shape: c.shape?.kind ?? null,
+  }));
+  console.log(JSON.stringify(out, null, 1));
+}
+DESCRIBE
+
+cp describe-columns.ts "$APP/describe-columns.ts"
+npx tsx describe-columns.ts src/schema.ts > "$WORK/cols-0.4x.json"
+( cd "$APP" && npx tsx describe-columns.ts src/cross-major.ts ) > "$WORK/cols-v1.json"
+
+cat > cross-major.ts <<'CROSS'
+import { readFileSync } from 'node:fs';
+
+/**
+ * The same schema, analyzed under both drizzle majors, has to describe the same columns.
+ *
+ * This is the systematic form of the bug that prompted the stage: the analyzer read v1's array
+ * signal and not 0.4x's, so `.array()` columns were `unknown` on the version most people have.
+ * A per-column diff catches every instance of that shape at once, including the ones nobody has
+ * thought to write a test for.
+ *
+ * Anything genuinely different between the majors belongs here, named, with a reason. An empty
+ * list is the claim that the analyzer is version independent.
+ *
+ * This catches divergence. It cannot catch both majors being wrong the same way, which is why the
+ * unnamed-column check below is separate rather than folded in: removing the analyzer's
+ * `PgEnumColumn` arm makes both majors report `unknown`, so this comparison stays silent and that
+ * one fires. Measured, not assumed.
+ */
+const ALLOWED: Record<string, string> = {};
+
+const a = JSON.parse(readFileSync(process.env.OLD_JSON!, 'utf8'));
+const b = JSON.parse(readFileSync(process.env.NEW_JSON!, 'utf8'));
+const key = (c: any) => c.name;
+const byName = (rows: any[]) => new Map(rows.map((c) => [key(c), c]));
+const old = byName(a);
+const now = byName(b);
+
+const names = [...new Set([...old.keys(), ...now.keys()])];
+const diffs: string[] = [];
+for (const n of names) {
+  const l = old.get(n);
+  const r = now.get(n);
+  if (!l || !r) {
+    diffs.push(`${n}: present on ${l ? '0.4x' : 'v1'} only`);
+    continue;
+  }
+  for (const f of Object.keys(l)) {
+    const lv = JSON.stringify(l[f]);
+    const rv = JSON.stringify(r[f]);
+    if (lv === rv) continue;
+    const waiver = ALLOWED[`${n}.${f}`];
+    if (waiver) continue;
+    diffs.push(`${n}.${f}: 0.4x ${lv}, v1 ${rv}`);
+  }
+}
+
+console.log(`    ${names.length} columns compared across both drizzle majors`);
+if (diffs.length) {
+  console.error('    FAIL: the analyzer describes the same schema differently per major:');
+  for (const d of diffs) console.error(`      ${d}`);
+  console.error('\n    A generator reads these fields, so a difference here is a different schema.');
+  process.exit(1);
+}
+CROSS
+
+OLD_JSON="$WORK/cols-0.4x.json" NEW_JSON="$WORK/cols-v1.json" npx tsx cross-major.ts || {
+  echo "FAIL: the analyzer is not consistent across drizzle-orm majors." >&2
+  exit 1
+}
 
 cat > check-old.ts <<'OLD_CHECK'
 import { SchemaAnalyzer } from '@drzl/analyzer';


### PR DESCRIPTION
## The narrow check was too narrow

The 0.4x stage added in #68 asserted only that no column comes back unnamed. That catches the
exact shape of the array bug and nothing else: a column mapped to the *wrong* type on one major
would sail through.

This analyzes the same schema, 20 column types wide, under **both** drizzle majors and compares
every field a generator reads:

```
    20 columns compared across both drizzle majors
```

`ALLOWED` is empty, which makes it a standing claim that the analyzer is version independent
rather than a list of exceptions. Covered: `smallint`, both `bigint` modes, `varchar`/`char` with
lengths, `numeric`, `doublePrecision`, `uuid`, `json`/`jsonb`, `date`, `timestamp`, enums, enum
arrays, and `text().array().array()`.

## Why two checks and not one

Measured rather than assumed. Removing the analyzer's `PgEnumColumn` arm makes **both** majors
report `unknown`, so the cross-major diff stays silent and the unnamed-column check fires. They
catch different things:

| check | catches |
| --- | --- |
| cross-major diff | the majors disagreeing |
| unnamed columns | both majors being wrong the same way |

## A correction to #68's changeset

Chasing that down showed I had overstated one of the two findings there. The changeset said both
bugs "produced schemas that accepted anything". That is true of the array bug and **not** of the
enum one:

- enum columns were unknown on **both** majors, not only 0.4x
- the emitted schemas were correct throughout, because every generator reads `enumValues` ahead of
  `tsType`

So it was a gap in the analysis model, not a validation hole. Corrected before it ships as a
changelog entry. The array bug was the validation hole and the text now says which was which.

## Verification

- 630 tests green, `pnpm typecheck` and `pnpm lint` clean
- full `verify-packed.sh` green including the new stage