### PR TITLE
feat(analyzer): warn when a column gets a validator that accepts anything

### DIFF
--- a/.changeset/warn-untyped-columns.md
+++ b/.changeset/warn-untyped-columns.md
@@ -1,0 +1,23 @@
+---
+'@drzl/analyzer': minor
+'@drzl/cli': minor
+---
+
+Warn when a column gets a validator that accepts anything
+
+`tsType: 'unknown'` is the exact shape two real bugs took: `.array()` and `pgEnum` columns came
+back untyped on drizzle-orm 0.4x, every generator emitted a validator accepting any value, and
+nothing anywhere said so. The only way to find out was to read the generated file.
+
+`verify-packed.sh` now fails on it, which protects this repository and does nothing for a user
+whose schema uses a column type DRZL has not modelled. That is the case where it matters most,
+because their validators are silently open and nobody has told them.
+
+The analyzer now reports `DRZL_ANL_UNKNOWN_COLUMN` per column, and the CLI prints a summary after
+analysis, naming the column and its SQL type. It stays a warning: the rest of the schema still
+generates and the generated code is still useful.
+
+The condition is "the emitted validator will be wide", not "the type is unknown". A `json` column
+is also untyped and is not wide, since the generators emit the JSON value space for it. A
+`customType` is wide, and gets a hint pointing at `.$type<T>()` with `typedColumns`, which is the
+documented fix.

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1201,6 +1201,38 @@ export class SchemaAnalyzer {
       const constraints = this.columnConstraints(col);
       if (v1?.shape) delete constraints.maxLength;
 
+      // A column with no type is how two real bugs looked from the outside: `.array()` and
+      // `pgEnum` columns on drizzle-orm 0.4x came back `unknown`, every generator emitted a
+      // schema that accepted anything, and nothing said so. `verify-packed.sh` fails on it now,
+      // which protects this repository and does nothing for a user whose schema uses a type
+      // nobody here has modelled. That is the case where it matters most.
+      //
+      // A warning rather than an error: the rest of the schema still generates, and the
+      // generated code is still useful. A `customType` legitimately has no knowable runtime
+      // shape, so this is a report rather than a defect.
+      //
+      // The condition is "the emitted validator will be wide", not "tsType is unknown". A json
+      // column is also `unknown` and is not wide: the generators emit the JSON value space for
+      // it. A `custom` shape is wide, and is the one case where the user has a documented fix.
+      const shape = (v1?.shape ?? (constraints as any)?.shape)?.kind;
+      const finalTs = (v1?.tsType ?? tsType) as string;
+      const wide = (finalTs === 'unknown' || finalTs === 'any') && (!shape || shape === 'custom');
+      if (wide) {
+        const sqlType =
+          typeof (col as any)?.getSQLType === 'function' ? (col as any).getSQLType() : undefined;
+        issues.push({
+          code: 'DRZL_ANL_UNKNOWN_COLUMN',
+          level: 'warn',
+          message: `Column "${colName}" on table "${tsName}" has no known type${
+            sqlType ? ` (SQL type ${sqlType})` : ''
+          }, so its validator will accept any value.`,
+          hint:
+            shape === 'custom'
+              ? 'A customType has no runtime shape to read. Declare it with .$type<T>() and turn on typedColumns to give the validator the type.'
+              : 'Open an issue naming the column type so it can be modelled, or declare it with .$type<T>() and turn on typedColumns.',
+        });
+      }
+
       columns.push({
         name: colName,
         tsType,

--- a/packages/analyzer/test/unnamed-columns.spec.ts
+++ b/packages/analyzer/test/unnamed-columns.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Telling the user when a column has no type.
+ *
+ * `tsType: 'unknown'` is the exact shape two real bugs took: `.array()` and `pgEnum` columns on
+ * drizzle-orm 0.4x. Nothing threw, every generator emitted a schema accepting anything, and the
+ * only way anyone found out was reading the generated file.
+ *
+ * `verify-packed.sh` now fails on it, which protects this repository. It does nothing for a user
+ * whose schema uses a column type nobody here has modelled yet, and that is the case where it
+ * matters most: their validators are silently open and no message says so.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function analyzeSource(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  return new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+}
+
+const UNNAMED = 'DRZL_ANL_UNKNOWN_COLUMN';
+
+describe('a column the analyzer cannot type', () => {
+  it('is reported as a warning naming the table, the column and the SQL type', async () => {
+    // A customType is the honest case: Drizzle knows the SQL type and nothing knows the runtime
+    // shape, so the analyzer genuinely cannot name it.
+    const a = await analyzeSource(
+      'unnamed-custom',
+      `
+      import { pgTable, customType } from 'drizzle-orm/pg-core';
+      const weird = customType({ dataType: () => 'tsvector' });
+      export const t = pgTable('t', { doc: weird('doc') });
+      `
+    );
+    const issue = a.issues.find((i) => i.code === UNNAMED);
+    expect(issue, `issues: ${JSON.stringify(a.issues)}`).toBeTruthy();
+    expect(issue!.level).toBe('warn');
+    expect(issue!.message).toContain('t');
+    expect(issue!.message).toContain('doc');
+    expect(issue!.message, 'says what the consequence is').toMatch(/accept any value/i);
+    expect(issue!.message, 'names the SQL type, which is the searchable part').toContain('tsvector');
+    expect(issue!.hint, 'says what to do about it').toMatch(/typedColumns/);
+  });
+
+  it('says nothing when every column has a type', async () => {
+    const a = await analyzeSource(
+      'unnamed-none',
+      `
+      import { pgTable, text, integer, pgEnum } from 'drizzle-orm/pg-core';
+      export const mood = pgEnum('mood', ['a', 'b']);
+      export const t = pgTable('t', {
+        a: text('a'),
+        b: integer('b'),
+        c: text('c').array(),
+        d: mood('d'),
+      });
+      `
+    );
+    expect(a.issues.filter((i) => i.code === UNNAMED)).toEqual([]);
+  });
+
+  it('reports one issue per column, not one for the whole schema', async () => {
+    const a = await analyzeSource(
+      'unnamed-many',
+      `
+      import { pgTable, customType } from 'drizzle-orm/pg-core';
+      const weird = customType({ dataType: () => 'tsvector' });
+      export const t = pgTable('t', { one: weird('one'), two: weird('two') });
+      `
+    );
+    const named = a.issues.filter((i) => i.code === UNNAMED).map((i) => i.message);
+    expect(named.length).toBe(2);
+    expect(named.some((m) => m.includes('one'))).toBe(true);
+    expect(named.some((m) => m.includes('two'))).toBe(true);
+  });
+
+  it('stays a warning, so it never fails a build on its own', async () => {
+    // A schema with an unmodelled column still generates, and the generated code is still
+    // useful. Turning this into an error would break working setups over a wide type.
+    const a = await analyzeSource(
+      'unnamed-level',
+      `
+      import { pgTable, customType } from 'drizzle-orm/pg-core';
+      const weird = customType({ dataType: () => 'tsvector' });
+      export const t = pgTable('t', { doc: weird('doc') });
+      `
+    );
+    expect(a.issues.some((i) => i.level === 'error')).toBe(false);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -98,6 +98,7 @@ program
       // needing to know the option exists.
       analysis.tables = filterTables(analysis.tables, cfg);
       spinner.succeed(`Analysis complete in ${Date.now() - t0}ms`);
+      reportWideColumns(analysis.issues);
       // Under --check the existing output is captured before anything overwrites it, so the
       // regenerated result can be compared against it and the tree put back either way.
       const driftDirs = computeGeneratorOutputDirs(cfg);
@@ -445,6 +446,7 @@ program
           includeHeuristicRelations: cfg.analyzer.includeHeuristicRelations,
         });
         analysis.tables = filterTables(analysis.tables, cfg);
+        if (!opts.json) reportWideColumns(analysis.issues);
 
         if (opts.pipeline === 'analyze') {
           if (opts.json) {
@@ -696,5 +698,30 @@ program
       process.exit(1);
     }
   });
+
+/**
+ * Tell the user which columns got a validator that accepts anything.
+ *
+ * This is the user-facing half of a check `verify-packed.sh` runs on this repository. Two real
+ * bugs took exactly this shape, `.array()` and `pgEnum` columns coming back untyped on
+ * drizzle-orm 0.4x, and the only way anyone noticed was reading the generated file. A user whose
+ * schema uses a type nobody here has modelled gets the same silence, and no gate of ours helps
+ * them.
+ *
+ * Printed once with a count rather than a line per column, so a schema with fifty custom types
+ * stays readable.
+ */
+function reportWideColumns(issues: Array<{ code?: string; message?: string; hint?: string }>) {
+  const wide = issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN');
+  if (!wide.length) return;
+  console.warn(
+    chalk.yellow(`\n${wide.length} column${wide.length === 1 ? '' : 's'} could not be typed:`)
+  );
+  for (const i of wide.slice(0, 10)) console.warn(chalk.gray(`  - ${i.message}`));
+  if (wide.length > 10) console.warn(chalk.gray(`  ... and ${wide.length - 10} more`));
+  // One hint for the set, since they are almost always the same two.
+  const hints = [...new Set(wide.map((i) => i.hint).filter(Boolean))];
+  for (const h of hints) console.warn(chalk.gray(`  ${h}`));
+}
 
 program.parseAsync(process.argv);


### PR DESCRIPTION
## The user-facing half of the check that caught #68

`tsType: 'unknown'` is the exact shape two real bugs took. `.array()` and `pgEnum` columns came
back untyped on drizzle-orm 0.4x, all five generators emitted a validator accepting any value, and
**nothing anywhere said so**. Reading the generated file was the only way to find out.

#68 made `verify-packed.sh` fail on it. That protects this repository and does nothing for a user
whose schema uses a column type DRZL has not modelled yet, which is where it matters most: their
validators are silently open and nobody has told them.

```
2 columns could not be typed:
  - Column "body" on table "docs" has no known type (SQL type tsvector), so its validator will accept any value.
  - Column "idx" on table "docs" has no known type (SQL type tsvector), so its validator will accept any value.
  A customType has no runtime shape to read. Declare it with .$type<T>() and turn on typedColumns to give the validator the type.
```

## The condition is "wide", not "unknown"

The first version keyed on `tsType === 'unknown'` and it was wrong in both directions:

| column | untyped | wide | warns |
| --- | --- | --- | --- |
| `json` / `jsonb` | yes | no, the generators emit the JSON value space | no |
| `customType` | yes | yes | yes, with a hint naming `.$type<T>()` and `typedColumns` |
| unmodelled built-in | yes | yes | yes, asking for an issue naming the type |

Naming the SQL type in the message is deliberate: `tsvector` is the searchable part, and it is
what an issue would need to say.

## Stays a warning

An unmodelled column still generates, and the generated code is still useful. Turning this into an
error would break working setups over a single wide type. Printed once with a count rather than a
line per column, so a schema with fifty custom types stays readable.

## Verification

- 634 tests green, `pnpm typecheck` and `pnpm lint` clean
- full `verify-packed.sh` green
- exercised through the real CLI on a real `customType` schema, which is how the wrong first
  condition was caught