### PR TITLE
perf(valibot): fold a numeric CHECK into the range, as zod now does

### DIFF
--- a/.changeset/fold-valibot-bounds.md
+++ b/.changeset/fold-valibot-bounds.md
@@ -1,0 +1,17 @@
+---
+'@drzl/generator-valibot': patch
+---
+
+Fold a numeric CHECK into valibot's range instead of adding an action beside it
+
+`CHECK (age >= 18)` on an integer column emitted `v.minValue(-2147483648), v.maxValue(2147483647),
+v.check((val) => val >= 18)`: a bound that can never fail, plus a closure saying what the bound
+should have said. It is now `v.minValue(18), v.maxValue(2147483647)`, matching the fix already
+applied to the zod generator.
+
+valibot has the exclusive forms natively, so `> 0` becomes `v.gtValue(0)` and `< 10` becomes
+`v.ltValue(10)` rather than closures. The issue valibot raises then carries `requirement: 0` as
+data instead of a sentence this generator wrote, which is what a client needs in order to render
+its own message.
+
+The pg fixture's valibot output falls from 397 to 360 bytes per column.

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -49,9 +49,39 @@ function vDateExpr(
  * so they are pasted rather than parsed. `literal` spells each one, which is the only difference
  * between the number and bigint cases.
  */
-function vBounds(c: Column, literal: (v: string) => string): string[] {
-  if (c.min === undefined || c.max === undefined) return [];
-  return [`v.minValue(${literal(c.min)})`, `v.maxValue(${literal(c.max)})`];
+function vBounds(
+  c: Column,
+  literal: (v: string) => string,
+  checks: ColumnCheck[] = []
+): string[] {
+  let lo = c.min !== undefined ? { action: 'minValue', value: c.min } : undefined;
+  let hi = c.max !== undefined ? { action: 'maxValue', value: c.max } : undefined;
+
+  // A CHECK replaces the end it narrows rather than sitting beside it. It cannot widen: the
+  // declared range is the column's type, and no CHECK makes an int32 hold more.
+  //
+  // valibot has the exclusive forms natively, so `> 0` is `v.gtValue(0)` rather than a closure,
+  // and the issue it raises carries `requirement: 0` as data instead of as a sentence this
+  // generator wrote.
+  for (const k of checks.filter((x) => x.column === c.name && x.kind === 'number')) {
+    if (k.operator === '>=') lo = { action: 'minValue', value: k.value };
+    else if (k.operator === '>') lo = { action: 'gtValue', value: k.value };
+    else if (k.operator === '<=') hi = { action: 'maxValue', value: k.value };
+    else if (k.operator === '<') hi = { action: 'ltValue', value: k.value };
+  }
+
+  return [lo, hi].filter(Boolean).map((x) => `v.${x!.action}(${literal(x!.value)})`);
+}
+
+/** Which checks `vBounds` has already stated, so they are not also emitted as actions. */
+function foldedIntoBounds(c: Column, checks: ColumnCheck[]): Set<ColumnCheck> {
+  if (c.arrayDimensions || c.shape) return new Set();
+  if (c.tsType !== 'number' && c.tsType !== 'bigint') return new Set();
+  return new Set(
+    checks.filter(
+      (k) => k.column === c.name && k.kind === 'number' && k.operator !== '=' && k.operator !== '<>'
+    )
+  );
 }
 
 /**
@@ -75,8 +105,9 @@ function vChecks(c: Column, checks: ColumnCheck[]): string[] {
     '=': '===',
     '<>': '!==',
   };
+  const folded = foldedIntoBounds(c, checks);
   return checks
-    .filter((k) => k.column === c.name)
+    .filter((k) => k.column === c.name && !folded.has(k))
     .map((k) => {
       const rhs = k.kind === 'string' ? JSON.stringify(k.value) : k.value;
       const shown = k.kind === 'string' ? `'${k.value}'` : k.value;
@@ -264,14 +295,14 @@ function vExprForColumn(
     case 'number': {
       return piped('v.number()', [
         ...(isIntegerColumn(c) ? ['v.integer()'] : []),
-        ...vBounds(c, (v) => v),
+        ...vBounds(c, (v) => v, checks),
       ]);
     }
     case 'bigint': {
       // Bounds must be bigint literals: a 64 bit bound written as a number rounds.
       return piped(
         'v.bigint()',
-        vBounds(c, (v) => `${v}n`)
+        vBounds(c, (v) => `${v}n`, checks)
       );
     }
     case 'boolean':

--- a/packages/generator-valibot/test/fold-bounds.spec.ts
+++ b/packages/generator-valibot/test/fold-bounds.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * A numeric CHECK tightens the declared range instead of adding an action beside it.
+ *
+ * `CHECK (age >= 18)` on an integer column emitted
+ * `v.minValue(-2147483648), v.maxValue(2147483647), v.check((val) => val >= 18)`: a bound that
+ * can never fail, plus a closure saying what the bound should have said.
+ *
+ * The message is the better reason to fix it. `v.check` produces whatever string this generator
+ * wrote; `v.minValue(18)` produces valibot's own issue, carrying `requirement: 18` as data rather
+ * than as prose. The zod generator was fixed the same way, and arktype and typebox never had the
+ * problem.
+ */
+import { describe, it, expect } from 'vitest';
+import { ValibotGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'number',
+    dbType: 'INTEGER',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    min: '-2147483648',
+    max: '2147483647',
+    integer: true,
+    ...over,
+  }) as Column;
+
+async function fieldOf(name: string, columns: Column[], checks: any[]) {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-vfold-'));
+  await new ValibotGenerator(analysis).generate({ outDir } as never);
+  const src = await fs.readFile(path.join(outDir, 't.valibot.ts'), 'utf8');
+  const block = src.match(/SelecttSchema = v\.object\(\{([\s\S]*?)\n\}\)/)?.[1] ?? src;
+  return block
+    .split(/\n(?=\s{2}\w+:)/)
+    .find((l) => l.trim().startsWith(`${name}:`))!
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+describe('a numeric CHECK', () => {
+  it('replaces the declared lower bound rather than sitting beside it', async () => {
+    const f = await fieldOf('age', [col('age')], [{ name: 'a', expression: 'age >= 18' }]);
+    expect(f).toContain('v.minValue(18)');
+    expect(f, 'the bound that can never fail is gone').not.toContain('-2147483648');
+    expect(f, 'and so is the closure').not.toContain('v.check');
+  });
+
+  it('replaces the upper bound the same way', async () => {
+    const f = await fieldOf('n', [col('n')], [{ expression: 'n <= 100' }]);
+    expect(f).toContain('v.maxValue(100)');
+    expect(f).not.toContain('2147483647');
+    expect(f).not.toContain('v.check');
+  });
+
+  it('uses the exclusive actions, which valibot has natively', async () => {
+    const gt = await fieldOf('n', [col('n')], [{ expression: 'n > 0' }]);
+    expect(gt).toContain('v.gtValue(0)');
+    expect(gt).not.toContain('v.check');
+    const lt = await fieldOf('n', [col('n')], [{ expression: 'n < 10' }]);
+    expect(lt).toContain('v.ltValue(10)');
+    expect(lt).not.toContain('v.check');
+  });
+
+  it('folds both ends of a BETWEEN', async () => {
+    const f = await fieldOf('n', [col('n')], [{ expression: 'n BETWEEN 0 AND 100' }]);
+    expect(f).toContain('v.minValue(0)');
+    expect(f).toContain('v.maxValue(100)');
+    expect(f).not.toContain('v.check');
+  });
+
+  it('keeps the declared range where no check narrows that end', async () => {
+    const f = await fieldOf('n', [col('n')], [{ expression: 'n >= 18' }]);
+    expect(f).toContain('v.maxValue(2147483647)');
+  });
+});


### PR DESCRIPTION
Same shape as #73, found by checking whether the other three generators had it. arktype and
typebox already folded; valibot did not.

```diff
 age: v.pipe(
   v.number(),
   v.integer(),
-  v.minValue(-2147483648),
+  v.minValue(18),
   v.maxValue(2147483647),
-  v.check((val) => val >= 18, 'a: age >= 18')
 )
```

A bound that can never fail, plus a closure saying what the bound should have said.

## The message is the point

valibot has the exclusive forms natively:

| CHECK | before | after |
| --- | --- | --- |
| `>= 18` | `v.check((val) => val >= 18, '...')` | `v.minValue(18)` |
| `> 0` | `v.check((val) => val > 0, '...')` | `v.gtValue(0)` |
| `<= 100` | `v.check((val) => val <= 100, '...')` | `v.maxValue(100)` |
| `< 10` | `v.check((val) => val < 10, '...')` | `v.ltValue(10)` |

The issue valibot raises then carries `requirement: 0` **as data**, rather than a sentence this
generator wrote that a client would have to parse to render its own message.

## Correctness

A `CHECK` can only narrow, never widen: the declared range is the column's type. Where no check
touches an end, the declared bound stays, and there is a test for that.

Verified against Postgres rather than only against tests:

```
    53 CHECK probes against a real Postgres (13 constrained columns)
    rows Postgres rejects and the validator accepts: DRZL 0, drizzle-orm 22
```

Unchanged from before the fold.

Output falls from 397 to 360 bytes per column on the pg fixture. 648 tests green, typecheck and
lint clean, full `verify-packed.sh` green.