### PR TITLE
feat(validation): apply length() checks in the arktype and typebox generators

### DIFF
--- a/.changeset/length-checks-everywhere.md
+++ b/.changeset/length-checks-everywhere.md
@@ -1,0 +1,24 @@
+---
+'@drzl/generator-arktype': minor
+'@drzl/generator-typebox': minor
+---
+
+Apply `length()` CHECK constraints in the ArkType and TypeBox generators
+
+`CHECK (length(name) >= 3)` was parsed, applied by zod and valibot, and dropped in silence by the
+other two: ArkType emitted a bare `string` and TypeBox a bare `Type.String()`. A constraint the
+database enforces and the validator does not is precisely the gap these generators exist to close.
+
+Neither uses its native length keyword, and that is deliberate. ArkType's `string >= 3` and
+TypeBox's `minLength` both count UTF-16 code units, while SQL's `length()` counts characters, so
+three thumbs-up characters are six units to both. On a minimum that only under-enforces; on a
+maximum it refuses rows the database accepts, which is the `varchar(n)` bug the zod generator
+already avoids by counting code points.
+
+So each goes where an exact count can be expressed: a `.narrow()` on the object for ArkType, and a
+branch of the same registered-kind intersection the row checks use for TypeBox. Null and absent
+both pass, matching SQL.
+
+The cost for TypeBox is that this constraint does not survive serialisation to JSON Schema, where
+a bare `minLength` would. Emitting the wrong count in a form that serialises is not a better
+trade.

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -4,6 +4,7 @@ import type {
   ColumnCheck,
   ColumnSet,
   ResolvedAffix,
+  LengthCheck,
   RowCheck,
   ValidationRenderer,
   ValidationGenerateOptions,
@@ -295,6 +296,39 @@ function atRowNarrows(rows: RowCheck[], cols: Column[]): string {
     .join('');
 }
 
+/**
+ * `CHECK (length(name) >= 3)` as a narrow on the object.
+ *
+ * It cannot be `string >= 3`. ArkType's string bound counts UTF-16 code units and SQL's
+ * `length()` counts characters, so three thumbs-up characters are six units to ArkType. For a
+ * minimum that only under-enforces; for a maximum it refuses rows the database accepts. The
+ * spread operator counts characters, and a narrow is where an expression can be written at all,
+ * so both ends go here rather than one being right and the other quietly wrong.
+ *
+ * Null and absent both pass, matching SQL, where a check involving NULL is satisfied.
+ */
+function atLengthNarrows(lengths: LengthCheck[], cols: Column[]): string {
+  const present = new Set(cols.map((c) => c.name));
+  const OPS: Record<LengthCheck['operator'], string> = {
+    '>=': '>=',
+    '>': '>',
+    '<=': '<=',
+    '<': '<',
+    '=': '===',
+    '<>': '!==',
+  };
+  return lengths
+    .filter((k) => present.has(k.column))
+    .map((k) => {
+      const v = `o[${JSON.stringify(k.column)}]`;
+      const msg = JSON.stringify(
+        `${k.name ? `${k.name}: ` : ''}length(${k.column}) ${k.operator} ${k.value}`
+      );
+      return `.narrow((o, ctx) => ${v} == null || [...${v}].length ${OPS[k.operator]} ${k.value} || ctx.mustBe(${msg}))`;
+    })
+    .join('');
+}
+
 function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
@@ -316,6 +350,7 @@ function renderTableSchemas(
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
   const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
   const cardinalities = parsedChecks.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : []));
+  const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
   const bodyInsert = renderObjectShape(
     insertCols,
     'insert',
@@ -347,15 +382,15 @@ function renderTableSchemas(
 
 export const ${insertSchema} = type({
 ${bodyInsert}
-})${atRowNarrows(rows, insertCols)};
+})${atRowNarrows(rows, insertCols)}${atLengthNarrows(lengths, insertCols)};
 
 export const ${updateSchema} = type({
 ${bodyUpdate}
-})${atRowNarrows(rows, updateCols)};
+})${atRowNarrows(rows, updateCols)}${atLengthNarrows(lengths, updateCols)};
 
 export const ${selectSchema} = type({
 ${bodySelect}
-})${atRowNarrows(rows, selectCols)};
+})${atRowNarrows(rows, selectCols)}${atLengthNarrows(lengths, selectCols)};
 
 export type ${insertType} = typeof ${insertSchema}["infer"];
 export type ${updateType} = typeof ${updateSchema}["infer"];

--- a/packages/generator-arktype/test/length.spec.ts
+++ b/packages/generator-arktype/test/length.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * `CHECK (length(name) >= 3)` in ArkType output.
+ *
+ * It was dropped entirely: the parser read it, the zod and valibot generators applied it, and
+ * ArkType emitted a bare `string`. A constraint the database enforces and the validator does not
+ * is the failure this project exists to prevent, so silence was the worst available answer.
+ *
+ * It cannot be `string >= 3`. ArkType's string bound counts UTF-16 code units and SQL's `length()`
+ * counts characters, so `'\u{1F44D}\u{1F44D}\u{1F44D}'` is three characters to Postgres and six
+ * units to ArkType. For a minimum that is merely too lenient; for a maximum it rejects rows the
+ * database accepts, which breaks working code. So it goes where an exact count can be written: a
+ * narrow on the object, beside the row-level checks.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArkTypeGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { type } from 'arktype';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(columns: Column[], checks: any[]): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-length');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.arktype.ts'), file);
+  return await import(file);
+}
+
+const run = (schema: any, v: unknown) => !(schema(v) instanceof type.errors);
+
+describe('a length() CHECK', () => {
+  it('is enforced', async () => {
+    const m = await schemasFor([col('n')], [{ name: 'a', expression: 'length(n) >= 3' }]);
+    expect(run(m.SelecttSchema, { n: 'ab' })).toBe(false);
+    expect(run(m.SelecttSchema, { n: 'abc' })).toBe(true);
+  });
+
+  it('counts characters, not UTF-16 units', async () => {
+    // Three thumbs-up is three characters to Postgres and six code units to JavaScript. A bound
+    // written as `string <= 5` refuses it; `length(n) <= 5` in SQL does not.
+    const m = await schemasFor([col('n')], [{ expression: 'length(n) <= 5' }]);
+    expect(run(m.SelecttSchema, { n: '\u{1F44D}\u{1F44D}\u{1F44D}' }), '3 characters').toBe(true);
+    expect(run(m.SelecttSchema, { n: 'abcdef' }), '6 characters').toBe(false);
+  });
+
+  it('passes when the column is absent, as SQL does', async () => {
+    const m = await schemasFor([col('n', { nullable: true })], [{ expression: 'length(n) >= 3' }]);
+    expect(run(m.UpdatetSchema, {}), 'omitted on update').toBe(true);
+    expect(run(m.SelecttSchema, { n: null }), 'null skips the check').toBe(true);
+  });
+
+  it('is absent when there is no length constraint', async () => {
+    const m = await schemasFor([col('n')], []);
+    expect(run(m.SelecttSchema, { n: '' })).toBe(true);
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -3,6 +3,7 @@ import type {
   ColumnCheck,
   ColumnSet,
   CardinalityCheck,
+  LengthCheck,
   ResolvedAffix,
   RowCheck,
   ValidationRenderer,
@@ -390,6 +391,7 @@ function renderTableSchemas(
   const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
   const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
   const cardinalities = parsedChecks.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : []));
+  const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
 
   const tj = typedJson
     ? { table: T, mode: 'select' as const, allColumns: typedJson.allColumns }
@@ -441,17 +443,19 @@ function renderTableSchemas(
   const rowCols = [insertCols, updateCols, selectCols].map(
     (cols) => new Set(cols.map((c) => c.name))
   );
-  const needsRows = rows.some((r) => rowCols.some((s) => s.has(r.left) && s.has(r.right)));
+  const needsRows =
+    rows.some((r) => rowCols.some((s) => s.has(r.left) && s.has(r.right))) ||
+    lengths.some((k) => rowCols.some((s) => s.has(k.column)));
   const rowImport = needsRows ? `, Kind, TypeRegistry` : '';
 
   return `import { Type${rowImport} } from '@sinclair/typebox';
 import type { Static } from '@sinclair/typebox';
 ${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}${needsRows ? `\n${ROW_PREAMBLE}` : ''}
-export const ${insertSchema} = ${tbWrapRows(`Type.Object({\n${bodyInsert}\n})`, rows, insertCols)};
+export const ${insertSchema} = ${tbWrapRows(`Type.Object({\n${bodyInsert}\n})`, rows, insertCols, lengths)};
 
-export const ${updateSchema} = ${tbWrapRows(`Type.Object({\n${bodyUpdate}\n})`, rows, updateCols)};
+export const ${updateSchema} = ${tbWrapRows(`Type.Object({\n${bodyUpdate}\n})`, rows, updateCols, lengths)};
 
-export const ${selectSchema} = ${tbWrapRows(`Type.Object({\n${bodySelect}\n})`, rows, selectCols)};
+export const ${selectSchema} = ${tbWrapRows(`Type.Object({\n${bodySelect}\n})`, rows, selectCols, lengths)};
 
 export type ${insertType} = Static<typeof ${insertSchema}>;
 export type ${updateType} = Static<typeof ${updateSchema}>;
@@ -483,7 +487,48 @@ const ROW_PREAMBLE = `TypeRegistry.Set('DrzlRowCheck', (schema: any, value: any)
  * rather than something wrong. `description` survives for a reader, and a failing validation
  * reports it on `error.schema.description`.
  */
-function tbWrapRows(objectExpr: string, rows: RowCheck[], cols: Column[]): string {
+/**
+ * `CHECK (length(name) >= 3)` as branches of the same intersection the row checks use.
+ *
+ * Not `minLength`. That keyword counts UTF-16 code units and SQL's `length()` counts characters,
+ * so three thumbs-up characters are six units: for a minimum that under-enforces, and for a
+ * maximum it refuses rows the database accepts. The spread operator counts characters, and the
+ * registered kind is the only place an expression can live, so both ends go here.
+ *
+ * The cost is that this constraint does not survive serialisation to JSON Schema, where a bare
+ * `minLength` would. Emitting the wrong count in a form that serialises is not a better trade.
+ */
+function tbLengthBranches(lengths: LengthCheck[], cols: Column[]): string[] {
+  const present = new Set(cols.map((c) => c.name));
+  const OPS: Record<LengthCheck['operator'], string> = {
+    '>=': '>=',
+    '>': '>',
+    '<=': '<=',
+    '<': '<',
+    '=': '===',
+    '<>': '!==',
+  };
+  return lengths
+    .filter((k) => present.has(k.column))
+    .map((k) => {
+      const v = `o[${JSON.stringify(k.column)}]`;
+      const msg = JSON.stringify(
+        `${k.name ? `${k.name}: ` : ''}length(${k.column}) ${k.operator} ${k.value}`
+      );
+      return `Type.Unsafe<unknown>({
+    [Kind]: 'DrzlRowCheck',
+    description: ${msg},
+    assert: (o: any) => o == null || ${v} == null || [...${v}].length ${OPS[k.operator]} ${k.value},
+  })`;
+    });
+}
+
+function tbWrapRows(
+  objectExpr: string,
+  rows: RowCheck[],
+  cols: Column[],
+  lengths: LengthCheck[] = []
+): string {
   const present = new Set(cols.map((c) => c.name));
   const OPS: Record<RowCheck['operator'], string> = {
     '>=': '>=',
@@ -508,8 +553,9 @@ function tbWrapRows(objectExpr: string, rows: RowCheck[], cols: Column[]): strin
     assert: (o: any) => o == null || ${l} == null || ${rt} == null || ${l} ${OPS[r.operator]} ${rt},
   })`;
     });
-  return branches.length
-    ? `Type.Intersect([\n  ${objectExpr},\n  ${branches.join(',\n  ')},\n])`
+  const all = [...branches, ...tbLengthBranches(lengths, cols)];
+  return all.length
+    ? `Type.Intersect([\n  ${objectExpr},\n  ${all.join(',\n  ')},\n])`
     : objectExpr;
 }
 

--- a/packages/generator-typebox/test/length.spec.ts
+++ b/packages/generator-typebox/test/length.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * `CHECK (length(name) >= 3)` in TypeBox output.
+ *
+ * It was dropped entirely: the parser read it, zod and valibot applied it, and TypeBox emitted a
+ * bare `Type.String()`.
+ *
+ * It cannot be `minLength`. That keyword counts UTF-16 code units and SQL's `length()` counts
+ * characters, so three thumbs-up characters are six units. For a minimum that only under-enforces;
+ * for a maximum it refuses rows the database accepts. The registered kind added for row checks
+ * can hold an exact count, so both ends go there rather than one being right and the other
+ * quietly wrong.
+ */
+import { describe, it, expect } from 'vitest';
+import { TypeBoxGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(columns: Column[], checks: any[]): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-length');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), file);
+  return await import(file);
+}
+
+describe('a length() CHECK', () => {
+  it('is enforced', async () => {
+    const m = await schemasFor([col('n')], [{ name: 'a', expression: 'length(n) >= 3' }]);
+    expect(Value.Check(m.SelecttSchema, { n: 'ab' })).toBe(false);
+    expect(Value.Check(m.SelecttSchema, { n: 'abc' })).toBe(true);
+  });
+
+  it('counts characters, not UTF-16 units', async () => {
+    const m = await schemasFor([col('n')], [{ expression: 'length(n) <= 5' }]);
+    expect(Value.Check(m.SelecttSchema, { n: '\u{1F44D}\u{1F44D}\u{1F44D}' }), '3 chars').toBe(true);
+    expect(Value.Check(m.SelecttSchema, { n: 'abcdef' }), '6 chars').toBe(false);
+  });
+
+  it('still checks the property type', async () => {
+    const m = await schemasFor([col('n')], [{ expression: 'length(n) >= 3' }]);
+    expect(Value.Check(m.SelecttSchema, { n: 123 })).toBe(false);
+  });
+
+  it('holds under the compiler', async () => {
+    const m = await schemasFor([col('n')], [{ expression: 'length(n) >= 3' }]);
+    const c = TypeCompiler.Compile(m.SelecttSchema);
+    expect(c.Check({ n: 'ab' })).toBe(false);
+    expect(c.Check({ n: 'abc' })).toBe(true);
+  });
+
+  it('passes when the column is absent or null, as SQL does', async () => {
+    const m = await schemasFor([col('n', { nullable: true })], [{ expression: 'length(n) >= 3' }]);
+    expect(Value.Check(m.UpdatetSchema, {}), 'omitted on update').toBe(true);
+    expect(Value.Check(m.SelecttSchema, { n: null }), 'null skips the check').toBe(true);
+  });
+
+  it('is absent when there is no length constraint', async () => {
+    const m = await schemasFor([col('n')], []);
+    expect(Value.Check(m.SelecttSchema, { n: '' })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Silently dropped

`CHECK (length(name) >= 3)` was parsed by the shared parser, applied by zod and valibot, and
emitted as **nothing** by the other two:

```ts
// arktype
export const SelecttSchema = type({ n: 'string' });
// typebox
export const SelecttSchema = Type.Object({ n: Type.String() });
```

A constraint the database enforces and the validator does not is exactly the gap these generators
exist to close. Found by generating the same one-column table with all four and reading the
output, which is worth doing per parsed form rather than assuming the four agree.

## Why not the native keyword

ArkType has `string >= 3`. TypeBox has `minLength`. Neither is used, and that is the interesting
part.

**Both count UTF-16 code units. SQL's `length()` counts characters.**

`'👍👍👍'` is three characters to Postgres and six code units to JavaScript.

| | minimum | maximum |
| --- | --- | --- |
| effect of using the native keyword | under-enforces, accepts short strings | **rejects rows the database accepts** |

The maximum case is the `varchar(n)` trap the zod generator already avoids by counting code
points, and it breaks working code rather than merely letting something through.

So each constraint goes where an exact count can be written:

- **ArkType**: a `.narrow()` on the object, beside the row-level checks
- **TypeBox**: a branch of the same registered-kind intersection the row checks use

Null and absent both pass, matching SQL, where a check involving NULL is satisfied.

## The trade, stated

For TypeBox this constraint **does not survive serialisation to JSON Schema**, where a bare
`minLength` would. That is a real loss and it is the right call anyway: emitting the wrong count in
a form that serialises is not a better trade than emitting the right one in a form that does not.

## Verification

- 658 tests across 86 files, green; `pnpm typecheck` and `pnpm lint` clean
- both generators' output is executed against the real library, including under
  `TypeCompiler.Compile` for TypeBox
- astral characters asserted directly, so the code-point counting is measured rather than claimed
- full `verify-packed.sh` green, with the Postgres CHECK gate unchanged at DRZL 0 / drizzle-orm 22