### PR TITLE
test(verify): make the four generators agree about every CHECK, not just every type

### DIFF
--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "jiti": "^2.7.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "build": "tsup src/cli.ts src/config.ts --format esm,cjs --sourcemap --dts",
     "dev": "node --loader ts-node/esm src/cli.ts --help",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^",

--- a/packages/generator-arktype/package.json
+++ b/packages/generator-arktype/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^",

--- a/packages/generator-json-schema/package.json
+++ b/packages/generator-json-schema/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^",

--- a/packages/generator-orpc/package.json
+++ b/packages/generator-orpc/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^",

--- a/packages/generator-service/package.json
+++ b/packages/generator-service/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^",

--- a/packages/generator-typebox/package.json
+++ b/packages/generator-typebox/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^",

--- a/packages/generator-valibot/package.json
+++ b/packages/generator-valibot/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^",

--- a/packages/generator-zod/package.json
+++ b/packages/generator-zod/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^",

--- a/packages/template-orpc-service/package.json
+++ b/packages/template-orpc-service/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/template-standard/package.json
+++ b/packages/template-standard/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
     "lint": "eslint . --ext .ts",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^"

--- a/packages/validation-core/package.json
+++ b/packages/validation-core/package.json
@@ -12,7 +12,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsup src/index.ts --dts --format esm,cjs",
-    "test": "vitest run"
+    "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^"

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1157,6 +1157,12 @@ import { DDL } from './ddl';
 // It is also the right semantic. Inserting one column is a partial row, and that is what the
 // database is being asked about.
 import { UpdatecheckedSchema as drzlUpdate } from './gen/pg/zod/checked.zod';
+import { UpdatecheckedSchema as vUpdate } from './gen/pg/valibot/checked.valibot';
+import { UpdatecheckedSchema as aUpdate } from './gen/pg/arktype/checked.arktype';
+import { UpdatecheckedSchema as tUpdate } from './gen/pg/typebox/checked.typebox';
+import * as v from 'valibot';
+import { type } from 'arktype';
+import { Value } from '@sinclair/typebox/value';
 import { createUpdateSchema } from 'drizzle-orm/zod';
 import { checked } from './schema';
 
@@ -1223,6 +1229,32 @@ const parses = (schema: any, col: string, v: unknown) => {
   }
 };
 
+/**
+ * The same probes through all four generators.
+ *
+ * A CHECK form is read once by the shared parser and then emitted four times, so a generator can
+ * drop one without any test noticing: `length()` was applied by zod and valibot and emitted as
+ * nothing at all by arktype and typebox, for as long as both have existed. The matrix table
+ * already cross-checks the four, and it carries no CHECK constraints, so it could never see this.
+ *
+ * Whole-object parsing, because a row-level check lives on the object and a per-field comparison
+ * cannot reach it.
+ */
+const RUNNERS: Record<string, (o: unknown) => boolean> = {
+  zod: (o) => drzlUpdate.safeParse(o).success,
+  valibot: (o) => v.safeParse(vUpdate as never, o).success,
+  arktype: (o) => !((aUpdate as any)(o) instanceof type.errors),
+  typebox: (o) => Value.Check(tUpdate as never, o),
+};
+
+const safely = (f: (o: unknown) => boolean, o: unknown) => {
+  try {
+    return f(o);
+  } catch {
+    return false;
+  }
+};
+
 type Row = { col: string; value: unknown; db: boolean; drzl: boolean; off: boolean };
 const rows: Row[] = [];
 for (const [col, values] of Object.entries(PROBES)) {
@@ -1259,6 +1291,29 @@ if (loose.length) {
   console.log('    accepted by DRZL but not by Postgres (parser declined to read the check):');
   for (const r of loose.slice(0, 10)) console.log(`      ${r.col} = ${show(r.value)}`);
 }
+
+const split: string[] = [];
+for (const [col, values] of Object.entries(PROBES)) {
+  for (const value of values) {
+    const verdicts = Object.entries(RUNNERS).map(
+      ([name, run]) => [name, safely(run, { [col]: value })] as const
+    );
+    const yes = verdicts.filter(([, r]) => r).map(([n]) => n);
+    const no = verdicts.filter(([, r]) => !r).map(([n]) => n);
+    if (yes.length && no.length) {
+      split.push(`      ${col} = ${show(value)}: ${yes.join('/')} accept, ${no.join('/')} reject`);
+    }
+  }
+}
+
+if (split.length) {
+  console.error('\n    FAIL: the four generators disagree about a CHECK:');
+  for (const line of split.slice(0, 20)) console.error(line);
+  console.error('\n    One of them is dropping a constraint the parser read.');
+  await db.close();
+  process.exit(1);
+}
+console.log('    all four generators agree on every CHECK probe');
 
 await db.close();
 CHECKS_TRUTH


### PR DESCRIPTION
## The gap this closes

A `CHECK` form is read **once** by the shared parser and emitted **four** times. One generator can
drop it while the other three apply it, and nothing notices.

Not hypothetical: `length()` was applied by zod and valibot and emitted as **nothing at all** by
arktype and typebox, for as long as both have existed (fixed in #75). It was found by generating a
one-column table and reading four files by hand.

## Why the existing cross-check missed it

There is already a "all four generators agree with each other" pass. It could never have caught
this:

- it runs **per field**, and a row-level check lives on the object, not a field
- it runs on the **matrix** table, which carries no `CHECK` constraints at all

So the `checked` table's probes now go through all four generators as whole objects.

## It reproduces the original bug

Removing the arktype length fix:

```
    FAIL: the four generators disagree about a CHECK:
      k_len = "ab": arktype accept, zod/valibot/typebox reject
      k_len = "": arktype accept, zod/valibot/typebox reject
      k_len_max = "abcdef": arktype accept, zod/valibot/typebox reject

    One of them is dropping a constraint the parser read.
```

It names the generator and the value. The hand comparison that originally found this took
considerably longer and only covered one form.

Current state:

```
    53 CHECK probes against a real Postgres (13 constrained columns)
    rows Postgres rejects and the validator accepts: DRZL 0, drizzle-orm 22
    all four generators agree on every CHECK probe
```

## Note on what it cannot catch

Like every cross-check, it is silent when all four are wrong the same way. That is what the
Postgres comparison directly above it is for, and the two are deliberately separate for the same
reason the cross-major diff and the unnamed-column check are.