### PR TITLE
test(verify): add SQLite as a second database authority for CHECK constraints

### DIFF
--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -517,7 +517,8 @@ export const matrix = mysqlTable('matrix', {
 PARITY_MYSQL
 
 cat > src/schema-sqlite.ts <<'PARITY_SQLITE'
-import { sqliteTable, text, integer, real, numeric, blob } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, real, numeric, blob, check } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
 
 export const matrix = sqliteTable('matrix', {
   s_text: text().notNull(),
@@ -538,6 +539,33 @@ export const matrix = sqliteTable('matrix', {
   s_blob_json: blob({ mode: 'json' }).notNull(),
   s_blob_bigint: blob({ mode: 'bigint' }).notNull(),
 });
+
+// The same CHECK forms as the Postgres fixture, minus the ones SQLite has no equivalent for:
+// no arrays and so no `cardinality()`, and no `char_length()`. SQLite enforces a CHECK exactly
+// as strictly as Postgres does, whatever its type affinity does elsewhere, so it is a real second
+// authority for this subsystem rather than a permissive one.
+export const checked = sqliteTable('checked', {
+  k_min: integer(),
+  k_max: integer(),
+  k_lo: integer(),
+  k_between: integer(),
+  k_eq: integer(),
+  k_in_s: text(),
+  k_in_n: integer(),
+  k_len: text(),
+  k_pair_a: integer(),
+  k_pair_b: integer(),
+}, (t) => [
+  check('k_min_c', sql`${t.k_min} >= 18`),
+  check('k_max_c', sql`${t.k_max} <= 100`),
+  check('k_lo_c', sql`${t.k_lo} > 0`),
+  check('k_between_c', sql`${t.k_between} BETWEEN 5 AND 15`),
+  check('k_eq_c', sql`${t.k_eq} = 7`),
+  check('k_in_s_c', sql`${t.k_in_s} IN ('a', 'b', 'c')`),
+  check('k_in_n_c', sql`${t.k_in_n} IN (1, 2, 3)`),
+  check('k_len_c', sql`length(${t.k_len}) >= 3`),
+  check('k_pair_c', sql`${t.k_pair_a} < ${t.k_pair_b}`),
+]);
 PARITY_SQLITE
 
 cat > src/parity.ts <<'PARITY_HARNESS'
@@ -1323,6 +1351,112 @@ if ! npx tsx src/checks-truth.ts; then
   exit 1
 fi
 
+
+cat > src/sqlite-truth.ts <<'SQLITE_TRUTH'
+/**
+ * CHECK constraints against SQLite itself, as a second database authority.
+ *
+ * SQLite's *type* checking is famously weak, which is why there is no type ground-truth stage for
+ * it: a non-STRICT column takes almost anything and measuring against it would say nothing. Its
+ * *CHECK* enforcement is not weak at all. It is exactly as strict as Postgres's, and `length()`
+ * counts characters there too, so three thumbs-up characters are three.
+ *
+ * `node:sqlite` is built into Node 22, so this costs no dependency and no install.
+ *
+ * The value is dialect coverage. The same parser reads a check expression rendered by a different
+ * dialect's SQL builder, and the emitted schema has to still mean what the database means.
+ */
+import { DatabaseSync } from 'node:sqlite';
+import { UpdatecheckedSchema as drzlUpdate } from './gen/sqlite/zod/checked.zod';
+
+const db = new DatabaseSync(':memory:');
+db.exec(`
+CREATE TABLE checked (
+  k_min integer CHECK (k_min >= 18),
+  k_max integer CHECK (k_max <= 100),
+  k_lo integer CHECK (k_lo > 0),
+  k_between integer CHECK (k_between BETWEEN 5 AND 15),
+  k_eq integer CHECK (k_eq = 7),
+  k_in_s text CHECK (k_in_s IN ('a', 'b', 'c')),
+  k_in_n integer CHECK (k_in_n IN (1, 2, 3)),
+  k_len text CHECK (length(k_len) >= 3),
+  k_pair_a integer,
+  k_pair_b integer,
+  CONSTRAINT k_pair_c CHECK (k_pair_a < k_pair_b)
+);
+`);
+
+const PROBES: Record<string, unknown[]> = {
+  k_min: [17, 18, 19, 0],
+  k_max: [99, 100, 101],
+  k_lo: [0, 1, 2],
+  k_between: [4, 5, 15, 16],
+  k_eq: [6, 7, 8],
+  k_in_s: ['a', 'c', 'd', ''],
+  k_in_n: [1, 3, 4],
+  k_len: ['ab', 'abc', '', '\u{1F44D}\u{1F44D}\u{1F44D}'],
+  k_pair_a: [1, 100],
+  k_pair_b: [1, 100],
+};
+
+function dbAccepts(col: string, value: unknown): boolean {
+  try {
+    db.exec('BEGIN');
+    db.prepare(`INSERT INTO checked (${col}) VALUES (?)`).run(value as never);
+    db.exec('ROLLBACK');
+    return true;
+  } catch {
+    try {
+      db.exec('ROLLBACK');
+    } catch {
+      /* already rolled back */
+    }
+    return false;
+  }
+}
+
+const parses = (col: string, v: unknown) => {
+  try {
+    return (drzlUpdate as any).safeParse({ [col]: v }).success;
+  } catch {
+    return false;
+  }
+};
+
+type Row = { col: string; value: unknown; db: boolean; drzl: boolean };
+const rows: Row[] = [];
+for (const [col, values] of Object.entries(PROBES)) {
+  for (const value of values) {
+    rows.push({ col, value, db: dbAccepts(col, value), drzl: parses(col, value) });
+  }
+}
+
+const strict = rows.filter((r) => r.db && !r.drzl);
+const loose = rows.filter((r) => !r.db && r.drzl);
+const show = (v: unknown) => JSON.stringify(v);
+
+console.log(`    ${rows.length} CHECK probes against a real SQLite (${Object.keys(PROBES).length} constrained columns)`);
+console.log(`    rows SQLite rejects and DRZL accepts: ${loose.length}`);
+
+if (strict.length) {
+  console.error('\n    FAIL: DRZL rejects rows SQLite accepts:');
+  for (const r of strict.slice(0, 20)) console.error(`      ${r.col} = ${show(r.value)}`);
+  db.close();
+  process.exit(1);
+}
+if (loose.length) {
+  console.log('    accepted by DRZL but not by SQLite:');
+  for (const r of loose.slice(0, 10)) console.log(`      ${r.col} = ${show(r.value)}`);
+}
+db.close();
+SQLITE_TRUTH
+
+# `node:sqlite` is still flagged experimental, and its warning is not news here.
+if ! npx tsx --disable-warning=ExperimentalWarning src/sqlite-truth.ts; then
+  echo "FAIL: a generated CHECK disagrees with SQLite." >&2
+  exit 1
+fi
+
 cd "$APP"
 
 # ---------------------------------------------------------------------------------------------
@@ -1547,5 +1681,5 @@ cd "$APP"
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
 echo "    typechecks under bundler, node16 and nodenext, and validates at least as strictly as"
 echo "    the first-party drizzle-orm validator modules across three dialects and three modes,"
-echo "    checked against a real Postgres, and analyzed with no column left unnamed on both"
-echo "    drizzle-orm majors."
+echo "    checked against a real Postgres and a real SQLite, and analyzed with no column left"
+echo "    unnamed on both drizzle-orm majors."


### PR DESCRIPTION
## Why SQLite, when its type checking is famously weak

There is no SQLite *type* ground-truth stage, deliberately: a non-STRICT column takes almost
anything, so measuring a validator against it would say nothing.

Its **CHECK enforcement is not weak at all**. It is exactly as strict as Postgres's:

```
a=17 reject     b=ab   reject
a=18 accept     b=abc  accept
```

And `length()` counts characters there too, so `'👍👍👍'` is three, matching Postgres and matching
the code-point counting the generators already do.

`node:sqlite` ships with Node 22, so this costs **no dependency, no install and no container**.

## What it covers that Postgres cannot

The same shared parser reading a check expression rendered by a **different dialect's SQL
builder**. If that rendering defeated the parser, every constraint would silently vanish from the
emitted schema, and SQLite would reject rows the validator accepts.

```
    32 CHECK probes against a real SQLite (10 constrained columns)
    rows SQLite rejects and DRZL accepts: 0
```

That zero is the evidence. A parser that could not read SQLite's rendering would report ten.

## On proving the direction of failure

Sabotaging a folded bound (`>= 18` emitted as `> 18`) fails in the **Postgres** stage first, since
one generator serves every dialect:

```
    FAIL: DRZL rejects rows Postgres accepts:
      k_min = 18
      k_between = 5
```

So that is where the over-strict proof lives, and this stage's job is the dialect-rendering one
above.

## Scope

No `cardinality()` and no `char_length()` in the SQLite fixture: SQLite has neither. Everything
else the parser reads is covered: `>=`, `<=`, `>`, `BETWEEN`, `=`, `IN` over strings and numbers,
`length()`, and a row-level comparison between two columns.

The summary line now reads "checked against a real Postgres and a real SQLite".