### PR TITLE
fix(cli): make the JSON Schema generator optional, so the CLI installs again

### DIFF
--- a/.changeset/cli-optional-json-schema.md
+++ b/.changeset/cli-optional-json-schema.md
@@ -1,0 +1,19 @@
+---
+'@drzl/cli': patch
+---
+
+Make `@drzl/generator-json-schema` an optional dependency, so the CLI installs again
+
+`@drzl/cli@4.13.0` shipped with a hard dependency on `@drzl/generator-json-schema@^0.2.0`, and
+that package failed to publish in the same release, so `npm install @drzl/cli` failed outright
+with a 404 for everyone.
+
+The publish failed because npm's trusted publishing has nothing to authenticate against for a
+package name that has never existed: `E404 PUT /@drzl%2fgenerator-json-schema`. The account
+disallows tokens, so the first version of any new package has to be published interactively before
+CI can take it over. That is a one-time step and it had not been done.
+
+An optional dependency that cannot be resolved is skipped rather than failing the install, so the
+CLI installs and works as it did before, and the JSON Schema generator is picked up automatically
+once it is on the registry. It is also the more honest declaration: the CLI imports every
+generator dynamically and already reports a missing one with an install hint.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@drzl/analyzer": "workspace:^",
     "@drzl/generator-arktype": "workspace:^",
-    "@drzl/generator-json-schema": "workspace:^",
     "@drzl/generator-orpc": "workspace:^",
     "@drzl/generator-service": "workspace:^",
     "@drzl/generator-typebox": "workspace:^",
@@ -67,5 +66,8 @@
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/omar-dulaimi"
+  },
+  "optionalDependencies": {
+    "@drzl/generator-json-schema": "workspace:^"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -238,7 +238,11 @@ program
             progress.stop();
             console.error(
               chalk.red('JSON Schema generator missing.'),
-              chalk.yellow('\nInstall with: npm install @drzl/generator-json-schema')
+              chalk.yellow('\nInstall with: npm install @drzl/generator-json-schema'),
+              // An optional dependency, unlike the other generators, until its npm trusted
+              // publisher exists. A missing optional dependency is skipped rather than failing
+              // the install, which is what keeps `npm i @drzl/cli` working meanwhile.
+              ''
             );
             console.error(chalk.gray('Error details:'), e?.message ?? e);
             process.exit(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,6 @@ importers:
       '@drzl/generator-arktype':
         specifier: workspace:^
         version: link:../generator-arktype
-      '@drzl/generator-json-schema':
-        specifier: workspace:^
-        version: link:../generator-json-schema
       '@drzl/generator-orpc':
         specifier: workspace:^
         version: link:../generator-orpc
@@ -124,6 +121,10 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+    optionalDependencies:
+      '@drzl/generator-json-schema':
+        specifier: workspace:^
+        version: link:../generator-json-schema
 
   packages/generator-arktype:
     dependencies:


### PR DESCRIPTION
## `npm install @drzl/cli` is currently broken

```
npm error 404  '@drzl/generator-json-schema@^0.2.0' is not in this registry.
```

`@drzl/cli@4.13.0` shipped with a **hard dependency** on `@drzl/generator-json-schema@^0.2.0`, and
that package **failed to publish in the same release**. Verified against the live registry, not
inferred:

| package | on npm |
| --- | --- |
| `@drzl/analyzer` | 1.13.0 |
| `@drzl/cli` | 4.13.0 |
| `@drzl/generator-arktype` | 3.9.0 |
| `@drzl/generator-typebox` | 0.7.0 |
| `@drzl/generator-valibot` | 3.13.0 |
| `@drzl/generator-zod` | 3.14.1 |
| `@drzl/generator-json-schema` | **missing** |

## Why the publish failed

```
error an error occurred while publishing @drzl/generator-json-schema: E404
"message": "404 Not Found - PUT https://registry.npmjs.org/@drzl%2fgenerator-json-schema"
```

npm trusted publishing has nothing to authenticate against for a package name that **has never
existed**. The account disallows tokens, so the first version of any new package must go out
interactively before CI can take over. One-time step, not yet done.

Adding the dependency in the same release as the new package is what turned "a feature is missing"
into "the CLI does not install".

## The fix

`optionalDependencies`. An optional dependency that cannot be resolved is **skipped** rather than
failing the install. Confirmed directly against npm:

```
added 5 packages in 3s
EXIT=0
```

It is also the more honest declaration. The CLI imports every generator dynamically and already
reports a missing one with an install hint, so nothing about the runtime behaviour changes: the
JSON Schema generator is picked up automatically once it reaches the registry.

## Still needed, and it needs npm credentials

One interactive publish of `@drzl/generator-json-schema`, then its trusted publisher configured on
the package page, after which CI handles it like the others. That is out of scope for this PR,
which exists to unbreak the install now.