### PR TITLE
test(verify): fail when a workspace dependency is not on the registry

### DIFF
--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1795,6 +1795,37 @@ if ! npx tsx check-old.ts; then
 fi
 cd "$APP"
 
+# ---------------------------------------------------------------------------------------------
+# Can the published packages actually be installed?
+#
+# `@drzl/cli@4.13.0` shipped with a hard dependency on a package added in the same release, whose
+# first publish failed because npm trusted publishing has nothing to authenticate against for a
+# name that has never existed. Every gate in this file was green: the tarballs were correct, the
+# workspace resolved, and `npm install @drzl/cli` failed with a 404 for everyone.
+#
+# The rule that would have caught it: a workspace dependency that is not yet on the registry has
+# to be optional, because an unresolvable optional dependency is skipped rather than failing the
+# install. Once it is published it can become a hard dependency like the rest.
+# ---------------------------------------------------------------------------------------------
+echo "==> workspace dependencies exist on the registry"
+cd "$ROOT"
+missing=0
+for pkg in packages/*/package.json; do
+  owner=$(node -p "require('./$pkg').name")
+  deps=$(node -p "Object.keys(require('./$pkg').dependencies||{}).filter(d=>d.startsWith('@drzl/')).join(' ')")
+  for dep in $deps; do
+    if ! npm view "$dep" version >/dev/null 2>&1; then
+      echo "    FAIL: $owner depends on $dep, which is not on the registry." >&2
+      echo "          A package awaiting its first publish must be an optionalDependency, or" >&2
+      echo "          installing $owner fails outright for everyone." >&2
+      missing=1
+    fi
+  done
+done
+[ "$missing" = 0 ] || exit 1
+echo "    every @drzl dependency resolves on npm"
+cd "$APP"
+
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
 echo "    typechecks under bundler, node16 and nodenext, and validates at least as strictly as"
 echo "    the first-party drizzle-orm validator modules across three dialects and three modes,"


### PR DESCRIPTION
## The gap this closes

`@drzl/cli@4.13.0` shipped with a hard dependency on a package added in the **same release**, whose
first publish failed. `npm install @drzl/cli` then failed with a 404 for everyone (fixed in #80).

Every gate in `verify-packed.sh` was green at the time. The tarballs were correct, the workspace
resolved, the generated output typechecked under three module resolutions, and 1450 probes agreed
with two real databases.

**Nothing here had ever asked the registry a question.** The packed tarballs are installed from a
local directory, so a dependency that exists only in the workspace looks exactly like one that
exists everywhere. That is the whole blind spot in one sentence.

## The rule

A workspace dependency awaiting its first publish must be an `optionalDependency`, because an
unresolvable optional dependency is **skipped** rather than failing the install. Once it is on the
registry it can become a hard dependency like the rest.

```
==> workspace dependencies exist on the registry
    every @drzl dependency resolves on npm
```

## Verified by reproducing what shipped

Restoring the exact `package.json` from the broken release:

```
    FAIL: @drzl/cli depends on @drzl/generator-json-schema, which is not on the registry.
          A package awaiting its first publish must be an optionalDependency, or
          installing @drzl/cli fails outright for everyone.
```

## Why npm rejected the first publish

For the record, since it will come up again for the next new package:

```
E404 "404 Not Found - PUT https://registry.npmjs.org/@drzl%2fgenerator-json-schema"
```

Trusted publishing has nothing to authenticate against for a name that has never existed, and the
account disallows tokens. The first version of any new package has to go out interactively, then
its trusted publisher is configured on the package page, after which CI handles it.