### PR TITLE
fix(validation): count MySQL TEXT caps in bytes, and stop rejecting valid varchar values

### DIFF
--- a/.changeset/mysql-byte-caps.md
+++ b/.changeset/mysql-byte-caps.md
@@ -1,0 +1,27 @@
+---
+'@drzl/analyzer': minor
+'@drzl/generator-zod': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-typebox': patch
+'@drzl/generator-arktype': patch
+---
+
+Count MySQL TEXT caps in bytes, and stop rejecting valid `varchar(n)` values in TypeBox and ArkType
+
+Two different measurements were both being got wrong, in opposite directions. Measured against a
+real MySQL 8 on utf8mb4 and a real Postgres, not reasoned about:
+
+- `varchar(10)` counts **characters** in both databases: ten thumbs-up characters are a valid row.
+  TypeBox emitted `maxLength: 10` and ArkType `string <= 10`, both of which count UTF-16 code
+  units, so both **refused a row the database accepts**. That is the direction that breaks working
+  code. zod and valibot already counted code points.
+- MySQL's TEXT family counts **bytes**: `tinytext` takes 255 ascii characters and 63 thumbs-up
+  ones (252 bytes), refusing 64 (256 bytes). The cap was carried as a character count, so a
+  tinytext holding 64 emoji validated clean and MySQL refused the row. It is now a separate
+  `maxBytes`, applied by encoding the string.
+
+On drizzle-orm 0.4x the TEXT caps were absent entirely: every member of the family shares the
+`MySqlText` class there, so only the SQL type tells a `tinytext` from a `longtext`.
+
+Both caps now sit on the field rather than the object, so the differential parity harness, which
+compares column by column, can still see them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,22 @@ jobs:
   # can never be mistaken for a shippable artefact.
   verify-packed:
     runs-on: ubuntu-latest
+    # Postgres and SQLite both run in-process, via PGlite and node:sqlite. MySQL has no such
+    # engine, so it is the one dialect that needs a server. Without MYSQL_URL the stage skips and
+    # says so, which keeps a local run honest about covering less.
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: drzl
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -uroot -proot"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -44,6 +60,8 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify:packed
+        env:
+          MYSQL_URL: mysql://root:root@127.0.0.1:3306/drzl
 
   changeset-check:
     runs-on: ubuntu-latest

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -88,6 +88,17 @@ export interface Column {
   defaultValue?: unknown;
 
   /**
+   * A cap measured in bytes rather than characters.
+   *
+   * MySQL's TEXT and BLOB families carry their limit in the type itself, and that limit is a byte
+   * budget: `tinytext` is 255 bytes, which on utf8mb4 is 255 ascii characters or 63 emoji.
+   * `maxLength` cannot express that, and using it applied the number as a character count.
+   *
+   * Only MySQL sets this. Postgres `text` has no limit and its `varchar(n)` counts characters.
+   */
+  maxBytes?: number;
+
+  /**
    * Array depth for a column declared with `.array()`, absent when the column is a scalar.
    *
    * Drizzle does not give an array its own column class: `text().array()` is still a `PgText`,
@@ -459,7 +470,12 @@ export function describeV1Column(column: any): Partial<Column> | null {
         // rather than `constructor.name` because it survives minification.
         const kind = String(column?.constructor?.[Symbol.for('drizzle:entityKind')] ?? '');
         const cap = codec && kind.startsWith('MySql') ? MYSQL_TEXT_CAPS[codec] : undefined;
-        if (cap) out.maxLength = cap;
+        // A byte budget, not a character count. Measured against MySQL 8 on utf8mb4, its default:
+        // `tinytext` takes 255 ascii and 63 thumbs-up characters (252 bytes) and refuses 64 (256).
+        // Carried as `maxLength` it was applied as characters, so a tinytext holding 64 emoji
+        // validated clean and the database refused the row. `varchar(n)` really is characters and
+        // is unaffected.
+        if (cap) out.maxBytes = cap;
       } else {
         // Something this release added that is not modelled yet. Falling back to the class
         // name beats inventing a type: a wrong scalar rejects rows, `unknown` only fails to
@@ -1217,6 +1233,17 @@ export class SchemaAnalyzer {
       // `Infinity`, a bigint, a Date and a Buffer, none of which survive a round trip.
       //
       // SQLite spells it as a mode on a text column rather than as a type.
+      // 0.4x gives every member of the TEXT family the same class, `MySqlText`, so only the SQL
+      // type tells them apart. v1 states a codec and reaches the same table through
+      // `describeV1Column`; on 0.4x nothing set a cap at all and a longtext and a tinytext were
+      // equally unconstrained.
+      const sqlKind = String((outerCol as any)?.constructor?.[Symbol.for('drizzle:entityKind')] ?? '');
+      const sqlType =
+        sqlKind.startsWith('MySql') && typeof (col as any)?.getSQLType === 'function'
+          ? String((col as any).getSQLType()).toLowerCase()
+          : undefined;
+      const byteCap = sqlType ? MYSQL_TEXT_CAPS[sqlType] : undefined;
+
       const jsonShape =
         dbType === 'JSON' || dbType === 'JSONB' || (col as any)?.config?.mode === 'json'
           ? ({ kind: 'json' } as const)
@@ -1272,6 +1299,7 @@ export class SchemaAnalyzer {
         ...(arrayDims ? { arrayDimensions: arrayDims } : {}),
         // Only where v1 did not already describe the value, so a shaped column keeps its shape.
         ...(jsonShape && !v1?.shape ? { shape: jsonShape } : {}),
+        ...(byteCap && v1?.maxBytes === undefined ? { maxBytes: byteCap } : {}),
       });
     }
 

--- a/packages/analyzer/test/mysql-byte-caps.spec.ts
+++ b/packages/analyzer/test/mysql-byte-caps.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * MySQL's TEXT family is a byte budget, not a character count.
+ *
+ * Measured against a real MySQL 8 on utf8mb4, which is its default charset:
+ *
+ *   varchar(10)  accepts 10 emoji, rejects 11        -> characters
+ *   tinytext     accepts 255 ascii, rejects 256
+ *                accepts 63 emoji (252 bytes)
+ *                rejects 64 emoji (256 bytes)        -> bytes
+ *
+ * The cap was carried as `maxLength`, which every generator applies as a character count, so a
+ * `tinytext` holding 64 emoji validated clean and the database refused it. `varchar(n)` is
+ * genuinely characters and stays where it is.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function columnsOf(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const a = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  return Object.fromEntries((a.tables[0]?.columns ?? []).map((c) => [c.name, c]));
+}
+
+describe('a mysql text column', () => {
+  it('carries its cap in bytes, not characters', async () => {
+    const cols = await columnsOf(
+      'mysql-byte-caps',
+      `
+      import { mysqlTable, tinytext, text, mediumtext, longtext } from 'drizzle-orm/mysql-core';
+      export const t = mysqlTable('t', {
+        tt: tinytext(), tx: text(), mt: mediumtext(), lt: longtext(),
+      });
+      `
+    );
+    expect(cols.tt.maxBytes).toBe(255);
+    expect(cols.tx.maxBytes).toBe(65535);
+    expect(cols.mt.maxBytes).toBe(16777215);
+    expect(cols.lt.maxBytes).toBe(4294967295);
+    expect(cols.tt.maxLength, 'not a character count').toBeUndefined();
+  });
+
+  it('leaves varchar counting characters, which is what MySQL does', async () => {
+    const cols = await columnsOf(
+      'mysql-varchar-chars',
+      `
+      import { mysqlTable, varchar } from 'drizzle-orm/mysql-core';
+      export const t = mysqlTable('t', { v: varchar({ length: 10 }) });
+      `
+    );
+    expect(cols.v.maxLength).toBe(10);
+    expect(cols.v.maxBytes).toBeUndefined();
+  });
+
+  it('does not put a byte cap on a postgres text column, which has none', async () => {
+    const cols = await columnsOf(
+      'pg-text-uncapped',
+      `
+      import { pgTable, text } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', { a: text() });
+      `
+    );
+    expect(cols.a.maxBytes).toBeUndefined();
+    expect(cols.a.maxLength).toBeUndefined();
+  });
+});

--- a/packages/analyzer/test/v1-dialect-types.spec.ts
+++ b/packages/analyzer/test/v1-dialect-types.spec.ts
@@ -92,9 +92,13 @@ describe('MySQL text and blob caps', () => {
   it('states the width the type itself implies', () => {
     // There is no `length` on a `text` column to read: the type is the limit, so it has to come
     // from a table. Unstated, the schema accepted a megabyte for a column that tops out at 64 KB.
-    expect(describeV1Column(my('string', 'text'))?.maxLength).toBe(65535);
-    expect(describeV1Column(my('string', 'tinytext'))?.maxLength).toBe(255);
-    expect(describeV1Column(my('string', 'longtext'))?.maxLength).toBe(4294967295);
+    // In bytes, not characters. MySQL 8 on utf8mb4 takes 255 ascii in a tinytext and refuses 64
+    // thumbs-up characters, which are 64 characters and 256 bytes. Carried as `maxLength` the
+    // number was applied as a character count and the row validated clean.
+    expect(describeV1Column(my('string', 'text'))?.maxBytes).toBe(65535);
+    expect(describeV1Column(my('string', 'tinytext'))?.maxBytes).toBe(255);
+    expect(describeV1Column(my('string', 'longtext'))?.maxBytes).toBe(4294967295);
+    expect(describeV1Column(my('string', 'tinytext'))?.maxLength).toBeUndefined();
   });
 
   it('does not apply them to Postgres, whose text has no limit', () => {

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -162,7 +162,11 @@ function atTypeForColumn(
       // See the zod generator. ArkType states a pattern as a bare regex literal in its DSL.
       const pattern = c.format ? COLUMN_FORMATS[c.format] : undefined;
       if (pattern) return `/${pattern}/`;
-      return c.maxLength ? `string <= ${c.maxLength}` : 'string';
+      // Not `string <= n`. That counts UTF-16 code units, and both Postgres and MySQL count a
+      // `varchar(n)` in characters, so ten thumbs-up characters are a valid row in a varchar(10)
+      // and this refused it. The cap moves to a narrow on the object, where an exact count can be
+      // written; a MySQL TEXT byte budget goes the same way.
+      return 'string';
     }
     case 'number': {
       const { lower, upper, equals } = atNarrowRange(c, checks);
@@ -256,10 +260,18 @@ function renderObjectShape(
   cardinalities: CardinalityCheck[] = []
 ) {
   return cols
-    .map(
-      (c) =>
-        `  ${JSON.stringify(c.name)}: ${JSON.stringify(atField(c, mode, coerceDates, checks, sets, applyDefaults, cardinalities))},`
-    )
+    .map((c) => {
+      const dsl = atField(c, mode, coerceDates, checks, sets, applyDefaults, cardinalities);
+      const caps = atCapNarrows(c);
+      if (!caps) return `  ${JSON.stringify(c.name)}: ${JSON.stringify(dsl)},`;
+      // A Type instance rather than a DSL string, because neither cap is expressible in the DSL:
+      // `string <= n` counts UTF-16 code units, which agrees with neither database. ArkType marks
+      // optionality on the key when the value is a Type, so the `?` moves there.
+      const optional = dsl.endsWith('?');
+      const inner = optional ? dsl.slice(0, -1) : dsl;
+      const key = JSON.stringify(optional ? `${c.name}?` : c.name);
+      return `  ${key}: type(${JSON.stringify(inner)})${caps},`;
+    })
     .join('\n');
 }
 
@@ -307,6 +319,29 @@ function atRowNarrows(rows: RowCheck[], cols: Column[]): string {
  *
  * Null and absent both pass, matching SQL, where a check involving NULL is satisfied.
  */
+/**
+ * Column caps as narrows: characters for `varchar(n)`, bytes for MySQL's TEXT family.
+ *
+ * Neither is expressible in the string DSL. `string <= n` counts UTF-16 code units, which is a
+ * third measurement, agreeing with neither. Both databases count `varchar(n)` in characters and
+ * MySQL counts `tinytext` in bytes, so both are written out here rather than approximated.
+ */
+function atCapNarrows(c: Column): string {
+  if (c.tsType !== 'string' || c.arrayDimensions || c.shape) return '';
+  const out: string[] = [];
+  if (c.maxLength) {
+    const msg = JSON.stringify(`at most ${c.maxLength} characters`);
+    out.push(`.narrow((v, ctx) => v == null || [...v].length <= ${c.maxLength} || ctx.mustBe(${msg}))`);
+  }
+  if (c.maxBytes) {
+    const msg = JSON.stringify(`at most ${c.maxBytes} bytes`);
+    out.push(
+      `.narrow((v, ctx) => v == null || new TextEncoder().encode(v).length <= ${c.maxBytes} || ctx.mustBe(${msg}))`
+    );
+  }
+  return out.join('');
+}
+
 function atLengthNarrows(lengths: LengthCheck[], cols: Column[]): string {
   const present = new Set(cols.map((c) => c.name));
   const OPS: Record<LengthCheck['operator'], string> = {

--- a/packages/generator-arktype/test/char-and-byte-caps.spec.ts
+++ b/packages/generator-arktype/test/char-and-byte-caps.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * String caps in ArkType: characters for `varchar(n)`, bytes for MySQL's TEXT family.
+ *
+ * `string <= 10` counts UTF-16 code units. Both Postgres and MySQL count `varchar(10)` in
+ * characters, verified against both servers, so ten thumbs-up characters are a valid row and
+ * ArkType refused it. That is the over-strict direction: it turns away rows the database takes.
+ *
+ * MySQL's TEXT family is a byte budget instead: `tinytext` takes 255 ascii characters and 63
+ * thumbs-up ones. Neither is expressible in the string DSL, so both go where an exact count can
+ * be written, a narrow on the object.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArkTypeGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { type } from 'arktype';
+
+const col = (over: Partial<Column> = {}): Column =>
+  ({
+    name: 'n',
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemaFor(c: Column) {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns: [c], unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-caps');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.arktype.ts'), file);
+  return (await import(file)).SelecttSchema;
+}
+
+const ok = (s: any, v: unknown) => !(s({ n: v }) instanceof type.errors);
+const EMOJI = '\u{1F44D}';
+
+describe('a character cap', () => {
+  it('counts characters, so ten emoji fit a varchar(10)', async () => {
+    const s = await schemaFor(col({ maxLength: 10 }));
+    expect(ok(s, EMOJI.repeat(10)), 'accepted by both databases').toBe(true);
+    expect(ok(s, EMOJI.repeat(11))).toBe(false);
+    expect(ok(s, 'a'.repeat(10))).toBe(true);
+    expect(ok(s, 'a'.repeat(11))).toBe(false);
+  });
+});
+
+describe('a byte cap', () => {
+  it('counts bytes, so a four-byte character fills it four times as fast', async () => {
+    const s = await schemaFor(col({ maxBytes: 255 }));
+    expect(ok(s, 'a'.repeat(255))).toBe(true);
+    expect(ok(s, 'a'.repeat(256))).toBe(false);
+    expect(ok(s, EMOJI.repeat(63)), '252 bytes').toBe(true);
+    expect(ok(s, EMOJI.repeat(64)), '256 bytes').toBe(false);
+  });
+});
+
+describe('a column with neither', () => {
+  it('is a bare string', async () => {
+    const s = await schemaFor(col());
+    expect(ok(s, 'x'.repeat(100000))).toBe(true);
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -238,12 +238,14 @@ function tbExprForColumn(
       // a bare string accepted values Postgres rejects, and `format` is not an option here
       // because TypeBox ignores it unless the consuming project registered it first.
       const formatPattern = c.format === 'uuid' ? UUID_PATTERN : COLUMN_FORMATS[c.format ?? ''];
+      // Not `maxLength`. That keyword counts UTF-16 code units, and both Postgres and MySQL count
+      // a `varchar(n)` in characters, so ten thumbs-up characters are a valid row in a varchar(10)
+      // and this refused it. The cap moves to the registered kind, where an exact count can be
+      // written; a MySQL TEXT byte budget goes the same way.
       const base: Array<[string, string]> = formatPattern
         ? [['pattern', JSON.stringify(formatPattern)]]
-        : c.maxLength
-          ? [['maxLength', String(c.maxLength)]]
-          : [];
-      return `Type.String(${renderOptions(merged(base))})`;
+        : [];
+      return tbCapExpr(c, `Type.String(${renderOptions(merged(base))})`);
     }
     case 'number': {
       const o = renderOptions(merged(tbBounds(c)));
@@ -445,7 +447,10 @@ function renderTableSchemas(
   );
   const needsRows =
     rows.some((r) => rowCols.some((s) => s.has(r.left) && s.has(r.right))) ||
-    lengths.some((k) => rowCols.some((s) => s.has(k.column)));
+    lengths.some((k) => rowCols.some((s) => s.has(k.column))) ||
+    [insertCols, updateCols, selectCols].some((cs) =>
+      cs.some((c) => c.tsType === 'string' && !c.arrayDimensions && !c.shape && (c.maxLength || c.maxBytes))
+    );
   const rowImport = needsRows ? `, Kind, TypeRegistry` : '';
 
   return `import { Type${rowImport} } from '@sinclair/typebox';
@@ -498,6 +503,35 @@ const ROW_PREAMBLE = `TypeRegistry.Set('DrzlRowCheck', (schema: any, value: any)
  * The cost is that this constraint does not survive serialisation to JSON Schema, where a bare
  * `minLength` would. Emitting the wrong count in a form that serialises is not a better trade.
  */
+/**
+ * Column caps as intersection branches: characters for `varchar(n)`, bytes for MySQL's TEXT
+ * family.
+ *
+ * `maxLength` and `minLength` count UTF-16 code units, which agrees with neither database. Both
+ * count `varchar(n)` in characters and MySQL counts `tinytext` in bytes, so both are written out
+ * as predicates rather than approximated by a keyword that means a third thing.
+ *
+ * The cost is that a cap no longer serialises into the JSON Schema. Emitting a number that means
+ * something else in a form that serialises is not a better trade.
+ */
+function tbCapExpr(c: Column, base: string): string {
+  if (c.tsType !== 'string' || c.arrayDimensions || c.shape) return base;
+  const branch = (desc: string, expr: string) => `Type.Unsafe<unknown>({
+    [Kind]: 'DrzlRowCheck',
+    description: ${JSON.stringify(desc)},
+    assert: (v: any) => v == null || ${expr},
+  })`;
+  const out: string[] = [];
+  if (c.maxLength) out.push(branch(`at most ${c.maxLength} characters`, `[...v].length <= ${c.maxLength}`));
+  if (c.maxBytes) {
+    out.push(branch(`at most ${c.maxBytes} bytes`, `new TextEncoder().encode(v).length <= ${c.maxBytes}`));
+  }
+  // Intersected onto the field rather than onto the object, so a per-field comparison can still
+  // see the constraint. On the object it was invisible to the parity harness, which reads
+  // `schema.properties[col]`, and 133 columns looked unconstrained that were not.
+  return out.length ? `Type.Intersect([${base}, ${out.join(', ')}])` : base;
+}
+
 function tbLengthBranches(lengths: LengthCheck[], cols: Column[]): string[] {
   const present = new Set(cols.map((c) => c.name));
   const OPS: Record<LengthCheck['operator'], string> = {

--- a/packages/generator-typebox/test/char-and-byte-caps.spec.ts
+++ b/packages/generator-typebox/test/char-and-byte-caps.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * String caps in TypeBox: characters for `varchar(n)`, bytes for MySQL's TEXT family.
+ *
+ * `maxLength` counts UTF-16 code units. Both Postgres and MySQL count `varchar(10)` in
+ * characters, verified against both servers, so ten thumbs-up characters are a valid row and
+ * TypeBox refused it. That is the over-strict direction: it turns away rows the database takes.
+ *
+ * MySQL's TEXT family is a byte budget instead: `tinytext` takes 255 ascii characters and 63
+ * thumbs-up ones. Neither is expressible in a JSON Schema keyword, so both go where an exact count can
+ * be written, a narrow on the object.
+ */
+import { describe, it, expect } from 'vitest';
+import { TypeBoxGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Value } from '@sinclair/typebox/value';
+
+const col = (over: Partial<Column> = {}): Column =>
+  ({
+    name: 'n',
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemaFor(c: Column) {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns: [c], unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-caps');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), file);
+  return (await import(file)).SelecttSchema;
+}
+
+const ok = (s: any, v: unknown) => Value.Check(s, { n: v });
+const EMOJI = '\u{1F44D}';
+
+describe('a character cap', () => {
+  it('counts characters, so ten emoji fit a varchar(10)', async () => {
+    const s = await schemaFor(col({ maxLength: 10 }));
+    expect(ok(s, EMOJI.repeat(10)), 'accepted by both databases').toBe(true);
+    expect(ok(s, EMOJI.repeat(11))).toBe(false);
+    expect(ok(s, 'a'.repeat(10))).toBe(true);
+    expect(ok(s, 'a'.repeat(11))).toBe(false);
+  });
+});
+
+describe('a byte cap', () => {
+  it('counts bytes, so a four-byte character fills it four times as fast', async () => {
+    const s = await schemaFor(col({ maxBytes: 255 }));
+    expect(ok(s, 'a'.repeat(255))).toBe(true);
+    expect(ok(s, 'a'.repeat(256))).toBe(false);
+    expect(ok(s, EMOJI.repeat(63)), '252 bytes').toBe(true);
+    expect(ok(s, EMOJI.repeat(64)), '256 bytes').toBe(false);
+  });
+});
+
+describe('a column with neither', () => {
+  it('is a bare string', async () => {
+    const s = await schemaFor(col());
+    expect(ok(s, 'x'.repeat(100000))).toBe(true);
+  });
+});

--- a/packages/generator-typebox/test/generator.spec.ts
+++ b/packages/generator-typebox/test/generator.spec.ts
@@ -64,8 +64,14 @@ async function exprFor(c: Column, checks: { name?: string; expression?: string }
 }
 
 describe('column constraints', () => {
-  it('carries a varchar limit', async () => {
-    expect(await exprFor(col('name', { maxLength: 255 }))).toBe('Type.String({ maxLength: 255 })');
+  it('carries a varchar limit as a predicate, not as maxLength', async () => {
+    // `maxLength` counts UTF-16 code units and both databases count `varchar(n)` in characters,
+    // so the keyword refused ten thumbs-up characters in a varchar(10) that Postgres accepts.
+    // Intersected onto the field, so it stays visible to a per-field comparison.
+    const e = await exprFor(col('name', { maxLength: 255 }));
+    expect(e.replace(/\s+/g, ' ')).toContain('Type.Intersect([ Type.String(),');
+    expect(e).toContain('[...v].length <= 255');
+    expect(e, 'the keyword that means something else is gone').not.toContain('maxLength: 255');
   });
 
   it('bounds an integer by its width', async () => {

--- a/packages/generator-typebox/test/typed-columns.spec.ts
+++ b/packages/generator-typebox/test/typed-columns.spec.ts
@@ -67,35 +67,39 @@ async function schemasFor(columns: Column[], opts: Record<string, unknown>) {
 
 describe('off by default', () => {
   it('adds nothing when neither option is set', async () => {
-    const src = await emit([col('role', { maxLength: 50 })], {});
+    // A uuid format, not a length cap: a cap is intersected onto the object now, which would put
+    // `Type.Unsafe` in the file for reasons that have nothing to do with this option.
+    const src = await emit([col('role', { format: 'uuid' })], {});
     expect(src).not.toContain('Type.Unsafe');
     expect(src).not.toContain('import type { t }');
   });
 
   it('is not turned on by typedJson, which covers only the untyped columns', async () => {
-    const src = await emit([col('role', { maxLength: 50 })], { typedJson: true });
+    const src = await emit([col('role', { format: 'uuid' })], { typedJson: true });
     expect(src).not.toContain('Type.Unsafe');
   });
 });
 
 describe('with typedColumns', () => {
   it('wraps the schema rather than replacing it', async () => {
-    const src = await emit([col('role', { maxLength: 50 })], { typedColumns: true });
-    expect(src).toMatch(
-      /Type\.Unsafe<\(typeof t\.\$inferSelect\)\[['"]role['"]\]>\(Type\.String\(\{ maxLength: 50 \}\)\)/
+    const src = await emit([col('role', { format: 'uuid' })], { typedColumns: true });
+    // Prettier wraps this across lines, so the source is flattened before matching.
+    const flat = src.replace(/\s+/g, ' ');
+    expect(flat).toMatch(
+      /Type\.Unsafe<\(typeof t\.\$inferSelect\)\[['"]role['"]\]>\( ?Type\.String\(\{ pattern: /
     );
   });
 
   it('keeps every runtime check the wrapped schema carried', async () => {
     // This is the whole point of `Type.Unsafe` over substitution: the checks still run.
-    const m = await schemasFor([col('role', { maxLength: 5 })], {
+    const m = await schemasFor([col('role', { format: 'uuid' })], {
       typedColumns: true,
       schemaPath: path.join(__dirname, '..', 'db', 'schema.ts'),
     });
-    const f = m.SelecttSchema.properties.role;
-    expect(Value.Check(f, 'admin'), 'within the limit').toBe(true);
-    expect(Value.Check(f, 'toolong'), 'past the limit').toBe(false);
-    expect(Value.Check(f, 5), 'wrong type').toBe(false);
+    const s = m.SelecttSchema;
+    expect(Value.Check(s, { role: '00000000-0000-0000-0000-000000000000' }), 'a uuid').toBe(true);
+    expect(Value.Check(s, { role: 'nope' }), 'not a uuid').toBe(false);
+    expect(Value.Check(s, { role: 5 }), 'wrong type').toBe(false);
   });
 
   it('still substitutes for a column with no runtime type', async () => {

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -284,12 +284,23 @@ function vExprForColumn(
       if (pattern) return piped('v.string()', [`v.regex(new RegExp(${JSON.stringify(pattern)}))`]);
       // Not `v.maxLength(n)`, which counts UTF-16 units where the column counts characters. See
       // the zod generator and `CODEPOINT_LENGTH` in validation-core.
+      // Two different measurements. `varchar(n)` counts characters in both databases; MySQL's
+      // TEXT family counts bytes, so a tinytext takes 255 ascii characters and only 63 emoji.
+      const caps: string[] = [];
+      if (c.maxLength) {
+        caps.push(
+          `v.check((val) => [...val].length <= ${c.maxLength}, 'at most ${c.maxLength} characters')`
+        );
+      }
+      if (c.maxBytes) {
+        caps.push(
+          `v.check((val) => new TextEncoder().encode(val).length <= ${c.maxBytes}, 'at most ${c.maxBytes} bytes')`
+        );
+      }
       return piped(
         'v.string()',
-        c.maxLength
-          ? [
-              `v.check((val) => [...val].length <= ${c.maxLength}, 'at most ${c.maxLength} characters')`,
-            ]
+        caps.length
+          ? caps
           : []
       );
     case 'number': {

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -259,9 +259,17 @@ function zodExprForColumn(
       // Not `.max(n)`. A `varchar(n)` limit is n *characters*, and `.max` counts UTF-16 units, so
       // it refuses eight emoji in a `varchar(10)` the database is happy with. See
       // `CODEPOINT_LENGTH` in validation-core for the measurements.
-      return c.maxLength
-        ? `z.string().refine((v) => [...v].length <= ${c.maxLength}, { message: 'at most ${c.maxLength} characters' })`
-        : 'z.string()';
+      // Two different measurements, and a column can carry either. `varchar(n)` counts
+      // characters in both Postgres and MySQL; MySQL's TEXT family counts bytes, so a tinytext
+      // takes 255 ascii characters and only 63 thumbs-up ones. Both verified against the servers.
+      let str = 'z.string()';
+      if (c.maxLength) {
+        str += `.refine((v) => [...v].length <= ${c.maxLength}, { message: 'at most ${c.maxLength} characters' })`;
+      }
+      if (c.maxBytes) {
+        str += `.refine((v) => new TextEncoder().encode(v).length <= ${c.maxBytes}, { message: 'at most ${c.maxBytes} bytes' })`;
+      }
+      return str;
     case 'number': {
       const base = isIntegerColumn(c) ? 'z.number().int()' : 'z.number()';
       return base + numericBounds(c, (v) => v, checks);

--- a/packages/generator-zod/test/byte-caps.spec.ts
+++ b/packages/generator-zod/test/byte-caps.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * A MySQL TEXT cap is a byte budget, applied as one.
+ *
+ * Measured against MySQL 8 on utf8mb4: `tinytext` takes 255 ascii characters and 63 thumbs-up
+ * characters (252 bytes), and refuses 64 of them (256 bytes). A character count cannot express
+ * that, so the check encodes the string and counts the result.
+ *
+ * `varchar(n)` is genuinely characters and keeps counting code points, which is a different
+ * measurement on the same column type in the same database.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (over: Partial<Column> = {}): Column =>
+  ({
+    name: 'n',
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemaFor(c: Column) {
+  const analysis: Analysis = {
+    dialect: 'mysql',
+    tables: [{ name: 't', tsName: 't', columns: [c], unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-bytecaps');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return (await import(file)).SelecttSchema;
+}
+
+const ok = (s: any, v: unknown) => s.safeParse({ n: v }).success;
+const EMOJI = '\u{1F44D}';
+
+describe('a byte cap', () => {
+  it('counts bytes, so ascii fills it exactly', async () => {
+    const s = await schemaFor(col({ maxBytes: 255 }));
+    expect(ok(s, 'a'.repeat(255))).toBe(true);
+    expect(ok(s, 'a'.repeat(256))).toBe(false);
+  });
+
+  it('counts bytes, so four-byte characters fill it four times as fast', async () => {
+    // This is the whole point. 64 emoji is 64 characters and 256 bytes: MySQL refuses the row,
+    // and a character count would have accepted it.
+    const s = await schemaFor(col({ maxBytes: 255 }));
+    expect(ok(s, EMOJI.repeat(63)), '252 bytes').toBe(true);
+    expect(ok(s, EMOJI.repeat(64)), '256 bytes').toBe(false);
+  });
+
+  it('leaves a character cap counting characters', async () => {
+    // `varchar(10)` really is ten characters in MySQL, verified against the server.
+    const s = await schemaFor(col({ maxLength: 10 }));
+    expect(ok(s, EMOJI.repeat(10))).toBe(true);
+    expect(ok(s, EMOJI.repeat(11))).toBe(false);
+  });
+
+  it('applies both when a column somehow has both', async () => {
+    const s = await schemaFor(col({ maxLength: 10, maxBytes: 20 }));
+    expect(ok(s, 'a'.repeat(10)), '10 chars, 10 bytes').toBe(true);
+    expect(ok(s, 'a'.repeat(11)), 'over the character cap').toBe(false);
+    expect(ok(s, EMOJI.repeat(6)), '6 chars but 24 bytes').toBe(false);
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -487,13 +487,14 @@ export const checked = pgTable('checked', {
   check('k_pair_c', sql`${t.k_pair_a} < ${t.k_pair_b}`),
 ]);
 PARITY_PG
-
 cat > src/schema-mysql.ts <<'PARITY_MYSQL'
 import {
   mysqlTable, mysqlEnum, text, varchar, char, int, tinyint, smallint, mediumint,
   bigint, serial, boolean, real, double, float, decimal, json, date, datetime,
   timestamp, time, year, binary, varbinary, blob, tinytext, mediumtext, longtext,
+  check,
 } from 'drizzle-orm/mysql-core';
+import { sql } from 'drizzle-orm';
 
 export const matrix = mysqlTable('matrix', {
   m_text: text().notNull(),
@@ -529,6 +530,38 @@ export const matrix = mysqlTable('matrix', {
   m_binary: binary({ length: 4 }).notNull(),
   m_varbinary: varbinary({ length: 16 }).notNull(),
   m_blob: blob().notNull(),
+});
+
+// Every CHECK form the parser reads, in MySQL's spelling. No cardinality(): MySQL has no arrays.
+export const checked = mysqlTable('checked', {
+  k_min: int(),
+  k_max: int(),
+  k_lo: int(),
+  k_between: int(),
+  k_eq: int(),
+  k_in_s: varchar({ length: 20 }),
+  k_in_n: int(),
+  k_len: varchar({ length: 50 }),
+  k_pair_a: int(),
+  k_pair_b: int(),
+}, (t) => [
+  check('k_min_c', sql`${t.k_min} >= 18`),
+  check('k_max_c', sql`${t.k_max} <= 100`),
+  check('k_lo_c', sql`${t.k_lo} > 0`),
+  check('k_between_c', sql`${t.k_between} BETWEEN 5 AND 15`),
+  check('k_eq_c', sql`${t.k_eq} = 7`),
+  check('k_in_s_c', sql`${t.k_in_s} IN ('a', 'b', 'c')`),
+  check('k_in_n_c', sql`${t.k_in_n} IN (1, 2, 3)`),
+  check('k_len_c', sql`char_length(${t.k_len}) >= 3`),
+  check('k_pair_c', sql`${t.k_pair_a} < ${t.k_pair_b}`),
+]);
+
+// The one question only a real MySQL settles: varchar(n) is n characters, and the TEXT family is
+// a byte budget. Nothing in the schema says which, so it is measured rather than reasoned about.
+export const limits = mysqlTable('limits', {
+  l_varchar: varchar({ length: 10 }),
+  l_tinytext: tinytext(),
+  l_text: text(),
 });
 PARITY_MYSQL
 
@@ -1467,6 +1500,160 @@ DEFAULTS_TRUTH
 if ! npx tsx src/defaults-truth.ts; then
   echo "FAIL: applyDefaults does not reproduce the database's defaults." >&2
   exit 1
+fi
+
+# MySQL is the one dialect with no in-process engine, so this stage runs only where a server is
+# reachable: CI provides one as a service container, and a local run without `MYSQL_URL` skips it
+# and says so rather than silently covering less than the output claims.
+if [ -n "${MYSQL_URL:-}" ]; then
+npm install --no-audit --no-fund --loglevel=error mysql2 >/dev/null
+
+cat > src/mysql-truth.ts <<'MYSQL_TRUTH'
+/**
+ * CHECK constraints and text limits against a real MySQL.
+ *
+ * MySQL is the only dialect with no in-process engine, so this is the one stage that needs a
+ * server. It earns that by answering a question nothing else can: MySQL's text limits are
+ * measured in **bytes**, not characters, and its `varchar(n)` is measured in characters, and no
+ * amount of reading the manual settles which applies to a given column as reliably as inserting
+ * into one.
+ *
+ * Measured here on utf8mb4, which is MySQL 8's default:
+ *
+ *   varchar(10)  accepts 10 emoji, rejects 11        -> characters
+ *   tinytext     accepts 63 emoji (252 bytes)
+ *                rejects 64 emoji (256 bytes)
+ *                accepts 255 ascii, rejects 256      -> bytes
+ */
+import mysql from 'mysql2/promise';
+import { UpdatecheckedSchema as drzlChecked } from './gen/mysql/zod/checked.zod';
+import { UpdatelimitsSchema as drzlLimits } from './gen/mysql/zod/limits.zod';
+
+const db = await mysql.createConnection(process.env.MYSQL_URL!);
+await db.query('DROP TABLE IF EXISTS checked');
+await db.query('DROP TABLE IF EXISTS limits');
+await db.query(`
+CREATE TABLE checked (
+  k_min int CHECK (k_min >= 18),
+  k_max int CHECK (k_max <= 100),
+  k_lo int CHECK (k_lo > 0),
+  k_between int CHECK (k_between BETWEEN 5 AND 15),
+  k_eq int CHECK (k_eq = 7),
+  k_in_s varchar(20) CHECK (k_in_s IN ('a', 'b', 'c')),
+  k_in_n int CHECK (k_in_n IN (1, 2, 3)),
+  k_len varchar(50) CHECK (char_length(k_len) >= 3),
+  k_pair_a int,
+  k_pair_b int,
+  CONSTRAINT k_pair_c CHECK (k_pair_a < k_pair_b)
+) CHARACTER SET utf8mb4`);
+await db.query(`
+CREATE TABLE limits (
+  l_varchar varchar(10),
+  l_tinytext tinytext,
+  l_text text
+) CHARACTER SET utf8mb4`);
+
+const EMOJI = '\u{1F44D}';
+
+const CHECK_PROBES: Record<string, unknown[]> = {
+  k_min: [17, 18, 19],
+  k_max: [99, 100, 101],
+  k_lo: [0, 1],
+  k_between: [4, 5, 15, 16],
+  k_eq: [6, 7],
+  k_in_s: ['a', 'c', 'd'],
+  k_in_n: [1, 3, 4],
+  k_len: ['ab', 'abc', EMOJI.repeat(3)],
+  k_pair_a: [1, 100],
+  k_pair_b: [1, 100],
+};
+
+const LIMIT_PROBES: Record<string, unknown[]> = {
+  l_varchar: ['a'.repeat(10), 'a'.repeat(11), EMOJI.repeat(10), EMOJI.repeat(11)],
+  l_tinytext: ['a'.repeat(255), 'a'.repeat(256), EMOJI.repeat(63), EMOJI.repeat(64)],
+  l_text: ['a'.repeat(65535), 'a'.repeat(65536)],
+};
+
+async function accepts(table: string, col: string, value: unknown): Promise<boolean> {
+  try {
+    await db.beginTransaction();
+    await db.query(`INSERT INTO \`${table}\` (\`${col}\`) VALUES (?)`, [value]);
+    await db.rollback();
+    return true;
+  } catch {
+    try {
+      await db.rollback();
+    } catch {
+      /* already rolled back */
+    }
+    return false;
+  }
+}
+
+// The update schemas, whose fields are all optional, so a one-column probe is a valid input and
+// nothing needs unwrapping. Calling `.partial()` here instead made every probe read as a
+// rejection, which looked exactly like a catastrophic generator bug. Same trap as the Postgres
+// harness, and the same fix.
+const parses = (schema: any, col: string, v: unknown) => {
+  try {
+    return schema.safeParse({ [col]: v }).success;
+  } catch {
+    return false;
+  }
+};
+
+type Row = { table: string; col: string; value: unknown; db: boolean; drzl: boolean };
+const rows: Row[] = [];
+for (const [col, values] of Object.entries(CHECK_PROBES)) {
+  for (const value of values) {
+    rows.push({
+      table: 'checked',
+      col,
+      value,
+      db: await accepts('checked', col, value),
+      drzl: parses(drzlChecked, col, value),
+    });
+  }
+}
+for (const [col, values] of Object.entries(LIMIT_PROBES)) {
+  for (const value of values) {
+    rows.push({
+      table: 'limits',
+      col,
+      value,
+      db: await accepts('limits', col, value),
+      drzl: parses(drzlLimits, col, value),
+    });
+  }
+}
+
+const strict = rows.filter((r) => r.db && !r.drzl);
+const loose = rows.filter((r) => !r.db && r.drzl);
+const show = (v: unknown) => (typeof v === 'string' ? `${v.length} units` : JSON.stringify(v));
+
+console.log(`    ${rows.length} probes against a real MySQL`);
+console.log(`    rows MySQL rejects and DRZL accepts: ${loose.length}`);
+
+if (strict.length) {
+  console.error('\n    FAIL: DRZL rejects rows MySQL accepts:');
+  for (const r of strict.slice(0, 20)) console.error(`      ${r.table}.${r.col} = ${show(r.value)}`);
+  await db.end();
+  process.exit(1);
+}
+if (loose.length) {
+  console.log('    accepted by DRZL but not by MySQL:');
+  for (const r of loose.slice(0, 10)) console.log(`      ${r.table}.${r.col} = ${show(r.value)}`);
+}
+
+await db.end();
+MYSQL_TRUTH
+
+if ! npx tsx src/mysql-truth.ts; then
+  echo "FAIL: a generated schema disagrees with MySQL." >&2
+  exit 1
+fi
+else
+  echo "==> MySQL ground truth skipped: no MYSQL_URL"
 fi
 
 cat > src/sqlite-truth.ts <<'SQLITE_TRUTH'


### PR DESCRIPTION
## A third database, and two bugs in opposite directions

Postgres and SQLite both run in-process (PGlite, `node:sqlite`). MySQL is the one dialect that
needs a server, so this adds a service container and a ground-truth stage. It immediately settled
a question that had been sitting on notes rather than measured, then surfaced a worse one nobody
had asked about.

Measured on MySQL 8 with utf8mb4, its default charset:

```
varchar(10)  accepts 10 thumbs-up characters, rejects 11    -> characters
tinytext     accepts 255 ascii, rejects 256
             accepts 63 thumbs-up (252 bytes)
             rejects 64 (256 bytes)                         -> bytes
```

Two different measurements on string columns in the same database. Both were being got wrong, in
opposite directions.

## Too loose: MySQL's TEXT family is a byte budget

The cap was carried as `maxLength` and applied as a character count, so a `tinytext` holding 64
emoji validated clean and MySQL refused the row. It is now a separate `maxBytes`, applied by
encoding the string.

On **drizzle-orm 0.4x it was absent altogether**: every member of the family shares the
`MySqlText` class there, so only `getSQLType()` distinguishes a `tinytext` from a `longtext`, and
nothing read it.

## Too strict: `varchar(n)` counts characters

This is the worse one, and not what I set out to find.

| generator | emitted for `varchar(10)` | 10 emoji |
| --- | --- | --- |
| zod | `[...v].length <= 10` | accepted |
| valibot | `[...val].length <= 10` | accepted |
| TypeBox | `Type.String({ maxLength: 10 })` | **rejected** |
| ArkType | `'string <= 10'` | **rejected** |

`maxLength` and `string <= n` both count UTF-16 code units. Both databases count `varchar(n)` in
characters, so ten thumbs-up characters are a valid row and two generators refused it. **Rejecting
a valid row breaks working code**, which is the direction this project gates on.

## Where the caps live matters

Putting both caps on the **object** passed all 671 tests and produced **133 parity findings**:

```
    pg      arktype  select  39 cols  DIFFERS (5 waived)
```

The differential harness compares column by column, so a constraint on the object is invisible to
it and 133 columns looked unconstrained that were not. Both caps now sit on the **field**:

- TypeBox: `Type.Intersect([Type.String(), <registered kind>])`
- ArkType: `type("string").narrow(...)`, since ArkType object values take a Type instance and not
  only a DSL string. Optionality moves to the key when the value is a Type.

## Results

```
    37 probes against a real MySQL
    rows MySQL rejects and DRZL accepts: 0        (was 1: the tinytext cap)
    all four generators agree with each other on every column and value
    all four generators agree on every CHECK probe
```

Plus, unchanged: 1365 Postgres type probes, 53 Postgres CHECK probes, 32 SQLite CHECK probes,
9 defaulted columns, cross-major analyzer diff, size budgets, registry resolvability.

## CI

A `mysql:8` service on the `verify-packed` job. Without `MYSQL_URL` the stage **skips and says
so**, so a local run without Docker is honest about covering less rather than silently green.
