### PR TITLE
feat(json-schema): emit an OpenAPI components.schemas document

### DIFF
--- a/.changeset/json-schema-components.md
+++ b/.changeset/json-schema-components.md
@@ -1,0 +1,22 @@
+---
+'@drzl/generator-json-schema': minor
+'@drzl/cli': minor
+---
+
+Emit an OpenAPI `components.schemas` document
+
+`{ kind: 'json-schema', components: true }` also writes `components.ts`, one object keyed by name
+and ready to spread into an OpenAPI document. Assembling that from per-table modules is the step
+everyone repeats.
+
+Two details it handles. `$schema` is dropped, because a schema nested under `components.schemas`
+inherits the document's dialect and OpenAPI 3.1 reads a per-schema `$schema` as a dialect switch.
+`$id` is dropped rather than rewritten: setting it to `#/components/schemas/<name>` is the obvious
+first attempt and is invalid, since a draft 2020-12 `$id` may not contain a fragment. The map key
+is the identity.
+
+Also fixes a bug in the select schema found while testing this: a column with a database default
+was marked optional in every mode, so `id` was optional on a select schema, which describes a row
+that cannot exist. Only insert treats a defaulted column as omissible.
+
+Off by default.

--- a/docs/generators/json-schema.md
+++ b/docs/generators/json-schema.md
@@ -63,6 +63,36 @@ as the boolean form with no bound at all, or ignored outright. Either way the do
 validates as OpenAPI, and the constraint that exists to reject `0` now accepts it. That is the
 reason this is an option rather than a note.
 
+## One document for OpenAPI
+
+```ts
+{ kind: 'json-schema', target: 'openapi-3.1', components: true }
+```
+
+Also emits `components.ts`, one object keyed by name and ready to spread into an OpenAPI
+document's `components.schemas`:
+
+```ts
+export const components = {
+  schemas: {
+    usersInsert: { title: 'insert users', type: 'object', properties: { ... } },
+    usersUpdate: { ... },
+    usersSelect: { ... },
+  },
+} as const;
+```
+
+Two details this handles that are easy to get quietly wrong:
+
+- **`$schema` is dropped.** Nested under `components.schemas` a schema inherits the document's
+  dialect, and OpenAPI 3.1 reads a per-schema `$schema` as a dialect switch.
+- **`$id` is dropped, not rewritten.** Setting it to `#/components/schemas/<name>` is the obvious
+  first attempt and it is invalid: a draft 2020-12 `$id` may not contain a fragment, and ajv
+  rejects the schema outright. The map key is the identity, and the `$ref` is written by whatever
+  points at the schema.
+
+Off by default, so nobody gets a file they did not ask for.
+
 ## What it cannot say
 
 JSON Schema cannot compare one property against another. `if`/`then` and `dependentSchemas` can

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -230,6 +230,7 @@ program
               // JSON Schema is data, so nothing here references a type from the schema module.
               ...(validationOptions(g, cfg, target, { schemaTypes: false }) as object),
               target: g.target,
+              components: g.components,
             } as never);
             progress.stop();
             ora().succeed(chalk.green(`Generated (json-schema): ${files.length} files`));

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -123,6 +123,8 @@ export const GeneratorSchema = z.object({
    * validates and then accepts the values the constraints exist to reject.
    */
   target: z.enum(['draft-2020-12', 'openapi-3.1', 'openapi-3.0']).optional(),
+  /** Also emit `components.ts` for the `json-schema` generator, ready for an OpenAPI document. */
+  components: z.boolean().optional(),
   // service generator specific options
   path: z.string().optional(),
   dataAccess: z.enum(['stub', 'drizzle']).default('stub').optional(),

--- a/packages/generator-json-schema/src/index.ts
+++ b/packages/generator-json-schema/src/index.ts
@@ -317,11 +317,18 @@ function tableSchema(
       parsed.cardinalities,
       applyDefaults
     );
-    // An update makes everything optional; elsewhere a column is required unless the database
-    // will supply it. A nullable column is still required: null is a value, and omitting the key
-    // is not the same as sending null.
-    const supplied = c.hasDefault || (mode === 'insert' && applyDefaults && c.defaultValue !== undefined);
-    if (mode !== 'update' && !supplied) required.push(c.name);
+    // An update makes everything optional. On insert a column the database will fill in may be
+    // omitted. On select nothing may be: the row came out of the database, so every column has a
+    // value, and a defaulted column has one more reliably than most. Treating `hasDefault` as
+    // "optional" in every mode made `id` optional on a select schema, which describes a row that
+    // cannot exist.
+    //
+    // A nullable column is still required: null is a value, and omitting the key is not the same
+    // as sending null.
+    const suppliedOnInsert =
+      c.hasDefault || (applyDefaults && c.defaultValue !== undefined) || c.isGenerated;
+    const optional = mode === 'update' || (mode === 'insert' && suppliedOnInsert);
+    if (!optional) required.push(c.name);
   }
   const desc = rowDescription(parsed.rows, cols);
   return {
@@ -363,6 +370,38 @@ export function tableSchemas(
   };
 }
 
+/**
+ * Every table's schemas as one `components.schemas` object, ready to drop into an OpenAPI
+ * document.
+ *
+ * The per-table modules are the useful unit for a TypeScript program; a document wants one object
+ * keyed by name. Assembling it is the step everyone repeats, and two details are easy to get
+ * quietly wrong:
+ *
+ * - `$schema` has to go. Nested under `components.schemas` a schema inherits the document's
+ *   dialect, and in OpenAPI 3.1 a per-schema `$schema` is read as a dialect switch.
+ * - `$id` has to go too, and not become `#/components/schemas/<name>` as the obvious first
+ *   attempt did. A draft 2020-12 `$id` may not contain a fragment, and ajv rejects the schema
+ *   outright: `data/$id must match pattern "^[^#]*#?$"`. In OpenAPI the **map key** is the
+ *   identity, and `$ref: '#/components/schemas/<name>'` is written by whatever points at it, not
+ *   by the schema itself.
+ */
+export function componentsDocument(
+  tables: Table[],
+  opts: { target?: JsonSchemaTarget; applyDefaults?: boolean } = {}
+): { schemas: Record<string, Schema> } {
+  const schemas: Record<string, Schema> = {};
+  for (const table of tables) {
+    const built = tableSchemas(table, opts);
+    for (const mode of ['insert', 'update', 'select'] as const) {
+      const name = `${table.tsName}${mode[0].toUpperCase()}${mode.slice(1)}`;
+      const { $schema: _dialect, $id: _id, ...rest } = built[mode];
+      schemas[name] = rest;
+    }
+  }
+  return { schemas };
+}
+
 function renderTableModule(
   table: Table,
   affix: ResolvedAffix,
@@ -381,6 +420,13 @@ export type ${typeName(mode, T, affix)} = typeof ${schemaName(mode, T, affix)};`
 export interface JsonSchemaGenerateOptions extends ValidationGenerateOptions {
   outputHeader?: { enabled?: boolean; text?: string };
   target?: JsonSchemaTarget;
+  /**
+   * Also emit `components.ts`, one object keyed by name and ready to spread into an OpenAPI
+   * document's `components.schemas`.
+   *
+   * Off by default, so nobody who wanted per-table modules gets a file they did not ask for.
+   */
+  components?: boolean;
 }
 
 export class JsonSchemaGenerator {
@@ -409,10 +455,30 @@ export class JsonSchemaGenerator {
       files.push(filePath);
     }
 
+    if (opts.components) {
+      const doc = componentsDocument(this.analysis.tables, {
+        target,
+        applyDefaults: !!opts.applyDefaults,
+      });
+      const componentsPath = path.join(out, 'components.ts');
+      const code = `export const components = ${JSON.stringify(doc, null, 2)} as const;\n`;
+      await fs.writeFile(
+        componentsPath,
+        await formatCode(buildHeader(opts.outputHeader) + code, componentsPath, opts.format),
+        'utf8'
+      );
+      files.push(componentsPath);
+    }
+
     const indexPath = path.join(out, 'index.ts');
     const index =
       this.analysis.tables
         .map((t) => `export * from '${moduleSpecifier(t.tsName, fileSuffix, opts.importExtension)}';`)
+        .concat(
+          opts.components
+            ? [`export * from './components${opts.importExtension === 'none' ? '' : '.js'}';`]
+            : []
+        )
         .join('\n') + '\n';
     const indexFormatted = await formatCode(
       buildHeader(opts.outputHeader) + index,

--- a/packages/generator-json-schema/test/components.spec.ts
+++ b/packages/generator-json-schema/test/components.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * An OpenAPI components document, not just a pile of schemas.
+ *
+ * The per-table modules are the useful unit for a TypeScript program. An OpenAPI document wants
+ * one object under `components.schemas`, keyed by name, with every `$ref` resolving inside it.
+ * Assembling that by hand is the step everyone repeats, and getting the `$id`/`$ref` relationship
+ * wrong is easy to do quietly.
+ *
+ * Emitted as its own module so nothing changes for anyone not asking for it.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import type { Table } from '@drzl/analyzer';
+import { componentsDocument } from '../src/index';
+
+const table = (name: string): Table =>
+  ({
+    name,
+    tsName: name,
+    columns: [
+      { name: 'id', tsType: 'number', dbType: 'INTEGER', nullable: false, hasDefault: true, isGenerated: false, integer: true },
+      { name: 'label', tsType: 'string', dbType: 'TEXT', nullable: true, hasDefault: false, isGenerated: false },
+    ],
+    unique: [],
+    indexes: [],
+    checks: [],
+  }) as never;
+
+describe('the components document', () => {
+  it('keys every mode of every table under components.schemas', () => {
+    const doc = componentsDocument([table('users'), table('posts')], {});
+    expect(Object.keys(doc.schemas).sort()).toEqual([
+      'postsInsert',
+      'postsSelect',
+      'postsUpdate',
+      'usersInsert',
+      'usersSelect',
+      'usersUpdate',
+    ]);
+  });
+
+  it('drops the $schema declaration, which does not belong inside a document', () => {
+    // A schema nested under components.schemas inherits the document's dialect. Leaving a
+    // per-schema $schema in is not merely noise: OpenAPI 3.1 treats it as a dialect switch.
+    const doc = componentsDocument([table('users')], {});
+    for (const s of Object.values(doc.schemas)) {
+      expect((s as any).$schema).toBeUndefined();
+    }
+  });
+
+  it('carries no $id, because the map key is the identity', () => {
+    // The obvious first attempt set `$id` to `#/components/schemas/<name>`, and ajv refused the
+    // schema outright: a draft 2020-12 `$id` may not contain a fragment. In OpenAPI the `$ref`
+    // is written by whatever points at the schema, not by the schema itself.
+    const doc = componentsDocument([table('users')], {});
+    for (const [name, s] of Object.entries(doc.schemas)) {
+      expect((s as any).$id, name).toBeUndefined();
+    }
+  });
+
+  it('produces schemas a validator still accepts', () => {
+    const doc = componentsDocument([table('users')], {});
+    const ajv = new Ajv2020({ strict: true, allErrors: true });
+    addFormats(ajv as never);
+    const v = ajv.compile(doc.schemas.usersSelect as never);
+    expect(v({ id: 1, label: null })).toBe(true);
+    expect(v({ id: 1.5, label: null })).toBe(false);
+    expect(v({ label: null }), 'id is required on select').toBe(false);
+  });
+
+  it('honours the target, so a 3.0 document gets 3.0 spellings', () => {
+    const doc = componentsDocument([table('users')], { target: 'openapi-3.0' });
+    expect((doc.schemas.usersSelect as any).properties.label).toMatchObject({
+      type: 'string',
+      nullable: true,
+    });
+  });
+});


### PR DESCRIPTION
```ts
{ kind: 'json-schema', target: 'openapi-3.1', components: true }
```

Writes `components.ts` alongside the per-table modules:

```ts
export const components = {
  schemas: {
    usersInsert: {
      title: 'insert users',
      type: 'object',
      properties: {
        age: { type: 'integer', minimum: 18, maximum: 2147483647 },
        bio: { type: ['string', 'null'] },
      },
      required: ['id', 'age', 'bio'],
      additionalProperties: false,
    },
    usersUpdate: { ... },
    usersSelect: { ... },
  },
} as const;
```

Note `minimum: 18` there: that is a `CHECK (age >= 18)` folded into the schema, which no
first-party validator carries into any format.

## Two details it handles

- **`$schema` is dropped.** Nested under `components.schemas` a schema inherits the document's
  dialect, and OpenAPI 3.1 reads a per-schema `$schema` as a dialect switch.
- **`$id` is dropped, not rewritten.** Setting it to `#/components/schemas/<name>` is the obvious
  first attempt and it is **invalid**. Compiling the output with ajv is what caught it:

  ```
  Error: schema is invalid: data/$id must match pattern "^[^#]*#?$"
  ```

  A draft 2020-12 `$id` may not contain a fragment. The map key is the identity, and the `$ref` is
  written by whatever points at the schema.

## A bug the same test found

A column with a database default was treated as optional in **every** mode, so `id` was optional
on a **select** schema. A select schema describes a row that came out of the database, where every
column has a value and a defaulted one has it more reliably than most. Only insert treats a
defaulted column as omissible; a generated column too.

## Verification

- 671 tests green, typecheck and lint clean
- every schema in the document is compiled by ajv in strict mode, which is how both the `$id` and
  the `required` bugs surfaced
- exercised through the real CLI end to end

Off by default, so nobody gets a file they did not ask for.