### PR TITLE
feat(validation): emit a batch duplicate finder, and fix unique() eating the primary key

### DIFF
--- a/.changeset/duplicate-finder.md
+++ b/.changeset/duplicate-finder.md
@@ -1,0 +1,33 @@
+---
+'@drzl/analyzer': patch
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-arktype': minor
+'@drzl/generator-typebox': minor
+'@drzl/cli': minor
+---
+
+Emit a batch duplicate finder, and stop reading a table-level `unique()` as the primary key
+
+`{ duplicateFinder: true }` on any of the four validation generators also emits
+`findDuplicate<Table>`: the rows in a batch that collide with an earlier row on a unique
+constraint.
+
+Uniqueness is the one constraint a per-row validator structurally cannot check, since it is a fact
+about the table rather than the row. What needs no database is whether a batch collides with
+itself, and that is the half a user can fix before sending anything. It matters for bulk inserts,
+where a thousand rows fail whole on one collision and the error names a constraint rather than a
+row.
+
+The finder follows SQL on null: a constraint is skipped for any row where one of its columns is
+null or absent, because NULL is not equal to NULL and a unique index permits repeats. Composite
+keys compare by JSON, so `[1, '2']` never collides with `['1', 2]`. The emitted function is plain
+TypeScript with no reference to any validation library, so all four generators emit the same one.
+
+Building it surfaced an analyzer bug it depended on. A table-level `unique('name').on(a, b)` keeps
+its columns directly on the builder and carries no `unique` flag, which is also true of a primary
+key builder, and the rule was "no flag means primary key". So the constraint was not merely
+lost: a table keyed on `id` reported a composite primary key on whatever the unique named, which
+is what the service and router generators build their lookups from. Builders are now told apart by
+`drizzle:entityKind`.

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1351,6 +1351,20 @@ export class SchemaAnalyzer {
       const cols = (cfg.columns ?? []).map((c: any) => toTs(c?.name)).filter(Boolean);
       if (!cols.length) continue;
 
+      // A table-level `unique()` keeps `columns` directly on the instance and carries no
+      // `unique` flag, exactly like a primary key builder, so "no flag means primary key" claimed
+      // it. The result was not a missing constraint but a wrong one: a table keyed on `id`
+      // reported a composite primary key on whatever the unique named, and the service and router
+      // generators build their lookups from that.
+      //
+      // `drizzle:entityKind` is the discriminator, as elsewhere in this file: it survives
+      // minification, and the dialect prefix varies while the suffix does not.
+      const entityKind = String(entry?.constructor?.[Symbol.for('drizzle:entityKind')] ?? '');
+      if (entityKind.endsWith('UniqueConstraintBuilder')) {
+        unique.push({ columns: cols, name: entry?.name });
+        continue;
+      }
+
       // Only an index has a `unique` flag, so its absence identifies the primary key.
       if (cfg.unique === undefined) {
         pkCols.splice(0, pkCols.length, ...cols);

--- a/packages/analyzer/test/table-unique.spec.ts
+++ b/packages/analyzer/test/table-unique.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * A table-level `unique()` constraint, which was being read as the primary key.
+ *
+ * The extra-config callback returns builders that are told apart by shape. An index builder keeps
+ * its data under `config` and carries a `unique` flag; a primary key builder keeps `columns`
+ * directly on the instance. The rule was "no `unique` flag means it is the primary key", and a
+ * `UniqueConstraintBuilder` also keeps `columns` directly on the instance and also has no
+ * `unique` flag, so it matched.
+ *
+ * The result was not a missing constraint but a wrong one: `unique('org_handle').on(org, handle)`
+ * replaced the table's primary key, so a table keyed on `id` reported a composite key on
+ * `['org', 'handle']`. The service and router generators build lookups from that.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function tableOf(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const a = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  return a.tables[0]!;
+}
+
+const DIALECTS = {
+  postgres: { mod: 'pg-core', table: 'pgTable', text: 'text', int: 'integer' },
+  mysql: { mod: 'mysql-core', table: 'mysqlTable', text: 'text', int: 'int' },
+  sqlite: { mod: 'sqlite-core', table: 'sqliteTable', text: 'text', int: 'integer' },
+};
+
+describe.each(Object.entries(DIALECTS))('%s', (dialect, d) => {
+  it('records a table-level unique as unique, and leaves the primary key alone', async () => {
+    const t = await tableOf(
+      `tbl-unique-${dialect}`,
+      `
+      import { ${d.table}, ${d.text}, ${d.int}, unique } from 'drizzle-orm/${d.mod}';
+      export const users = ${d.table}('users', {
+        id: ${d.int}('id').primaryKey(),
+        org: ${d.text}('org').notNull(),
+        handle: ${d.text}('handle').notNull(),
+      }, (t) => [unique('org_handle').on(t.org, t.handle)]);
+      `
+    );
+    expect(t.unique).toEqual([{ columns: ['org', 'handle'], name: 'org_handle' }]);
+    expect(t.primaryKey?.columns, 'the unique must not become the primary key').not.toEqual([
+      'org',
+      'handle',
+    ]);
+  });
+
+  it('still reads a real composite primary key', async () => {
+    const t = await tableOf(
+      `tbl-pk-${dialect}`,
+      `
+      import { ${d.table}, ${d.text}, primaryKey } from 'drizzle-orm/${d.mod}';
+      export const t = ${d.table}('t', {
+        a: ${d.text}('a').notNull(),
+        b: ${d.text}('b').notNull(),
+      }, (x) => [primaryKey({ columns: [x.a, x.b] })]);
+      `
+    );
+    expect(t.primaryKey?.columns).toEqual(['a', 'b']);
+  });
+
+  it('reads both at once without either eating the other', async () => {
+    const t = await tableOf(
+      `tbl-both-${dialect}`,
+      `
+      import { ${d.table}, ${d.text}, unique, primaryKey } from 'drizzle-orm/${d.mod}';
+      export const t = ${d.table}('t', {
+        a: ${d.text}('a').notNull(),
+        b: ${d.text}('b').notNull(),
+        c: ${d.text}('c').notNull(),
+      }, (x) => [primaryKey({ columns: [x.a, x.b] }), unique('c_uq').on(x.c)]);
+      `
+    );
+    expect(t.primaryKey?.columns).toEqual(['a', 'b']);
+    expect(t.unique).toEqual([{ columns: ['c'], name: 'c_uq' }]);
+  });
+});

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -99,6 +99,14 @@ export const GeneratorSchema = z.object({
   typedColumns: z.boolean().optional(),
   // Reproduce literal column defaults in the insert schema, so parsing fills them in.
   applyDefaults: z.boolean().optional(),
+  /**
+   * Emit `findDuplicate<Table>` beside the schemas: the rows in a batch that collide with an
+   * earlier row on a unique constraint.
+   *
+   * Uniqueness is the one constraint a per-row validator structurally cannot see, since it is a
+   * fact about the table rather than the row. This checks the half that needs no database.
+   */
+  duplicateFinder: z.boolean().optional(),
   naming: NamingSchema.optional(),
   outputHeader: z
     .object({

--- a/packages/cli/src/validation-options.ts
+++ b/packages/cli/src/validation-options.ts
@@ -23,6 +23,7 @@ type GeneratorConfig = {
   applyDefaults?: unknown;
   typedJson?: unknown;
   typedColumns?: unknown;
+  duplicateFinder?: unknown;
 };
 
 export interface GeneratorCapabilities {
@@ -53,6 +54,7 @@ export function validationOptions(
     affix: g.affix,
     coerceDates: g.coerceDates,
     applyDefaults: g.applyDefaults,
+    duplicateFinder: g.duplicateFinder,
     // Only where the generator can act on them, so an unsupported option is absent rather than
     // present and ignored.
     ...(caps.schemaTypes

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -14,6 +14,7 @@ import {
   insertColumns,
   isIntegerColumn,
   parseCheck,
+  renderDuplicateFinder,
   updateColumns,
   selectColumns,
   formatCode,
@@ -368,7 +369,8 @@ function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
-  applyDefaults = false
+  applyDefaults = false,
+  wantsDuplicateFinder = false
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -413,7 +415,14 @@ function renderTableSchemas(
     applyDefaults,
     cardinalities
   );
-  return `import { type } from 'arktype';
+    // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
+  // half that needs no database: whether a batch collides with itself.
+  const finder = wantsDuplicateFinder
+    ? renderDuplicateFinder(table, `findDuplicate${T}`, insertType)
+    : undefined;
+  const duplicates = finder ? `\n${finder}\n` : '';
+
+return `import { type } from 'arktype';
 
 export const ${insertSchema} = type({
 ${bodyInsert}
@@ -430,11 +439,20 @@ ${bodySelect}
 export type ${insertType} = typeof ${insertSchema}["infer"];
 export type ${updateType} = typeof ${updateSchema}["infer"];
 export type ${selectType} = typeof ${selectSchema}["infer"];
-`;
+${duplicates}`;
 }
 
 export interface ArkTypeGenerateOptions extends ValidationGenerateOptions {
   outputHeader?: { enabled?: boolean; text?: string };
+  /**
+   * Also emit `findDuplicate<Table>` beside the schemas: the rows in a batch that collide with an
+   * earlier row on a unique constraint.
+   *
+   * Uniqueness is the one constraint a per-row validator structurally cannot see, since it is a
+   * fact about the table. This checks the half that needs no database. Off by default, because
+   * generated code ships in the consumer's bundle.
+   */
+  duplicateFinder?: boolean;
 }
 
 export class ArkTypeGenerator implements ValidationRenderer<ArkTypeGenerateOptions> {
@@ -454,7 +472,8 @@ export class ArkTypeGenerator implements ValidationRenderer<ArkTypeGenerateOptio
     // rename identifiers, never modules, so the barrel and importPath keep resolving.
     for (const table of this.analysis.tables) {
       const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
-      const code = renderTableSchemas(table, affix, coerceDates, !!opts.applyDefaults);
+      const code = renderTableSchemas(table, affix, coerceDates, !!opts.applyDefaults,
+      !!opts?.duplicateFinder);
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
         filePath,
@@ -476,7 +495,13 @@ export class ArkTypeGenerator implements ValidationRenderer<ArkTypeGenerateOptio
   }
 
   renderTable(table: Table, opts?: ArkTypeGenerateOptions) {
-    return renderTableSchemas(table, resolveAffix(opts), opts?.coerceDates ?? 'input');
+    return renderTableSchemas(
+      table,
+      resolveAffix(opts),
+      opts?.coerceDates ?? 'input',
+      !!opts?.applyDefaults,
+      !!opts?.duplicateFinder
+    );
   }
 
   private defaultIndex(analysis: Analysis, opts: ArkTypeGenerateOptions) {

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -17,6 +17,7 @@ import {
   moduleFileName,
   moduleSpecifier,
   parseCheck,
+  renderDuplicateFinder,
   resolveAffix,
   resolveConfiguredImport,
   schemaName,
@@ -373,7 +374,8 @@ function renderTableSchemas(
   affix: ResolvedAffix,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   typedJson?: { schemaSpecifier: string; allColumns?: boolean },
-  applyDefaults = false
+  applyDefaults = false,
+  wantsDuplicateFinder = false
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -453,7 +455,14 @@ function renderTableSchemas(
     );
   const rowImport = needsRows ? `, Kind, TypeRegistry` : '';
 
-  return `import { Type${rowImport} } from '@sinclair/typebox';
+    // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
+  // half that needs no database: whether a batch collides with itself.
+  const finder = wantsDuplicateFinder
+    ? renderDuplicateFinder(table, `findDuplicate${T}`, insertType)
+    : undefined;
+  const duplicates = finder ? `\n${finder}\n` : '';
+
+return `import { Type${rowImport} } from '@sinclair/typebox';
 import type { Static } from '@sinclair/typebox';
 ${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}${needsRows ? `\n${ROW_PREAMBLE}` : ''}
 export const ${insertSchema} = ${tbWrapRows(`Type.Object({\n${bodyInsert}\n})`, rows, insertCols, lengths)};
@@ -465,7 +474,7 @@ export const ${selectSchema} = ${tbWrapRows(`Type.Object({\n${bodySelect}\n})`, 
 export type ${insertType} = Static<typeof ${insertSchema}>;
 export type ${updateType} = Static<typeof ${updateSchema}>;
 export type ${selectType} = Static<typeof ${selectSchema}>;
-`;
+${duplicates}`;
 }
 
 /**
@@ -595,6 +604,15 @@ function tbWrapRows(
 
 export interface TypeBoxGenerateOptions extends ValidationGenerateOptions {
   outputHeader?: { enabled?: boolean; text?: string };
+  /**
+   * Also emit `findDuplicate<Table>` beside the schemas: the rows in a batch that collide with an
+   * earlier row on a unique constraint.
+   *
+   * Uniqueness is the one constraint a per-row validator structurally cannot see, since it is a
+   * fact about the table. This checks the half that needs no database. Off by default, because
+   * generated code ships in the consumer's bundle.
+   */
+  duplicateFinder?: boolean;
 }
 
 export class TypeBoxGenerator implements ValidationRenderer<TypeBoxGenerateOptions> {
@@ -634,7 +652,8 @@ export class TypeBoxGenerator implements ValidationRenderer<TypeBoxGenerateOptio
 
     for (const table of this.analysis.tables) {
       const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
-      const code = renderTableSchemas(table, affix, coerceDates, typedJson, !!opts.applyDefaults);
+      const code = renderTableSchemas(table, affix, coerceDates, typedJson, !!opts.applyDefaults,
+      !!opts?.duplicateFinder);
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
         filePath,
@@ -661,7 +680,8 @@ export class TypeBoxGenerator implements ValidationRenderer<TypeBoxGenerateOptio
       resolveAffix(opts),
       opts?.coerceDates ?? 'input',
       undefined,
-      !!opts?.applyDefaults
+      !!opts?.applyDefaults,
+      !!opts?.duplicateFinder
     );
   }
 

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -11,6 +11,7 @@ import {
   insertColumns,
   isIntegerColumn,
   parseCheck,
+  renderDuplicateFinder,
   resolveConfiguredImport,
   updateColumns,
   selectColumns,
@@ -444,7 +445,8 @@ function renderTableSchemas(
   affix: ResolvedAffix,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   applyDefaults = false,
-  typedColumns?: { schemaSpecifier: string }
+  typedColumns?: { schemaSpecifier: string },
+  wantsDuplicateFinder = false
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -510,7 +512,14 @@ function renderTableSchemas(
     (c) => c.shape?.kind === 'json'
   );
 
-  return `import * as v from 'valibot';
+    // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
+  // half that needs no database: whether a batch collides with itself.
+  const finder = wantsDuplicateFinder
+    ? renderDuplicateFinder(table, `findDuplicate${T}`, insertType)
+    : undefined;
+  const duplicates = finder ? `\n${finder}\n` : '';
+
+return `import * as v from 'valibot';
 import type { InferInput, InferOutput } from 'valibot';
 ${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}
 export const ${insertSchema} = ${wrapRows(`v.object({\n${bodyInsert}\n})`, rows, insertCols)};
@@ -522,11 +531,20 @@ export const ${selectSchema} = ${wrapRows(`v.object({\n${bodySelect}\n})`, rows,
 export type ${insertType} = InferInput<typeof ${insertSchema}>;
 export type ${updateType} = InferInput<typeof ${updateSchema}>;
 export type ${selectType} = InferOutput<typeof ${selectSchema}>;
-`;
+${duplicates}`;
 }
 
 export interface ValibotGenerateOptions extends ValidationGenerateOptions {
   outputHeader?: { enabled?: boolean; text?: string };
+  /**
+   * Also emit `findDuplicate<Table>` beside the schemas: the rows in a batch that collide with an
+   * earlier row on a unique constraint.
+   *
+   * Uniqueness is the one constraint a per-row validator structurally cannot see, since it is a
+   * fact about the table. This checks the half that needs no database. Off by default, because
+   * generated code ships in the consumer's bundle.
+   */
+  duplicateFinder?: boolean;
 }
 
 export class ValibotGenerator implements ValidationRenderer<ValibotGenerateOptions> {
@@ -570,7 +588,8 @@ export class ValibotGenerator implements ValidationRenderer<ValibotGenerateOptio
         affix,
         coerceDates,
         !!opts.applyDefaults,
-        typedColumns
+        typedColumns,
+      !!opts?.duplicateFinder
       );
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
@@ -593,7 +612,14 @@ export class ValibotGenerator implements ValidationRenderer<ValibotGenerateOptio
   }
 
   renderTable(table: Table, opts?: ValibotGenerateOptions) {
-    return renderTableSchemas(table, resolveAffix(opts), opts?.coerceDates ?? 'input');
+    return renderTableSchemas(
+      table,
+      resolveAffix(opts),
+      opts?.coerceDates ?? 'input',
+      !!opts?.applyDefaults,
+      undefined,
+      !!opts?.duplicateFinder
+    );
   }
 
   private defaultIndex(analysis: Analysis, opts: ValibotGenerateOptions) {

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -14,6 +14,7 @@ import type {
 import {
   formatCode,
   parseCheck,
+  renderDuplicateFinder,
   resolveConfiguredImport,
   COLUMN_FORMATS,
   insertColumns,
@@ -435,7 +436,8 @@ function renderTableSchemas(
   affix: ResolvedAffix,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   typedJson?: { schemaSpecifier: string; allColumns?: boolean },
-  applyDefaults = false
+  applyDefaults = false,
+  wantsDuplicateFinder = false
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -520,18 +522,34 @@ ${bodyUpdate}
 export type ${updateType} = z.input<typeof ${updateSchema}>;
 `;
 
-  return `import { z } from 'zod';
+    // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
+  // half that needs no database: whether a batch collides with itself.
+  const finder = wantsDuplicateFinder
+    ? renderDuplicateFinder(table, `findDuplicate${T}`, insertType)
+    : undefined;
+  const duplicates = finder ? `\n${finder}\n` : '';
+
+return `import { z } from 'zod';
 ${schemaImport}
 ${writes}export const ${selectSchema} = z.object({
 ${bodySelect}
 })${rowRefinements(rows, selectCols)};
 
 ${writeTypes}export type ${selectType} = z.output<typeof ${selectSchema}>;
-`;
+${duplicates}`;
 }
 
 export interface ZodGenerateOptions extends ValidationGenerateOptions {
   outputHeader?: { enabled?: boolean; text?: string };
+  /**
+   * Also emit `findDuplicate<Table>` beside the schemas: the rows in a batch that collide with an
+   * earlier row on a unique constraint.
+   *
+   * Uniqueness is the one constraint a per-row validator structurally cannot see, since it is a
+   * fact about the table. This checks the half that needs no database. Off by default, because
+   * generated code ships in the consumer's bundle.
+   */
+  duplicateFinder?: boolean;
 }
 
 export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
@@ -573,7 +591,8 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
     // rename identifiers, never modules, so the barrel and importPath keep resolving.
     for (const table of this.analysis.tables) {
       const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
-      const code = renderTableSchemas(table, affix, coerceDates, typedJson, !!opts.applyDefaults);
+      const code = renderTableSchemas(table, affix, coerceDates, typedJson, !!opts.applyDefaults,
+      !!opts?.duplicateFinder);
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
         filePath,
@@ -597,7 +616,14 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
   }
 
   renderTable(table: Table, opts?: ZodGenerateOptions) {
-    return renderTableSchemas(table, resolveAffix(opts), opts?.coerceDates ?? 'input');
+    return renderTableSchemas(
+      table,
+      resolveAffix(opts),
+      opts?.coerceDates ?? 'input',
+      undefined,
+      !!opts?.applyDefaults,
+      !!opts?.duplicateFinder
+    );
   }
 
   renderIndex?(analysis: Analysis, opts?: ZodGenerateOptions): string;

--- a/packages/validation-core/src/duplicates.ts
+++ b/packages/validation-core/src/duplicates.ts
@@ -1,0 +1,81 @@
+/**
+ * A duplicate finder for a batch of rows, emitted beside the schemas.
+ *
+ * A validator checks one row at a time, so uniqueness is the one constraint it structurally
+ * cannot see: whether a value is unique is a fact about the table, not about the row. That is
+ * fine for a single insert, where the database answers immediately. It is not fine for a bulk
+ * insert, where a batch of a thousand rows fails whole on one collision and the error names a
+ * constraint rather than a row.
+ *
+ * What *is* checkable without the database is whether a batch collides with **itself**, and that
+ * is worth checking, because it is the half a user can fix before sending anything.
+ *
+ * The emitted function is plain TypeScript with no reference to any validation library, so all
+ * four generators emit the same thing. It is rendered from one place for that reason.
+ */
+import type { Key, Table } from '@drzl/analyzer';
+
+/** The unique constraints worth emitting a finder for. */
+function usableKeys(table: Table): Key[] {
+  return (table.unique ?? []).filter((k) => k.columns.length > 0);
+}
+
+/**
+ * `findDuplicate<Table>s` for a table with unique constraints, or nothing.
+ *
+ * `rowType` is the name of the insert type, which is what a caller has in hand before an insert.
+ * Passed in rather than derived, because each generator names its types differently.
+ */
+export function renderDuplicateFinder(
+  table: Table,
+  fnName: string,
+  rowType: string
+): string | undefined {
+  const keys = usableKeys(table);
+  if (!keys.length) return undefined;
+
+  const constraints = keys
+    .map((k, i) => {
+      const name = k.name ?? k.columns.join('_');
+      return `  { name: ${JSON.stringify(name)}, columns: ${JSON.stringify(k.columns)} }${
+        i === keys.length - 1 ? '' : ','
+      }`;
+    })
+    .join('\n');
+
+  return `/**
+ * Rows in \`rows\` that collide with an earlier row on a unique constraint.
+ *
+ * Uniqueness is a fact about the table rather than about a row, so no schema can check it. This
+ * checks the half that needs no database: whether the batch collides with itself. A batch that
+ * passes here can still collide with rows already stored.
+ *
+ * A constraint is skipped for any row where one of its columns is null or absent, matching SQL,
+ * where NULL is not equal to NULL and a unique index therefore permits repeats.
+ */
+export function ${fnName}(
+  rows: readonly ${rowType}[]
+): Array<{ index: number; constraint: string; firstIndex: number }> {
+  const constraints = [
+${constraints}
+  ] as const;
+  const seen = constraints.map(() => new Map<string, number>());
+  const out: Array<{ index: number; constraint: string; firstIndex: number }> = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i] as Record<string, unknown>;
+    for (let c = 0; c < constraints.length; c++) {
+      const cols = constraints[c].columns;
+      const values = cols.map((col) => row?.[col]);
+      if (values.some((v) => v === null || v === undefined)) continue;
+      // JSON, so a composite key compares by value and \`[1, "2"]\` never collides with
+      // \`["1", 2]\`. A join on a separator would.
+      const key = JSON.stringify(values);
+      const first = seen[c].get(key);
+      if (first === undefined) seen[c].set(key, i);
+      else out.push({ index: i, constraint: constraints[c].name, firstIndex: first });
+    }
+  }
+  return out;
+}`;
+}

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -240,3 +240,5 @@ export async function formatCode(code: string, filePath: string, fmt?: FormatOpt
 
 // Re-export analyzer types for test/type convenience
 // (Keep local Table as exported type)
+
+export * from './duplicates';

--- a/packages/validation-core/test/duplicates.spec.ts
+++ b/packages/validation-core/test/duplicates.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * The batch duplicate finder, executed rather than string-matched.
+ *
+ * Uniqueness is the one constraint a per-row validator structurally cannot see. What is checkable
+ * without a database is whether a batch collides with itself, which is the half a user can fix
+ * before sending anything.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { renderDuplicateFinder } from '../src/duplicates';
+import type { Table } from '@drzl/analyzer';
+
+const table = (unique: Array<{ name?: string; columns: string[] }>): Table =>
+  ({ name: 't', tsName: 't', columns: [], unique, indexes: [], checks: [] }) as never;
+
+let seq = 0;
+
+/** Write the emitted function to a module and import it, so the assertions run real code. */
+async function finderFor(unique: Array<{ name?: string; columns: string[] }>) {
+  const src = renderDuplicateFinder(table(unique), 'findDuplicates', 'Row');
+  expect(src, 'nothing emitted').toBeTruthy();
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-dup-'));
+  const file = path.join(dir, `d${seq++}.ts`);
+  await fs.writeFile(file, `type Row = Record<string, unknown>;\n${src}\n`, 'utf8');
+  return (await import(file)).findDuplicates as (rows: unknown[]) => any[];
+}
+
+describe('a single-column unique constraint', () => {
+  it('reports the later row and points at the first', async () => {
+    const f = await finderFor([{ name: 'email_uq', columns: ['email'] }]);
+    const out = f([{ email: 'a' }, { email: 'b' }, { email: 'a' }]);
+    expect(out).toEqual([{ index: 2, constraint: 'email_uq', firstIndex: 0 }]);
+  });
+
+  it('says nothing when the batch is clean', async () => {
+    const f = await finderFor([{ columns: ['email'] }]);
+    expect(f([{ email: 'a' }, { email: 'b' }])).toEqual([]);
+  });
+
+  it('reports every repeat, not just the second', async () => {
+    const f = await finderFor([{ name: 'u', columns: ['x'] }]);
+    expect(f([{ x: 1 }, { x: 1 }, { x: 1 }]).map((d) => d.index)).toEqual([1, 2]);
+  });
+});
+
+describe('a composite unique constraint', () => {
+  it('collides only when every column matches', async () => {
+    const f = await finderFor([{ name: 'pair', columns: ['a', 'b'] }]);
+    const out = f([
+      { a: 1, b: 1 },
+      { a: 1, b: 2 },
+      { a: 2, b: 1 },
+      { a: 1, b: 1 },
+    ]);
+    expect(out).toEqual([{ index: 3, constraint: 'pair', firstIndex: 0 }]);
+  });
+
+  it('does not confuse a number with the same digits as a string', async () => {
+    // A key joined on a separator would collide these. JSON does not.
+    const f = await finderFor([{ name: 'pair', columns: ['a', 'b'] }]);
+    expect(f([{ a: 1, b: '2' }, { a: '1', b: 2 }])).toEqual([]);
+  });
+});
+
+describe('null, which SQL treats as never equal to itself', () => {
+  it('permits repeats where a column is null', async () => {
+    // A unique index accepts any number of NULLs, because NULL = NULL is unknown. A finder that
+    // reported these would send people chasing rows the database is perfectly happy with.
+    const f = await finderFor([{ name: 'u', columns: ['x'] }]);
+    expect(f([{ x: null }, { x: null }])).toEqual([]);
+  });
+
+  it('permits repeats where a column is absent', async () => {
+    const f = await finderFor([{ name: 'u', columns: ['x'] }]);
+    expect(f([{}, {}])).toEqual([]);
+  });
+
+  it('skips a composite constraint when any part is null', async () => {
+    const f = await finderFor([{ name: 'pair', columns: ['a', 'b'] }]);
+    expect(f([{ a: 1, b: null }, { a: 1, b: null }])).toEqual([]);
+  });
+});
+
+describe('several constraints at once', () => {
+  it('reports each independently', async () => {
+    const f = await finderFor([
+      { name: 'by_email', columns: ['email'] },
+      { name: 'by_handle', columns: ['handle'] },
+    ]);
+    const out = f([
+      { email: 'a', handle: 'h1' },
+      { email: 'a', handle: 'h2' },
+      { email: 'b', handle: 'h1' },
+    ]);
+    expect(out).toEqual([
+      { index: 1, constraint: 'by_email', firstIndex: 0 },
+      { index: 2, constraint: 'by_handle', firstIndex: 0 },
+    ]);
+  });
+});
+
+describe('a table with no unique constraint', () => {
+  it('gets no function at all', () => {
+    expect(renderDuplicateFinder(table([]), 'f', 'Row')).toBeUndefined();
+    expect(renderDuplicateFinder(table([{ columns: [] }]), 'f', 'Row')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The one constraint a validator cannot check

Uniqueness is a fact about the **table**, not the row, so no per-row schema can see it. That is
fine for a single insert, where the database answers immediately. It is not fine for a bulk
insert, where a thousand rows fail whole on one collision and the error names a constraint rather
than a row.

What needs no database is whether a batch collides with **itself**, and that is the half a user
can fix before sending anything.

```ts
{ kind: 'zod', duplicateFinder: true }
```

```ts
export function findDuplicateusers(
  rows: readonly InsertusersInput[]
): Array<{ index: number; constraint: string; firstIndex: number }> {
  const constraints = [
    { name: 'email', columns: ['email'] },
    { name: 'org_handle', columns: ['org', 'handle'] },
  ] as const;
  ...
}
```

Two details it gets right, both tested by executing the emitted function:

- **Null follows SQL.** A constraint is skipped for any row where one of its columns is null or
  absent, because `NULL = NULL` is unknown and a unique index permits repeats. Reporting those
  would send people chasing rows the database is perfectly happy with.
- **Composite keys compare by JSON**, so `[1, '2']` never collides with `['1', 2]`. A
  separator-joined key would.

The function is plain TypeScript with no reference to any validation library, so it is rendered
once in `validation-core` and emitted identically by all four generators.

## The bug it depended on, which is the more serious half

A table-level `unique('org_handle').on(t.org, t.handle)` keeps its columns **directly on the
builder** and carries **no `unique` flag**. So does a primary key builder. The rule was "no flag
means primary key".

So this table:

```ts
pgTable('users', {
  id: integer('id').primaryKey(),
  org: text('org').notNull(),
  handle: text('handle').notNull(),
}, (t) => [unique('org_handle').on(t.org, t.handle)]);
```

analyzed as:

```
primaryKey: {"columns":["org","handle"]}     <- wrong; the key is `id`
unique    : []                                <- lost
```

The constraint was not merely missing: it **replaced the primary key**, and the service and router
generators build their lookups from that.

Builders are now told apart by `drizzle:entityKind`, matched on the suffix so it holds for
`PgUniqueConstraintBuilder`, `MySqlUniqueConstraintBuilder` and the SQLite one alike. Nine cases
across the three dialects: a unique alone, a real composite primary key alone, and both on one
table without either eating the other.

## Verification

- 695 tests green, typecheck and lint clean
- the emitted finder is written to a module and executed, not string-matched
- full `verify-packed.sh` green
- exercised through the real CLI, which is how the missing composite constraint was spotted

Off by default: generated code ships in the consumer's bundle.