### PR TITLE
docs: document duplicateFinder, and state the databases the gate runs against

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Zero‑friction codegen for Drizzle ORM. Analyze your schema. Generate validatio
 - Analyzer: turns Drizzle schemas into a normalized analysis model
 - Generators: Zod, Valibot, ArkType, TypeBox validation; JSON Schema and OpenAPI; typed CRUD services; router templates (oRPC)
 - Batteries: formatting, naming, reusable/shared schemas, relation support
-- Verified against a real Postgres: 1365 type probes and 53 CHECK probes per commit, via PGlite.
-  On the CHECK probes DRZL accepts 0 rows Postgres rejects; `drizzle-orm/zod` accepts 22
+- Verified against real databases every commit: 1365 type probes and 53 CHECK probes against Postgres
+  (PGlite), 32 against SQLite (`node:sqlite`), and 37 against MySQL (a CI service container).
+  On the CHECK probes DRZL accepts 0 rows the database rejects; `drizzle-orm/zod` accepts 22
 - Monorepo: pnpm workspace, lockstep releases with Changesets
 
 ## Install & Use

--- a/docs/generators/arktype.md
+++ b/docs/generators/arktype.md
@@ -159,3 +159,46 @@ these names when it imports shared schemas.
 ::: tip Need something else?
 If this generator doesn't cover what you need, DM me on X (https://x.com/omardulaimidev) and we can scope it together.
 :::
+
+## `duplicateFinder`
+
+Uniqueness is the one constraint a per-row validator structurally cannot check: whether a value is
+unique is a fact about the table, not about the row. No first-party validator attempts it, and
+neither does a schema here.
+
+What needs no database is whether a **batch collides with itself**, and that is the half you can
+fix before sending anything. It matters for a bulk insert, where a thousand rows fail whole on one
+collision and the error names a constraint rather than a row.
+
+```ts
+{ kind: 'arktype', path: 'src/validators/arktype', duplicateFinder: true }
+```
+
+emits, for a table with unique constraints:
+
+```ts
+export function findDuplicateusers(
+  rows: readonly InsertusersInput[]
+): Array<{ index: number; constraint: string; firstIndex: number }> { ... }
+```
+
+```ts
+findDuplicateusers([
+  { email: 'a@b.co', org: 'x', handle: 'h' },
+  { email: 'a@b.co', org: 'y', handle: 'h' },
+]);
+// [{ index: 1, constraint: 'email', firstIndex: 0 }]
+```
+
+Two details it follows:
+
+- **Null is not equal to null.** A constraint is skipped for any row where one of its columns is
+  null or absent, because a unique index accepts any number of NULLs. Reporting those would send
+  you chasing rows the database is perfectly happy with.
+- **Composite keys compare by value.** The key is JSON, so `[1, '2']` never collides with
+  `['1', 2]`, which a separator-joined key would.
+
+A batch that passes can still collide with rows already stored. This checks the half that needs no
+round trip.
+
+Off by default: generated code ships in your bundle.

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -177,3 +177,46 @@ inferred type is replaced. Implies `typedJson`. Off by default.
 ## Peer dependency
 
 `@sinclair/typebox` >= 0.32, which your project provides.
+
+## `duplicateFinder`
+
+Uniqueness is the one constraint a per-row validator structurally cannot check: whether a value is
+unique is a fact about the table, not about the row. No first-party validator attempts it, and
+neither does a schema here.
+
+What needs no database is whether a **batch collides with itself**, and that is the half you can
+fix before sending anything. It matters for a bulk insert, where a thousand rows fail whole on one
+collision and the error names a constraint rather than a row.
+
+```ts
+{ kind: 'typebox', path: 'src/validators/typebox', duplicateFinder: true }
+```
+
+emits, for a table with unique constraints:
+
+```ts
+export function findDuplicateusers(
+  rows: readonly InsertusersInput[]
+): Array<{ index: number; constraint: string; firstIndex: number }> { ... }
+```
+
+```ts
+findDuplicateusers([
+  { email: 'a@b.co', org: 'x', handle: 'h' },
+  { email: 'a@b.co', org: 'y', handle: 'h' },
+]);
+// [{ index: 1, constraint: 'email', firstIndex: 0 }]
+```
+
+Two details it follows:
+
+- **Null is not equal to null.** A constraint is skipped for any row where one of its columns is
+  null or absent, because a unique index accepts any number of NULLs. Reporting those would send
+  you chasing rows the database is perfectly happy with.
+- **Composite keys compare by value.** The key is JSON, so `[1, '2']` never collides with
+  `['1', 2]`, which a separator-joined key would.
+
+A batch that passes can still collide with rows already stored. This checks the half that needs no
+round trip.
+
+Off by default: generated code ships in your bundle.

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -179,3 +179,46 @@ these names when it imports shared schemas.
 ::: tip Need something else?
 If this generator doesn't cover what you need, DM me on X (https://x.com/omardulaimidev) and we can scope it together.
 :::
+
+## `duplicateFinder`
+
+Uniqueness is the one constraint a per-row validator structurally cannot check: whether a value is
+unique is a fact about the table, not about the row. No first-party validator attempts it, and
+neither does a schema here.
+
+What needs no database is whether a **batch collides with itself**, and that is the half you can
+fix before sending anything. It matters for a bulk insert, where a thousand rows fail whole on one
+collision and the error names a constraint rather than a row.
+
+```ts
+{ kind: 'valibot', path: 'src/validators/valibot', duplicateFinder: true }
+```
+
+emits, for a table with unique constraints:
+
+```ts
+export function findDuplicateusers(
+  rows: readonly InsertusersInput[]
+): Array<{ index: number; constraint: string; firstIndex: number }> { ... }
+```
+
+```ts
+findDuplicateusers([
+  { email: 'a@b.co', org: 'x', handle: 'h' },
+  { email: 'a@b.co', org: 'y', handle: 'h' },
+]);
+// [{ index: 1, constraint: 'email', firstIndex: 0 }]
+```
+
+Two details it follows:
+
+- **Null is not equal to null.** A constraint is skipped for any row where one of its columns is
+  null or absent, because a unique index accepts any number of NULLs. Reporting those would send
+  you chasing rows the database is perfectly happy with.
+- **Composite keys compare by value.** The key is JSON, so `[1, '2']` never collides with
+  `['1', 2]`, which a separator-joined key would.
+
+A batch that passes can still collide with rows already stored. This checks the half that needs no
+round trip.
+
+Off by default: generated code ships in your bundle.

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -475,3 +475,46 @@ these names when it imports shared schemas.
 ::: tip Need something else?
 If this generator doesn't cover what you need, DM me on X (https://x.com/omardulaimidev) and we can scope it together.
 :::
+
+## `duplicateFinder`
+
+Uniqueness is the one constraint a per-row validator structurally cannot check: whether a value is
+unique is a fact about the table, not about the row. No first-party validator attempts it, and
+neither does a schema here.
+
+What needs no database is whether a **batch collides with itself**, and that is the half you can
+fix before sending anything. It matters for a bulk insert, where a thousand rows fail whole on one
+collision and the error names a constraint rather than a row.
+
+```ts
+{ kind: 'zod', path: 'src/validators/zod', duplicateFinder: true }
+```
+
+emits, for a table with unique constraints:
+
+```ts
+export function findDuplicateusers(
+  rows: readonly InsertusersInput[]
+): Array<{ index: number; constraint: string; firstIndex: number }> { ... }
+```
+
+```ts
+findDuplicateusers([
+  { email: 'a@b.co', org: 'x', handle: 'h' },
+  { email: 'a@b.co', org: 'y', handle: 'h' },
+]);
+// [{ index: 1, constraint: 'email', firstIndex: 0 }]
+```
+
+Two details it follows:
+
+- **Null is not equal to null.** A constraint is skipped for any row where one of its columns is
+  null or absent, because a unique index accepts any number of NULLs. Reporting those would send
+  you chasing rows the database is perfectly happy with.
+- **Composite keys compare by value.** The key is JSON, so `[1, '2']` never collides with
+  `['1', 2]`, which a separator-joined key would.
+
+A batch that passes can still collide with rows already stored. This checks the half that needs no
+round trip.
+
+Off by default: generated code ships in your bundle.


### PR DESCRIPTION
`duplicateFinder` shipped in #85 undocumented, which is the same gap that once left TypeBox
unmentioned in the root README after it was added.

One section per generator, since all four emit the same function, covering the two details that
are easy to assume wrong:

- null is not equal to null, so a constraint is skipped where a column is null or absent
- composite keys compare by value, so `[1, '2']` never collides with `['1', 2]`

and the limit worth stating plainly: a batch that passes can still collide with rows already
stored.

The README also claimed the gate runs against Postgres alone. It is now three databases:

| database | how | probes |
| --- | --- | --- |
| Postgres | PGlite, in-process | 1365 type + 53 CHECK |
| SQLite | `node:sqlite`, built into Node 22 | 32 CHECK |
| MySQL | CI service container | 37 |