### PR TITLE
docs: bring every page, README and comment back in line with what the code does

### DIFF
--- a/.changeset/array-element-caps.md
+++ b/.changeset/array-element-caps.md
@@ -1,0 +1,17 @@
+---
+'@drzl/generator-arktype': patch
+'@drzl/generator-typebox': patch
+---
+
+Cap array elements again in the ArkType and TypeBox generators
+
+Moving `varchar(n)` caps off the UTF-16 keywords dropped them for array columns: `varchar(50).array()`
+emitted a bare `string[]` and `Type.Array(Type.String())`. The cap describes the element, not the
+list, so it now goes on the element, with `.array()` wrapping it in ArkType.
+
+For TypeBox that also fixed an emitted module that threw on import. The check deciding whether to
+emit the registry preamble still excluded array columns while the expression no longer did, so a
+file used `[Kind]` without importing it. Both now read one shared predicate.
+
+Found by regenerating the documentation examples, which is the only reason anything looked at a
+capped array.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,17 @@ Thanks for your interest in contributing! This guide explains how to set up your
 - Build, Test, Lint, Format:
   - `pnpm build`
   - `pnpm -r test`
+  - `pnpm typecheck`
   - `pnpm lint`
   - `pnpm format`
+- The gate that matters:
+  - `pnpm verify:packed` packs every package, installs the tarballs into an empty project,
+    generates from three dialects, typechecks the output under three module resolutions, compares
+    it column by column against the official `drizzle-orm` validators, and runs it against a real
+    Postgres (PGlite) and a real SQLite (`node:sqlite`). Set `MYSQL_URL` to include MySQL, which
+    CI provides as a service container; without it that stage skips and says so.
+  - It takes a couple of minutes and it is the only thing here that exercises what a consumer
+    actually gets. Everything else imports from source.
 
 ## Repo Structure (packages/)
 
@@ -60,14 +69,21 @@ Examples:
 - [ ] Changes are focused and documented
 - [ ] Tests added or updated
 - [ ] `pnpm -r test` passes locally
-- [ ] `pnpm lint` passes (no new warnings/errors)
-- [ ] README/CHANGELOG updated where appropriate
+- [ ] `pnpm typecheck` and `pnpm lint` pass (no new warnings/errors)
+- [ ] `pnpm verify:packed` passes
+- [ ] Docs updated where behaviour changed, including the emitted examples on the generator pages
+- [ ] A changeset added for anything a consumer can observe
 
 ## Testing Philosophy
 
 - Prefer unit‑level tests near the code under test.
 - Use temporary directories for any filesystem output and clean up after tests.
 - Keep tests independent and deterministic.
+- **Execute the emitted code rather than matching its text.** Source text cannot tell a schema
+  that validates from one that merely parses, and most of the real bugs found here were emitted
+  modules that read correctly and behaved wrongly, including several that threw on import.
+- **Check a new gate by breaking something on purpose.** A gate that has never failed has not been
+  shown to work; several here went green on their first run while measuring nothing.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Zero‑friction codegen for Drizzle ORM. Analyze your schema. Generate validatio
 - Analyzer: turns Drizzle schemas into a normalized analysis model
 - Generators: Zod, Valibot, ArkType, TypeBox validation; JSON Schema and OpenAPI; typed CRUD services; router templates (oRPC)
 - Batteries: formatting, naming, reusable/shared schemas, relation support
-- Verified against real databases every commit: 1365 type probes and 53 CHECK probes against Postgres
-  (PGlite), 32 against SQLite (`node:sqlite`), and 37 against MySQL (a CI service container).
+- Verified against three real databases every commit: 1400 type probes and 53 CHECK probes against
+  Postgres (PGlite), 32 against SQLite (`node:sqlite`), 37 against MySQL (a CI service container).
   On the CHECK probes DRZL accepts 0 rows the database rejects; `drizzle-orm/zod` accepts 22
 - Monorepo: pnpm workspace, lockstep releases with Changesets
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in DRZL! Please read the full guide in [CONTRIBUTING.md](https://github.com/omar-dulaimi/drzl/blob/master/CONTRIBUTING.md).
+Thanks for your interest in DRZL! Please read the full guide in [CONTRIBUTING.md](https://github.com/use-drzl/drzl/blob/master/CONTRIBUTING.md).
 
 Quick checklist:
 

--- a/docs/examples/validation-mix.md
+++ b/docs/examples/validation-mix.md
@@ -30,7 +30,7 @@ export default defineConfig({
 
 ## Switch libraries
 
-Change `validation.library` to `valibot` or `arktype` and the generator will adapt input/output wiring accordingly. TypeBox is not available here: see [TypeBox → Why it cannot back an oRPC router](/generators/typebox#why-it-cannot-back-an-orpc-router).
+Change `validation.library` to `valibot` or `arktype` and the generator will adapt input/output wiring accordingly. TypeBox is not available here: see [TypeBox → Why it cannot back an oRPC router](/generators/typebox#why-it-cannot-back-an-orpc-router). Neither is `json-schema`, for the same reason: a router types its input and output as a Standard Schema, and a plain JSON Schema is data rather than a validator. Add a [`json-schema` generator](/generators/json-schema) alongside if you also want a document to publish.
 
 ::: tip Need something else?
 If this example doesn't cover what you need, DM me on X (https://x.com/omardulaimidev) and we can scope it together.

--- a/docs/generators/arktype.md
+++ b/docs/generators/arktype.md
@@ -35,22 +35,56 @@ declares becomes part of the type itself:
 
 ```ts
 id:    "string.uuid",                    // uuid()
-name:  "string <= 255",                  // varchar(255)
 small: "-32768 <= number <= 32767",      // smallint()
+
+// A varchar cap counts characters, which the string DSL cannot express, so the field holds a
+// Type carrying a narrow. See "Character limits count characters" below.
+name: type("string").narrow(
+  (v, ctx) => v == null || [...v].length <= 255 || ctx.mustBe("at most 255 characters")
+),
 ```
 
 A `check()` narrows that range rather than sitting beside it. **No official Drizzle validator
 module enforces CHECK constraints**, in any library:
 
 ```ts
-age:   "18 <= number <= 2147483647",     // check(sql`${t.age} >= 18`) on an integer
-score: "(0 <= number <= 100 | null)",    // check(sql`${t.score} BETWEEN 0 AND 100`)
-tier:  "'gold'",                         // check(sql`${t.tier} = 'gold'`)
+age:   "18 <= number.integer <= 2147483647",  // check(sql`${t.age} >= 18`) on an integer
+score: "(0 <= number.integer <= 100 | null)", // check(sql`${t.score} BETWEEN 0 AND 100`)
+n:     "number > 0",                          // check(sql`${t.n} > 0`) on a double
+tags:  "string[] >= 2",                       // check(sql`cardinality(${t.tags}) >= 2`)
+tier:  "'gold'",                              // check(sql`${t.tier} = 'gold'`)
 ```
 
-An exclusive comparison stays exclusive, so `CHECK (n > 0)` yields `0 < number`. An equality on a
-string becomes a literal type. Because the constraint is folded into the range, a nullable column
-reads `(0 <= number <= 100 | null)`, which lets `null` through exactly as SQL does.
+The `.integer` is load bearing: an integer range does not imply integrality in ArkType, and
+without it every `integer()` column accepted `1.5`.
+
+A **lone** bound is written on the right of the type, as `number > 0`. ArkType refuses a left
+bound with no right bound (`0 < number` is a parse error), so the module used to throw the moment
+anything imported it. A pair still reads `0 < number < 10`.
+
+An equality on a string becomes a literal type. Because a constraint is folded into the range, a
+nullable column reads `(0 <= number.integer <= 100 | null)`, which lets `null` through exactly as
+SQL does.
+
+### What goes on the object
+
+Two constraints cannot live in a field's type, and both go on the object as a `.narrow`:
+
+```ts
+})
+  .narrow((o, ctx) =>
+    o['lo'] == null || o['hi'] == null || o['lo'] < o['hi'] || ctx.mustBe('order: lo < hi'))
+  .narrow((o, ctx) =>
+    o['name'] == null || [...o['name']].length >= 3 || ctx.mustBe('len: length(name) >= 3'));
+```
+
+- **`CHECK (lo < hi)`** compares two columns, so neither field alone can decide it. Both sides are
+  null-guarded, matching SQL, where a comparison involving NULL leaves the CHECK satisfied.
+- **`CHECK (length(name) >= 3)`** counts characters, and `string >= 3` counts UTF-16 code units.
+  See [Character limits count characters](#character-limits-count-characters).
+
+A constraint naming a column the mode does not carry, a generated column on insert say, is left
+out rather than evaluated against `undefined`.
 
 Only unambiguous comparisons are translated; see
 [Zod → CHECK constraints](/generators/zod#check-constraints) for what is skipped and why.
@@ -64,7 +98,11 @@ not what an enum array means:
 ```ts
 tags:  "string[]",                      // text().array()
 moods: "('happy' | 'sad')[]",           // moodEnum().array()
-names: "(string <= 50)[]",              // varchar(50).array()
+
+// varchar(50).array(): the cap limits each entry, so the narrow goes on the element.
+names: type("string")
+  .narrow((v, ctx) => v == null || [...v].length <= 50 || ctx.mustBe("at most 50 characters"))
+  .array(),
 ```
 
 | Column                      | Emitted                                           |
@@ -88,15 +126,33 @@ comparison operators take numeric literals, so a 64 bit bound cannot be written 
 DSL at all; `drizzle-orm/arktype` states it through a narrow predicate built with the builder
 API instead. Every other column type is bounded here exactly as the official module bounds it.
 
-## Character limits are approximate
+## Character limits count characters
 
-A `varchar(n)` limit is n **characters**, and ArkType's `string <= n` counts `.length`, which is
-UTF-16 code units. The two agree until the text leaves the basic plane: a `varchar(10)` column
-accepts ten emoji, and `string <= 10` refuses eight of them.
+A `varchar(n)` limit is n **characters**, in both Postgres and MySQL. ArkType's `string <= n`
+counts UTF-16 code units, which is a different measurement: a `varchar(10)` column accepts ten
+emoji and `string <= 10` refuses eight of them.
 
-ArkType states a length declaratively and this generator emits one string per field, so there is
-nowhere to put a code-point count. The zod and valibot generators are exact here; pair one of them
-with this generator if your columns hold emoji or other astral-plane text near their limit.
+That is the direction that breaks working code, so the cap is not written in the string DSL at
+all. The field holds a Type instead, carrying a narrow that counts code points:
+
+```ts
+name: type("string").narrow(
+  (v, ctx) => v == null || [...v].length <= 255 || ctx.mustBe("at most 255 characters")
+),
+```
+
+For an array column the narrow goes on the element, since `varchar(50).array()` limits each entry
+rather than the list:
+
+```ts
+tags: type("string")
+  .narrow((v, ctx) => v == null || [...v].length <= 50 || ctx.mustBe("at most 50 characters"))
+  .array(),
+```
+
+MySQL's TEXT family is a byte budget rather than a character count, and gets a narrow counting
+encoded bytes. All four generators agree on every one of these, checked column by column against
+`drizzle-orm/arktype` and against Postgres, SQLite and MySQL on every commit.
 
 See [Zod, character limits](/generators/zod#character-limits-count-characters) for the
 measurements against Postgres.

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -34,7 +34,7 @@ export type SelectpeopleOutput = Static<typeof SelectpeopleSchema>;
 
 | Column              | Emitted                                                                |
 | ------------------- | ---------------------------------------------------------------------- |
-| `varchar(255)`      | `Type.String({ maxLength: 255 })`                                      |
+| `varchar(255)`      | `Type.Intersect([Type.String(), <code-point cap>])`, see below          |
 | `uuid()`            | `Type.String({ pattern: '...' })`                                      |
 | `smallint()`        | `Type.Integer({ minimum: -32768, maximum: 32767 })`                    |
 | `real()`            | `Type.Number({ minimum: -8388608, maximum: 8388607 })`                 |
@@ -51,12 +51,44 @@ valid uuid. A pattern needs no setup and behaves the same everywhere, so that is
 **No official Drizzle validator module enforces these**, in any library. TypeBox states them
 declaratively:
 
-| Constraint                        | Emitted                    |
-| --------------------------------- | -------------------------- |
-| `CHECK (age >= 18)`               | `minimum: 18`              |
-| `CHECK (n > 0)`                   | `exclusiveMinimum: 0`      |
-| `CHECK (score BETWEEN 0 AND 100)` | `minimum: 0, maximum: 100` |
-| `CHECK (tier = 'gold')`           | `Type.Literal("gold")`     |
+| Constraint                          | Emitted                    |
+| ----------------------------------- | -------------------------- |
+| `CHECK (age >= 18)`                 | `minimum: 18`              |
+| `CHECK (n > 0)`                     | `exclusiveMinimum: 0`      |
+| `CHECK (score BETWEEN 0 AND 100)`   | `minimum: 0, maximum: 100` |
+| `CHECK (tier = 'gold')`             | `Type.Literal("gold")`     |
+| `CHECK (cardinality(tags) >= 2)`    | `minItems: 2`              |
+| `CHECK (status IN ('a', 'b'))`      | `Type.Union([...literals])` |
+
+A bound **replaces** the end of the declared range it narrows rather than sitting beside it: a
+CHECK can only narrow, never widen, since the range is the column's type.
+
+### What goes on the object
+
+Two constraints have no keyword at all, and both become branches of an intersection carrying a
+registered kind:
+
+```ts
+export const SelecttSchema = Type.Intersect([
+  Type.Object({ ... }),
+  Type.Unsafe<unknown>({
+    [Kind]: 'DrzlRowCheck',
+    description: 'order: lo < hi',
+    assert: (o: any) => o == null || o['lo'] == null || o['hi'] == null || o['lo'] < o['hi'],
+  }),
+]);
+```
+
+- **`CHECK (lo < hi)`** compares two columns, so no field can decide it. Both sides are
+  null-guarded, matching SQL.
+- **`CHECK (length(name) >= 3)`** counts characters, and `minLength` counts UTF-16 code units.
+
+Intersecting is what keeps the properties checked. Setting the kind on the object itself parses,
+enforces the predicate, and **silently stops validating the fields**, so `{ lo: 'x' }` passes.
+Both `Value.Check` and `TypeCompiler` honour the intersection.
+
+Serialising to JSON Schema stays valid: the branch carries no keywords, so it renders as a schema
+that accepts everything, keeping its `description` so a reader still learns the rule.
 
 An equality becomes `Type.Literal`, not a `const` option. TypeBox accepts a `const` option on
 `Type.String` and `Type.Integer` and then ignores it: `Type.String({ const: 'gold' })` validates
@@ -74,7 +106,8 @@ A column declared with `.array()` becomes `Type.Array` of the element, with the 
 constraints intact:
 
 ```ts
-tags:   Type.Array(Type.String({ maxLength: 50 })),
+// varchar(50).array(): the cap limits each entry, so it is intersected onto the element.
+tags:   Type.Array(Type.Intersect([Type.String(), /* at most 50 characters */])),
 scores: Type.Array(Type.Integer({ minimum: -32768, maximum: 32767 })),
 ```
 
@@ -122,18 +155,41 @@ The generator itself is unaffected: TypeBox schemas are the right choice whereve
 yourself, or hand them to something that speaks JSON Schema. Pair it with a `zod` generator if you
 also want oRPC routers in the same project.
 
-## Character limits are approximate
+## Character limits count characters
 
-A `varchar(n)` limit is n **characters**, and TypeBox's `maxLength` counts `.length`, which is
-UTF-16 code units. The two agree until the text leaves the basic plane: a `varchar(10)` column
-accepts ten emoji, and `maxLength: 10` refuses eight of them.
+A `varchar(n)` limit is n **characters**, in both Postgres and MySQL. TypeBox's `maxLength` counts
+UTF-16 code units, which is a different measurement: a `varchar(10)` column accepts ten emoji and
+`maxLength: 10` refuses eight of them. JSON Schema defines the keyword in code points, so this is
+TypeBox's implementation rather than the spec, but the effect is the same.
 
-JSON Schema defines `maxLength` in code points, so this is TypeBox's implementation rather than
-the spec, and there is no predicate to hook in a declarative schema. The zod and valibot
-generators are exact here.
+That is the direction that breaks working code, so the keyword is not used. The cap is intersected
+onto the field as a registered kind, which counts code points:
+
+```ts
+name: Type.Intersect([
+  Type.String(),
+  Type.Unsafe<unknown>({
+    [Kind]: 'DrzlRowCheck',
+    description: 'at most 255 characters',
+    assert: (v: any) => v == null || [...v].length <= 255,
+  }),
+]),
+```
+
+For an array column it goes on the element, since `varchar(50).array()` limits each entry rather
+than the list.
+
+The trade is that this cap does not survive `JSON.stringify` into a JSON Schema, where a bare
+`maxLength` would. Emitting a number that means something else in a form that serialises is not a
+better trade. If you want the document, the
+[JSON Schema generator](/generators/json-schema) emits one directly.
+
+MySQL's TEXT family is a byte budget rather than a character count, and gets a branch counting
+encoded bytes. Both are honoured by `Value.Check` and by `TypeCompiler`, and all four generators
+agree on every one of them, checked against Postgres, SQLite and MySQL on every commit.
 
 See [Zod, character limits](/generators/zod#character-limits-count-characters) for the
-measurements against Postgres.
+measurements against the databases.
 
 ## `applyDefaults`
 
@@ -168,7 +224,9 @@ ordinary string to anything reading it at runtime and the narrowing is lost.
 ```
 
 ```ts
-role: Type.Unsafe<(typeof users.$inferSelect)['role']>(Type.String({ maxLength: 50 })),
+role: Type.Unsafe<(typeof users.$inferSelect)['role']>(
+  Type.Intersect([Type.String(), /* at most 50 characters */])
+),
 ```
 
 `Type.Unsafe<T>` wraps the existing schema, so every check it carried still runs and only the

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -35,7 +35,7 @@ What the column declares is enforced, in Valibot's pipeline form:
 
 ```ts
 id:    v.pipe(v.string(), v.uuid()),                      // uuid()
-name:  v.pipe(v.string(), v.maxLength(255)),              // varchar(255)
+name:  v.pipe(v.string(), v.check((val) => [...val].length <= 255, 'at most 255 characters')),  // varchar(255)
 small: v.pipe(v.number(), v.integer(),                    // smallint()
               v.minValue(-32768), v.maxValue(32767)),
 ```
@@ -45,15 +45,24 @@ enforces CHECK constraints**, in any library:
 
 ```ts
 // check('age_adult', sql`${t.age} >= 18`)
-age: v.pipe(v.number(), v.integer(), v.minValue(-2147483648), v.maxValue(2147483647),
-            v.check((val) => val >= 18, "age_adult: age >= 18")),
+age: v.pipe(v.number(), v.integer(), v.minValue(18), v.maxValue(2147483647)),
+
+// check('n_range', sql`${t.n} > 0`)
+n: v.pipe(v.number(), v.integer(), v.gtValue(0), v.maxValue(2147483647)),
 ```
 
-The constraint sits on the inner schema, so `v.nullable()` wrapping it lets `null` through. That
-matches SQL, where a CHECK passes when it evaluates to TRUE **or NULL**.
+A numeric comparison **replaces** the end of the range it narrows rather than sitting beside it. A
+CHECK can only narrow, never widen, since the declared range is the column's type. valibot has the
+exclusive forms natively, so `> 0` is `v.gtValue(0)` rather than a closure, and the issue it
+raises carries `requirement: 0` as data rather than a sentence this generator wrote.
 
-Only unambiguous comparisons are translated. Cross-column comparisons such as
-`start_date < end_date`, compound predicates, function calls and regex matches are skipped rather
+A constraint with no native form stays a `v.check`. The constraint sits on the inner schema, so
+`v.nullable()` wrapping it lets `null` through. That matches SQL, where a CHECK passes when it
+evaluates to TRUE **or NULL**.
+
+Only unambiguous comparisons are translated. `start_date < end_date` is applied on the object,
+`length()` and `cardinality()` are applied on the field, and disjunctions, negations, regex
+matches and unrecognised function calls are skipped rather
 than guessed at, since a schema enforcing a guess rejects rows the database would accept. See
 [Zod → CHECK constraints](/generators/zod#check-constraints) for the full table.
 
@@ -63,7 +72,7 @@ A column declared with `.array()` produces a schema for the array, keeping every
 declares inside it:
 
 ```ts
-tags:   v.array(v.pipe(v.string(), v.maxLength(50))),          // varchar(50).array()
+tags:   v.array(v.pipe(v.string(), v.check((val) => [...val].length <= 50, 'at most 50 characters'))),  // varchar(50).array()
 scores: v.array(v.pipe(v.number(), v.integer(), v.minValue(-32768), v.maxValue(32767))),
 ```
 

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -174,19 +174,25 @@ this**, in any library: a table declaring `check('age_adult', sql\`${t.age} >= 1
 
 ```ts
 // check('age_adult', sql`${t.age} >= 18`)
-age: z.number().int().gte(-2147483648).lte(2147483647)
-  .refine((v) => v >= 18, { message: "age_adult: age >= 18" }),
+age: z.number().int().gte(18).lte(2147483647),
 
 // check('score_range', sql`${t.score} BETWEEN 0 AND 100`)
-score: z.number().int()
-  .refine((v) => v >= 0, { message: "score_range: score >= 0" })
-  .refine((v) => v <= 100, { message: "score_range: score <= 100" })
-  .nullable(),
+score: z.number().int().gte(0).lte(100).nullable(),
 ```
 
-Note the ordering on `score`: the refinement sits inside `.nullable()`, so `null` skips it. That
-is deliberate, because a SQL CHECK passes when it evaluates to TRUE **or NULL**. Enforcing it on
-a nullable column would make the schema stricter than the database.
+A numeric comparison **replaces** the end of the range it narrows rather than sitting beside it. A
+CHECK can only narrow, never widen, since the declared range is the column's type, so
+`.gte(-2147483648).lte(2147483647).refine((v) => v >= 18)` was a bound that can never fail plus a
+closure saying what the bound should have said.
+
+The error is the reason this matters more than the speed. `.gte(18)` produces zod's own `Too
+small, expected number to be >=18`, with the bound machine-readable on the issue, rather than a
+sentence this generator wrote that a client would have to parse.
+
+A constraint that has no native form stays a refinement, and where one does the ordering is
+deliberate: it sits inside `.nullable()`, so `null` skips it. A SQL CHECK passes when it evaluates
+to TRUE **or NULL**, and enforcing it on a nullable column would make the schema stricter than the
+database.
 
 ### `IN` lists become enums
 
@@ -202,11 +208,11 @@ predicate, and the static type narrows with it.
 
 ```ts
 // check('n_bounds', sql`${t.n} > 0 AND ${t.n} < 10 AND ${t.n} <> 5`)
-n: z.number().int()
-  .refine((v) => v > 0, { message: "n_bounds: n > 0" })
-  .refine((v) => v < 10, { message: "n_bounds: n < 10" })
+n: z.number().int().gt(0).lt(10)
   .refine((v) => v !== 5, { message: "n_bounds: n <> 5" }),
 ```
+
+The two bounds fold into the range; the inequality has no native form and stays a refinement.
 
 Every part of an `AND` has to hold on its own, which is exactly what a list of refinements means.
 The split walks the expression rather than splitting on the text, so the `AND` inside a `BETWEEN`
@@ -246,14 +252,18 @@ against a scalar literal says nothing usable about an array, whereas this one is
 
 **Only unambiguous constraints are translated.** These are skipped rather than guessed at:
 
-| Skipped                       | Why                                                      |
-| ----------------------------- | -------------------------------------------------------- |
-| `start_date < end_date`       | A statement about the row, not about either field        |
-| `age >= 18 OR age <= 65`      | A disjunction cannot be split the way a conjunction can  |
-| `NOT (age >= 18)`             | Same: negation changes the scope of everything inside it |
-| `age >= 18 AND length(n) > 3` | One part is not understood, so neither is enforced       |
+| Skipped                            | Why                                                      |
+| ---------------------------------- | -------------------------------------------------------- |
+| `age >= 18 OR age <= 65`           | A disjunction cannot be split the way a conjunction can  |
+| `NOT (age >= 18)`                  | Same: negation changes the scope of everything inside it |
+| `age >= 18 AND lower(n) = 'x'`     | One part is not understood, so neither is enforced       |
+| `email ~ '^[a-z]+$'`               | Postgres `~` is POSIX ERE, not JavaScript's regex dialect |
+| `octet_length(s) <= 5`             | Bytes, and the column's encoding is not in the schema    |
 
-| `email ~ '^[a-z]+$'` | Postgres `~` is POSIX ERE, not JavaScript's regex dialect |
+Applied, and worth naming because they read like exceptions: `start_date < end_date` goes on the
+object as a row-level check, `length()` and `char_length()` count code points, `cardinality()`
+bounds an array, `BETWEEN` folds into the range, and `IN` becomes an enum. A conjunction is
+applied when **every** part is understood.
 
 A schema that quietly enforces a _guess_ at your constraint is worse than one enforcing nothing,
 because it rejects rows the database would have accepted.

--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -83,13 +83,18 @@ generator wrote.
 ## What is not measured here
 
 Correctness against the database, which is checked separately and continuously. `verify-packed.sh`
-runs 1365 type probes and 53 `CHECK` probes against a real Postgres via PGlite on every commit:
+runs the emitted schemas against **three real databases** on every commit: Postgres in-process via
+PGlite, SQLite via `node:sqlite`, and MySQL as a CI service container.
 
 ```
-    1365 probes against a real Postgres (39 columns)
-    agree with the database: DRZL 974, drizzle-orm 946
+    1400 probes against a real Postgres (40 columns)
+    agree with the database: DRZL 1007, drizzle-orm 979
     DRZL closer than drizzle-orm on 28, further on 0
 
     53 CHECK probes against a real Postgres (13 constrained columns)
     rows Postgres rejects and the validator accepts: DRZL 0, drizzle-orm 22
+
+    9 defaulted columns, 9 reproduced by applyDefaults
+    32 CHECK probes against a real SQLite (10 constrained columns)
+    37 probes against a real MySQL
 ```

--- a/packages/analyzer/README.md
+++ b/packages/analyzer/README.md
@@ -47,6 +47,17 @@ The CLI consumes this analysis to generate validation, services, and routers.
 - relations (incl. inferred), enums
 - issues (warnings/errors) for constraints and shape
 
+Per column, beyond the type: `nullable`, `hasDefault`, `defaultValue` (literal defaults only),
+`isGenerated`, `enumValues`, `maxLength` (characters), `maxBytes` (MySQL's TEXT family is a byte
+budget, which is a different measurement on the same kind of column), `min`/`max`,
+`arrayDimensions`, `format`, and `shape` for values that are not scalars (json, buffer, tuple,
+vector, bitstring, customType).
+
+`DRZL_ANL_UNKNOWN_COLUMN` is reported for any column whose validator would accept anything, which
+is the shape a missing type mapping takes: nothing throws, and every row passes.
+
 ## Notes
 
-- Best‑effort introspection aligned with Drizzle symbols across versions.
+- Best‑effort introspection aligned with Drizzle symbols across versions. Both live majors are
+  covered and diffed against each other in CI: 0.4x and v1 model arrays and enums differently, and
+  reading only one silently typed every `.array()` column as `unknown` on the other.

--- a/packages/cli/src/sponsor.ts
+++ b/packages/cli/src/sponsor.ts
@@ -23,6 +23,7 @@ const tips = [
   'Pair DRZL watch mode with drizzle-kit to keep schema & API synced.',
   'Templatize your ORPC routers to roll out new endpoints safely.',
   'Need typed validators? Enable the zod, valibot, arktype, or typebox generators.',
+  'Need JSON Schema or OpenAPI? The json-schema generator emits both, with no runtime dependency.',
   'Use output headers to track generated files and trim noisy diffs.',
 ];
 

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -271,7 +271,12 @@ function renderObjectShape(
       const optional = dsl.endsWith('?');
       const inner = optional ? dsl.slice(0, -1) : dsl;
       const key = JSON.stringify(optional ? `${c.name}?` : c.name);
-      return `  ${key}: type(${JSON.stringify(inner)})${caps},`;
+      // The cap describes the element, so for an array column the narrow goes on the element and
+      // `.array()` wraps it. Narrowing the array instead would ask how many characters a list has.
+      const dims = c.arrayDimensions ?? 0;
+      const element = dims ? inner.replace(/(\[\])+$/, '').replace(/^\((.*)\)$/, '$1') : inner;
+      const wrap = '.array()'.repeat(dims);
+      return `  ${key}: type(${JSON.stringify(element)})${caps}${wrap},`;
     })
     .join('\n');
 }
@@ -328,7 +333,7 @@ function atRowNarrows(rows: RowCheck[], cols: Column[]): string {
  * MySQL counts `tinytext` in bytes, so both are written out here rather than approximated.
  */
 function atCapNarrows(c: Column): string {
-  if (c.tsType !== 'string' || c.arrayDimensions || c.shape) return '';
+  if (c.tsType !== 'string' || c.shape) return '';
   const out: string[] = [];
   if (c.maxLength) {
     const msg = JSON.stringify(`at most ${c.maxLength} characters`);

--- a/packages/generator-arktype/test/char-and-byte-caps.spec.ts
+++ b/packages/generator-arktype/test/char-and-byte-caps.spec.ts
@@ -74,3 +74,16 @@ describe('a column with neither', () => {
     expect(ok(s, 'x'.repeat(100000))).toBe(true);
   });
 });
+
+describe('an array of capped strings', () => {
+  it('caps the element, not the array', async () => {
+    // `varchar(50).array()` limits each element. Dropping the cap because the column is an array
+    // is how the first version of this went: the field is the array, and the cap describes what
+    // is in it.
+    const s = await schemaFor(col({ maxLength: 3, arrayDimensions: 1, tsType: 'string' }));
+    expect(ok(s, ['ab', 'abc'])).toBe(true);
+    expect(ok(s, ['abcd'])).toBe(false);
+    expect(ok(s, [EMOJI.repeat(3)]), '3 characters').toBe(true);
+    expect(ok(s, []), 'an empty array is fine').toBe(true);
+  });
+});

--- a/packages/generator-typebox/package.json
+++ b/packages/generator-typebox/package.json
@@ -35,7 +35,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/use-drzl/drzl",
-    "directory": "packages/generator-valibot"
+    "directory": "packages/generator-typebox"
   },
   "funding": {
     "type": "github",

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -450,9 +450,7 @@ function renderTableSchemas(
   const needsRows =
     rows.some((r) => rowCols.some((s) => s.has(r.left) && s.has(r.right))) ||
     lengths.some((k) => rowCols.some((s) => s.has(k.column))) ||
-    [insertCols, updateCols, selectCols].some((cs) =>
-      cs.some((c) => c.tsType === 'string' && !c.arrayDimensions && !c.shape && (c.maxLength || c.maxBytes))
-    );
+    [insertCols, updateCols, selectCols].some((cs) => cs.some(tbNeedsCapKind));
   const rowImport = needsRows ? `, Kind, TypeRegistry` : '';
 
     // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
@@ -523,8 +521,21 @@ const ROW_PREAMBLE = `TypeRegistry.Set('DrzlRowCheck', (schema: any, value: any)
  * The cost is that a cap no longer serialises into the JSON Schema. Emitting a number that means
  * something else in a form that serialises is not a better trade.
  */
+/**
+ * Whether this column's cap needs the registered kind.
+ *
+ * Shared with the preamble check on purpose. They were two copies of the same condition and they
+ * drifted the moment one changed: an array of `varchar(n)` emitted `[Kind]` into a file that did
+ * not import it, so the module threw the moment anything loaded it.
+ */
+function tbNeedsCapKind(c: Column): boolean {
+  // Not excluded for an array column: the cap describes the *element*, and the array wraps it
+  // after, so `varchar(50).array()` caps each entry.
+  return c.tsType === 'string' && !c.shape && !!(c.maxLength || c.maxBytes);
+}
+
 function tbCapExpr(c: Column, base: string): string {
-  if (c.tsType !== 'string' || c.arrayDimensions || c.shape) return base;
+  if (!tbNeedsCapKind(c)) return base;
   const branch = (desc: string, expr: string) => `Type.Unsafe<unknown>({
     [Kind]: 'DrzlRowCheck',
     description: ${JSON.stringify(desc)},

--- a/packages/generator-typebox/test/char-and-byte-caps.spec.ts
+++ b/packages/generator-typebox/test/char-and-byte-caps.spec.ts
@@ -74,3 +74,13 @@ describe('a column with neither', () => {
     expect(ok(s, 'x'.repeat(100000))).toBe(true);
   });
 });
+
+describe('an array of capped strings', () => {
+  it('caps the element, not the array', async () => {
+    const s = await schemaFor(col({ maxLength: 3, arrayDimensions: 1, tsType: 'string' }));
+    expect(ok(s, ['ab', 'abc'])).toBe(true);
+    expect(ok(s, ['abcd'])).toBe(false);
+    expect(ok(s, [EMOJI.repeat(3)]), '3 characters').toBe(true);
+    expect(ok(s, []), 'an empty array is fine').toBe(true);
+  });
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -283,8 +283,8 @@ function vExprForColumn(
       // See the zod generator: a bare string accepted values Postgres rejects.
       const pattern = c.format ? COLUMN_FORMATS[c.format] : undefined;
       if (pattern) return piped('v.string()', [`v.regex(new RegExp(${JSON.stringify(pattern)}))`]);
-      // Not `v.maxLength(n)`, which counts UTF-16 units where the column counts characters. See
-      // the zod generator and `CODEPOINT_LENGTH` in validation-core.
+      // Not `v.maxLength(n)`, which counts UTF-16 units where the column counts characters. All
+      // four generators count code points; see `CODEPOINT_LENGTH` in validation-core.
       // Two different measurements. `varchar(n)` counts characters in both databases; MySQL's
       // TEXT family counts bytes, so a tinytext takes 255 ascii characters and only 63 emoji.
       const caps: string[] = [];

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -258,8 +258,8 @@ function zodExprForColumn(
       const pattern = c.format ? COLUMN_FORMATS[c.format] : undefined;
       if (pattern) return `z.string().regex(new RegExp(${JSON.stringify(pattern)}))`;
       // Not `.max(n)`. A `varchar(n)` limit is n *characters*, and `.max` counts UTF-16 units, so
-      // it refuses eight emoji in a `varchar(10)` the database is happy with. See
-      // `CODEPOINT_LENGTH` in validation-core for the measurements.
+      // it refuses eight emoji in a `varchar(10)` the database is happy with. All four generators
+      // count code points now; see `CODEPOINT_LENGTH` in validation-core for the measurements.
       // Two different measurements, and a column can carry either. `varchar(n)` counts
       // characters in both Postgres and MySQL; MySQL's TEXT family counts bytes, so a tinytext
       // takes 255 ascii characters and only 63 thumbs-up ones. Both verified against the servers.

--- a/packages/validation-core/README.md
+++ b/packages/validation-core/README.md
@@ -50,6 +50,23 @@ Shared interfaces and helpers used by validation generators.
     output and misses `node16`/`nodenext` ES modules. `'ts'` needs
     `allowImportingTsExtensions`. `.mts` and `.cts` become `.mjs` and `.cjs` under both
     `'js'` and `'none'`, since an extensionless specifier never resolves to them.
+- CHECK constraints (shared by every generator that reads them)
+  - `parseCheck(expression, name)` -> the parts of a `CHECK` that can be stated with certainty:
+    column comparisons, `BETWEEN`, `IN (...)`, top-level `AND`, `length()`/`char_length()`,
+    `cardinality()`/`array_length(col, 1)`, and comparisons between two columns. A disjunction, a
+    negation, `octet_length`, an unrecognised function call and a regex match are all refused
+    whole rather than half-applied.
+  - `COLUMN_FORMATS` -> patterns for the column formats that are expressible. Only `numeric` is:
+    Postgres accepts `today`, `January 8, 1999` and `allballs`, so a date or time pattern would
+    reject rows the database takes.
+  - `CODEPOINT_LENGTH` -> `[...v].length`, since `varchar(n)` counts characters and JavaScript's
+    `.length` counts UTF-16 units. All four generators use it.
+  - `isIntegerColumn(c)`
+- Uniqueness
+  - `renderDuplicateFinder(table, fnName, rowType)` -> the source of a function returning the rows
+    in a batch that collide with an earlier row on a unique constraint. Plain TypeScript with no
+    reference to any validation library, so all four generators emit the same one. Null and absent
+    columns skip a constraint, matching SQL.
 - Naming (shared by every generator that emits a schema name)
   - `resolveAffix({ affix, schemaSuffix })` -> `ResolvedAffix`
   - `schemaName(mode, tsName, resolved)`, `typeName(mode, tsName, resolved)`

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -191,8 +191,15 @@ export const COLUMN_FORMATS: Record<string, string> = {
  * Refusing a user's emoji is the failure mode this avoids, and it is the same rule applied
  * everywhere else here: never reject what the database accepts.
  *
- * `@sinclair/typebox` and ArkType cannot express it. Both state a length declaratively with no
- * predicate to hook, so they keep the UTF-16 form and are documented as approximate.
+ * All four generators count code points. `@sinclair/typebox` and ArkType cannot say it in their
+ * declarative forms, so neither uses `maxLength` or `string <= n`: TypeBox intersects a registered
+ * kind onto the field and ArkType puts a Type carrying a narrow there. Both cost something,
+ * TypeBox's cap no longer serialising into a JSON Schema, and emitting a number that means a
+ * different measurement is not a better trade.
+ *
+ * MySQL's TEXT family is a byte budget rather than a character count, carried separately as
+ * `maxBytes`. Two measurements on string columns in the same database, verified against a real
+ * MySQL 8 on utf8mb4: `varchar(10)` takes ten emoji, `tinytext` takes 63 of them and refuses 64.
  */
 export const CODEPOINT_LENGTH = '[...v].length';
 

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -423,6 +423,9 @@ export const matrix = pgTable('matrix', {
 
   // --- arrays ---
   c_text_arr: text().array().notNull(),
+  // A capped element inside an array. Without one, dropping the element's cap looked identical to
+  // keeping it: every array in this fixture held an uncapped type.
+  c_varchar_arr: varchar({ length: 10 }).array().notNull(),
   c_int_arr: integer().array().notNull(),
   c_enum_arr: moodEnum().array().notNull(),
 
@@ -681,6 +684,10 @@ const POOL: [string, unknown][] = [
   ["'25:99:99'", '25:99:99'],
   ['{}', {}], ["{a:'s'}", { a: 's' }], ['[]', []], ["['a']", ['a']], ['[1,2]', [1, 2]],
   ["['happy']", ['happy']], ['[1,2,3]', [1, 2, 3]],
+  // An array holding a value past its element's cap. Every array probe above holds something
+  // short, so dropping an element's constraint looked identical to keeping it: two generators
+  // stopped capping array elements and nothing here could tell.
+  ['["11-char"]', ['x'.repeat(11)]], ['["3 emoji"]', ['\u{1F44D}\u{1F44D}\u{1F44D}']],
   ['Buffer', Buffer.from('ab')], ['Uint8Array', new Uint8Array([1, 2])],
   ["'999.999.999.999'", '999.999.999.999'], ["'10.0.0.1'", '10.0.0.1'],
   ['{x:1,y:2}', { x: 1, y: 2 }], ["'12.5'", '12.5'], ["'0101'", '0101'], ["'010'", '010'],
@@ -1060,6 +1067,7 @@ CREATE TABLE matrix (
   c_time time,
   c_interval interval,
   c_text_arr text[],
+  c_varchar_arr varchar(10)[],
   c_int_arr integer[],
   c_enum_arr mood[],
   c_bytea bytea,
@@ -2016,5 +2024,6 @@ cd "$APP"
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
 echo "    typechecks under bundler, node16 and nodenext, and validates at least as strictly as"
 echo "    the first-party drizzle-orm validator modules across three dialects and three modes,"
-echo "    checked against a real Postgres and a real SQLite, and analyzed with no column left"
-echo "    unnamed on both drizzle-orm majors."
+echo "    checked against a real Postgres, a real SQLite and, where MYSQL_URL is set, a real"
+echo "    MySQL, with applyDefaults compared against what the database writes, and analyzed with"
+echo "    no column left unnamed on either drizzle-orm major."


### PR DESCRIPTION
A sweep for anything that no longer matches what the code does. It found more than prose.

## Docs that described fixed bugs as current limitations

Both the ArkType and TypeBox pages carried a section titled **"Character limits are approximate"**,
describing exactly the `varchar(n)`/emoji over-strictness those generators no longer have. They now
describe what they do instead, and why the declarative keyword is not used.

The ArkType page also documented a **crash as a feature**:

> An exclusive comparison stays exclusive, so `CHECK (n > 0)` yields `0 < number`.

ArkType refuses a left bound with no right bound, so that form threw the moment anything imported
the module. It reads `number > 0` now.

## A page that contradicted itself

The zod page listed `start_date < end_date` as **skipped** in one table, and documented it as
**enforced** two sections further down. It also listed `age >= 18 AND length(n) > 3` as
unparseable, when both halves are understood.

The skipped list is now what the parser actually refuses, checked against it rather than recalled:

```
APPLIED  start_date < end_date        skipped  age >= 18 OR age <= 65
APPLIED  age >= 18 AND length(n) > 3  skipped  NOT (age >= 18)
APPLIED  cardinality(tags) >= 2       skipped  age >= 18 AND lower(name) = 'x'
APPLIED  char_length(s) <= 5          skipped  octet_length(s) <= 5
```

## Numbers re-measured, not adjusted

1400 Postgres probes over 40 columns, DRZL agreeing 1007 to `drizzle-orm`'s 979. The gate's own
closing summary claimed Postgres and SQLite; it now names MySQL and the `applyDefaults` check too.

## The bug regenerating the examples found

`tags` is a `varchar(50)[]`. The output was:

```ts
tags: 'string[]',                       // arktype
tags: Type.Array(Type.String()),        // typebox
```

Moving the cap off the UTF-16 keywords had **dropped it entirely for array columns**. The cap
describes the element, not the list, so it now goes on the element with `.array()` wrapping it.

For TypeBox that also fixed an **emitted module that threw on import**: the check deciding whether
to emit the registry preamble still excluded array columns while the expression no longer did, so
a file used `[Kind]` without importing it. Both now read one shared predicate, since two copies of
a condition drift the moment one changes.

### Why no gate caught it

The parity fixture had no `varchar(n)` array, and every array probe in the pool held something
short, so a dropped element constraint looked identical to a kept one. Both are fixed:

```
    1400 probes against a real Postgres (40 columns)
```

and reintroducing the regression now fails:

```
    the four generators disagree with each other:
        c_varchar_arr: ...
```

## Smaller corrections

- `@drzl/generator-typebox` pointed at `packages/generator-valibot` in its **published** repository
  metadata
- the docs linked the pre-transfer `omar-dulaimi/drzl` URL rather than `use-drzl/drzl`
- `CONTRIBUTING` never mentioned `pnpm verify:packed`, the only check that exercises what a
  consumer actually gets, and its testing philosophy now states the two rules this week kept
  proving: execute the emitted code rather than matching its text, and break a new gate on purpose
- `validation-core` and `analyzer` READMEs list what they actually export now, including
  `parseCheck`, `CODEPOINT_LENGTH`, `renderDuplicateFinder` and `maxBytes`
- a sponsor tip and the validation-mix example mention the JSON Schema generator

## Verification

- 697 tests across 93 files, typecheck and lint clean, full `verify-packed.sh` green including
  MySQL
- **every code block added to the docs was executed against the real library**, not transcribed,
  including the TypeBox trap the page warns about:

  ```
  all documented arktype expressions behave as claimed
  all documented typebox claims hold, including the trap
  ```
- an audit confirms all 23 generator config options appear in the docs
