### PR TITLE
fix(build): stop shipping prettier inside three packages

### DIFF
--- a/.changeset/externalize-prettier.md
+++ b/.changeset/externalize-prettier.md
@@ -1,0 +1,29 @@
+---
+'@drzl/validation-core': minor
+'@drzl/generator-orpc': minor
+'@drzl/generator-service': minor
+---
+
+Stop shipping prettier inside three packages, and make the CommonJS build format at all
+
+`@drzl/validation-core`, `@drzl/generator-orpc` and `@drzl/generator-service` each published at
+about 2.8 MB packed and 11 MB unpacked. All three carried a copy of `formatCode` built on
+`await import('prettier')`, which is a specifier tsup resolves statically, so esbuild inlined the
+whole formatter behind it: prettier's Flow parser, its TypeScript parser, babel, postcss, yaml and
+the rest. Installing `@drzl/cli` pulled in roughly 32 MB of duplicated parsers.
+
+Prettier is now an optional peer dependency, marked external in every build that can reach it.
+The two private copies of `formatCode` are gone; both packages use the one exported by
+`@drzl/validation-core`, which they already depended on. The three packages now publish at 34 KB,
+15 KB and 8 KB packed, and 88 KB, 59 KB and 18 KB unpacked.
+
+**What changes for you.** DRZL formats with the prettier already in your project, using your
+config, exactly as before. If your project has no prettier and no biome, generated files are
+written as rendered: the same valid TypeScript with worse whitespace, rather than nothing at all.
+Add `prettier` as a dev dependency if you want it formatted.
+
+Along the way this fixes formatting for CommonJS consumers, where it never worked. The bundled
+prettier in `dist/index.cjs` called `createRequire(import.meta.url)`, and `import.meta.url` is
+undefined in a CJS bundle, so the first call threw, the `catch` swallowed it and the code came
+back unformatted. Every `require('@drzl/validation-core')` consumer carried 5.5 MB of formatter
+that could not run. Resolving the real prettier fixes it.

--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -18,7 +18,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --clean",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
   },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,4 +52,7 @@ export default defineConfig({
 
 Notes
 
-- `format.engine: 'auto'` tries Prettier, then Biome.
+- `format.engine: 'auto'` tries Prettier, then Biome. Both are your own: neither is bundled, and
+  DRZL uses whichever it finds in your project, with your config. With neither installed the
+  generated files are written exactly as rendered, which is the same valid TypeScript with worse
+  whitespace. Add `prettier` as a dev dependency if you want it formatted.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/cli.ts src/config.ts --format esm,cjs --sourcemap --dts",
+    "build": "tsup src/cli.ts src/config.ts --format esm,cjs --sourcemap --dts --clean",
     "dev": "node --loader ts-node/esm src/cli.ts --help",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"

--- a/packages/generator-arktype/README.md
+++ b/packages/generator-arktype/README.md
@@ -43,7 +43,9 @@ generators: [{ kind: 'arktype', path: 'src/validators/arktype' }];
 
 ## Notes
 
-- Formatting integrates with Prettier/Biome (via `format.engine: 'auto'`).
+- Formatting integrates with Prettier/Biome (via `format.engine: 'auto'`). Neither is bundled;
+  whichever your project has is used, with your config, and with neither the files are written
+  as rendered.
 
 ## Custom names
 

--- a/packages/generator-arktype/package.json
+++ b/packages/generator-arktype/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --clean",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
   },

--- a/packages/generator-json-schema/package.json
+++ b/packages/generator-json-schema/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --clean",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
   },

--- a/packages/generator-orpc/package.json
+++ b/packages/generator-orpc/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --external prettier --clean",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
   },

--- a/packages/generator-orpc/src/index.ts
+++ b/packages/generator-orpc/src/index.ts
@@ -1,6 +1,7 @@
 import type { Analysis, Column, Table } from '@drzl/analyzer';
 import type { AffixOptions, ImportExtension } from '@drzl/validation-core';
 import {
+  formatCode,
   importSpecifier,
   resolveAffix,
   resolveConfiguredImport,
@@ -457,44 +458,6 @@ export class ORPCGenerator {
     return specs;
   }
 
-  private async formatCode(
-    code: string,
-    filePath: string,
-    fmt?: GenerateOptions['format']
-  ): Promise<string> {
-    if (fmt && fmt.enabled === false) return code;
-    const engine = fmt?.engine ?? 'auto';
-    // Best-effort: use user's Prettier if available; otherwise return original
-    try {
-      if (engine === 'prettier' || engine === 'auto') {
-        const prettier: any = await import('prettier');
-        const cfgRef = fmt?.configPath ?? filePath;
-        const cfg = await prettier.resolveConfig(cfgRef).catch(() => null);
-        return prettier.format(code, {
-          ...(cfg ?? {}),
-          parser: 'typescript',
-          filepath: filePath,
-        });
-      }
-    } catch {}
-    try {
-      if (engine === 'biome' || engine === 'auto') {
-        // Dynamic import via Function to avoid bundler/module resolution at build time
-        const dynamicImport: any = Function('s', 'return import(s)');
-        const biome: any = await dynamicImport('@biomejs/biome').catch(() => null);
-        if (biome && (biome.formatContent || (biome as any).format)) {
-          if (biome.formatContent) {
-            const res = await biome.formatContent(code, { filePath });
-            return (res && (res.content || res.formatted)) ?? code;
-          }
-          const res = await (biome as any).format?.(code, { filePath });
-          return res ?? code;
-        }
-      }
-    } catch {}
-    return code;
-  }
-
   async generate(opts: GenerateOptions) {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
@@ -532,7 +495,7 @@ export class ORPCGenerator {
     // Emit one file per table or a placeholder when none.
     if (!this.analysis.tables.length) {
       const p = path.join(out, 'placeholder.orpc.ts');
-      const formatted = await this.formatCode(
+      const formatted = await formatCode(
         buildHeader(opts.outputHeader) + this.renderPlaceholder(),
         p,
         opts.format
@@ -549,7 +512,7 @@ export class ORPCGenerator {
       const filePath = template.filePath(table, { outDir: out, naming: opts.naming });
       await fs.mkdir(path.dirname(filePath), { recursive: true });
       const content = this.renderRouter(table, template, out, opts);
-      const formatted = await this.formatCode(
+      const formatted = await formatCode(
         buildHeader(opts.outputHeader) + content,
         filePath,
         opts.format
@@ -580,7 +543,7 @@ export class ORPCGenerator {
         .join('\n');
       const barrel = `${importLines}\n\nexport const ${groupName} = {\n${bodyLines}\n};\n`;
       const barrelPath = path.join(out, 'index.ts');
-      const barrelFormatted = await this.formatCode(
+      const barrelFormatted = await formatCode(
         buildHeader(opts.outputHeader) + barrel,
         barrelPath,
         opts.format

--- a/packages/generator-orpc/test/formatting.spec.ts
+++ b/packages/generator-orpc/test/formatting.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * The routers this generator writes are still formatted, after losing their private formatter.
+ *
+ * This package used to carry its own copy of `formatCode`, with its own `await import('prettier')`
+ * that bundled 11 MB of prettier into `dist`. Deleting the copy in favour of the one exported by
+ * @drzl/validation-core is invisible to every other test here: unformatted output is still valid
+ * TypeScript, still parses, still typechecks, and none of the sibling specs assert on whitespace.
+ * A wired-up call that silently stopped formatting would therefore look exactly like success.
+ *
+ * So this compares the emitted file against what prettier makes of the same file, rather than
+ * against a fixed string, which keeps it honest without pinning prettier's output style.
+ */
+import { describe, it, expect } from 'vitest';
+import { ORPCGenerator } from '../src';
+import type { Analysis } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const analysis: Analysis = {
+  dialect: 'sqlite',
+  tables: [
+    {
+      name: 'users',
+      tsName: 'users',
+      columns: [
+        {
+          name: 'id',
+          tsType: 'number',
+          dbType: 'INTEGER',
+          nullable: false,
+          hasDefault: true,
+          isGenerated: true,
+        },
+        {
+          name: 'email',
+          tsType: 'string',
+          dbType: 'TEXT',
+          nullable: false,
+          hasDefault: false,
+          isGenerated: false,
+        },
+      ],
+      unique: [],
+      indexes: [],
+      primaryKey: { columns: ['id'] },
+    } as never,
+  ],
+  enums: [],
+  relations: [],
+  issues: [],
+};
+
+/** Emit into a temp directory, so no .prettierrc.json above it can affect the comparison. */
+async function emit(format?: { enabled?: boolean }) {
+  const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-orpc-fmt-'));
+  await new ORPCGenerator(analysis).generate({ outputDir, format } as never);
+  return {
+    router: await fs.readFile(path.join(outputDir, 'users.ts'), 'utf8'),
+    barrel: await fs.readFile(path.join(outputDir, 'index.ts'), 'utf8'),
+    at: path.join(outputDir, 'users.ts'),
+  };
+}
+
+describe('emitted oRPC output', () => {
+  it('is formatted by prettier, not merely written out', async () => {
+    const formatted = await emit();
+    const raw = await emit({ enabled: false });
+    const prettier = await import('prettier');
+    expect(formatted.router).toBe(
+      await prettier.format(raw.router, { parser: 'typescript', filepath: raw.at })
+    );
+    // The two agreeing would also be satisfied by output that needs no formatting, so the raw
+    // form has to be different for the comparison above to have proved anything.
+    expect(formatted.router).not.toBe(raw.router);
+  });
+
+  it('formats the router barrel too', async () => {
+    const { barrel } = await emit();
+    const { barrel: raw } = await emit({ enabled: false });
+    expect(barrel).not.toBe(raw);
+  });
+
+  it('still honours format.enabled false', async () => {
+    // The one setting a shared implementation could plausibly drop, and the only way a user has
+    // of keeping DRZL's hands off their whitespace.
+    const { router } = await emit({ enabled: false });
+    expect(router).toMatch(/from '/);
+  });
+});

--- a/packages/generator-service/package.json
+++ b/packages/generator-service/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --external prettier --clean",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
   },

--- a/packages/generator-service/src/index.ts
+++ b/packages/generator-service/src/index.ts
@@ -1,6 +1,6 @@
 import type { Analysis, Table, Column } from '@drzl/analyzer';
 import type { ImportExtension } from '@drzl/validation-core';
-import { importSpecifier, resolveConfiguredImport } from '@drzl/validation-core';
+import { formatCode, importSpecifier, resolveConfiguredImport } from '@drzl/validation-core';
 
 export interface ServiceGenerateOptions {
   outDir: string;
@@ -190,30 +190,6 @@ export class ${Service} {
 export class ServiceGenerator {
   constructor(private analysis: Analysis) {}
 
-  private async format(code: string, filePath: string, fmt?: ServiceGenerateOptions['format']) {
-    if (fmt && fmt.enabled === false) return code;
-    const engine = fmt?.engine ?? 'auto';
-    try {
-      if (engine === 'prettier' || engine === 'auto') {
-        const prettier: any = await import('prettier');
-        const cfgRef = fmt?.configPath ?? filePath;
-        const cfg = await prettier.resolveConfig(cfgRef).catch(() => null);
-        return prettier.format(code, { ...(cfg ?? {}), parser: 'typescript', filepath: filePath });
-      }
-    } catch {}
-    try {
-      if (engine === 'biome' || engine === 'auto') {
-        const dynamicImport: any = Function('s', 'return import(s)');
-        const biome: any = await dynamicImport('@biomejs/biome').catch(() => null);
-        if (biome?.formatContent) {
-          const res = await biome.formatContent(code, { filePath });
-          return (res && (res.content || res.formatted)) ?? code;
-        }
-      }
-    } catch {}
-    return code;
-  }
-
   async generate(opts: ServiceGenerateOptions) {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
@@ -242,12 +218,12 @@ export class ServiceGenerator {
         opts.databaseInjection,
         opts.importExtension
       );
-      const formattedTypes = await this.format(
+      const formattedTypes = await formatCode(
         buildHeader(opts.outputHeader) + typesCode,
         typesPath,
         opts.format
       );
-      const formattedSvc = await this.format(
+      const formattedSvc = await formatCode(
         buildHeader(opts.outputHeader) + svcCode,
         svcPath,
         opts.format

--- a/packages/generator-service/test/formatting.spec.ts
+++ b/packages/generator-service/test/formatting.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * The services this generator writes are still formatted, after losing their private formatter.
+ *
+ * This package used to carry its own copy of `formatCode`, with its own `await import('prettier')`
+ * that bundled 11 MB of prettier into `dist`. Deleting the copy in favour of the one exported by
+ * @drzl/validation-core is invisible to every other test here: unformatted output is still valid
+ * TypeScript, still parses, still typechecks, and none of the sibling specs assert on whitespace.
+ * A wired-up call that silently stopped formatting would therefore look exactly like success.
+ *
+ * So this compares the emitted file against what prettier makes of the same file, rather than
+ * against a fixed string, which keeps it honest without pinning prettier's output style.
+ */
+import { describe, it, expect } from 'vitest';
+import { ServiceGenerator } from '../src';
+import type { Analysis } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const analysis: Analysis = {
+  dialect: 'sqlite',
+  tables: [
+    {
+      name: 'users',
+      tsName: 'users',
+      columns: [
+        {
+          name: 'id',
+          tsType: 'number',
+          dbType: 'INTEGER',
+          nullable: false,
+          hasDefault: true,
+          isGenerated: true,
+        },
+        {
+          name: 'email',
+          tsType: 'string',
+          dbType: 'TEXT',
+          nullable: false,
+          hasDefault: false,
+          isGenerated: false,
+        },
+      ],
+      unique: [],
+      indexes: [],
+      primaryKey: { columns: ['id'] },
+    } as never,
+  ],
+  enums: [],
+  relations: [],
+  issues: [],
+};
+
+/** Emit into a temp directory, so no .prettierrc.json above it can affect the comparison. */
+async function emit(format?: { enabled?: boolean }) {
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-svc-fmt-'));
+  const files = await new ServiceGenerator(analysis).generate({
+    outDir,
+    dataAccess: 'stub',
+    format,
+  });
+  const service = files.find((f) => /Service\.ts$/.test(f))!;
+  const types = files.find((f) => /types\/users\.ts$/.test(f))!;
+  return {
+    service: await fs.readFile(service, 'utf8'),
+    types: await fs.readFile(types, 'utf8'),
+    at: service,
+  };
+}
+
+describe('emitted service output', () => {
+  it('is formatted by prettier, not merely written out', async () => {
+    const formatted = await emit();
+    const raw = await emit({ enabled: false });
+    const prettier = await import('prettier');
+    expect(formatted.service).toBe(
+      await prettier.format(raw.service, { parser: 'typescript', filepath: raw.at })
+    );
+    // The two agreeing would also be satisfied by output that needs no formatting, so the raw
+    // form has to be different for the comparison above to have proved anything.
+    expect(formatted.service).not.toBe(raw.service);
+  });
+
+  it('formats the types file too, which is written by the same call', async () => {
+    const { types } = await emit();
+    const { types: raw } = await emit({ enabled: false });
+    expect(types).not.toBe(raw);
+  });
+
+  it('still honours format.enabled false', async () => {
+    // The one setting a shared implementation could plausibly drop, and the only way a user has
+    // of keeping DRZL's hands off their whitespace.
+    const { service } = await emit({ enabled: false });
+    expect(service).toContain('export class UserService {');
+  });
+});

--- a/packages/generator-typebox/package.json
+++ b/packages/generator-typebox/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --clean",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
   },

--- a/packages/generator-valibot/package.json
+++ b/packages/generator-valibot/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --clean",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
   },

--- a/packages/generator-zod/package.json
+++ b/packages/generator-zod/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --clean",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
   },

--- a/packages/template-orpc-service/package.json
+++ b/packages/template-orpc-service/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --clean",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
   },

--- a/packages/template-standard/package.json
+++ b/packages/template-standard/package.json
@@ -11,7 +11,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --clean",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
   },

--- a/packages/validation-core/package.json
+++ b/packages/validation-core/package.json
@@ -11,11 +11,19 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --dts --format esm,cjs",
+    "build": "tsup src/index.ts --dts --format esm,cjs --external prettier --clean",
     "test": "vitest run --testTimeout=20000"
   },
   "dependencies": {
     "@drzl/analyzer": "workspace:^"
+  },
+  "peerDependencies": {
+    "prettier": ">=3"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -221,6 +221,19 @@ export function selectColumns(table: Table): Column[] {
   return table.columns;
 }
 
+/**
+ * Pretty-print emitted code with whatever formatter the consumer already has.
+ *
+ * Both formatters are optional peers, reached at call time and never bundled. Prettier used to be
+ * bundled, because tsup resolves the specifier below statically and esbuild then inlined all of
+ * it: 11 MB per package across the three that had a copy of this function, roughly 32 MB for
+ * anyone installing @drzl/cli. It is `--external` in every build script that can reach it, and
+ * no-bundled-formatter.spec.ts builds those scripts and checks.
+ *
+ * Neither absence is an error. A consumer with no formatter gets the code as rendered, which is
+ * valid TypeScript that merely looks worse, and losing generated files at the last step would be
+ * a far worse trade than losing their whitespace.
+ */
 export async function formatCode(code: string, filePath: string, fmt?: FormatOptions) {
   if (fmt && fmt.enabled === false) return code;
   const engine = fmt?.engine ?? 'auto';
@@ -239,6 +252,13 @@ export async function formatCode(code: string, filePath: string, fmt?: FormatOpt
       if (biome?.formatContent) {
         const res = await biome.formatContent(code, { filePath });
         return (res && (res.content || res.formatted)) ?? code;
+      }
+      // Biome has shipped this entry point under both names. The second was only ever tried by
+      // the oRPC generator's private copy of this function, and is kept here so that folding the
+      // copies together takes nothing away from it.
+      if (biome?.format) {
+        const res = await biome.format(code, { filePath });
+        return res ?? code;
       }
     }
   } catch {}

--- a/packages/validation-core/test/format-without-prettier.spec.ts
+++ b/packages/validation-core/test/format-without-prettier.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * `formatCode` when prettier cannot be resolved.
+ *
+ * Prettier is an optional peer, so the common case for a consumer who never asked for it is that
+ * the module is simply not there. A missing optional peer surfaces as a rejected dynamic import,
+ * and an unhandled one would take down `drzl generate` at the last step, after every file had
+ * already been rendered. The existing `try {} catch {}` suggests that cannot happen; asserting it
+ * is the difference between suggesting and knowing.
+ *
+ * Absence is simulated here rather than uninstalled, so the whole file mocks the module away.
+ * The real artefact is exercised against a real missing peer, in a child process with no
+ * node_modules at all, by no-bundled-formatter.spec.ts.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import { formatCode } from '../src';
+
+// What Node throws for a bare specifier it cannot resolve. Thrown from the factory rather than
+// returned as a stub module, because a stub would exercise a prettier that exists and misbehaves,
+// which is a different failure.
+vi.mock('prettier', () => {
+  throw new Error("Cannot find package 'prettier' imported from drzl");
+});
+
+const filePath = path.join(os.tmpdir(), 'drzl-format-probe', 'schema.ts');
+const mangled = "export  const  a={x:1,y:'two'}\n";
+
+describe('formatCode with prettier unresolvable', () => {
+  it('really cannot resolve prettier here', async () => {
+    // Without this the rest of the file passes for the wrong reason the day the mock stops
+    // applying: prettier would format, the code would come back changed, and only the two
+    // assertions below would be left to notice.
+    await expect(import('prettier')).rejects.toThrow();
+  });
+
+  it('returns the code unchanged instead of throwing', async () => {
+    expect(await formatCode(mangled, filePath)).toBe(mangled);
+  });
+
+  it('returns the code unchanged when prettier is demanded by name', async () => {
+    // `engine: 'prettier'` skips the biome fallback entirely, so this is the path with nothing
+    // left to catch the rejection.
+    expect(await formatCode(mangled, filePath, { engine: 'prettier' })).toBe(mangled);
+  });
+});

--- a/packages/validation-core/test/format.spec.ts
+++ b/packages/validation-core/test/format.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * `formatCode` when prettier is installed, executed rather than string-matched.
+ *
+ * Prettier is no longer bundled into this package; it is an optional peer resolved at call time.
+ * The failure that buys is silent: unformatted output is still valid TypeScript, so formatting
+ * could stop happening for every user of every generator while the entire suite stayed green.
+ * Nothing else here would notice, because nothing else asserts on whitespace.
+ *
+ * So these feed deliberately mangled input through and demand prettier's exact output back.
+ * Its pair, format-without-prettier.spec.ts, covers the other half: the peer being absent has
+ * to degrade to unformatted code rather than throw.
+ */
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import { formatCode } from '../src';
+
+// Outside the workspace on purpose. `resolveConfig` walks up from this path, so a path inside
+// the repo would pick up .prettierrc.json and the expected output would then depend on it.
+const filePath = path.join(os.tmpdir(), 'drzl-format-probe', 'schema.ts');
+
+const mangled = "export  const  a={x:1,y:'two'}\nexport  function  f(  n:number  ){return n+1}\n";
+
+describe('formatCode with prettier resolvable', () => {
+  it('returns prettier output rather than the input', async () => {
+    // Prettier's defaults, since nothing above a temp directory configures it: double quotes,
+    // semicolons, two-space indent. Spelled out in full so that formatting being skipped, or
+    // quietly replaced by something else, cannot pass.
+    expect(await formatCode(mangled, filePath)).toBe(
+      'export const a = { x: 1, y: "two" };\nexport function f(n: number) {\n  return n + 1;\n}\n'
+    );
+  });
+
+  it('honours a nearby prettier config instead of imposing its own defaults', async () => {
+    // The repo's own .prettierrc.json sets singleQuote, and this path resolves against it.
+    // A formatter that ignored the user's config would be as wrong as one that did not run.
+    const inRepo = path.join(import.meta.dirname, 'format-config-probe.ts');
+    expect(await formatCode(mangled, inRepo)).toContain("y: 'two'");
+  });
+
+  it('leaves the code untouched when formatting is switched off', async () => {
+    expect(await formatCode(mangled, filePath, { enabled: false })).toBe(mangled);
+  });
+
+  it('falls through to the input when the chosen engine is biome and biome is absent', async () => {
+    // The biome branch is reached through a `Function`-built import precisely so no bundler can
+    // see it. Selecting it with biome uninstalled must degrade, not throw.
+    expect(await formatCode(mangled, filePath, { engine: 'biome' })).toBe(mangled);
+  });
+});

--- a/packages/validation-core/test/no-bundled-formatter.spec.ts
+++ b/packages/validation-core/test/no-bundled-formatter.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * The published bundles must not contain a formatter, and must still work without one.
+ *
+ * `formatCode` reached prettier through `await import('prettier')`, a specifier tsup can resolve
+ * statically, so esbuild inlined the whole of prettier into `dist`: 11 MB per package across the
+ * three that had a copy of the function, roughly 32 MB pulled in by installing `@drzl/cli`. The
+ * source looked correct throughout. Only the artefact was wrong, which is why this asserts on a
+ * real build rather than on the source.
+ *
+ * It builds each package with the `build` script from its own package.json, so removing the
+ * `--external` flag there fails here rather than only at publish time, and it runs the built
+ * entry in a child process with no node_modules in scope, which is a genuinely missing optional
+ * peer rather than a mocked one.
+ *
+ * It lives in validation-core because validation-core owns `formatCode`; the other two packages
+ * are covered here because they are the ones that used to carry a private copy of it.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..');
+
+/** Every package that has ever reached `formatCode`, and so could bundle a formatter again. */
+const packages = ['validation-core', 'generator-orpc', 'generator-service'];
+
+/**
+ * A formatter is megabytes; everything DRZL emits is tens of kilobytes. Anything between the two
+ * is worth a look, so the ceiling is deliberately far above the real figure rather than a budget
+ * to be tuned. Raising it is not the fix for a build that started bundling a dependency.
+ */
+const CEILING = 1_000_000;
+
+/**
+ * A string prettier's own source contains and nothing here does. The size check alone would catch
+ * a whole formatter; this one names it, and catches a partial parser too.
+ */
+const MARKER = 'prettier-ignore';
+
+const built = new Map<string, Promise<string>>();
+
+/** Run a package's real build script into a temp directory, so nothing stale can answer for it. */
+function build(pkg: string): Promise<string> {
+  const existing = built.get(pkg);
+  if (existing) return existing;
+  const run = (async () => {
+    const dir = path.join(repoRoot, 'packages', pkg);
+    const manifest = JSON.parse(await fs.readFile(path.join(dir, 'package.json'), 'utf8'));
+    const script: string = manifest.scripts.build;
+    expect(script, `${pkg} has no build script`).toMatch(/^tsup /);
+    const out = await fs.mkdtemp(path.join(os.tmpdir(), `drzl-build-${pkg}-`));
+    // `pnpm exec` so the workspace's own tsup answers, and a shell so the script is run exactly
+    // as written rather than re-assembled from parsed arguments.
+    execFileSync('pnpm', ['exec', 'sh', '-c', `${script} --out-dir ${out}`], {
+      cwd: dir,
+      stdio: 'pipe',
+    });
+    return out;
+  })();
+  built.set(pkg, run);
+  return run;
+}
+
+async function outputFiles(dir: string) {
+  const names = (await fs.readdir(dir)).filter((f) => /\.(js|cjs|mjs)$/.test(f));
+  return Promise.all(
+    names.map(async (name) => ({ name, text: await fs.readFile(path.join(dir, name), 'utf8') }))
+  );
+}
+
+describe.each(packages)('%s, freshly built', (pkg) => {
+  it('is small enough that no formatter can be hiding in it', async () => {
+    const dir = await build(pkg);
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    let total = 0;
+    for (const e of entries) {
+      if (e.isFile()) total += (await fs.stat(path.join(dir, e.name))).size;
+    }
+    expect(total, `${pkg} dist is ${(total / 1e6).toFixed(1)} MB`).toBeLessThan(CEILING);
+  });
+
+  it('contains no prettier source', async () => {
+    const dir = await build(pkg);
+    const offenders = (await outputFiles(dir)).filter((f) => f.text.includes(MARKER));
+    expect(offenders.map((f) => f.name)).toEqual([]);
+  });
+});
+
+describe('the built validation-core entry', () => {
+  it('still asks for prettier by name, rather than having lost the call', async () => {
+    // The cheap way to shrink the bundle is to stop calling prettier at all, which would pass
+    // both checks above and silently unformat every generated file. The specifier surviving in
+    // the output is what separates "external" from "gone".
+    const dir = await build('validation-core');
+    const esm = await fs.readFile(path.join(dir, 'index.js'), 'utf8');
+    const cjs = await fs.readFile(path.join(dir, 'index.cjs'), 'utf8');
+    expect(esm).toMatch(/import\("prettier"\)/);
+    expect(cjs).toMatch(/require\("prettier"\)/);
+  });
+
+  it('returns the code unchanged when prettier is genuinely not installed', async () => {
+    const dir = await build('validation-core');
+    // A copy outside the workspace, so Node's resolver cannot walk up into this repo's
+    // node_modules and find prettier there.
+    const sandbox = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-no-peer-'));
+    for (const name of await fs.readdir(dir)) {
+      await fs.copyFile(path.join(dir, name), path.join(sandbox, name));
+    }
+    // Without this, `.js` in a directory with no manifest is read as CommonJS.
+    await fs.writeFile(path.join(sandbox, 'package.json'), '{"type":"module"}');
+    await fs.writeFile(
+      path.join(sandbox, 'probe.mjs'),
+      [
+        'const input = "export  const  a={x:1,y:\'two\'}\\n";',
+        "const at = new URL('./generated.ts', import.meta.url).pathname;",
+        'let resolved = true;',
+        "try { await import('prettier'); } catch { resolved = false; }",
+        'const out = {};',
+        "for (const entry of ['./index.js', './index.cjs']) {",
+        '  const mod = await import(entry);',
+        '  const fn = mod.formatCode ?? mod.default?.formatCode;',
+        '  out[entry] = (await fn(input, at)) === input;',
+        '}',
+        'process.stdout.write(JSON.stringify({ resolved, out }));',
+      ].join('\n')
+    );
+    // A child process, because vitest resolves bare specifiers through vite against this
+    // workspace: an in-process import would have found the repo's prettier and proved nothing.
+    const raw = execFileSync(process.execPath, ['probe.mjs'], { cwd: sandbox, encoding: 'utf8' });
+    const result = JSON.parse(raw);
+    expect(result.resolved, 'prettier resolved in the sandbox, so this proved nothing').toBe(false);
+    expect(result.out).toEqual({ './index.js': true, './index.cjs': true });
+  });
+});

--- a/packages/validation-core/test/no-bundled-formatter.spec.ts
+++ b/packages/validation-core/test/no-bundled-formatter.spec.ts
@@ -96,8 +96,11 @@ describe('the built validation-core entry', () => {
     const dir = await build('validation-core');
     const esm = await fs.readFile(path.join(dir, 'index.js'), 'utf8');
     const cjs = await fs.readFile(path.join(dir, 'index.cjs'), 'utf8');
+    // Both, and in the same form: esbuild leaves an external `import()` alone in a CJS bundle
+    // rather than lowering it to `require`, which is what lets a CommonJS consumer reach an
+    // ESM-only prettier at all.
     expect(esm).toMatch(/import\("prettier"\)/);
-    expect(cjs).toMatch(/require\("prettier"\)/);
+    expect(cjs).toMatch(/import\("prettier"\)/);
   });
 
   it('returns the code unchanged when prettier is genuinely not installed', async () => {

--- a/packages/validation-core/test/no-bundled-formatter.spec.ts
+++ b/packages/validation-core/test/no-bundled-formatter.spec.ts
@@ -7,10 +7,21 @@
  * source looked correct throughout. Only the artefact was wrong, which is why this asserts on a
  * real build rather than on the source.
  *
- * It builds each package with the `build` script from its own package.json, so removing the
- * `--external` flag there fails here rather than only at publish time, and it runs the built
- * entry in a child process with no node_modules in scope, which is a genuinely missing optional
- * peer rather than a mocked one.
+ * It builds each package with the `build` script from its own package.json rather than a build
+ * of its own, and runs the built entry in a child process with no node_modules in scope, which is
+ * a genuinely missing optional peer rather than a mocked one.
+ *
+ * What the byte-level checks below can and cannot see, measured rather than assumed. Two separate
+ * things keep prettier out of the bundle, and **either one alone is sufficient**: the
+ * `--external prettier` flag in the build script, and the `peerDependencies` entry, which tsup
+ * externalises by default. Deleting either one on its own leaves all of these green, because the
+ * bundle really is still correct. Only deleting both puts prettier back, and that these catch.
+ *
+ * That leaves a gap those checks structurally cannot cover, so it is asserted directly at the
+ * bottom of this file: dropping the peer entry keeps the bundle small and still breaks users.
+ * pnpm links an optional peer into the package's own node_modules only because it is declared,
+ * so without the entry `import('prettier')` resolves to nothing for a pnpm consumer and their
+ * output silently stops being formatted, with no size change to notice it by.
  *
  * It lives in validation-core because validation-core owns `formatCode`; the other two packages
  * are covered here because they are the ones that used to carry a private copy of it.
@@ -135,5 +146,36 @@ describe('the built validation-core entry', () => {
     const result = JSON.parse(raw);
     expect(result.resolved, 'prettier resolved in the sandbox, so this proved nothing').toBe(false);
     expect(result.out).toEqual({ './index.js': true, './index.cjs': true });
+  });
+});
+
+describe('the two declarations that keep prettier external', () => {
+  const manifest = async () =>
+    JSON.parse(
+      await fs.readFile(path.join(repoRoot, 'packages/validation-core/package.json'), 'utf8')
+    );
+
+  it('declares prettier as an optional peer, and the install honours it', async () => {
+    // The one deletion nothing above can see. Removing this entry leaves the bundle exactly as
+    // small and correct as it is now, and stops prettier resolving for a pnpm consumer, because
+    // pnpm links an optional peer into the package's own node_modules only when it is declared.
+    // Their generated files would quietly stop being formatted with no size change to notice by.
+    const pkg = await manifest();
+    expect(pkg.peerDependencies?.prettier).toBe('>=3');
+    expect(pkg.peerDependenciesMeta?.prettier?.optional).toBe(true);
+    // Declared and then actually linked, which is the mechanism rather than the intent. A missing
+    // link here means the entry was added without the lockfile being regenerated.
+    await expect(
+      fs.stat(path.join(repoRoot, 'packages/validation-core/node_modules/prettier'))
+    ).resolves.toBeTruthy();
+  });
+
+  it('also passes --external prettier, which is a second and independent guarantee', async () => {
+    // tsup externalises peerDependencies on its own, so this flag is redundant while the entry
+    // above exists, and that is the point: either one alone keeps prettier out of the bundle, so
+    // one of them being lost is survivable. Delete this assertion if you delete the flag, and
+    // know that the peer entry is then all that stands between this build and 11 MB.
+    const pkg = await manifest();
+    expect(pkg.scripts.build).toContain('--external prettier');
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ importers:
       '@drzl/analyzer':
         specifier: workspace:^
         version: link:../analyzer
+      prettier:
+        specifier: '>=3'
+        version: 3.9.6
     devDependencies:
       tsup:
         specifier: ^8.5.1

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -26,10 +26,41 @@ APP="$WORK/consumer"
 mkdir -p "$TARS" "$APP/src/db"
 
 echo "==> building"
+# A file in every dist that no build produces, checked for afterwards.
+#
+# `files: ["dist"]` packs whatever is in the directory, and tsup does not clean it unless told to,
+# so anything a previous build left behind is published. That is not theoretical: @drzl/cli's dist
+# held 46 files totalling 950 KB where a clean build produces 16 and 417 KB, 30 stale
+# content-hashed chunks from three different dates, and validation-core held two full generations
+# of prettier's parser chunks. CI checks out fresh and never sees it; a maintainer running
+# `pnpm release` locally publishes it. The size ceiling below cannot catch this, because stale
+# chunks are small.
+#
+# A canary rather than a file-list comparison, because it costs one build instead of two and
+# fails for exactly one reason: this package's build does not clean its output.
+CANARY='stale-canary.js'
+for dir in "$ROOT"/packages/*/; do
+  mkdir -p "$dir/dist"
+  echo '// seeded by verify-packed; a build that cleans its output removes this' > "$dir/dist/$CANARY"
+done
+
 # `build:packages`, not `build`: the workspace also contains the docs site, whose vitepress
 # build is slow and cannot affect a tarball. This is the same filtered, topologically sorted
 # build the release workflow runs, so what gets packed here is what gets packed there.
 (cd "$ROOT" && pnpm build:packages >/dev/null)
+
+stale=""
+for dir in "$ROOT"/packages/*/; do
+  [ -e "$dir/dist/$CANARY" ] && stale="$stale $(basename "$dir")"
+  rm -f "$dir/dist/$CANARY"
+done
+if [ -n "$stale" ]; then
+  echo "FAIL: these builds do not clean their output dir, so stale files from a previous" >&2
+  echo "      build get published:$stale" >&2
+  echo "      Add --clean to the tsup invocation in each package's build script." >&2
+  exit 1
+fi
+echo "    every build cleans its output dir"
 
 echo "==> packing publishable packages"
 count=0
@@ -182,13 +213,17 @@ rm -f load-probe.mjs
 
 # Exit code alone is not enough: a generator that writes an empty barrel still exits 0.
 #
-# Either quote, because the quote is the formatter's and not the generator's: the generator emits
-# single quotes and prettier's defaults rewrite them. Pinning the double-quoted form made this
-# read as an assertion about the `.js` extension while actually asserting that prettier had run,
-# and it failed with "the barrel does not emit a .js specifier" over a barrel that plainly did.
-grep -qE "export \* from ['\"]\./users\.zod\.js['\"];" "$BARREL" || {
-  echo "FAIL: the barrel does not emit a .js specifier. Generated output will not resolve" >&2
-  echo "      under moduleResolution node16 or nodenext. Barrel was:" >&2
+# Double quotes deliberately, and they are load-bearing twice over. The generator emits single
+# quotes; the double ones are prettier's defaults rewriting them, so this line is also the only
+# end-to-end proof in the whole run that formatting actually happened through a real install of
+# the optional peer. Nothing else here would notice formatting silently stopping, which is not
+# hypothetical: the CJS bundle formatted nothing at all for as long as it existed and every gate
+# stayed green. The single-quoted form is asserted further down, with prettier hidden.
+grep -q 'export \* from "./users.zod.js";' "$BARREL" || {
+  echo "FAIL: the barrel is not what a consumer with prettier installed should get. Either the" >&2
+  echo "      .js specifier is missing, so the output will not resolve under moduleResolution" >&2
+  echo "      node16 or nodenext, or the optional peer stopped being used and nothing was" >&2
+  echo "      formatted. Barrel was:" >&2
   cat "$BARREL" >&2
   exit 1
 }

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -48,6 +48,28 @@ if [ "$count" -eq 0 ]; then
   exit 1
 fi
 
+# What each package weighs on the wire, which is the only number a user pays.
+#
+# Three of these shipped at 2.8 MB packed and 11 MB unpacked, because `await import('prettier')`
+# is a specifier tsup can resolve and esbuild inlined the whole formatter behind it. Installing
+# @drzl/cli pulled in roughly 32 MB of duplicated prettier parsers. Nothing in the workspace could
+# see it: the source was right, the tests passed, and only the artefact was wrong.
+#
+# The ceiling is per tarball and deliberately far above the real figures, which are tens of
+# kilobytes. It is a tripwire for a dependency that got bundled, not a byte budget. Raising it is
+# not how you fix a build that started inlining one.
+TARBALL_CEILING=1000000
+size_over=0
+for tgz in "$TARS"/*.tgz; do
+  bytes=$(wc -c < "$tgz")
+  if [ "$bytes" -gt "$TARBALL_CEILING" ]; then
+    echo "FAIL: $(basename "$tgz") is $bytes bytes packed, over the ${TARBALL_CEILING} ceiling." >&2
+    echo "      Something is being bundled that should be external." >&2
+    size_over=1
+  fi
+done
+[ "$size_over" = 0 ] || exit 1
+
 echo "==> installing them into an empty project"
 # A real foreign key, because the oRPC generator derives relation endpoints from one and a
 # schema without any would exercise none of that path.
@@ -102,8 +124,13 @@ node -e "
 # and npm's flat layout is the harsher test of whether `dependencies` are actually declared.
 # valibot, arktype and @orpc/server are peers of the generators, so the generated tree cannot
 # typecheck without them present, exactly as in a consumer's project.
+#
+# prettier is here because it is now an *optional* peer of @drzl/validation-core rather than
+# something bundled into it, and npm does not install optional peers. Naming it is what a
+# consumer who wants formatted output does, and it makes this run cover the peer resolving from
+# a real install. The stage further down removes it again to cover the other case.
 npm install --no-audit --no-fund --loglevel=error \
-  "$TARS"/*.tgz drizzle-orm zod valibot arktype @orpc/server typescript tsx >/dev/null
+  "$TARS"/*.tgz drizzle-orm zod valibot arktype @orpc/server typescript tsx prettier >/dev/null
 
 if [ ! -e node_modules/.bin/drzl ]; then
   echo "FAIL: the drzl bin did not resolve after a real install." >&2
@@ -154,7 +181,12 @@ fi
 rm -f load-probe.mjs
 
 # Exit code alone is not enough: a generator that writes an empty barrel still exits 0.
-grep -q 'export \* from "./users.zod.js";' "$BARREL" || {
+#
+# Either quote, because the quote is the formatter's and not the generator's: the generator emits
+# single quotes and prettier's defaults rewrite them. Pinning the double-quoted form made this
+# read as an assertion about the `.js` extension while actually asserting that prettier had run,
+# and it failed with "the barrel does not emit a .js specifier" over a barrel that plainly did.
+grep -qE "export \* from ['\"]\./users\.zod\.js['\"];" "$BARREL" || {
   echo "FAIL: the barrel does not emit a .js specifier. Generated output will not resolve" >&2
   echo "      under moduleResolution node16 or nodenext. Barrel was:" >&2
   cat "$BARREL" >&2
@@ -261,6 +293,62 @@ EOF
   fi
   echo "    $dialect ok"
 done
+
+# ---------------------------------------------------------------------------------------------
+# The consumer who has no formatter at all.
+#
+# prettier used to be bundled into three packages, 11 MB each, so formatting could not fail to be
+# available. It is an optional peer now, which makes "no formatter installed" an ordinary and
+# supported state rather than a broken install. The whole run happens after every file has been
+# rendered, so an unhandled rejection there would lose a completed generation at the last step.
+#
+# Hidden rather than uninstalled, because npm would take the tarballs with it.
+# ---------------------------------------------------------------------------------------------
+echo "==> generating with no formatter installed"
+mv node_modules/prettier node_modules/.prettier-hidden
+cat > drzl.config.ts <<'CONFIG'
+export default {
+  schema: './src/db/schema.ts',
+  outDir: './src/unformatted/api',
+  generators: [
+    { kind: 'zod', path: './src/unformatted/zod' },
+    { kind: 'service', path: './src/unformatted/services' },
+    { kind: 'orpc' },
+  ],
+};
+CONFIG
+if ! npx drzl generate >/dev/null; then
+  mv node_modules/.prettier-hidden node_modules/prettier
+  echo "FAIL: drzl generate does not survive prettier being absent. It is an optional peer," >&2
+  echo "      so this is a normal install, and the failure would come after every file was" >&2
+  echo "      already rendered." >&2
+  exit 1
+fi
+mv node_modules/.prettier-hidden node_modules/prettier
+
+# Unformatted has to still mean complete and valid. Single quotes are what the generator emits
+# before a formatter sees it, so this also confirms nothing formatted the file behind our backs
+# and made the check vacuous.
+grep -q "export \* from './users.zod.js';" src/unformatted/zod/index.ts || {
+  echo "FAIL: the unformatted barrel is not what the generator emits. Was:" >&2
+  cat src/unformatted/zod/index.ts >&2
+  exit 1
+}
+cat > tsconfig.unformatted.json <<'EOF'
+{
+  "compilerOptions": {
+    "strict": true, "noEmit": true, "target": "es2022",
+    "module": "nodenext", "moduleResolution": "nodenext", "skipLibCheck": true
+  },
+  "include": ["src/unformatted/**/*.ts", "src/db/**/*.ts"]
+}
+EOF
+if ! npx tsc -p tsconfig.unformatted.json; then
+  echo "FAIL: output emitted without a formatter does not typecheck. Formatting is cosmetic," >&2
+  echo "      so anything broken here was broken before prettier tidied it." >&2
+  exit 1
+fi
+echo "    unformatted output is complete and typechecks"
 
 # ---------------------------------------------------------------------------------------------
 # Every config the documentation tells a reader to write.


### PR DESCRIPTION
Plan items 1 to 4. Executed with a fresh implementer, an adversarial task review, one fix round,
and a scoped re-review, each verifying by execution rather than by reading.

## The defect

```
@drzl/validation-core:   11,081,554 bytes unpacked  (2.88 MB packed)
@drzl/generator-orpc:    11,056,126                 (2.86 MB)
@drzl/generator-service: 11,014,132                 (2.85 MB)
```

`formatCode` did `await import('prettier')`. That specifier is statically analysable, so esbuild
inlined the whole formatter, including its Flow and TypeScript parsers. `generator-orpc` and
`generator-service` each carried their **own private copy** of `formatCode`, which is why three
packages paid for it. Installing `@drzl/cli` pulled roughly **32 MB of duplicated parsers**.

Nothing in the workspace could see it: the source was right, the tests passed, only the artefact
was wrong.

## After

| package | dist before | dist after | packed before | packed after |
| --- | ---: | ---: | ---: | ---: |
| `@drzl/validation-core` | 11,081,554 | **89,940** | 2.88 MB | **34 KB** |
| `@drzl/generator-orpc` | 11,056,126 | **60,310** | 2.86 MB | **15 KB** |
| `@drzl/generator-service` | 11,014,132 | **18,852** | 2.85 MB | **8 KB** |

Prettier is external to every bundle and declared an optional peer of `@drzl/validation-core`. The
two private `formatCode` copies are gone; both packages already depended on validation-core. The
one real behavioural difference between the copies (oRPC also accepted a biome `format` export)
moved into the shared implementation rather than being dropped.

## The bug this uncovered

**The bundled prettier never worked in CJS at all.**

```
TypeError [ERR_INVALID_ARG_VALUE]: The argument 'filename' must be a file URL object,
file URL string, or absolute path string. Received undefined
    at createRequire (node:internal/modules/cjs/loader:1910:11)
    at .../prettier/index.mjs (index.cjs:71925:48)
```

Prettier's ESM entry calls `createRequire(import.meta.url)`, and esbuild substitutes `undefined`
for `import.meta.url` in a CJS bundle. `formatCode`'s `catch {}` swallowed it, so every
`require('@drzl/validation-core')` consumer got unformatted output while paying 5.5 MB for a
formatter that threw on first use. Both entries are now exercised by tests.

## `@drzl/cli` was publishing 30 stale files

Found by the task review. `packages/cli/dist` held **46 files / 950,124 bytes** where a clean
build is **16 / 416,106**: 30 survivors from three different dates, and `files: ["dist"]` ships
all of them from a local `pnpm release`. tsup does not clean its output directory. All 12 packages
now pass `--clean`.

The three packages this PR shrank had emitted 15 hashed chunks each until this branch, so their
"`--clean` is a no-op" property is a property of the fix, not a guarantee.

## Gates added, each proven able to fail

- **Per-tarball size ceiling** (1 MB). A tripwire for a bundled dependency, not a byte budget.
- **A staleness gate**: seeds a canary into every `packages/*/dist`, runs the real build, fails on
  any survivor. Verified it reports `STALE: generator-zod` when `--clean` is removed from one
  package, and nothing otherwise. It is a staleness gate, not a grep for the flag.
- **A "no formatter installed" stage**: hides `node_modules/prettier`, regenerates, asserts the run
  exits 0, the barrel comes out in the generator's own single quotes, and the unformatted tree
  still typechecks under `nodenext`.
- **Bundle assertions** on size, on a prettier marker string, and on the `import("prettier")`
  specifier surviving in `dist`.

## A gate that was really asserting something else

`verify:packed` grepped for `export * from "./users.zod.js";` in **double quotes**. The generator
emits single quotes; prettier's defaults rewrite them. So that assertion passed only because
prettier was bundled, and it was the only end-to-end signal that formatting ran at all.

The first attempt loosened it to accept either quote. The review caught that as a weakening: with
prettier installed the strict grep passes untouched. It is restored strict in the main stage, with
the single-quote form asserted in the new unformatted stage, so **both** states are covered.

## Review found a false claim in the gate's own comment

The spec's header said removing `--external prettier` would fail it. Mutation testing showed it
does not: `peerDependencies: { prettier }` alone is enough for tsup to externalize. Dropping
*either* alone leaves the bundle correct; only dropping **both** puts prettier back. Both are now
asserted individually, and the comment says what is actually true.

| mutation | result |
| --- | --- |
| drop `--external prettier` | 1 failed / 9 passed |
| drop the peer block | 1 failed / 9 passed |
| drop both | 6 failed / 4 passed, `expected 11083380 to be less than 1000000` |

## Behaviour change, disclosed

A consumer with neither prettier nor biome installed now gets generated files exactly as rendered:
the same valid TypeScript, single-quoted and less tidily wrapped. That is inherent in making
prettier optional, and it is the trade for 32 MB. CJS consumers move the other way, from
unformatted to formatted, because their formatter never ran.

Generated output is otherwise **byte-identical**: the review generated from source at both commits
and diffed.

## Verification

720 tests across 98 files, `pnpm typecheck` and `pnpm lint` clean, and the full `verify:packed`
green: parity across three dialects, 1400 Postgres probes, 53 Postgres and 32 SQLite CHECK probes,
the cross-major analyzer diff, and the new size, staleness and no-formatter stages.
