### PR TITLE
test(verify): assert the published artefacts are loadable and correctly described

### DIFF
--- a/packages/cli/test/every-entry-loads.spec.ts
+++ b/packages/cli/test/every-entry-loads.spec.ts
@@ -1,6 +1,6 @@
 /**
- * Every entry point a published package names has to load, in both module formats, from a plain
- * Node process running against `dist`.
+ * Every entry point a published package names loads, in both module formats, from a plain Node
+ * process running against `dist`.
  *
  * `@drzl/validation-core`'s CommonJS bundle emitted unformatted output for its entire life.
  * `formatCode` reached prettier through `createRequire(import.meta.url)`, which esbuild lowers to
@@ -15,17 +15,24 @@
  * format that loads and exports a different shape is the same defect one step later.
  *
  * The CommonJS twin is checked even where no `exports` map names it, because tsup emits it under
- * `--format esm,cjs` and `files: ["dist"]` publishes it. A file that ships is a file a consumer
- * can reach.
+ * `--format esm,cjs` and `files: ["dist"]` publishes it.
  *
  * The CLI's own entry is a bin: it calls `program.parseAsync(process.argv)` at module scope, so
  * importing it runs the program. It is exercised the way a consumer reaches it instead, by being
  * run, which is the only form in which a CommonJS bundle that cannot start would show up.
  *
+ * **What this does and does not prove.** The child inherits the Node running the tests, which in
+ * this repo is 22.13 or newer, because pnpm 11 declares that floor and the workspace cannot be
+ * installed below it. From Node 22.12 onwards `require()` of an ES module is allowed, and that is
+ * what carries ten of these thirteen entries. It is not what the packages advertise: every
+ * manifest says `engines.node: ">=18.17.0"`. So a green run here means the bundles load on the
+ * Node this repo develops on, and says nothing about the floor the packages claim. The gap is
+ * measured rather than left to a comment, at the bottom of this file.
+ *
  * This asserts on the build, so the build has to have happened. `pnpm build` first.
  */
 import { describe, it, expect } from 'vitest';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -251,5 +258,79 @@ describe.each(cases)('$name $entry.subpath', ({ dir, entry }) => {
     }
     // Both sides at once, so a diff names the entry rather than reporting two unrelated failures.
     expect(result.cjs.exports).toEqual(result.esm.exports);
+  });
+});
+
+/**
+ * The same CommonJS files, on the Node the packages say they run on.
+ *
+ * `engines.node` is `">=18.17.0"` in all twelve manifests. `require()` of an ES module did not
+ * exist before Node 22.12, and ten of these thirteen entries need it, so on the advertised floor
+ * they throw `ERR_REQUIRE_ESM`. The block above cannot see that, because the Node running the
+ * tests is 22.13 or newer: pnpm 11 declares that floor and the workspace cannot be installed
+ * below it.
+ *
+ * `--no-experimental-require-module` turns the newer behaviour off, which is the closest a modern
+ * Node gets to the old one for this question.
+ *
+ * The cause is one line repeated: every failing bundle does `require("@drzl/<sibling>")`, and
+ * every DRZL package is `"type": "module"` with an ESM `main`, so the CommonJS build of one
+ * package can only reach another through an ESM file. The three that survive are exactly the
+ * three whose CommonJS bundle requires no `@drzl` sibling at all.
+ *
+ * This pins the measurement rather than endorsing it. It fails if the set grows, which is a new
+ * package inheriting the defect, and it fails if the set shrinks, which is the defect being fixed
+ * and this table needing to say so. It is not a passing grade for the CommonJS builds.
+ *
+ * Measured 2026-08-03 on Node 22.22.0.
+ */
+const ON_THE_ADVERTISED_ENGINE_FLOOR: Record<string, 'loads' | 'ERR_REQUIRE_ESM'> = {
+  'analyzer .': 'loads',
+  'cli .': 'ERR_REQUIRE_ESM',
+  'cli ./config': 'ERR_REQUIRE_ESM',
+  'generator-arktype .': 'ERR_REQUIRE_ESM',
+  'generator-json-schema .': 'ERR_REQUIRE_ESM',
+  'generator-orpc .': 'ERR_REQUIRE_ESM',
+  'generator-service .': 'ERR_REQUIRE_ESM',
+  'generator-typebox .': 'ERR_REQUIRE_ESM',
+  'generator-valibot .': 'ERR_REQUIRE_ESM',
+  'generator-zod .': 'ERR_REQUIRE_ESM',
+  'template-orpc-service .': 'ERR_REQUIRE_ESM',
+  'template-standard .': 'loads',
+  'validation-core .': 'loads',
+};
+
+const NO_REQUIRE_ESM = '--no-experimental-require-module';
+/** Node below 22.12 has no such flag and refuses to start, and on those versions the block above
+ *  measures this anyway, because there `require()` of an ES module is simply not available. */
+const flagAccepted = (() => {
+  try {
+    execFileSync(process.execPath, [NO_REQUIRE_ESM, '-e', ''], { stdio: 'pipe', timeout: 30_000 });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe.runIf(flagAccepted)('the CommonJS builds, on Node without require(esm)', () => {
+  it('still fail exactly where they are known to fail, and nowhere else', () => {
+    const measured: Record<string, string> = {};
+    for (const { dir, entry } of cases) {
+      const abs = path.join(packagesDir, dir, entry.cjs);
+      // `-e` with the path interpolated as a JSON literal, so nothing has to be escaped by hand.
+      // The error code is printed rather than thrown, so a bin that starts and then exits on its
+      // own argv cannot be mistaken for a load failure.
+      const src = `try { require(${JSON.stringify(abs)}); } catch (e) { process.stderr.write('DRZL_LOAD_ERROR:' + (e.code || e.name)); }`;
+      // spawnSync rather than execFileSync: the child reports the load failure on stderr and then
+      // exits 0, so execFileSync would return without ever handing the stderr over.
+      const run = spawnSync(process.execPath, [NO_REQUIRE_ESM, '-e', src], {
+        cwd: probeDir,
+        encoding: 'utf8',
+        timeout: 60_000,
+      });
+      const marker = String(run.stderr ?? '').match(/DRZL_LOAD_ERROR:(\w+)/);
+      measured[`${dir} ${entry.subpath}`] = marker ? marker[1] : 'loads';
+    }
+    expect(measured).toEqual(ON_THE_ADVERTISED_ENGINE_FLOOR);
   });
 });

--- a/packages/cli/test/every-entry-loads.spec.ts
+++ b/packages/cli/test/every-entry-loads.spec.ts
@@ -24,10 +24,13 @@
  * **What this does and does not prove.** The child inherits the Node running the tests, which in
  * this repo is 22.13 or newer, because pnpm 11 declares that floor and the workspace cannot be
  * installed below it. From Node 22.12 onwards `require()` of an ES module is allowed, and that is
- * what carries ten of these thirteen entries. It is not what the packages advertise: every
- * manifest says `engines.node: ">=18.17.0"`. So a green run here means the bundles load on the
- * Node this repo develops on, and says nothing about the floor the packages claim. The gap is
- * measured rather than left to a comment, at the bottom of this file.
+ * what carries ten of these thirteen entries. It is not what the packages advertise: eleven
+ * manifests say `engines.node: ">=18.17.0"` and `@drzl/cli` says `">=22"`, and every one of those
+ * floors predates 22.12. That last sentence is checked rather than trusted, by the first test
+ * below, because the previous version of this paragraph asserted a number that was wrong for one
+ * of the twelve. So a green run here means the bundles load on the Node this repo develops on,
+ * and says nothing about the floor the packages claim. The gap is measured rather than left to a
+ * comment, at the bottom of this file.
  *
  * This asserts on the build, so the build has to have happened. `pnpm build` first.
  */
@@ -46,6 +49,7 @@ interface Manifest {
   main?: string;
   bin?: Record<string, string>;
   exports?: Record<string, string | Record<string, string>>;
+  engines?: { node?: string };
 }
 
 const rel = (p: string) => p.replace(/^\.\//, '');
@@ -210,6 +214,29 @@ it('found every publishable package', () => {
   expect(cases.length).toBeGreaterThanOrEqual(publishable.length);
 });
 
+it('advertises a Node floor older than require(esm) everywhere', () => {
+  // The premise of the table at the bottom of this file, and of the header's claim about it,
+  // turned into something that fails rather than something a reader has to believe. The floors
+  // are not uniform: eleven manifests say 18.17.0 and @drzl/cli says 22, and a comment that said
+  // otherwise shipped once already.
+  const tooNew = publishable
+    .map(({ dir, manifest }) => {
+      const declared = manifest.engines?.node ?? '';
+      const m = declared.match(/>=\s*(\d+)(?:\.(\d+))?/);
+      const major = m ? Number(m[1]) : Number.NaN;
+      const minor = m ? Number(m[2] ?? 0) : Number.NaN;
+      // 22.12 is where `require()` of an ES module arrived. A floor at or above it would mean
+      // the table below is measuring a Node no consumer is promised, and is no longer evidence.
+      const predates = major < 22 || (major === 22 && minor < 12);
+      return { dir, declared, predates };
+    })
+    .filter((p) => !p.predates);
+  expect(
+    tooNew,
+    'engines.node no longer predates require(esm), so the table below is moot'
+  ).toEqual([]);
+});
+
 const entriesOf = (dir: string) => entryPoints(publishable.find((p) => p.dir === dir)!.manifest);
 
 describe.each(cases)('$name $entry.subpath', ({ dir, entry }) => {
@@ -264,11 +291,12 @@ describe.each(cases)('$name $entry.subpath', ({ dir, entry }) => {
 /**
  * The same CommonJS files, on the Node the packages say they run on.
  *
- * `engines.node` is `">=18.17.0"` in all twelve manifests. `require()` of an ES module did not
- * exist before Node 22.12, and ten of these thirteen entries need it, so on the advertised floor
- * they throw `ERR_REQUIRE_ESM`. The block above cannot see that, because the Node running the
- * tests is 22.13 or newer: pnpm 11 declares that floor and the workspace cannot be installed
- * below it.
+ * `engines.node` names a floor below 22.12 in all twelve manifests: eleven say `">=18.17.0"` and
+ * `@drzl/cli` says `">=22"`, which still predates it. That is asserted further up rather than
+ * left as a sentence here. `require()` of an ES module did not exist before 22.12, and ten of
+ * these thirteen entries need it, so on the advertised floor they throw `ERR_REQUIRE_ESM`. The
+ * block above cannot see that, because the Node running the tests is 22.13 or newer: pnpm 11
+ * declares that floor and the workspace cannot be installed below it.
  *
  * `--no-experimental-require-module` turns the newer behaviour off, which is the closest a modern
  * Node gets to the old one for this question.
@@ -331,6 +359,10 @@ describe.runIf(flagAccepted)('the CommonJS builds, on Node without require(esm)'
       const marker = String(run.stderr ?? '').match(/DRZL_LOAD_ERROR:(\w+)/);
       measured[`${dir} ${entry.subpath}`] = marker ? marker[1] : 'loads';
     }
-    expect(measured).toEqual(ON_THE_ADVERTISED_ENGINE_FLOOR);
+    expect(
+      measured,
+      'a + row is a package that has newly inherited this defect; a - row is one that no longer ' +
+        'has it, so update ON_THE_ADVERTISED_ENGINE_FLOOR and say which change fixed it'
+    ).toEqual(ON_THE_ADVERTISED_ENGINE_FLOOR);
   });
 });

--- a/packages/cli/test/every-entry-loads.spec.ts
+++ b/packages/cli/test/every-entry-loads.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * Every entry point a published package names has to load, in both module formats, from a plain
+ * Node process running against `dist`.
+ *
+ * `@drzl/validation-core`'s CommonJS bundle emitted unformatted output for its entire life.
+ * `formatCode` reached prettier through `createRequire(import.meta.url)`, which esbuild lowers to
+ * `createRequire(undefined)` in a CJS bundle, and a bare `catch {}` swallowed the throw. It
+ * survived because nothing in this repo had ever loaded a CJS build: every other test imports
+ * from source, and vitest resolves those imports through vite against the workspace, so an
+ * in-process `import` says nothing about what tsup emitted. One package is covered by
+ * `packages/validation-core/test/no-bundled-formatter.spec.ts`; this covers the other eleven.
+ *
+ * Hence a child process, plain Node, absolute paths into `dist`: `require()` for the CommonJS
+ * twin and `import()` for the ESM entry, with the two export surfaces then compared, because a
+ * format that loads and exports a different shape is the same defect one step later.
+ *
+ * The CommonJS twin is checked even where no `exports` map names it, because tsup emits it under
+ * `--format esm,cjs` and `files: ["dist"]` publishes it. A file that ships is a file a consumer
+ * can reach.
+ *
+ * The CLI's own entry is a bin: it calls `program.parseAsync(process.argv)` at module scope, so
+ * importing it runs the program. It is exercised the way a consumer reaches it instead, by being
+ * run, which is the only form in which a CommonJS bundle that cannot start would show up.
+ *
+ * This asserts on the build, so the build has to have happened. `pnpm build` first.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..');
+const packagesDir = path.join(repoRoot, 'packages');
+
+interface Manifest {
+  name: string;
+  private?: boolean;
+  main?: string;
+  bin?: Record<string, string>;
+  exports?: Record<string, string | Record<string, string>>;
+}
+
+const rel = (p: string) => p.replace(/^\.\//, '');
+
+/** Read from disk rather than listed, so a package added later is covered without editing this. */
+const publishable = fs
+  .readdirSync(packagesDir)
+  .filter((dir) => fs.existsSync(path.join(packagesDir, dir, 'package.json')))
+  .map((dir) => ({
+    dir,
+    manifest: JSON.parse(
+      fs.readFileSync(path.join(packagesDir, dir, 'package.json'), 'utf8')
+    ) as Manifest,
+  }))
+  .filter((p) => !p.manifest.private);
+
+interface Entry {
+  subpath: string;
+  esm: string;
+  cjs: string;
+  isBin: boolean;
+  /** Whether package.json names the CommonJS file, or it was derived as the twin beside the ESM
+   *  one. Only the wording of a failure depends on this, and getting it wrong sends the reader
+   *  looking for a field that is not there. */
+  cjsDeclared: boolean;
+}
+
+/**
+ * The entries a consumer can reach, each paired with the CommonJS twin beside it.
+ *
+ * `exports` when there is one, `main` otherwise. The twin is taken from the `require` condition
+ * where the map declares it and derived from the ESM filename where it does not, which is nine of
+ * the twelve packages: they publish a `.cjs` that no condition names.
+ */
+function entryPoints(m: Manifest): Entry[] {
+  const bins = new Set(Object.values(m.bin ?? {}).map(rel));
+  const found = new Map<string, Entry>();
+  const add = (subpath: string, esm: string | undefined, cjs: string | undefined) => {
+    if (!esm) return;
+    const esmPath = rel(esm);
+    found.set(subpath, {
+      subpath,
+      esm: esmPath,
+      cjs: cjs ? rel(cjs) : esmPath.replace(/\.js$/, '.cjs'),
+      isBin: bins.has(esmPath),
+      cjsDeclared: Boolean(cjs),
+    });
+  };
+  if (m.exports) {
+    for (const [subpath, conditions] of Object.entries(m.exports)) {
+      if (typeof conditions === 'string') add(subpath, conditions, undefined);
+      else add(subpath, conditions.import ?? conditions.default, conditions.require);
+    }
+  } else {
+    add('.', m.main, undefined);
+  }
+  return [...found.values()];
+}
+
+/**
+ * Loads both formats of every entry and reports what each exported, or how it failed.
+ *
+ * One child per package: `execFileSync` is synchronous and twelve processes cost less than
+ * twenty-four. Written to a temp directory rather than into the package, because resolution for
+ * an absolute path does not consult the caller's location and a probe file left in `dist` would
+ * be published by `files: ["dist"]`.
+ */
+const PROBE = `
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { writeFileSync } from 'node:fs';
+
+const job = JSON.parse(process.argv[2]);
+const require = createRequire(pathToFileURL(job.pkgDir + '/probe.cjs').href);
+const describe = (mod) =>
+  Object.fromEntries(Object.keys(mod).sort().map((k) => {
+    // typeof rather than the value: a CJS interop wrapper that turns a class into a plain object
+    // exports the same name and is not the same module.
+    try { return [k, typeof mod[k]]; } catch (e) { return [k, 'THREW: ' + e.message]; }
+  }));
+
+const out = {};
+for (const entry of job.entries) {
+  const result = {};
+  for (const format of ['esm', 'cjs']) {
+    const abs = job.pkgDir + '/' + entry[format];
+    try {
+      const mod = format === 'cjs' ? require(abs) : await import(pathToFileURL(abs).href);
+      result[format] = { exports: describe(mod) };
+    } catch (err) {
+      result[format] = { error: String(err && err.stack ? err.stack : err) };
+    }
+  }
+  out[entry.subpath] = result;
+}
+// To a file rather than to stdout: an entry that logs on import would land in the middle of the
+// JSON, and the parent would report a parse error instead of the module that printed.
+writeFileSync(job.resultFile, JSON.stringify(out));
+`;
+
+const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'drzl-entry-probe-'));
+const probeFile = path.join(probeDir, 'probe.mjs');
+fs.writeFileSync(probeFile, PROBE);
+
+type Loaded = { exports?: Record<string, string>; error?: string };
+const loaded = new Map<string, Record<string, Record<'esm' | 'cjs', Loaded>>>();
+
+function load(dir: string, entries: Entry[]) {
+  const cached = loaded.get(dir);
+  if (cached) return cached;
+  const pkgDir = path.join(packagesDir, dir);
+  const resultFile = path.join(probeDir, `${dir}.json`);
+  const job = JSON.stringify({ pkgDir, resultFile, entries: entries.filter((e) => !e.isBin) });
+  execFileSync(process.execPath, [probeFile, job], {
+    cwd: probeDir,
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  const parsed = JSON.parse(fs.readFileSync(resultFile, 'utf8'));
+  loaded.set(dir, parsed);
+  return parsed;
+}
+
+/** A missing dist means the build has not run; a missing file inside one is a real defect. */
+function requireBuilt(dir: string, file: string, declared: boolean) {
+  const dist = path.join(packagesDir, dir, 'dist');
+  if (!fs.existsSync(dist)) {
+    throw new Error(
+      `packages/${dir}/dist does not exist. These assertions are about the built artefact, ` +
+        `not the source: run 'pnpm build' first.`
+    );
+  }
+  const abs = path.join(packagesDir, dir, file);
+  const why = declared
+    ? `packages/${dir}/package.json points at ${file}, which the build did not emit.`
+    : `packages/${dir} publishes no ${file} beside its ESM entry, so its build has stopped ` +
+      `emitting CommonJS. Check for --format esm,cjs in the build script.`;
+  expect(fs.existsSync(abs), `${why} dist holds: ${fs.readdirSync(dist).join(', ')}`).toBe(true);
+  return abs;
+}
+
+const cases = publishable.flatMap(({ dir, manifest }) =>
+  entryPoints(manifest).map((entry) => ({ dir, name: manifest.name, entry }))
+);
+
+it('found every publishable package', () => {
+  // A discovery bug here would empty the table below and every assertion would pass vacuously.
+  expect(publishable.map((p) => p.dir).sort()).toEqual([
+    'analyzer',
+    'cli',
+    'generator-arktype',
+    'generator-json-schema',
+    'generator-orpc',
+    'generator-service',
+    'generator-typebox',
+    'generator-valibot',
+    'generator-zod',
+    'template-orpc-service',
+    'template-standard',
+    'validation-core',
+  ]);
+  expect(cases.length).toBeGreaterThanOrEqual(publishable.length);
+});
+
+const entriesOf = (dir: string) => entryPoints(publishable.find((p) => p.dir === dir)!.manifest);
+
+describe.each(cases)('$name $entry.subpath', ({ dir, entry }) => {
+  it('emits both an ESM entry and its CommonJS twin', () => {
+    requireBuilt(dir, entry.esm, true);
+    requireBuilt(dir, entry.cjs, entry.cjsDeclared);
+  });
+
+  if (entry.isBin) {
+    it.each(['esm', 'cjs'] as const)('runs as a program from the %s build', (format) => {
+      const abs = requireBuilt(dir, entry[format], format === 'esm' || entry.cjsDeclared);
+      // A bin cannot be imported for its exports: this one parses argv at module scope. Running
+      // it is what a consumer does and is the only thing that catches a bundle that cannot start.
+      const out = execFileSync(process.execPath, [abs, '--version'], {
+        cwd: probeDir,
+        encoding: 'utf8',
+        timeout: 60_000,
+      });
+      expect(
+        out.trim().length,
+        `${dir} ${format} bin printed nothing for --version`
+      ).toBeGreaterThan(0);
+    });
+    return;
+  }
+
+  it.each(['esm', 'cjs'] as const)('loads from the %s build and exports something', (format) => {
+    requireBuilt(dir, entry[format], format === 'esm' || entry.cjsDeclared);
+    const result = load(dir, entriesOf(dir))[entry.subpath][format];
+    expect(result.error, `${dir} ${entry.subpath} failed to load as ${format}`).toBeUndefined();
+    expect(
+      Object.keys(result.exports ?? {}).length,
+      `${dir} ${entry.subpath} loaded as ${format} and exported nothing`
+    ).toBeGreaterThan(0);
+  });
+
+  it('exports the same names, with the same types, from both builds', () => {
+    const result = load(dir, entriesOf(dir))[entry.subpath];
+    // A load failure on either side would show up here as an unhelpful "undefined", so it is
+    // named instead; the test above is the one that owns that failure.
+    for (const format of ['esm', 'cjs'] as const) {
+      expect(
+        result[format].error,
+        `${dir} ${entry.subpath} did not load as ${format}, so there is nothing to compare`
+      ).toBeUndefined();
+    }
+    // Both sides at once, so a diff names the entry rather than reporting two unrelated failures.
+    expect(result.cjs.exports).toEqual(result.esm.exports);
+  });
+});

--- a/packages/cli/test/package-metadata.spec.ts
+++ b/packages/cli/test/package-metadata.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * The metadata every package publishes has to describe that package.
+ *
+ * `@drzl/generator-typebox` shipped `"repository": { "directory": "packages/generator-valibot" }`
+ * for its whole life, so its npm page's "source" link sent every reader to a sibling package. It
+ * was found by hand, months in, and nothing about the package was otherwise wrong: it built,
+ * published and worked. A copy-pasted manifest is the normal way a package is created here, so
+ * the field that has to be edited afterwards is the field that gets missed.
+ *
+ * These are cheap and they are checked from the workspace rather than from a tarball because
+ * `pnpm pack` copies the manifest through unchanged apart from resolving `workspace:` ranges. The
+ * tarball's own contents, and whether the files these fields point at actually ship, are asserted
+ * in scripts/verify-packed.sh, which is the stage that has a tarball to look inside.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..');
+const packagesDir = path.join(repoRoot, 'packages');
+
+interface Manifest {
+  name: string;
+  private?: boolean;
+  description?: string;
+  keywords?: string[];
+  files?: string[];
+  repository?: { type?: string; url?: string; directory?: string };
+  funding?: { type?: string; url?: string };
+  publishConfig?: { access?: string; registry?: string; provenance?: boolean };
+}
+
+const read = (file: string) => JSON.parse(fs.readFileSync(file, 'utf8'));
+
+const publishable: { dir: string; manifest: Manifest }[] = fs
+  .readdirSync(packagesDir)
+  .filter((dir) => fs.existsSync(path.join(packagesDir, dir, 'package.json')))
+  .map((dir) => ({ dir, manifest: read(path.join(packagesDir, dir, 'package.json')) as Manifest }))
+  .filter((p) => !p.manifest.private);
+
+const root = read(path.join(repoRoot, 'package.json'));
+
+/**
+ * The word that tells one package from another, which is the directory name with the family
+ * prefix removed: `generator-valibot` is distinguished by `valibot`, not by `generator`.
+ *
+ * This is the form a copy-paste survivor takes. A description lifted from the valibot package
+ * says "valibot", never "generator-valibot", so matching on the full directory name would miss
+ * exactly the case this exists for.
+ */
+const term = (dir: string) => dir.replace(/^(generator|template)-/, '');
+
+/** Lowercased, with every run of non-alphanumerics collapsed to one hyphen, so "JSON Schema"
+ *  and "json-schema" are the same string and a term cannot hide behind punctuation. */
+const normalise = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+
+const terms = publishable.map((p) => term(p.dir));
+
+it('found every publishable package', () => {
+  // Without this the table below could quietly go empty and every assertion would pass on
+  // nothing at all.
+  expect(publishable.map((p) => p.dir).sort()).toEqual([
+    'analyzer',
+    'cli',
+    'generator-arktype',
+    'generator-json-schema',
+    'generator-orpc',
+    'generator-service',
+    'generator-typebox',
+    'generator-valibot',
+    'generator-zod',
+    'template-orpc-service',
+    'template-standard',
+    'validation-core',
+  ]);
+});
+
+describe.each(publishable)('$manifest.name', ({ dir, manifest }) => {
+  it('is named after the directory it lives in', () => {
+    expect(manifest.name).toBe(`@drzl/${dir}`);
+  });
+
+  it('points repository.directory at its own source', () => {
+    // The typebox/valibot mix-up, and the only assertion in this file that has already caught a
+    // real one.
+    expect(manifest.repository?.directory).toBe(`packages/${dir}`);
+  });
+
+  it('points at this repository', () => {
+    expect(manifest.repository?.url).toBe('https://github.com/use-drzl/drzl');
+  });
+
+  it('carries the same funding link as the workspace', () => {
+    // Copied from the root manifest rather than written out here, so the two cannot drift apart
+    // without this failing.
+    expect(manifest.funding).toEqual(root.funding);
+  });
+
+  it('publishes publicly, to npm, with provenance', () => {
+    // The release workflow also sets NPM_CONFIG_PROVENANCE, so this is the second of two
+    // switches. Whether the published artefact actually carries an attestation is a question
+    // about the registry, and is asserted in scripts/verify-packed.sh.
+    expect(manifest.publishConfig).toEqual({
+      access: 'public',
+      registry: 'https://registry.npmjs.org/',
+      provenance: true,
+    });
+  });
+
+  it('ships dist and nothing from the working tree', () => {
+    // `pnpm pack` adds package.json, README and LICENSE on its own whatever `files` says, so an
+    // entry naming any of those is redundant rather than wrong. Anything else listed here is
+    // source, configuration or test material that a consumer has no use for.
+    expect(manifest.files).toContain('dist');
+    const shippable = /^(dist|README\.md|LICENSE|CHANGELOG\.md)$/;
+    expect(manifest.files?.filter((f) => !shippable.test(f))).toEqual([]);
+  });
+
+  it('does not describe itself with another package name', () => {
+    const own = term(dir);
+    // A term that is part of this package's own term cannot be evidence of a copy-paste:
+    // `orpc` is inside `orpc-service`, and the template is entitled to say the word.
+    const foreign = terms.filter((t) => t !== own && !own.includes(t));
+    const text = normalise([manifest.description ?? '', ...(manifest.keywords ?? [])].join(' '));
+    expect(foreign.filter((t) => text.includes(t))).toEqual([]);
+  });
+});
+
+it('gives no two packages the same description', () => {
+  // The other half of a copy-paste: the wrong name is caught above, an identical description that
+  // names nothing is caught here.
+  const described = publishable.filter((p) => p.manifest.description);
+  const seen = new Map<string, string>();
+  const clashes: string[] = [];
+  for (const p of described) {
+    const key = normalise(p.manifest.description!);
+    const first = seen.get(key);
+    if (first) clashes.push(`${first} and ${p.manifest.name} share a description`);
+    else seen.set(key, p.manifest.name);
+  }
+  expect(clashes).toEqual([]);
+});

--- a/packages/cli/test/package-metadata.spec.ts
+++ b/packages/cli/test/package-metadata.spec.ts
@@ -54,7 +54,33 @@ const term = (dir: string) => dir.replace(/^(generator|template)-/, '');
  *  and "json-schema" are the same string and a term cannot hide behind punctuation. */
 const normalise = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 
-const terms = publishable.map((p) => term(p.dir));
+/**
+ * Whether a term appears in some text as whole words rather than as a substring.
+ *
+ * Both sides are already hyphen-joined by `normalise`, so wrapping each in hyphens turns "does
+ * this text contain these words in this order" into one `includes`. Without the wrapping, "cli"
+ * matches "client" and every description of the oRPC generator that mentions a typed client
+ * would read as a copy-paste from the CLI package.
+ */
+const mentions = (text: string, t: string) => `-${text}-`.includes(`-${t}-`);
+
+/**
+ * Terms that are ordinary words in this domain, and so cannot be evidence of anything.
+ *
+ * Whole-word matching is not enough on its own here, because some of these directory names are
+ * also words a correct description needs. "Standard Schema" is the name of the specification the
+ * generators target and is already used in packages/generator-orpc/src/index.ts and its README,
+ * so it would convict @drzl/generator-zod of copying @drzl/template-standard. "Service" is what
+ * the service generator emits and what an oRPC router calls. "CLI" and "analyzer" are ordinary
+ * nouns any of these packages may need.
+ *
+ * Everything left is a proper noun that belongs to exactly one package: arktype, json-schema,
+ * orpc, typebox, valibot, zod, orpc-service, validation-core. Those are the ones a copied
+ * description carries over, which is the case this check exists for.
+ */
+const TOO_GENERIC_TO_CONVICT = new Set(['analyzer', 'cli', 'service', 'standard']);
+
+const terms = publishable.map((p) => term(p.dir)).filter((t) => !TOO_GENERIC_TO_CONVICT.has(t));
 
 it('found every publishable package', () => {
   // Without this the table below could quietly go empty and every assertion would pass on
@@ -122,7 +148,7 @@ describe.each(publishable)('$manifest.name', ({ dir, manifest }) => {
     // `orpc` is inside `orpc-service`, and the template is entitled to say the word.
     const foreign = terms.filter((t) => t !== own && !own.includes(t));
     const text = normalise([manifest.description ?? '', ...(manifest.keywords ?? [])].join(' '));
-    expect(foreign.filter((t) => text.includes(t))).toEqual([]);
+    expect(foreign.filter((t) => mentions(text, t))).toEqual([]);
   });
 });
 

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -2278,17 +2278,23 @@ echo "    every @drzl dependency resolves on npm"
 # workflow still passes, the packages still publish, and the only difference is that npm stops
 # showing where the tarball was built and `npm audit signatures` stops being able to answer.
 #
-# Measured 2026-08-03, over every version of every package: all attested except
-# @drzl/generator-json-schema@0.2.0 and @drzl/generator-typebox@0.0.0, which are the two first
-# publishes done by hand. That is not a workflow defect. npm trusted publishing has nothing to
-# authenticate against for a name that has never existed, so a package's very first version cannot
-# be published by CI at all, and cannot carry provenance. Every version published by CI since has
-# one.
+# Measured 2026-08-03, over every version of every package: 203 published, 201 attested. The two
+# without are @drzl/generator-json-schema@0.2.0 and @drzl/generator-typebox@0.0.0, and both are a
+# package's very first version. That is not a workflow defect and it is not fixable: npm trusted
+# publishing authenticates against a package that already exists, so the first version of a new
+# name has to be published by hand and cannot carry provenance. Every version published by CI
+# since has one.
 #
-# So this asks about the version tagged `latest`, not about the version in this working tree,
-# which during a release has not been published yet. A package whose only version is that
-# hand-made first one will fail here, and that is the correct answer: what npm is serving really
-# is unattested. Publishing the next version through CI clears it.
+# This asks about the version tagged `latest`, not about the version in this working tree, which
+# during a release has not been published yet.
+#
+# It deliberately skips a package whose `latest` is its only published version, and that
+# exemption is load-bearing rather than tidiness. `pnpm verify:packed` runs as a step in
+# release.yml *before* `changeset publish`, so a gate that failed on a hand-published first
+# version would abort the job before the publish step, and the CI publish that is the only way to
+# attest that package could never run. The repo would be one new package away from a release
+# deadlock, and it has added a new package twice in the last two releases. A second unattested
+# version is a real finding and still fails: by then CI has published at least once.
 # ---------------------------------------------------------------------------------------------
 echo "==> published packages carry a provenance attestation"
 unattested=0
@@ -2302,14 +2308,27 @@ for pkg in packages/*/package.json; do
     continue
   fi
   predicate=$(npm view "$name" dist.attestations.provenance.predicateType 2>/dev/null || true)
-  if [ -z "$predicate" ]; then
-    echo "    FAIL: $name@$version is on npm with no provenance attestation." >&2
-    echo "          Check that release.yml still sets NPM_CONFIG_PROVENANCE and still grants" >&2
-    echo "          id-token: write, and that the publish ran from CI rather than by hand." >&2
-    unattested=1
-  else
+  if [ -n "$predicate" ]; then
     echo "    $name@$version  $predicate"
+    continue
   fi
+  # `npm view <pkg> versions --json` answers with a bare string when there is exactly one, and an
+  # array otherwise, so the count cannot be taken from the shape of the output alone.
+  versions_json=$(npm view "$name" versions --json 2>/dev/null || echo 'null')
+  published=$(node -e "
+    const v = JSON.parse(process.argv[1]);
+    process.stdout.write(String(v === null ? 0 : Array.isArray(v) ? v.length : 1));
+  " "$versions_json")
+  if [ "$published" -le 1 ]; then
+    echo "    $name@$version is a first publish, which had to be made by hand and so carries no"
+    echo "        attestation. The next release attests it; failing here would prevent that release."
+    continue
+  fi
+  echo "    FAIL: $name@$version is on npm with no provenance attestation, and it is not this" >&2
+  echo "          package's first version ($published published), so it should have come from" >&2
+  echo "          CI. Check that release.yml still sets NPM_CONFIG_PROVENANCE and still grants" >&2
+  echo "          id-token: write, and that the publish ran from CI rather than by hand." >&2
+  unattested=1
 done
 [ "$unattested" = 0 ] || exit 1
 cd "$APP"

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -2336,6 +2336,23 @@ const ACCEPT = 'application/vnd.npm.install-v1+json';
 
 let bad = 0;
 let notFound = 0;
+/**
+ * The positive control, and the thing that makes the exemption below safe to draw.
+ *
+ * `dist.attestations` being absent from a response is not the same observation as the package
+ * having no attestation, and the difference decides the verdict: absent reads as "CI has never
+ * published this", which is the branch that passes. A mirror configured as `registry` that drops
+ * the field, or an abbreviated packument that stops carrying it, would put every package on that
+ * branch and the stage would go green having measured nothing. `dist.attestations` is not in the
+ * documented `dist` field set for the abbreviated document, so this is a shape npm is entitled to
+ * change.
+ *
+ * So an absence is only allowed to mean anything once this run has seen the field present
+ * somewhere. That is a positive observation that the source reports attestations at all.
+ */
+let attestedVersionsSeen = 0;
+/** Verdicts deferred until the control above is known, so nothing prints a reason it cannot back. */
+const exempt = [];
 for (const name of names) {
   let doc;
   try {
@@ -2363,18 +2380,14 @@ for (const name of names) {
   }
 
   const attested = versions.filter((v) => doc.versions[v].dist?.attestations);
+  attestedVersionsSeen += attested.length;
   const predicate = doc.versions[latest].dist?.attestations?.provenance?.predicateType;
   if (predicate) {
     console.log(`    ${name}@${latest}  ${predicate}`);
     continue;
   }
   if (attested.length === 0) {
-    console.log(
-      `    ${name}@${latest} has no attestation, and neither does any of its ` +
-        `${versions.length} version(s), so CI has never published it. npm trusted publishing ` +
-        `cannot authenticate a name that has never existed, so the first publish is made by ` +
-        `hand. Failing here would abort the release that would attest it.`
-    );
+    exempt.push({ name, latest, versions: versions.length });
     continue;
   }
   console.error(
@@ -2394,6 +2407,33 @@ if (names.length > 1 && notFound === names.length) {
   console.error('          registry pointed at the wrong place, not a workspace that has never');
   console.error('          published anything. Check `npm config get registry` and .npmrc.');
   bad++;
+}
+
+if (exempt.length && attestedVersionsSeen === 0) {
+  // Nothing in this run carried the field, so "this package has no attestation" and "this source
+  // does not report attestations" are the same observation and cannot be told apart. Neither is
+  // a pass. Naming the packages matters: if they really are all awaiting a first CI publish, that
+  // is the answer, and it needs a person rather than a default.
+  console.error(`    FAIL: not one of the ${names.length} package(s) read from ${base} carried a`);
+  console.error('          dist.attestations field on any version, so this run cannot tell a');
+  console.error('          package that has never been published by CI from a registry that does');
+  console.error('          not report attestations at all. Unattested here:');
+  for (const e of exempt) console.error(`            ${e.name}@${e.latest} (${e.versions} version(s))`);
+  console.error('          Check that `npm config get registry` is registry.npmjs.org and not a');
+  console.error('          mirror, then confirm on the package page whether provenance is really');
+  console.error('          absent.');
+  bad++;
+} else {
+  for (const e of exempt) {
+    console.log(
+      `    ${e.name}@${e.latest} has no attestation, and neither does any of its ` +
+        `${e.versions} version(s), so CI has never published it. npm trusted publishing ` +
+        `cannot authenticate a name that has never existed, so the first publish is made by ` +
+        `hand. Failing here would abort the release that would attest it. ` +
+        `(${attestedVersionsSeen} attested version(s) seen elsewhere in this run, so the field ` +
+        `is being reported.)`
+    );
+  }
 }
 
 if (bad) process.exit(1);

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -2288,49 +2288,119 @@ echo "    every @drzl dependency resolves on npm"
 # This asks about the version tagged `latest`, not about the version in this working tree, which
 # during a release has not been published yet.
 #
-# It deliberately skips a package whose `latest` is its only published version, and that
-# exemption is load-bearing rather than tidiness. `pnpm verify:packed` runs as a step in
-# release.yml *before* `changeset publish`, so a gate that failed on a hand-published first
-# version would abort the job before the publish step, and the CI publish that is the only way to
-# attest that package could never run. The repo would be one new package away from a release
-# deadlock, and it has added a new package twice in the last two releases. A second unattested
-# version is a real finding and still fails: by then CI has published at least once.
+# The one exemption is load-bearing rather than tidiness. `pnpm verify:packed` runs as a step in
+# release.yml *before* `changeset publish`, so a gate that failed on a package CI has never
+# published would abort the job before the publish step, and the CI publish that is the only way
+# to attest that package could never run. The repo would be one new package away from a release
+# deadlock, and it added one in each of the last two releases.
+#
+# So the exemption is stated as what it actually needs to be: skip when *no* version of the
+# package carries an attestation, which is exactly "CI has never published this". Counting
+# versions instead is close but not the same thing, and the difference is a live deadlock shape:
+# a package hand-published twice before CI takes over has two versions and no attestation, and
+# the documented remediation for a broken release here is a hand publish, so it is the obvious
+# way to arm it.
+#
+# The stronger form also detects more. `drizzle` has 33 versions and none attested, so CI has
+# never published it and there is nothing to regress. `eslint-plugin-drizzle` has 251 versions of
+# which 239 are attested and `latest` is not, which is a provenance setup that used to work and
+# has stopped. Only the second is this gate's business, and a version count cannot tell them
+# apart.
+#
+# Every error is a hard failure. An earlier draft skipped when the version lookup failed, which
+# printed "this is a first publish" over a network error and exited 0.
 # ---------------------------------------------------------------------------------------------
 echo "==> published packages carry a provenance attestation"
-unattested=0
-for pkg in packages/*/package.json; do
-  name=$(node -p "const p=require('./$pkg'); p.private ? '' : p.name")
-  [ -z "$name" ] && continue
-  # The stage above already fails the run if the registry is unreachable, so a failure here is a
-  # package that has never been published rather than a network problem.
-  if ! version=$(npm view "$name" version 2>/dev/null); then
-    echo "    $name has no published version yet, so there is nothing to attest"
-    continue
-  fi
-  predicate=$(npm view "$name" dist.attestations.provenance.predicateType 2>/dev/null || true)
-  if [ -n "$predicate" ]; then
-    echo "    $name@$version  $predicate"
-    continue
-  fi
-  # `npm view <pkg> versions --json` answers with a bare string when there is exactly one, and an
-  # array otherwise, so the count cannot be taken from the shape of the output alone.
-  versions_json=$(npm view "$name" versions --json 2>/dev/null || echo 'null')
-  published=$(node -e "
-    const v = JSON.parse(process.argv[1]);
-    process.stdout.write(String(v === null ? 0 : Array.isArray(v) ? v.length : 1));
-  " "$versions_json")
-  if [ "$published" -le 1 ]; then
-    echo "    $name@$version is a first publish, which had to be made by hand and so carries no"
-    echo "        attestation. The next release attests it; failing here would prevent that release."
-    continue
-  fi
-  echo "    FAIL: $name@$version is on npm with no provenance attestation, and it is not this" >&2
-  echo "          package's first version ($published published), so it should have come from" >&2
-  echo "          CI. Check that release.yml still sets NPM_CONFIG_PROVENANCE and still grants" >&2
-  echo "          id-token: write, and that the publish ran from CI rather than by hand." >&2
-  unattested=1
-done
-[ "$unattested" = 0 ] || exit 1
+names=$(node -e "
+  const fs = require('fs');
+  const out = [];
+  for (const dir of fs.readdirSync('packages')) {
+    const file = 'packages/' + dir + '/package.json';
+    if (!fs.existsSync(file)) continue;
+    const p = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (!p.private) out.push(p.name);
+  }
+  process.stdout.write(out.join(' '));
+")
+cat > "$WORK/check-provenance.mjs" <<'PROVENANCE'
+/**
+ * One abbreviated packument per package, which is the only response that carries every version's
+ * `dist.attestations` in a single request. `npm view` cannot answer this: a range resolves to one
+ * version, so asking it per version would be one request per version, and one of the fixtures
+ * this is reasoned about has 251 of them.
+ */
+const [registry, ...names] = process.argv.slice(2);
+const base = registry.replace(/\/$/, '');
+// The abbreviated document, roughly a third the size of the full one, and it carries `dist`.
+const ACCEPT = 'application/vnd.npm.install-v1+json';
+
+let bad = 0;
+let notFound = 0;
+for (const name of names) {
+  let doc;
+  try {
+    const res = await fetch(`${base}/${name.replace('/', '%2f')}`, { headers: { accept: ACCEPT } });
+    if (res.status === 404) {
+      notFound++;
+      console.log(`    ${name} has no published version yet, so there is nothing to attest`);
+      continue;
+    }
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    doc = await res.json();
+  } catch (err) {
+    // Never a skip. A registry that cannot be read is an unanswered question, not a pass.
+    console.error(`    FAIL: could not read ${name} from ${base}: ${err.message}`);
+    bad++;
+    continue;
+  }
+
+  const latest = doc['dist-tags']?.latest;
+  const versions = Object.keys(doc.versions ?? {});
+  if (!latest || !doc.versions?.[latest]) {
+    console.error(`    FAIL: ${name} has no version tagged latest, which npm should never serve.`);
+    bad++;
+    continue;
+  }
+
+  const attested = versions.filter((v) => doc.versions[v].dist?.attestations);
+  const predicate = doc.versions[latest].dist?.attestations?.provenance?.predicateType;
+  if (predicate) {
+    console.log(`    ${name}@${latest}  ${predicate}`);
+    continue;
+  }
+  if (attested.length === 0) {
+    console.log(
+      `    ${name}@${latest} has no attestation, and neither does any of its ` +
+        `${versions.length} version(s), so CI has never published it. npm trusted publishing ` +
+        `cannot authenticate a name that has never existed, so the first publish is made by ` +
+        `hand. Failing here would abort the release that would attest it.`
+    );
+    continue;
+  }
+  console.error(
+    `    FAIL: ${name}@${latest} carries no provenance attestation, but ${attested.length} of ` +
+      `its ${versions.length} versions do, so this package's provenance used to work and has ` +
+      `stopped. Check that release.yml still sets NPM_CONFIG_PROVENANCE and still grants ` +
+      `id-token: write, and that this version was published by CI rather than by hand.`
+  );
+  bad++;
+}
+
+// A registry pointed somewhere wrong answers 404 for everything, and every package would then
+// take the "not published yet" line and the stage would pass having measured nothing. One
+// unpublished package is ordinary; all of them is a broken registry.
+if (names.length > 1 && notFound === names.length) {
+  console.error(`    FAIL: ${base} answered 404 for all ${names.length} packages. That is a`);
+  console.error('          registry pointed at the wrong place, not a workspace that has never');
+  console.error('          published anything. Check `npm config get registry` and .npmrc.');
+  bad++;
+}
+
+if (bad) process.exit(1);
+PROVENANCE
+if ! node "$WORK/check-provenance.mjs" "$(npm config get registry)" $names; then
+  exit 1
+fi
 cd "$APP"
 
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -9,8 +9,9 @@
 # that omitted a required file, a build that silently emitted nothing, a generated import specifier
 # that did not resolve under the consumer's compiler.
 #
-# So this packs all ten packages, installs them into an empty project, runs the README's headline
-# command, and typechecks the emitted tree under every moduleResolution TypeScript still supports.
+# So this packs every publishable package, checks each tarball holds what its manifest promises,
+# installs them into an empty project, runs the README's headline command, and typechecks the
+# emitted tree under every moduleResolution TypeScript still supports.
 # The last part is the point: DRZL emits `.js` specifiers precisely so the output compiles under
 # node16 and nodenext, and nothing else in CI would notice if that regressed.
 #
@@ -100,6 +101,131 @@ for tgz in "$TARS"/*.tgz; do
   fi
 done
 [ "$size_over" = 0 ] || exit 1
+
+# ---------------------------------------------------------------------------------------------
+# What is inside each tarball, against what its own manifest promises is there.
+#
+# `files` is a list of directories, not of entry points, so the two are only ever connected by
+# hand. A `types` field naming a file the build never emitted, or an `exports` subpath pointing
+# somewhere outside `dist`, both pack cleanly and fail only later: in a consumer's editor, which
+# just goes quiet, or at their first import. Nothing in the workspace can see either, because in a
+# working tree every one of those paths has `src` sitting next to `dist` to fall back on.
+#
+# The manifest is read out of the tarball rather than off disk, because the tarball's copy is the
+# one npm serves and it is not the same file: pnpm rewrites `workspace:` ranges into it on the way
+# past.
+# ---------------------------------------------------------------------------------------------
+echo "==> what each tarball contains"
+cat > "$WORK/inspect-tarballs.mjs" <<'INSPECT'
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const dir = process.argv[2];
+const strip = (p) => String(p).replace(/^\.\//, '');
+
+/**
+ * Things a consumer has no use for, and which reach a tarball only by a `files` entry that is too
+ * wide or by a build writing outside `dist`. Sources are the expensive one: they are the bulk of
+ * a package by size and they let a consumer's bundler resolve past the built entry into
+ * unpublished code.
+ */
+const BANNED = [
+  [/^src\//, 'source'],
+  [/^(test|tests|__tests__)\//, 'tests'],
+  [/^node_modules\//, 'an installed dependency tree'],
+  [/(^|\/)tsconfig[^/]*\.json$/, 'compiler configuration'],
+  [/\.tsbuildinfo$/, 'an incremental build cache'],
+  [/(^|\/)(vitest|eslint|tsup|prettier)\.config\./, 'tooling configuration'],
+  [/\.(spec|test)\.[cm]?[jt]sx?$/, 'a test file'],
+  [/^\.(npmrc|env)/, 'local machine configuration'],
+];
+
+let bad = 0;
+const tarballs = fs.readdirSync(dir).filter((f) => f.endsWith('.tgz')).sort();
+if (!tarballs.length) {
+  console.error('FAIL: no tarballs to inspect.');
+  process.exit(1);
+}
+
+for (const file of tarballs) {
+  const tgz = path.join(dir, file);
+  const listed = execFileSync('tar', ['-tzf', tgz], { encoding: 'utf8' })
+    .split('\n')
+    .map(strip)
+    .filter((l) => l && !l.endsWith('/'));
+  // Every path in an npm tarball is under `package/`; the manifest's paths are relative to it.
+  const shipped = new Set(listed.map((l) => l.replace(/^package\//, '')));
+  const raw = execFileSync('tar', ['-xzOf', tgz, 'package/package.json'], { encoding: 'utf8' });
+  const pkg = JSON.parse(raw);
+
+  const problems = [];
+
+  // Every path the manifest names, wherever it names it. `exports` is walked to any depth rather
+  // than read at a fixed one, because conditions nest and a subpath added later would otherwise
+  // be checked by nothing.
+  const referenced = new Map();
+  const note = (where, value) => {
+    if (typeof value === 'string' && value) referenced.set(strip(value), where);
+  };
+  note('main', pkg.main);
+  note('types', pkg.types);
+  note('module', pkg.module);
+  for (const [name, target] of Object.entries(pkg.bin ?? {})) note(`bin.${name}`, target);
+  const walk = (node, at) => {
+    if (typeof node === 'string') return note(at, node);
+    if (node && typeof node === 'object') {
+      for (const [k, v] of Object.entries(node)) walk(v, `${at}[${k}]`);
+    }
+  };
+  walk(pkg.exports, 'exports');
+
+  for (const [target, where] of referenced) {
+    if (!shipped.has(target)) {
+      problems.push(`${where} names ${target}, which is not in the tarball`);
+    }
+  }
+
+  // Every ESM entry's CommonJS twin. The builds all pass --format esm,cjs and `files: ["dist"]`
+  // publishes the result, so the twin is part of the artefact whether or not a condition names
+  // it, and @drzl/validation-core's twin was broken for its whole life with nothing looking at it.
+  for (const [target, where] of referenced) {
+    if (!target.endsWith('.js')) continue;
+    const twin = target.replace(/\.js$/, '.cjs');
+    if (!shipped.has(twin)) {
+      problems.push(`${where} ships ${target} but no ${twin} beside it`);
+    }
+  }
+
+  for (const entry of shipped) {
+    for (const [pattern, what] of BANNED) {
+      if (pattern.test(entry)) problems.push(`ships ${entry}, which is ${what}`);
+    }
+  }
+
+  // A `workspace:` range that survived packing installs for nobody. pnpm rewrites them on the way
+  // into the tarball, so one surviving here means this artefact was not produced by `pnpm pack`.
+  if (/"workspace:/.test(raw)) {
+    problems.push('its manifest still carries a workspace: range, which npm cannot resolve');
+  }
+
+  if (problems.length) {
+    bad++;
+    console.error(`FAIL: ${pkg.name}`);
+    for (const p of problems) console.error(`      ${p}`);
+  } else {
+    console.log(`    ${pkg.name.padEnd(30)} ${shipped.size} files, every entry point present`);
+  }
+}
+
+if (bad) {
+  console.error(`      ${bad} tarball(s) do not contain what their manifest promises.`);
+  process.exit(1);
+}
+INSPECT
+if ! node "$WORK/inspect-tarballs.mjs" "$TARS"; then
+  exit 1
+fi
 
 echo "==> installing them into an empty project"
 # A real foreign key, because the oRPC generator derives relation endpoints from one and a
@@ -2142,6 +2268,50 @@ for pkg in packages/*/package.json; do
 done
 [ "$missing" = 0 ] || exit 1
 echo "    every @drzl dependency resolves on npm"
+
+# ---------------------------------------------------------------------------------------------
+# Does what npm actually serves carry a provenance attestation?
+#
+# The release workflow sets NPM_CONFIG_PROVENANCE and grants `id-token: write`, and both of those
+# are statements of intent. The attestation is the result, it is produced by a different machine,
+# and nothing looked at it. Losing it is silent in exactly the way this whole file exists for: the
+# workflow still passes, the packages still publish, and the only difference is that npm stops
+# showing where the tarball was built and `npm audit signatures` stops being able to answer.
+#
+# Measured 2026-08-03, over every version of every package: all attested except
+# @drzl/generator-json-schema@0.2.0 and @drzl/generator-typebox@0.0.0, which are the two first
+# publishes done by hand. That is not a workflow defect. npm trusted publishing has nothing to
+# authenticate against for a name that has never existed, so a package's very first version cannot
+# be published by CI at all, and cannot carry provenance. Every version published by CI since has
+# one.
+#
+# So this asks about the version tagged `latest`, not about the version in this working tree,
+# which during a release has not been published yet. A package whose only version is that
+# hand-made first one will fail here, and that is the correct answer: what npm is serving really
+# is unattested. Publishing the next version through CI clears it.
+# ---------------------------------------------------------------------------------------------
+echo "==> published packages carry a provenance attestation"
+unattested=0
+for pkg in packages/*/package.json; do
+  name=$(node -p "const p=require('./$pkg'); p.private ? '' : p.name")
+  [ -z "$name" ] && continue
+  # The stage above already fails the run if the registry is unreachable, so a failure here is a
+  # package that has never been published rather than a network problem.
+  if ! version=$(npm view "$name" version 2>/dev/null); then
+    echo "    $name has no published version yet, so there is nothing to attest"
+    continue
+  fi
+  predicate=$(npm view "$name" dist.attestations.provenance.predicateType 2>/dev/null || true)
+  if [ -z "$predicate" ]; then
+    echo "    FAIL: $name@$version is on npm with no provenance attestation." >&2
+    echo "          Check that release.yml still sets NPM_CONFIG_PROVENANCE and still grants" >&2
+    echo "          id-token: write, and that the publish ran from CI rather than by hand." >&2
+    unattested=1
+  else
+    echo "    $name@$version  $predicate"
+  fi
+done
+[ "$unattested" = 0 ] || exit 1
 cd "$APP"
 
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
@@ -2149,4 +2319,6 @@ echo "    typechecks under bundler, node16 and nodenext, and validates at least 
 echo "    the first-party drizzle-orm validator modules across three dialects and three modes,"
 echo "    checked against a real Postgres, a real SQLite and, where MYSQL_URL is set, a real"
 echo "    MySQL, with applyDefaults compared against what the database writes, and analyzed with"
-echo "    no column left unnamed on either drizzle-orm major."
+echo "    no column left unnamed on either drizzle-orm major. Every tarball holds the files its"
+echo "    manifest names and nothing from the working tree, and every package npm is serving"
+echo "    carries a provenance attestation."


### PR DESCRIPTION
Plan items 5, 6, 8 and 9. Four assertions about what reaches npm, sharing one premise the previous
task proved twice over: **the workspace can be entirely correct while the artefact is wrong.**

Three fix rounds, each with an independent scoped re-review that reproduced the proofs rather than
reading them. Every round found something real.

## Item 9 — provenance, answered

Nobody had checked whether `NPM_CONFIG_PROVENANCE: true` actually produced anything.

**203 published versions swept, 201 attested.** Every package's `latest` is among them. The two
gaps are `@drzl/generator-json-schema@0.2.0` and `@drzl/generator-typebox@0.0.0`, both hand-published
first versions, which npm trusted publishing structurally cannot do for a name that has never
existed. The decoded SLSA payload for `@drzl/cli@4.14.0` names `use-drzl/drzl`,
`.github/workflows/release.yml`, `refs/heads/master`.

Verified independently by the reviewer, character for character.

## The gate for it would have deadlocked every release

`pnpm verify:packed` is a `release.yml` step at line 76; `changeset publish` is at line 120. A new
package's first version is necessarily hand-published and unattested, so the first draft of this
gate would have aborted the job **before the publish that would attest it**. Its own comment said
"publishing the next version through CI clears it", and it was what prevented exactly that.

Had it existed a week ago it would have blocked the `0.3.0` release that fixed the first instance.

The predicate went through two corrections:

1. "skip a package with exactly one version" — sufficient but not necessary. A package
   hand-published **twice** still deadlocks, and this repo's documented remediation for a broken
   release is a hand publish.
2. "skip iff no version carries `dist.attestations`" — correct, and proved against two real
   packages that distinguish it: `drizzle` (33 versions, **0** attested, never CI-published,
   correctly skips) and `eslint-plugin-drizzle` (251 versions, **239** attested, `latest` missing,
   correctly fails).

## Then that fix fail-opened through an absent field

A 200 response with `dist.attestations` simply **absent** read as "CI has never published it", and
the whole stage exited 0. Proven by serving the real packuments with the field deleted: twelve skip
lines, exit 0, where the earlier count-based predicate had failed loudly.

Closed with a positive control: concluding "never CI-published" now requires a positive observation
that the registry reports attestations at all.

```
one package stripped   -> EXIT=0, "173 attested version(s) seen elsewhere in this run"
all twelve stripped    -> EXIT=1, "not one of the 12 package(s) carried a dist.attestations field"
```

The 173 is computed, not hardcoded: 201 attested across the twelve, minus `@drzl/cli`'s 28.

## Item 6 — every entry loads, and what that revealed

`@drzl/validation-core`'s CJS build had been silently broken for its whole life and nothing loaded
it. Now all thirteen entries of all twelve packages are `require()`d and `import()`ed in a real
child process, with their export names compared.

It revealed a live defect. **Ten of twelve CJS bundles cannot load below Node 22.12**, while every
package declares `engines.node: ">=18.17.0"`:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../validation-core/dist/index.js
from .../generator-zod/dist/index.cjs not supported.
```

Root cause is one line: `@drzl/validation-core` is `{ "main": "dist/index.js", "type": "module" }`
with **no `exports` map**. The three packages that do load are exactly those whose CJS bundle
requires no `@drzl` sibling. Fixing it means changing published module resolution for ten packages,
so it is filed as its own task rather than done here. The gap is pinned by a measured table that
fails if the set grows or shrinks.

## Items 5 and 8

Tarballs are inspected after packing: `main`, `types`, `module`, `bin` and `exports` are walked to
any depth and must exist; nothing from the working tree may ship; a surviving `workspace:` range
fails. `repository.directory` must match the package's real path, which is how
`@drzl/generator-typebox` came to point at `packages/generator-valibot` for its whole life.

## Every gate proven able to fail

18 of them, each by breaking what it guards. The reviewers reproduced proofs from every round; the
one time a claim did not hold, it was corrected in the next round rather than argued about.

The recurring failure mode on this branch, six instances across both tasks, is a check that is
green for a reason unrelated to what it claims. The rule that came out of it, now applied
throughout: **an error is never a value, and neither is an absence.** A 404 stays a pass because it
is a positive observation; `attested.length === 0` is not.

## Verification

860 tests across 100 files, `pnpm typecheck` and `pnpm lint` clean, and the full `verify:packed`
green across 17 stages.
