### PR TITLE
test(verify): run parity for all four generators on every dialect

### DIFF
--- a/.changeset/arktype-bigint-range.md
+++ b/.changeset/arktype-bigint-range.md
@@ -1,5 +1,5 @@
 ---
-'@drzl/generator-arktype': patch
+'@drzl/generator-arktype': minor
 ---
 
 Bound bigint columns in the arktype output, which accepted values no int64 can hold
@@ -25,4 +25,5 @@ import and takes whatever imported it down.
 **What changes for you.** Generated arktype schemas for `bigint`, `bigserial` and SQLite
 `blob({ mode: 'bigint' })` columns now reject a bigint outside the int64 range. If you were
 relying on a value larger than the column can store passing validation, it will now be refused,
-which is the behaviour the other four generators already had.
+which is the behaviour the zod, valibot and typebox generators already had, and the behaviour of
+`drizzle-orm/arktype` itself.

--- a/.changeset/arktype-bigint-range.md
+++ b/.changeset/arktype-bigint-range.md
@@ -1,0 +1,28 @@
+---
+'@drzl/generator-arktype': patch
+---
+
+Bound bigint columns in the arktype output, which accepted values no int64 can hold
+
+A `bigint({ mode: 'bigint' })` column emitted the bare ArkType type `bigint` and nothing else, so
+the generated schema accepted `2n ** 70n`. zod, valibot and typebox all bound the same column, and
+so does `drizzle-orm/arktype`, which made this the one place where DRZL's output was *looser* than
+the first-party validator rather than stricter. On Postgres, MySQL and SQLite alike, a row this
+schema passed could be one the database refuses.
+
+The reason it was left unstated was half right. ArkType's string DSL genuinely cannot carry the
+bound: `type('bigint >= -9223372036854775808n')` throws "Comparator >= must be followed by a
+corresponding literal", and the same bound written as a number rounds, since 9223372036854775807
+is not representable as a double. But `.narrow` can carry it, and this generator already used
+`.narrow` for every `varchar(n)` character cap and every MySQL byte cap. Bigint columns now use
+the same mechanism, and a `CHECK` folds into the bound exactly as it does for a number column.
+
+Null still passes, matching SQL and matching the existing cap narrows. An array column bounds its
+element rather than the array. A bound that could only be rendered as a syntax error, such as a
+fractional one, is left off rather than emitted, because a module ArkType cannot parse throws at
+import and takes whatever imported it down.
+
+**What changes for you.** Generated arktype schemas for `bigint`, `bigserial` and SQLite
+`blob({ mode: 'bigint' })` columns now reject a bigint outside the int64 range. If you were
+relying on a value larger than the column can store passing validation, it will now be refused,
+which is the behaviour the other four generators already had.

--- a/.changeset/arktype-nullable-array-element.md
+++ b/.changeset/arktype-nullable-array-element.md
@@ -1,0 +1,29 @@
+---
+'@drzl/generator-arktype': patch
+---
+
+Apply a column's constraint to the element of a nullable array, not to the array
+
+A constraint on an array column describes each element: `varchar({ length: 5 }).array()` caps every
+entry at five characters. This generator recovered the element by stripping a trailing `[]` off the
+rendered type, which is only correct when nothing else is wrapped around the brackets. A nullable
+array renders as `(string[] | null)`, which has no trailing `[]`, so the whole union was treated as
+the element and `.array()` wrapped that.
+
+The result, for `varchar({ length: 5 }).array()` with no `.notNull()`:
+
+| value | before | after |
+| --- | --- | --- |
+| `null` | rejected | accepted |
+| `['ab']` | rejected | accepted |
+| `[['ab']]` | accepted | rejected |
+
+A two-dimensional array came out a dimension too deep for the same reason. Both now agree with
+`drizzle-orm/arktype` and with DRZL's own zod, valibot and typebox output on every probe.
+
+The constraint now stays on the value, where the type expression is already right about
+dimensions and nullability, and the predicate walks in one `.every` per dimension instead. An
+empty list satisfies a constraint on elements, and a null passes at every level, matching SQL.
+
+**What changes for you.** If you have a nullable array column with a length cap, its generated
+arktype schema was refusing valid rows and accepting nested ones. Both stop.

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -267,8 +267,17 @@ function renderObjectShape(
       const dsl = atField(c, mode, coerceDates, checks, sets, applyDefaults, cardinalities);
       // A defaultable definition is only valid as an object property: `type("bigint = 7")` throws
       // "Defaultable definitions like 'number = 0' are only valid as properties in an object or
-      // tuple" at import. So a bound is not moved onto a field that carries an applied default,
-      // where it would trade a missing constraint for a module nothing can load.
+      // tuple" at import. So a bound is not moved onto a field carrying an applied default, where
+      // it would trade a missing constraint for a module nothing can load.
+      //
+      // That leaves a hole rather than closing one, and it is observable. `.default(null)` on a
+      // nullable bigint emits `"(bigint | null) = null"`, which loads, so its *insert* schema is
+      // unbounded while select and update are bounded. It is the only value for which the hole
+      // shows: `.default(7)` on a bigint is refused as "Default for n must be a bigint", and a
+      // bigint-valued default crashes this generator on `JSON.stringify` before reaching here.
+      // Closing it means moving the default off the DSL and onto the Type, where
+      // `.default(null)` does work and does keep the narrow. That is a change to the whole
+      // applyDefaults path, which has two further defects of its own, and is tracked separately.
       const defaulted = mode === 'insert' && applyDefaults && c.defaultValue !== undefined;
       const caps = atCapNarrows(c) + (defaulted ? '' : atBigintNarrow(c, checks));
       if (!caps) return `  ${JSON.stringify(c.name)}: ${JSON.stringify(dsl)},`;
@@ -278,12 +287,12 @@ function renderObjectShape(
       const optional = dsl.endsWith('?');
       const inner = optional ? dsl.slice(0, -1) : dsl;
       const key = JSON.stringify(optional ? `${c.name}?` : c.name);
-      // The cap describes the element, so for an array column the narrow goes on the element and
-      // `.array()` wraps it. Narrowing the array instead would ask how many characters a list has.
-      const dims = c.arrayDimensions ?? 0;
-      const element = dims ? inner.replace(/(\[\])+$/, '').replace(/^\((.*)\)$/, '$1') : inner;
-      const wrap = '.array()'.repeat(dims);
-      return `  ${key}: type(${JSON.stringify(element)})${caps}${wrap},`;
+      // The whole rendered type, unpicked no further. This used to strip the array brackets off
+      // to narrow the element and then call `.array()` to put them back, which was correct only
+      // for a bare `T[]`: a nullable array renders `(T[] | null)` and the union became the
+      // element, and a two-dimensional array came out three deep. The dimensions belong to the
+      // DSL, which already gets them right, and `atNarrow` walks into them instead.
+      return `  ${key}: type(${JSON.stringify(inner)})${caps},`;
     })
     .join('\n');
 }
@@ -333,12 +342,40 @@ function atRowNarrows(rows: RowCheck[], cols: Column[]): string {
  * Null and absent both pass, matching SQL, where a check involving NULL is satisfied.
  */
 /**
- * Column caps as narrows: characters for `varchar(n)`, bytes for MySQL's TEXT family.
+ * One field-level narrow, whose predicate reaches the element of an array column.
  *
- * Neither is expressible in the string DSL. `string <= n` counts UTF-16 code units, which is a
- * third measurement, agreeing with neither. Both databases count `varchar(n)` in characters and
- * MySQL counts `tinytext` in bytes, so both are written out here rather than approximated.
+ * Every constraint this file puts on a field describes a *value*: how many characters it has, what
+ * range it lies in. For an array column that is a statement about each element, while the column's
+ * own nullability is a statement about the list. The two used to be separated by string surgery:
+ * the rendered type had a trailing `[]` stripped off to recover the element, the narrow went on
+ * that, and `.array()` put the list back.
+ *
+ * It only ever worked when nothing else was wrapped around the brackets. A nullable array renders
+ * as `(bigint[] | null)`, so the whole union became the "element" and `.array()` wrapped it: the
+ * schema then refused `null` and `[1n]`, accepted `[[1n]]` and `[null]`, and for a bigint would
+ * not even compile, since `>=` cannot be applied to `bigint[]`. A two-dimensional array came out a
+ * dimension too deep for the same reason.
+ *
+ * So the narrow stays on the whole value, where the DSL string is already correct about
+ * dimensions, nullability and any cardinality bound, and the predicate walks in one `.every` per
+ * dimension instead. `.every` on an empty list is true, which is right: a list with no elements
+ * breaks no constraint on elements. Null passes at every level, matching SQL, where a comparison
+ * involving NULL leaves the check satisfied.
+ *
+ * A narrow is not reached at all unless the base type already matched, so the `.every` is only
+ * ever called on something ArkType has confirmed is an array.
  */
+function atNarrow(c: Column, predicate: (v: string) => string, message: string): string {
+  const dims = c.arrayDimensions ?? 0;
+  // `v` for the value itself, so a non-array column emits exactly what it always did.
+  const name = (i: number) => (i === 0 ? 'v' : `e${i}`);
+  let body = predicate(name(dims));
+  for (let i = dims; i > 0; i--) {
+    body = `${name(i - 1)}.every((${name(i)}) => ${name(i)} == null || ${body})`;
+  }
+  return `.narrow((v, ctx) => v == null || ${body} || ctx.mustBe(${JSON.stringify(message)}))`;
+}
+
 /**
  * A bigint column's range as a narrow, because the string DSL cannot state one.
  *
@@ -359,37 +396,49 @@ function atBigintNarrow(c: Column, checks: ColumnCheck[]): string {
   // does not parse throws at import and takes everything importing it with it. A bound this
   // cannot render is left off rather than rendered wrongly.
   const literal = (v: string) => (/^-?\d+$/.test(v) ? `${v}n` : undefined);
-  const parts: string[] = [];
+  const parts: ((v: string) => string)[] = [];
   if (equals !== undefined) {
     const e = literal(equals);
     if (!e) return '';
-    parts.push(`v === ${e}`);
+    parts.push((v) => `${v} === ${e}`);
   } else {
     for (const b of [lower, upper]) {
       if (!b) continue;
       const l = literal(b.value);
       if (!l) return '';
-      parts.push(`v ${b.op} ${l}`);
+      parts.push((v) => `${v} ${b.op} ${l}`);
     }
   }
   if (!parts.length) return '';
-  const msg = JSON.stringify(
-    equals !== undefined ? `exactly ${equals}` : `between ${lower?.value ?? 'any'} and ${upper?.value ?? 'any'}`
+  return atNarrow(
+    c,
+    (v) => `(${parts.map((p) => p(v)).join(' && ')})`,
+    equals !== undefined
+      ? `exactly ${equals}`
+      : `between ${lower?.value ?? 'any'} and ${upper?.value ?? 'any'}`
   );
-  return `.narrow((v, ctx) => v == null || (${parts.join(' && ')}) || ctx.mustBe(${msg}))`;
 }
 
+/**
+ * Column caps as narrows: characters for `varchar(n)`, bytes for MySQL's TEXT family.
+ *
+ * Neither is expressible in the string DSL. `string <= n` counts UTF-16 code units, which is a
+ * third measurement, agreeing with neither. Both databases count `varchar(n)` in characters and
+ * MySQL counts `tinytext` in bytes, so both are written out here rather than approximated.
+ */
 function atCapNarrows(c: Column): string {
   if (c.tsType !== 'string' || c.shape) return '';
   const out: string[] = [];
   if (c.maxLength) {
-    const msg = JSON.stringify(`at most ${c.maxLength} characters`);
-    out.push(`.narrow((v, ctx) => v == null || [...v].length <= ${c.maxLength} || ctx.mustBe(${msg}))`);
+    out.push(atNarrow(c, (v) => `[...${v}].length <= ${c.maxLength}`, `at most ${c.maxLength} characters`));
   }
   if (c.maxBytes) {
-    const msg = JSON.stringify(`at most ${c.maxBytes} bytes`);
     out.push(
-      `.narrow((v, ctx) => v == null || new TextEncoder().encode(v).length <= ${c.maxBytes} || ctx.mustBe(${msg}))`
+      atNarrow(
+        c,
+        (v) => `new TextEncoder().encode(${v}).length <= ${c.maxBytes}`,
+        `at most ${c.maxBytes} bytes`
+      )
     );
   }
   return out.join('');

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -178,8 +178,10 @@ function atTypeForColumn(
       return atRange(isIntegerColumn(c) ? 'number.integer' : 'number', lower, upper);
     }
     case 'bigint':
-      // ArkType compares bigints against bigint literals, and a 64 bit bound cannot be written
-      // as a number without rounding, so the range is left unstated rather than stated wrongly.
+      // Bare here on purpose. The string DSL cannot carry this bound at all:
+      // `bigint >= -9223372036854775808n` is a parse error, "Comparator >= must be followed by a
+      // corresponding literal", and writing the bound as a number instead rounds it. The range
+      // goes on as a narrow, the same builder the character caps use. See `atBigintNarrow`.
       return 'bigint';
     case 'boolean':
       return 'boolean';
@@ -263,7 +265,12 @@ function renderObjectShape(
   return cols
     .map((c) => {
       const dsl = atField(c, mode, coerceDates, checks, sets, applyDefaults, cardinalities);
-      const caps = atCapNarrows(c);
+      // A defaultable definition is only valid as an object property: `type("bigint = 7")` throws
+      // "Defaultable definitions like 'number = 0' are only valid as properties in an object or
+      // tuple" at import. So a bound is not moved onto a field that carries an applied default,
+      // where it would trade a missing constraint for a module nothing can load.
+      const defaulted = mode === 'insert' && applyDefaults && c.defaultValue !== undefined;
+      const caps = atCapNarrows(c) + (defaulted ? '' : atBigintNarrow(c, checks));
       if (!caps) return `  ${JSON.stringify(c.name)}: ${JSON.stringify(dsl)},`;
       // A Type instance rather than a DSL string, because neither cap is expressible in the DSL:
       // `string <= n` counts UTF-16 code units, which agrees with neither database. ArkType marks
@@ -332,6 +339,46 @@ function atRowNarrows(rows: RowCheck[], cols: Column[]): string {
  * third measurement, agreeing with neither. Both databases count `varchar(n)` in characters and
  * MySQL counts `tinytext` in bytes, so both are written out here rather than approximated.
  */
+/**
+ * A bigint column's range as a narrow, because the string DSL cannot state one.
+ *
+ * `type('bigint >= -9223372036854775808n')` throws "Comparator >= must be followed by a
+ * corresponding literal", and the same bound written as a number rounds: 9223372036854775807
+ * is not representable as a double. So this generator emitted a bare `bigint` and accepted
+ * `2n ** 70n`, which every other generator rejects and which no int64 column can hold. That is
+ * the one direction this project says generated output must never take, looser than the
+ * first-party validator, and the packed gate had it waived on all three dialects.
+ *
+ * A narrow can hold it, exactly as the character caps do. Null passes, matching SQL and matching
+ * the cap narrows, so the guard belongs here rather than in a wrapping union.
+ */
+function atBigintNarrow(c: Column, checks: ColumnCheck[]): string {
+  if (c.tsType !== 'bigint' || c.shape) return '';
+  const { lower, upper, equals } = atNarrowRange(c, checks);
+  // A bigint literal has to be an integer: `1.5n` is a syntax error, and an emitted module that
+  // does not parse throws at import and takes everything importing it with it. A bound this
+  // cannot render is left off rather than rendered wrongly.
+  const literal = (v: string) => (/^-?\d+$/.test(v) ? `${v}n` : undefined);
+  const parts: string[] = [];
+  if (equals !== undefined) {
+    const e = literal(equals);
+    if (!e) return '';
+    parts.push(`v === ${e}`);
+  } else {
+    for (const b of [lower, upper]) {
+      if (!b) continue;
+      const l = literal(b.value);
+      if (!l) return '';
+      parts.push(`v ${b.op} ${l}`);
+    }
+  }
+  if (!parts.length) return '';
+  const msg = JSON.stringify(
+    equals !== undefined ? `exactly ${equals}` : `between ${lower?.value ?? 'any'} and ${upper?.value ?? 'any'}`
+  );
+  return `.narrow((v, ctx) => v == null || (${parts.join(' && ')}) || ctx.mustBe(${msg}))`;
+}
+
 function atCapNarrows(c: Column): string {
   if (c.tsType !== 'string' || c.shape) return '';
   const out: string[] = [];

--- a/packages/generator-arktype/test/bigint-range.spec.ts
+++ b/packages/generator-arktype/test/bigint-range.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * A bigint column's range in ArkType output.
+ *
+ * This generator emitted a bare `bigint` and nothing else, so a `bigint({ mode: 'bigint' })`
+ * column accepted `2n ** 70n`: a value no int64 column can hold, that zod, valibot and typebox
+ * all reject, and that `drizzle-orm/arktype` rejects too. Looser than the first-party validator
+ * is the one direction this project says generated output must never take, and it was waived on
+ * all three dialects in the packed gate rather than fixed.
+ *
+ * The reason recorded for the waiver was half true. ArkType's *string DSL* genuinely cannot state
+ * it: `type('bigint >= -9223372036854775808n')` throws "Comparator >= must be followed by a
+ * corresponding literal", and writing the bound as a number rounds, since 9223372036854775807 is
+ * not representable as a double. But `.narrow` can hold it, and this generator already uses
+ * `.narrow` for every character cap.
+ *
+ * Every case but the last runs the emitted module. An expression ArkType cannot parse throws at
+ * import rather than validating loosely, so "the source looks right" is not enough. The last case
+ * says at its own site why it is the exception.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArkTypeGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { type } from 'arktype';
+
+const INT64_MIN = '-9223372036854775808';
+const INT64_MAX = '9223372036854775807';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    min: INT64_MIN,
+    max: INT64_MAX,
+    ...over,
+  }) as Column;
+
+async function schemasFor(
+  columns: Column[],
+  opts: { checks?: { name?: string; expression?: string }[]; applyDefaults?: boolean } = {}
+) {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [
+      { name: 't', tsName: 't', columns, unique: [], indexes: [], checks: opts.checks ?? [] },
+    ] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-atbig-'));
+  await new ArkTypeGenerator(analysis).generate({
+    outDir,
+    applyDefaults: opts.applyDefaults ?? false,
+  } as never);
+  const file = path.join(outDir, 't.arktype.ts');
+  const source = await fs.readFile(file, 'utf8');
+  // Loading is separate and explicit, because it is itself an assertion: an expression ArkType
+  // cannot parse throws here rather than validating loosely. One case below deliberately does not
+  // load, and says why.
+  return { source, load: () => import(file) };
+}
+
+const ok = (schema: any, value: unknown) => !(schema({ n: value }) instanceof type.errors);
+
+describe('an int64 column', () => {
+  it('rejects a value no int64 can hold, in every mode', async () => {
+    const mod = await (await schemasFor([col('n')])).load();
+    for (const name of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      const s = mod[name];
+      expect(ok(s, 1n), `${name} accepts a small bigint`).toBe(true);
+      expect(ok(s, BigInt(INT64_MAX)), `${name} accepts the maximum`).toBe(true);
+      expect(ok(s, BigInt(INT64_MIN)), `${name} accepts the minimum`).toBe(true);
+      expect(ok(s, 2n ** 70n), `${name} rejects above the maximum`).toBe(false);
+      expect(ok(s, -(2n ** 70n)), `${name} rejects below the minimum`).toBe(false);
+    }
+  });
+
+  it('still takes null when the column is nullable', async () => {
+    const mod = await (await schemasFor([col('n', { nullable: true })])).load();
+    expect(ok(mod.SelecttSchema, null)).toBe(true);
+    expect(ok(mod.SelecttSchema, 2n ** 70n)).toBe(false);
+  });
+
+  it('bounds the element of an array column rather than the array', async () => {
+    const mod = await (await schemasFor([col('n', { arrayDimensions: 1 })])).load();
+    expect(ok(mod.SelecttSchema, [1n])).toBe(true);
+    expect(ok(mod.SelecttSchema, [2n ** 70n])).toBe(false);
+  });
+});
+
+describe('a CHECK on a bigint column', () => {
+  it('narrows the declared range', async () => {
+    const mod = await (
+      await schemasFor([col('n')], { checks: [{ name: 'n_min', expression: 'n >= 10' }] })
+    ).load();
+    expect(ok(mod.SelecttSchema, 10n)).toBe(true);
+    expect(ok(mod.SelecttSchema, 9n)).toBe(false);
+    expect(ok(mod.SelecttSchema, 2n ** 70n)).toBe(false);
+  });
+});
+
+describe('a bound ArkType could only state wrongly', () => {
+  it('is left off rather than emitted as a syntax error', async () => {
+    // `1.5n` does not parse, and an emitted module that does not parse throws at import and takes
+    // whatever imported it down. A column claiming a fractional bigint bound is nonsense the
+    // analyzer should never produce, so the only requirement is that it stays loadable.
+    const { source, load } = await schemasFor([col('n', { min: '1.5', max: '9.5' })]);
+    expect(source).not.toContain('1.5n');
+    const mod = await load();
+    expect(ok(mod.SelecttSchema, 1n)).toBe(true);
+  });
+});
+
+describe('a bigint column carrying an applied default', () => {
+  /**
+   * Asserted on the source rather than by running it, which this file otherwise never does.
+   *
+   * The module cannot be loaded today, for a reason that predates the bound and is not fixed
+   * here: `applyDefaults` renders the default with `JSON.stringify`, so a bigint column emits
+   * `bigint = 7` and ArkType refuses it with "Default for n must be a bigint (was a number)". A
+   * bigint-valued default fails even earlier, in the generator, with "Do not know how to
+   * serialize a BigInt". Both are reported separately.
+   *
+   * What is checked here is only that this change does not add a second reason it cannot load:
+   * `type("bigint = 7").narrow(...)` would throw "Defaultable definitions ... are only valid as
+   * properties", which is what the guard at the call site exists to avoid.
+   */
+  it('keeps the bound off the defaulted field, which cannot carry a narrow', async () => {
+    const { source } = await schemasFor([col('n', { hasDefault: true, defaultValue: 7 as never })], {
+      applyDefaults: true,
+    });
+    const insert = source.match(/InserttSchema = type\(\{([\s\S]*?)\n\}\)/)?.[1];
+    expect(insert, `no insert schema in:\n${source}`).toBeTruthy();
+    expect(insert).toContain('= 7');
+    expect(insert).not.toContain('narrow');
+    // Select carries no default, so the bound is on it as usual. This is the positive control:
+    // without it, a generator that emitted no bound at all would pass the two lines above.
+    const select = source.match(/SelecttSchema = type\(\{([\s\S]*?)\n\}\)/)?.[1];
+    expect(select).toContain('narrow');
+  });
+});

--- a/packages/generator-arktype/test/bigint-range.spec.ts
+++ b/packages/generator-arktype/test/bigint-range.spec.ts
@@ -120,29 +120,89 @@ describe('a bound ArkType could only state wrongly', () => {
 
 describe('a bigint column carrying an applied default', () => {
   /**
-   * Asserted on the source rather than by running it, which this file otherwise never does.
+   * The bound is dropped on a field that carries an applied default, because a defaultable
+   * definition is only valid as an object property: `type("(bigint | null) = null").narrow(...)`
+   * throws at import. Remove the guard in the generator and this test fails by not loading.
    *
-   * The module cannot be loaded today, for a reason that predates the bound and is not fixed
-   * here: `applyDefaults` renders the default with `JSON.stringify`, so a bigint column emits
-   * `bigint = 7` and ArkType refuses it with "Default for n must be a bigint (was a number)". A
-   * bigint-valued default fails even earlier, in the generator, with "Do not know how to
-   * serialize a BigInt". Both are reported separately.
+   * It is checked by loading rather than by reading the source, because the source cannot show
+   * the part that matters: the module loads, and its insert schema is unbounded while select and
+   * update are bounded. An earlier version of this test asserted on the text and claimed no such
+   * module could load at all, which was wrong and unfalsifiable in that form.
    *
-   * What is checked here is only that this change does not add a second reason it cannot load:
-   * `type("bigint = 7").narrow(...)` would throw "Defaultable definitions ... are only valid as
-   * properties", which is what the guard at the call site exists to avoid.
+   * `null` is the only default value that reaches this state. `.default(7)` on a bigint is
+   * refused by ArkType as "Default for n must be a bigint", and a bigint-valued default crashes
+   * the generator on `JSON.stringify`. Both are applyDefaults defects tracked separately, and
+   * fixing them, or moving the default onto the Type where `.default()` keeps the narrow, should
+   * turn the first expectation below into `false` and this comment into history.
    */
-  it('keeps the bound off the defaulted field, which cannot carry a narrow', async () => {
-    const { source } = await schemasFor([col('n', { hasDefault: true, defaultValue: 7 as never })], {
-      applyDefaults: true,
+  it('loads, and is unbounded on insert alone, which is the cost of the guard', async () => {
+    const { load } = await schemasFor(
+      [col('n', { nullable: true, hasDefault: true, defaultValue: null as never })],
+      { applyDefaults: true }
+    );
+    const mod = await load();
+    expect(ok(mod.InserttSchema, 2n ** 70n), 'insert: the bound the guard drops').toBe(true);
+    expect(ok(mod.SelecttSchema, 2n ** 70n), 'select: bounded as usual').toBe(false);
+    expect(ok(mod.UpdatetSchema, 2n ** 70n), 'update: bounded as usual').toBe(false);
+    expect(ok(mod.InserttSchema, 1n), 'insert still accepts a valid value').toBe(true);
+  });
+});
+
+/**
+ * Array columns, where the constraint describes the element and the column's nullability
+ * describes the whole list.
+ *
+ * These are one family with the character caps rather than a bigint concern, and they are here
+ * because a bigint array is how the defect was found. The generator used to derive the element by
+ * stripping a trailing `[]` off the rendered type string, which is correct only when nothing else
+ * is wrapped around it. A nullable array renders as `(bigint[] | null)`, so the whole union became
+ * the "element" and `.array()` wrapped that: `[[1n]]` and `[null]` were accepted, `null` and
+ * `[1n]` were refused, and for bigint the emitted TypeScript did not compile, because `>=` cannot
+ * be applied to `bigint[]`. The same shape was silently wrong for a capped string array on master,
+ * where it compiled and only misvalidated.
+ */
+describe('an array column', () => {
+  const cases: [string, Column][] = [
+    ['bigint, not null', col('n', { arrayDimensions: 1 })],
+    ['bigint, nullable', col('n', { arrayDimensions: 1, nullable: true })],
+  ];
+  for (const [label, column] of cases) {
+    it(`${label}: bounds the element and lets the column's own nullability stand`, async () => {
+      const mod = await (await schemasFor([column])).load();
+      const s = mod.SelecttSchema;
+      expect(ok(s, [1n]), 'a list of valid elements').toBe(true);
+      expect(ok(s, []), 'an empty list').toBe(true);
+      expect(ok(s, [2n ** 70n]), 'an element above the maximum').toBe(false);
+      expect(ok(s, [[1n]]), 'a list of lists, one dimension too many').toBe(false);
+      expect(ok(s, [null]), 'a null element').toBe(false);
+      expect(ok(s, 1n), 'a bare element where a list belongs').toBe(false);
+      expect(ok(s, null), `null itself`).toBe(column.nullable === true);
     });
-    const insert = source.match(/InserttSchema = type\(\{([\s\S]*?)\n\}\)/)?.[1];
-    expect(insert, `no insert schema in:\n${source}`).toBeTruthy();
-    expect(insert).toContain('= 7');
-    expect(insert).not.toContain('narrow');
-    // Select carries no default, so the bound is on it as usual. This is the positive control:
-    // without it, a generator that emitted no bound at all would pass the two lines above.
-    const select = source.match(/SelecttSchema = type\(\{([\s\S]*?)\n\}\)/)?.[1];
-    expect(select).toContain('narrow');
+  }
+
+  it('a nullable capped-string array bounds the element too', async () => {
+    // The pre-existing instance of the same defect, which compiled and so was never noticed.
+    const column = {
+      ...col('n', { arrayDimensions: 1, nullable: true }),
+      tsType: 'string',
+      dbType: 'TEXT',
+      maxLength: 5,
+      min: undefined,
+      max: undefined,
+    } as Column;
+    const mod = await (await schemasFor([column])).load();
+    const s = mod.SelecttSchema;
+    expect(ok(s, ['ab']), 'a list of short strings').toBe(true);
+    expect(ok(s, null), 'null, which the column allows').toBe(true);
+    expect(ok(s, ['abcdef']), 'an element over the cap').toBe(false);
+    expect(ok(s, [['ab']]), 'a list of lists').toBe(false);
+  });
+
+  it('bounds the element of a two-dimensional array at the right depth', async () => {
+    const mod = await (await schemasFor([col('n', { arrayDimensions: 2 })])).load();
+    const s = mod.SelecttSchema;
+    expect(ok(s, [[1n]])).toBe(true);
+    expect(ok(s, [[2n ** 70n]])).toBe(false);
+    expect(ok(s, [1n]), 'one dimension too few').toBe(false);
   });
 });

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1444,9 +1444,15 @@ echo "==> typechecking the parity matrix output"
 #
 # The carve-out is by column, so the other 38 pg and 28 mysql columns are still compiled: the two
 # modules are copied with exactly those field lines dropped, and the copy is what this stage
-# checks. `assert-removed` below fails if a different number of lines goes, so the carve-out
-# cannot quietly widen to cover a real defect.
-mkdir -p src/gen-tsc
+# checks.
+#
+# Two things have to stay true of an exclusion, and only the first of them used to be checked:
+# that it still covers what it says, and that it is still needed at all. The inline line count
+# below is the first. The probes are the second, and they are the reason this is not a waiver that
+# outlives its defect: each carved column is put back on its own, and the result has to still fail
+# to compile. Simulating the generator fix, by making those three columns emit `"string"`, used to
+# leave them silently un-typechecked for ever with the stage printing that everything compiles.
+mkdir -p src/gen-tsc src/carve-probe
 node - <<'CARVE'
 import fs from 'node:fs';
 const CARVED = { pg: ['c_numeric', 'c_decimal'], mysql: ['m_decimal'] };
@@ -1466,6 +1472,17 @@ for (const [dialect, cols] of Object.entries(CARVED)) {
     process.exit(1);
   }
   fs.writeFileSync(`src/gen-tsc/${dialect}-matrix.arktype.ts`, kept.join('\n'));
+  // One probe per carved column: the compiled copy with that column, and only that column, put
+  // back. Somewhere outside the include above, so the stage's own run does not compile them.
+  for (const col of cols) {
+    const one = new RegExp(`^\\s*"${col}\\??":`);
+    const withCol = lines.filter((l) => !drop.test(l) || one.test(l));
+    if (withCol.length !== kept.length + MODES) {
+      console.error(`FAIL: restoring ${col} into the ${dialect} copy did not put back ${MODES} lines.`);
+      process.exit(1);
+    }
+    fs.writeFileSync(`src/carve-probe/${dialect}-${col}.ts`, withCol.join('\n'));
+  }
 }
 CARVE
 cat > tsconfig.gen.json <<'EOF'
@@ -1488,8 +1505,10 @@ cat > tsconfig.gen.json <<'EOF'
 EOF
 # The originals are excluded because the copies stand in for them, and their barrels with them:
 # `exclude` only filters the entry list, so `index.ts` re-exporting the matrix module would pull
-# the original straight back in. The barrel is five re-export lines and the copy covers what it
-# would have said.
+# the original straight back in. Those barrels are four re-export lines on pg and three on mysql,
+# and the copies cover the modules they name. What is given up with them is narrow and worth
+# saying: the barrel is no longer the thing that pulls its modules in here, so a barrel line
+# naming a module that does not exist would not be caught by this stage.
 if ! npx tsc -p tsconfig.gen.json; then
   echo "FAIL: the parity matrix output does not compile under tsc --strict." >&2
   echo "      Generated code that does not typecheck is not usable output, however it behaves" >&2
@@ -1497,6 +1516,30 @@ if ! npx tsc -p tsconfig.gen.json; then
   exit 1
 fi
 echo "    every generator's matrix output compiles under --strict, module nodenext"
+
+# The other direction: does each carved column still earn its carve?
+#
+# A count of removed lines says the exclusion still matches the emitted shape. It says nothing
+# about whether the defect is still there, so the day the generator stops putting a regex in the
+# type expression, these columns would stay out of the typecheck for ever and this stage would go
+# on printing that everything compiles. That is the same stale-waiver shape as the cross-generator
+# list further up, which had exactly this hole in the opposite direction.
+#
+# Compiled one at a time on purpose. TypeScript's instantiation budget is global to a compilation,
+# so a single run over all three probes would report only the first to exhaust it and the other two
+# would look resolved.
+carve_dead=0
+for probe in src/carve-probe/*.ts; do
+  if npx tsc --strict --noEmit --target es2022 --module nodenext --moduleResolution nodenext \
+      --skipLibCheck "$probe" >/dev/null 2>&1; then
+    echo "FAIL: $probe compiles, so that column no longer needs carving out of the typecheck." >&2
+    echo "      Delete it from CARVED above rather than leaving a column excluded for a defect" >&2
+    echo "      that has been fixed." >&2
+    carve_dead=1
+  fi
+done
+[ "$carve_dead" = 0 ] || exit 1
+echo "    each carved column still fails on its own, so the carve-out is still earning it"
 
 cat > src/json-schema-valid.ts <<'JSON_SCHEMA_VALID'
 /**
@@ -1702,11 +1745,12 @@ size_fail=0
 # table. Measured rather than guessed, because a budget raised to make a number fit is worth
 # nothing: on the original 62 columns arktype emits 223 bytes per column, up from 213, and those
 # ten bytes are the bigint bound and the array element walk, both of them constraints that were
-# missing. The two new columns cost 920 bytes each, four times the average, because a
-# nullable capped array is the longest thing this generator emits and it is emitted once per mode.
-# So the mixed average moved to 244 without any generator emitting more for the same input, which
-# is the same effect recorded above for the CHECK columns. The three figures reconcile:
-# 13827 + 1840 = 15667 bytes, and the 1840 includes the 37-byte barrel line for the new module.
+# missing. The two new columns cost 1803 bytes of module, about 900 each, four times the average,
+# because a nullable capped array is the longest thing this generator emits and it is emitted once
+# per mode. So the mixed average moved to 244 without any generator emitting more for the same
+# input, which is the same effect recorded above for the CHECK columns. The figures reconcile:
+# 13827 without the table, plus 1803 for the module and the 37-byte barrel line naming it,
+# is the 15667 this script prints.
 report_size src/gen/pg/zod      zod      420  || size_fail=1
 report_size src/gen/pg/valibot  valibot  540  || size_fail=1
 report_size src/gen/pg/arktype  arktype  280  || size_fail=1

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -924,9 +924,15 @@ const POOL: [string, unknown][] = [
   ['5 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}'],
   ["'not-a-uuid'", 'not-a-uuid'], ['uuid', '3f2504e0-4f89-11d3-9a0c-0305e82c3301'],
   ["'zzz'", 'zzz'], ["'a'", 'a'], ["'happy'", 'happy'],
+  // A member of the `varchar({ enum: ['x', 'y'] })` fixture column. Without it the pool held no
+  // value that column accepts, so both sides rejected all of it and the comparison agreed while
+  // measuring nothing. The vacuity check below is what found it.
+  ["'x'", 'x'],
   ['0', 0], ['1', 1], ['1.5', 1.5], ['-1', -1], ['200', 200], ['40000', 40000],
   ['9000000', 9000000], ['2147483648', 2147483648], ['9007199254740993', 9007199254740993],
-  ['1900', 1900], ['2500', 2500], ['NaN', NaN], ['Infinity', Infinity],
+  // 1900 and 2500 sit either side of MySQL's YEAR range and nothing sat inside it, so `m_year`
+  // was the same vacuous agreement as the enum above: rejected by both, proving nothing.
+  ['1900', 1900], ['2000', 2000], ['2500', 2500], ['NaN', NaN], ['Infinity', Infinity],
   ['1n', 1n], ['2n**70n', 2n ** 70n], ['true', true], ['false', false],
   ['Date', new Date('2020-01-01T00:00:00Z')], ["'2020-01-01'", '2020-01-01'],
   ["'2020-01-01T00:00:00Z'", '2020-01-01T00:00:00Z'], ["'12:00:00'", '12:00:00'],
@@ -981,61 +987,115 @@ const safeField = (lib: Lib, s: any, k: string) => {
  * Divergences that are deliberate and reasoned. Anything not named here is a finding, so a new
  * disagreement fails this script rather than quietly widening the list.
  *
- * Keyed `<library>/<column>`; a bare column name applies to every library.
+ * Keyed `<dialect>/<library>/<column>`; `<dialect>/<column>` applies to every library on that
+ * dialect. The dialect is part of the key because this file compared all four libraries on
+ * Postgres alone for most of its life, and a waiver keyed on a column name would have started
+ * covering a same-named column on MySQL or SQLite the moment those dialects were widened. The
+ * fixtures use distinct `c_`/`m_`/`s_` prefixes, which makes the dialect redundant today and
+ * load-bearing the day someone adds a column without one.
  */
 const ALLOWED: Record<string, string> = {
   // Binary payloads are typed as Uint8Array rather than Buffer. A Buffer is a Uint8Array, so
   // nothing official accepts is turned away. The wider check needs no `@types/node`, survives a
   // runtime where `Buffer` is undefined, and makes bytea and blob validate the same way.
-  c_bytea: 'Uint8Array accepted where official demands a Buffer',
-  s_blob_buf: 'as c_bytea',
+  'pg/c_bytea': 'Uint8Array accepted where official demands a Buffer',
+  'sqlite/s_blob_buf': 'as pg/c_bytea',
   // `coerceDates` defaults to coercing on insert and update, which is a documented DRZL option
   // and is what `coerceDates: 'none'` turns off to match official exactly. Only strings and
   // numbers are coerced: null, booleans and arrays are rejected, which `z.coerce.date()` accepts.
-  c_date_d: 'coerceDates accepts a date string or epoch number on write',
-  c_ts_d: 'as c_date_d',
-  m_date: 'as c_date_d',
-  m_datetime: 'as c_date_d',
-  m_ts: 'as c_date_d',
-  s_int_ts: 'as c_date_d',
-  s_int_ts_ms: 'as c_date_d',
+  'pg/c_date_d': 'coerceDates accepts a date string or epoch number on write',
+  'pg/c_ts_d': 'as pg/c_date_d',
+  'mysql/m_date': 'as pg/c_date_d',
+  'mysql/m_datetime': 'as pg/c_date_d',
+  'mysql/m_ts': 'as pg/c_date_d',
+  'sqlite/s_int_ts': 'as pg/c_date_d',
+  'sqlite/s_int_ts_ms': 'as pg/c_date_d',
   // Official emits `Type.String({ format: 'uuid' })`, and TypeBox fails a format it has no entry
   // for rather than ignoring it, so that schema rejects every valid uuid in any project that has
   // not populated `FormatRegistry` first. This generator emits a pattern, which needs no setup.
-  'typebox/c_uuid': 'official uses an unregistered `format`, which rejects every uuid',
+  'pg/typebox/c_uuid': 'official uses an unregistered `format`, which rejects every uuid',
   // A character limit counts *characters*; official counts `.length`, which is UTF-16 units, so
   // it refuses three emoji in a `char(4)` the database accepts. Measured against Postgres.
-  c_char: 'character limit counts code points; official counts UTF-16 units',
-  m_char: 'as c_char',
+  'pg/c_char': 'character limit counts code points; official counts UTF-16 units',
+  'mysql/m_char': 'as pg/c_char',
   // Stricter than official, and verified against Postgres itself through PGlite: a `numeric`
   // column is a string, and a bare string schema accepts 'hello' where the database rejects it.
   // Official accepts all of these; the database does not.
-  c_numeric: 'numeric format enforced; official accepts any string, Postgres does not',
-  c_decimal: 'as c_numeric',
-  m_decimal: 'as c_numeric',
+  'pg/c_numeric': 'numeric format enforced; official accepts any string, Postgres does not',
+  'pg/c_decimal': 'as pg/c_numeric',
+  'mysql/m_decimal': 'as pg/c_numeric',
   // Stricter than official, in DRZL's favour.
-  'valibot/c_json': 'DRZL rejects Infinity and non-plain objects; official accepts both',
-  'valibot/c_jsonb': 'as valibot/c_json',
-  'valibot/c_jsonb_typed': 'as valibot/c_json',
-  'valibot/c_point': 'v.strictTuple rejects a third element; official v.tuple ignores extras',
-  'valibot/c_geometry': 'as valibot/c_point',
+  'pg/valibot/c_json': 'DRZL rejects Infinity and non-plain objects; official accepts both',
+  'pg/valibot/c_jsonb': 'as pg/valibot/c_json',
+  'pg/valibot/c_jsonb_typed': 'as pg/valibot/c_json',
+  'mysql/valibot/m_json': 'as pg/valibot/c_json',
+  'sqlite/valibot/s_text_json': 'as pg/valibot/c_json',
+  'sqlite/valibot/s_blob_json': 'as pg/valibot/c_json',
+  // A `blob()` with no mode is Drizzle's json mode, not its buffer mode, so this is the same
+  // column shape as s_blob_json and gets the same reasoning. `s_blob_buf` above is the buffer one.
+  'sqlite/valibot/s_blob': 'as pg/valibot/c_json; a bare blob() is Drizzle json mode',
+  'pg/valibot/c_point': 'v.strictTuple rejects a third element; official v.tuple ignores extras',
+  'pg/valibot/c_geometry': 'as pg/valibot/c_point',
+  // Official emits `Type.RegExp`, whose check runs `RegExp.prototype.test` against the raw value,
+  // and `test` stringifies what it is given: `[]` becomes '' and matches `^[01]*$`. So official
+  // accepts an empty array for a binary column. This generator emits a `string` carrying a
+  // `pattern`, which refuses a non-string before the pattern is consulted. Postgres masks the
+  // same hole on `c_bit` only because that column has a `minLength` an array cannot satisfy.
+  'mysql/typebox/m_binary': 'official Type.RegExp accepts a non-string whose string form matches',
+  'mysql/typebox/m_varbinary': 'as mysql/typebox/m_binary',
   // ArkType states a bigint range through a narrow predicate built with its builder API. This
-  // generator emits one string per field, and the string DSL's comparators take numeric literals.
-  'arktype/c_bigint_b': 'ArkType cannot bound a bigint in its string DSL',
-  'arktype/s_blob_bigint': 'as arktype/c_bigint_b',
+  // generator emits one string per field, and the string DSL's comparators take numeric literals:
+  // `type('bigint >= -9223372036854775808n')` is a parse error, not a wider schema.
+  'pg/arktype/c_bigint_b': 'ArkType cannot bound a bigint in its string DSL',
+  'sqlite/arktype/s_blob_bigint': 'as pg/arktype/c_bigint_b',
+  'mysql/arktype/m_bigint_b': 'as pg/arktype/c_bigint_b',
 };
 
-const allowed = (lib: string, col: string) => ALLOWED[`${lib}/${col}`] ?? ALLOWED[col];
+const usedWaivers = new Set<string>();
+const allowed = (dialect: string, lib: string, col: string) => {
+  for (const key of [`${dialect}/${lib}/${col}`, `${dialect}/${col}`]) {
+    if (ALLOWED[key]) {
+      usedWaivers.add(key);
+      return ALLOWED[key];
+    }
+  }
+  return undefined;
+};
 
-/** Cross-generator gaps that follow from what each library can express, not from a defect. */
-const CROSS_ALLOWED = (k: string) =>
-  k.startsWith('c_json') ||
-  k.startsWith('c_jsonb') ||
-  /bigint_b|blob_bigint/.test(k) ||
+/**
+ * Cross-generator gaps that follow from what each library can express, not from a defect in one
+ * generator. Keyed `<dialect>/<column>` and carrying its reason, for the same reason ALLOWED is.
+ */
+const CROSS_ALLOWED: Record<string, string> = {
+  // ArkType's string DSL has no recursive JSON value, so this generator emits
+  // `number | object | string | boolean | null`, which takes NaN, Infinity and any object at all.
+  // The other three build a real JSON value check. A capability difference between the libraries:
+  // official `drizzle-orm/arktype` produces the same widening, which is why this shows up here and
+  // not against official.
+  'pg/c_json': "arktype's string DSL cannot state a recursive JSON value",
+  'pg/c_jsonb': 'as pg/c_json',
+  'pg/c_jsonb_typed': 'as pg/c_json',
+  'mysql/m_json': 'as pg/c_json',
+  'sqlite/s_text_json': 'as pg/c_json',
+  'sqlite/s_blob_json': 'as pg/c_json',
+  'sqlite/s_blob': 'as pg/c_json; a bare blob() is Drizzle json mode',
+  // As `pg/arktype/c_bigint_b` above: the three others bound the bigint, arktype cannot.
+  'pg/c_bigint_b': 'ArkType cannot bound a bigint in its string DSL',
+  'mysql/m_bigint_b': 'as pg/c_bigint_b',
+  'sqlite/s_blob_bigint': 'as pg/c_bigint_b',
   // zod and valibot count code points for a character limit; TypeBox and ArkType state a length
   // declaratively with no predicate to hook, so they keep the UTF-16 form and stay approximate for
   // astral text. A capability difference between the libraries, not a defect in one generator.
-  k === 'c_char';
+  'pg/c_char': 'zod and valibot count code points; TypeBox and ArkType count UTF-16 units',
+};
+
+const usedCrossWaivers = new Set<string>();
+const crossAllowed = (dialect: string, col: string) => {
+  const key = `${dialect}/${col}`;
+  if (!CROSS_ALLOWED[key]) return false;
+  usedCrossWaivers.add(key);
+  return true;
+};
 
 const DIALECTS = [
   {
@@ -1052,14 +1112,24 @@ const DIALECTS = [
   {
     name: 'mysql',
     table: myTable,
-    libs: ['zod'],
-    mods: { zod: () => import('./gen/mysql/zod/matrix.zod.js') } as Record<string, () => Promise<any>>,
+    libs: ['zod', 'valibot', 'arktype', 'typebox'],
+    mods: {
+      zod: () => import('./gen/mysql/zod/matrix.zod.js'),
+      valibot: () => import('./gen/mysql/valibot/matrix.valibot.js'),
+      arktype: () => import('./gen/mysql/arktype/matrix.arktype.js'),
+      typebox: () => import('./gen/mysql/typebox/matrix.typebox.js'),
+    } as Record<string, () => Promise<any>>,
   },
   {
     name: 'sqlite',
     table: sqTable,
-    libs: ['zod'],
-    mods: { zod: () => import('./gen/sqlite/zod/matrix.zod.js') } as Record<string, () => Promise<any>>,
+    libs: ['zod', 'valibot', 'arktype', 'typebox'],
+    mods: {
+      zod: () => import('./gen/sqlite/zod/matrix.zod.js'),
+      valibot: () => import('./gen/sqlite/valibot/matrix.valibot.js'),
+      arktype: () => import('./gen/sqlite/arktype/matrix.arktype.js'),
+      typebox: () => import('./gen/sqlite/typebox/matrix.typebox.js'),
+    } as Record<string, () => Promise<any>>,
   },
 ];
 
@@ -1088,30 +1158,58 @@ for (const d of DIALECTS) {
       const oShape = OFFICIAL.zod[mode](d.table as never).shape;
       const rows: string[] = [];
       let waived = 0;
+      // Columns where both sides yielded a field and the pool was actually pushed through them.
+      // Printing the shape's column count says how many columns *exist*, which is not the same
+      // number and stayed reassuring in a run that compared none of them.
+      let compared = 0;
 
       for (const k of Object.keys(oShape)) {
         const o = safeField(lib, official, k);
         const m = safeField(lib, mine, k);
-        if (!o && !m) continue;
+        if (!o && !m) {
+          // Never a skip. Both sides absent means this column was measured by nothing, and
+          // `safeField` returns undefined for a lookup that threw as well as for one that was
+          // missing, so the quiet version of this branch reported parity on an exception.
+          rows.push(`        ${k}: neither official nor DRZL yielded a field, so nothing was compared`);
+          continue;
+        }
         if (!m) {
-          if (allowed(libName, k)) { waived++; continue; }
+          if (allowed(d.name, libName, k)) { waived++; continue; }
           rows.push(`        ${k}: official has it, DRZL omits it`);
           continue;
         }
         if (!o) {
-          if (allowed(libName, k)) { waived++; continue; }
+          if (allowed(d.name, libName, k)) { waived++; continue; }
           rows.push(`        ${k}: DRZL has it, official omits it`);
           continue;
         }
+        compared++;
         const looser: string[] = [];
         const tighter: string[] = [];
+        let officialTook = false;
+        let drzlTook = false;
         for (const [label, x] of POOL) {
           const a = safeOk(lib, o, x);
           const b = safeOk(lib, m, x);
+          officialTook ||= a;
+          drzlTook ||= b;
           if (a !== b) (b ? looser : tighter).push(label);
         }
+        // A column both sides reject every probe for agrees perfectly and proves nothing: the two
+        // schemas could be a correct one and a broken one and this loop could not tell them apart.
+        // It is not hypothetical. `c_varchar_enum` accepts only 'x' or 'y' and `m_year` only
+        // 1901..2155, and the pool held no member of either, so two columns had been sitting in
+        // this comparison contributing a confident nothing. Deliberately outside the waiver check
+        // below: a waiver says a difference is fine, not that a column need not be measured.
+        if (!officialTook && !drzlTook) {
+          rows.push(
+            `        ${k}: neither side accepts any pool value, so this column proves nothing.` +
+              `\n          Add a value this column accepts to POOL.`
+          );
+          continue;
+        }
         if (!looser.length && !tighter.length) continue;
-        if (allowed(libName, k)) { waived++; continue; }
+        if (allowed(d.name, libName, k)) { waived++; continue; }
         rows.push(
           `        ${k}:` +
             (looser.length ? `\n          DRZL accepts, official rejects: ${looser.join(', ')}` : '') +
@@ -1119,9 +1217,16 @@ for (const d of DIALECTS) {
         );
       }
 
+      // A run that compared no column at all would otherwise print `parity` and pass. That is the
+      // shape of failure this file has been bitten by most: the stage was green because it had
+      // measured nothing, not because there was nothing to find.
+      if (compared === 0) {
+        rows.push('        no column was compared on both sides, so this pairing measured nothing');
+      }
+
       console.log(
         `    ${d.name.padEnd(7)} ${libName.padEnd(8)} ${mode.padEnd(7)} ` +
-          `${Object.keys(oShape).length} cols  ${rows.length ? 'DIFFERS' : 'parity'}` +
+          `${compared}/${Object.keys(oShape).length} cols compared  ${rows.length ? 'DIFFERS' : 'parity'}` +
           `${waived ? ` (${waived} waived)` : ''}`
       );
       if (rows.length) {
@@ -1131,12 +1236,12 @@ for (const d of DIALECTS) {
     }
   }
 
-  // Pass 2, on the dialect that has all four generators.
+  // Pass 2, on every dialect that has all four generators, which is now all three.
   if (d.libs.length === 4) {
     const oShape = OFFICIAL.zod.select(d.table as never).shape;
     const disagreements: string[] = [];
     for (const k of Object.keys(oShape)) {
-      if (CROSS_ALLOWED(k)) continue;
+      if (crossAllowed(d.name, k)) continue;
       const fields: Record<string, any> = {};
       for (const lib of d.libs) fields[lib] = safeField(LIBS[lib], loaded[lib].SelectmatrixSchema, k);
       const absent = Object.entries(fields).filter(([, f]) => !f).map(([n]) => n);
@@ -1154,20 +1259,39 @@ for (const d of DIALECTS) {
       }
     }
     if (disagreements.length) {
-      console.log('    the four generators disagree with each other:');
+      console.log(`    the four ${d.name} generators disagree with each other:`);
       console.log(disagreements.join('\n'));
       findings += disagreements.length;
     } else {
-      console.log('    all four generators agree with each other on every column and value');
+      console.log(`    all four ${d.name} generators agree with each other on every column and value`);
     }
   }
+}
+
+// A waiver that suppresses nothing is not harmless. It is a sentence claiming a divergence exists
+// and is fine, sitting next to the divergences that really do, and the next person to widen this
+// file reads it as covered ground. Every key above has to earn its place on this run or be
+// deleted, which is also the only thing standing between this list and being used as a way to
+// make a failure go away.
+const deadWaivers = [
+  ...Object.keys(ALLOWED).filter((k) => !usedWaivers.has(k)).map((k) => `ALLOWED[${k}]`),
+  ...Object.keys(CROSS_ALLOWED).filter((k) => !usedCrossWaivers.has(k)).map((k) => `CROSS_ALLOWED[${k}]`),
+];
+if (deadWaivers.length) {
+  console.error('FAIL: these waivers suppressed nothing on this run, so they describe a');
+  console.error('      divergence that no longer happens. Delete them rather than keeping a');
+  console.error('      reason for something nobody can observe:');
+  for (const k of deadWaivers) console.error(`      ${k}`);
 }
 
 if (findings) {
   console.error(`FAIL: ${findings} parity finding(s). A generated schema looser than the`);
   console.error('      first-party module accepts rows the database will reject.');
-  process.exit(1);
 }
+
+// Counted separately and exited on together, so one run reports both rather than hiding the
+// second behind the first. A dead waiver is not a looser schema and must not be described as one.
+if (findings || deadWaivers.length) process.exit(1);
 PARITY_HARNESS
 
 # drizzle-orm is pinned: the parity target is a specific release, and a floating one would turn
@@ -1182,9 +1306,15 @@ npm install --no-audit --no-fund --loglevel=error \
 
 for dialect in pg mysql sqlite; do
   case "$dialect" in
+    # All four libraries on every dialect. It was four on Postgres and one everywhere else, so
+    # valibot, arktype and typebox had never been compared with anything on MySQL or SQLite:
+    # eighteen combinations with no differential coverage at all. The official modules take any
+    # Drizzle table regardless of dialect, so there was never a structural reason for it. Widening
+    # this also turns pass 2, the cross-generator check, on for MySQL and SQLite, which is where it
+    # found the arktype json column disagreeing with its three siblings.
     pg)     schema=src/schema.ts;        libs="zod valibot arktype typebox" ;;
-    mysql)  schema=src/schema-mysql.ts;  libs="zod" ;;
-    sqlite) schema=src/schema-sqlite.ts; libs="zod" ;;
+    mysql)  schema=src/schema-mysql.ts;  libs="zod valibot arktype typebox" ;;
+    sqlite) schema=src/schema-sqlite.ts; libs="zod valibot arktype typebox" ;;
   esac
   gens=""
   for lib in $libs; do gens="$gens    { kind: '$lib', path: 'src/gen/$dialect/$lib' },"$'\n'; done
@@ -3091,7 +3221,8 @@ cd "$APP"
 
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
 echo "    typechecks under bundler, node16 and nodenext, and validates at least as strictly as"
-echo "    the first-party drizzle-orm validator modules across three dialects and three modes,"
+echo "    all four first-party drizzle-orm validator modules on each of three dialects and three"
+echo "    modes, with the four generators cross-checked against each other on every dialect,"
 echo "    checked against a real Postgres, a real SQLite and, where MYSQL_URL is set, a real"
 echo "    MySQL, with applyDefaults compared against what the database writes, and analyzed with"
 echo "    no column left unnamed on either drizzle-orm major. The JSON Schema output compiles"

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1083,10 +1083,11 @@ const CROSS_ALLOWED: Record<string, string> = {
   'pg/c_bigint_b': 'ArkType cannot bound a bigint in its string DSL',
   'mysql/m_bigint_b': 'as pg/c_bigint_b',
   'sqlite/s_blob_bigint': 'as pg/c_bigint_b',
-  // zod and valibot count code points for a character limit; TypeBox and ArkType state a length
-  // declaratively with no predicate to hook, so they keep the UTF-16 form and stay approximate for
-  // astral text. A capability difference between the libraries, not a defect in one generator.
-  'pg/c_char': 'zod and valibot count code points; TypeBox and ArkType count UTF-16 units',
+  // No `c_char` entry. There was one, reading "zod and valibot count code points; TypeBox and
+  // ArkType count UTF-16 units", and it had been dead since arktype and typebox were changed to
+  // count code points as well. All four now emit a `[...v].length` predicate and agree on every
+  // probe including astral text, so there is nothing to waive. It survived because the waiver was
+  // marked used by the column merely existing; see the note at the crossAllowed call site.
 };
 
 const usedCrossWaivers = new Set<string>();
@@ -1241,22 +1242,29 @@ for (const d of DIALECTS) {
     const oShape = OFFICIAL.zod.select(d.table as never).shape;
     const disagreements: string[] = [];
     for (const k of Object.keys(oShape)) {
-      if (crossAllowed(d.name, k)) continue;
       const fields: Record<string, any> = {};
       for (const lib of d.libs) fields[lib] = safeField(LIBS[lib], loaded[lib].SelectmatrixSchema, k);
+      const found: string[] = [];
       const absent = Object.entries(fields).filter(([, f]) => !f).map(([n]) => n);
       if (absent.length) {
-        disagreements.push(`        ${k}: missing from ${absent.join(', ')}`);
-        continue;
-      }
-      for (const [label, x] of POOL) {
-        const verdicts = d.libs.map((n) => [n, safeOk(LIBS[n], fields[n], x)] as const);
-        const yes = verdicts.filter(([, r]) => r).map(([n]) => n);
-        const no = verdicts.filter(([, r]) => !r).map(([n]) => n);
-        if (yes.length && no.length) {
-          disagreements.push(`        ${k} on ${label}: ${yes.join('/')} accept, ${no.join('/')} reject`);
+        found.push(`        ${k}: missing from ${absent.join(', ')}`);
+      } else {
+        for (const [label, x] of POOL) {
+          const verdicts = d.libs.map((n) => [n, safeOk(LIBS[n], fields[n], x)] as const);
+          const yes = verdicts.filter(([, r]) => r).map(([n]) => n);
+          const no = verdicts.filter(([, r]) => !r).map(([n]) => n);
+          if (yes.length && no.length) {
+            found.push(`        ${k} on ${label}: ${yes.join('/')} accept, ${no.join('/')} reject`);
+          }
         }
       }
+      if (!found.length) continue;
+      // The waiver is consulted only once there is something for it to suppress. Asking first
+      // marked the key used because the column exists in the fixture, which made the dead-waiver
+      // check below true of `ALLOWED` and false of `CROSS_ALLOWED`: a waiver naming a real column
+      // the four generators agree about sat there indefinitely, and `pg/c_char` was one.
+      if (crossAllowed(d.name, k)) continue;
+      disagreements.push(...found);
     }
     if (disagreements.length) {
       console.log(`    the four ${d.name} generators disagree with each other:`);

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1418,13 +1418,66 @@ done
 # is caught and read as a rejection, and rejection was the answer for most probe values anyway.
 # ---------------------------------------------------------------------------------------------
 echo "==> typechecking the parity matrix output"
+# Three columns are carved out of this stage, not two modules, for one defect that predates the
+# branch. Each claim below was measured, after two earlier attempts at this comment asserted
+# mechanisms that turned out not to exist.
+#
+# `c_numeric` and `c_decimal` on Postgres, and `m_decimal` on MySQL, each fail TS2589 on their own,
+# in a file holding nothing else. The arktype generator states a numeric format as a bare regex
+# literal inside the type expression, and that literal is around 200 characters that ArkType parses
+# in the type system. It is the one emitted construct expensive enough to exhaust the instantiation
+# budget by itself.
+#
+# What it is *not*, each checked rather than assumed:
+#
+#   - Not this branch's doing. Rewriting the emitted pg file back to the exact form the generator
+#     produced before the bigint bound and before the array fix reproduces it at the same position.
+#   - Not the narrows. Stripping every `.narrow(...)` from the pg matrix, leaving the same 40
+#     fields, fails identically at (7,40).
+#   - Not the number of fields. Every one of the 40 pg fields compiles alone except those two, and
+#     the first 10 compile together with or without their narrows.
+#   - Not the table size. sqlite's matrix is clean because it has no numeric-format column, not
+#     because it has 14 columns: SQLite `numeric` carries no format and emits a plain `"string"`.
+#
+# So the repair is to stop putting a 200-character regex in the type expression, not to change how
+# a whole-table object is emitted. That is reported separately and not done here.
+#
+# The carve-out is by column, so the other 38 pg and 28 mysql columns are still compiled: the two
+# modules are copied with exactly those field lines dropped, and the copy is what this stage
+# checks. `assert-removed` below fails if a different number of lines goes, so the carve-out
+# cannot quietly widen to cover a real defect.
+mkdir -p src/gen-tsc
+node - <<'CARVE'
+import fs from 'node:fs';
+const CARVED = { pg: ['c_numeric', 'c_decimal'], mysql: ['m_decimal'] };
+const MODES = 3;
+for (const [dialect, cols] of Object.entries(CARVED)) {
+  const from = `src/gen/${dialect}/arktype/matrix.arktype.ts`;
+  const lines = fs.readFileSync(from, 'utf8').split('\n');
+  const drop = new RegExp(`^\\s*"(${cols.join('|')})\\??":`);
+  const kept = lines.filter((l) => !drop.test(l));
+  const removed = lines.length - kept.length;
+  if (removed !== cols.length * MODES) {
+    console.error(
+      `FAIL: carving ${cols.join(', ')} out of ${from} removed ${removed} lines, not ` +
+        `${cols.length * MODES}. The emitted shape changed, so this exclusion no longer covers ` +
+        `what it says it covers and may now be hiding a real error.`
+    );
+    process.exit(1);
+  }
+  fs.writeFileSync(`src/gen-tsc/${dialect}-matrix.arktype.ts`, kept.join('\n'));
+}
+CARVE
 cat > tsconfig.gen.json <<'EOF'
 {
   "compilerOptions": {
     "strict": true, "noEmit": true, "target": "es2022",
     "module": "nodenext", "moduleResolution": "nodenext", "skipLibCheck": true
   },
-  "include": ["src/gen/**/*.ts", "src/schema.ts", "src/schema-mysql.ts", "src/schema-sqlite.ts"],
+  "include": [
+    "src/gen/**/*.ts", "src/gen-tsc/**/*.ts",
+    "src/schema.ts", "src/schema-mysql.ts", "src/schema-sqlite.ts"
+  ],
   "exclude": [
     "src/gen/pg/arktype/matrix.arktype.ts",
     "src/gen/mysql/arktype/matrix.arktype.ts",
@@ -1433,29 +1486,10 @@ cat > tsconfig.gen.json <<'EOF'
   ]
 }
 EOF
-# Four exclusions, named rather than silent, for one reported defect that predates this branch.
-#
-# The arktype output for the pg and mysql matrix tables each fail on their own with TS2589, "Type
-# instantiation is excessively deep and possibly infinite", at the `type({...})` call wrapping the
-# whole table. The sqlite one, 14 columns, is fine. What is known about it, each measured rather
-# than assumed:
-#
-#   - It is not this branch's doing. Rewriting the emitted pg file back to the exact form the
-#     generator produced before the bigint bound and before the array fix reproduces it at the
-#     identical position.
-#   - It is not the per-field `.narrow().narrow()` chain. Collapsing all fifteen double-narrow
-#     chains in the mysql file into single ones does not clear it.
-#   - It is the number of narrowed fields in one object literal, and the budget is global to the
-#     compilation: check the three arktype trees together and only the first file to exhaust it is
-#     reported, which is why this looked at first like a mysql-only problem.
-#
-# The barrels are excluded with them because `exclude` only filters the entry list: `index.ts`
-# re-exports the matrix module and would pull it back in.
-#
-# Nothing had ever compiled this output, and nothing had ever generated arktype for MySQL at all
-# until this branch widened the parity dialects, which is why a defect older than the branch
-# surfaced with it. Fixing it means changing how the generator emits a whole-table object, which
-# is a separate piece of work from anything here.
+# The originals are excluded because the copies stand in for them, and their barrels with them:
+# `exclude` only filters the entry list, so `index.ts` re-exporting the matrix module would pull
+# the original straight back in. The barrel is five re-export lines and the copy covers what it
+# would have said.
 if ! npx tsc -p tsconfig.gen.json; then
   echo "FAIL: the parity matrix output does not compile under tsc --strict." >&2
   echo "      Generated code that does not typecheck is not usable output, however it behaves" >&2
@@ -1668,10 +1702,11 @@ size_fail=0
 # table. Measured rather than guessed, because a budget raised to make a number fit is worth
 # nothing: on the original 62 columns arktype emits 223 bytes per column, up from 213, and those
 # ten bytes are the bigint bound and the array element walk, both of them constraints that were
-# missing. The two new columns cost about 750 bytes each, three times the average, because a
-# nullable capped array is the longest thing this generator emits and it is emitted three times,
-# once per mode. So the mixed average moved to 248 without any generator emitting more for the
-# same input, which is the same effect recorded above for the CHECK columns.
+# missing. The two new columns cost 920 bytes each, four times the average, because a
+# nullable capped array is the longest thing this generator emits and it is emitted once per mode.
+# So the mixed average moved to 244 without any generator emitting more for the same input, which
+# is the same effect recorded above for the CHECK columns. The three figures reconcile:
+# 13827 + 1840 = 15667 bytes, and the 1840 includes the 37-byte barrel line for the new module.
 report_size src/gen/pg/zod      zod      420  || size_fail=1
 report_size src/gen/pg/valibot  valibot  540  || size_fail=1
 report_size src/gen/pg/arktype  arktype  280  || size_fail=1

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1457,6 +1457,8 @@ node - <<'CARVE'
 import fs from 'node:fs';
 const CARVED = { pg: ['c_numeric', 'c_decimal'], mysql: ['m_decimal'] };
 const MODES = 3;
+const excludes = [];
+let probes = 0;
 for (const [dialect, cols] of Object.entries(CARVED)) {
   const from = `src/gen/${dialect}/arktype/matrix.arktype.ts`;
   const lines = fs.readFileSync(from, 'utf8').split('\n');
@@ -1473,7 +1475,7 @@ for (const [dialect, cols] of Object.entries(CARVED)) {
   }
   fs.writeFileSync(`src/gen-tsc/${dialect}-matrix.arktype.ts`, kept.join('\n'));
   // One probe per carved column: the compiled copy with that column, and only that column, put
-  // back. Somewhere outside the include above, so the stage's own run does not compile them.
+  // back. Somewhere outside the include below, so the stage's own run does not compile them.
   for (const col of cols) {
     const one = new RegExp(`^\\s*"${col}\\??":`);
     const withCol = lines.filter((l) => !drop.test(l) || one.test(l));
@@ -1482,33 +1484,53 @@ for (const [dialect, cols] of Object.entries(CARVED)) {
       process.exit(1);
     }
     fs.writeFileSync(`src/carve-probe/${dialect}-${col}.ts`, withCol.join('\n'));
+    probes++;
   }
+  // The exclusions come from the same map as the copies, rather than being written out beside it.
+  // Hardcoding them meant the two could disagree, and in exactly one direction: emptying CARVED
+  // wrote no stand-in copies while the exclude list went on hiding both original modules, so 40
+  // Postgres and 29 MySQL columns were dropped from the typecheck entirely and the stage still
+  // said everything compiled. Derived, an empty CARVED excludes nothing and the originals are
+  // compiled directly, which fails loudly if the defect is still there.
+  excludes.push(
+    `src/gen/${dialect}/arktype/matrix.arktype.ts`,
+    // The barrel with it: `exclude` only filters the entry list, so an `index.ts` re-exporting the
+    // matrix module would pull the original straight back in.
+    `src/gen/${dialect}/arktype/index.ts`
+  );
 }
+fs.writeFileSync('carve-manifest.txt', String(probes));
+fs.writeFileSync(
+  'tsconfig.gen.json',
+  JSON.stringify(
+    {
+      compilerOptions: {
+        strict: true,
+        noEmit: true,
+        target: 'es2022',
+        module: 'nodenext',
+        moduleResolution: 'nodenext',
+        skipLibCheck: true,
+      },
+      include: [
+        'src/gen/**/*.ts',
+        'src/gen-tsc/**/*.ts',
+        'src/schema.ts',
+        'src/schema-mysql.ts',
+        'src/schema-sqlite.ts',
+      ],
+      exclude: excludes,
+    },
+    null,
+    2
+  )
+);
 CARVE
-cat > tsconfig.gen.json <<'EOF'
-{
-  "compilerOptions": {
-    "strict": true, "noEmit": true, "target": "es2022",
-    "module": "nodenext", "moduleResolution": "nodenext", "skipLibCheck": true
-  },
-  "include": [
-    "src/gen/**/*.ts", "src/gen-tsc/**/*.ts",
-    "src/schema.ts", "src/schema-mysql.ts", "src/schema-sqlite.ts"
-  ],
-  "exclude": [
-    "src/gen/pg/arktype/matrix.arktype.ts",
-    "src/gen/mysql/arktype/matrix.arktype.ts",
-    "src/gen/pg/arktype/index.ts",
-    "src/gen/mysql/arktype/index.ts"
-  ]
-}
-EOF
-# The originals are excluded because the copies stand in for them, and their barrels with them:
-# `exclude` only filters the entry list, so `index.ts` re-exporting the matrix module would pull
-# the original straight back in. Those barrels are four re-export lines on pg and three on mysql,
-# and the copies cover the modules they name. What is given up with them is narrow and worth
-# saying: the barrel is no longer the thing that pulls its modules in here, so a barrel line
-# naming a module that does not exist would not be caught by this stage.
+# The originals are excluded because the copies stand in for them, and their barrels with them.
+# Those barrels are four re-export lines on pg and three on mysql, and the copies cover the modules
+# they name. What is given up is narrow and worth saying: the barrel is no longer the thing that
+# pulls its modules in here, so a barrel line naming a module that does not exist would not be
+# caught by this stage.
 if ! npx tsc -p tsconfig.gen.json; then
   echo "FAIL: the parity matrix output does not compile under tsc --strict." >&2
   echo "      Generated code that does not typecheck is not usable output, however it behaves" >&2
@@ -1525,21 +1547,48 @@ echo "    every generator's matrix output compiles under --strict, module nodene
 # on printing that everything compiles. That is the same stale-waiver shape as the cross-generator
 # list further up, which had exactly this hole in the opposite direction.
 #
-# Compiled one at a time on purpose. TypeScript's instantiation budget is global to a compilation,
-# so a single run over all three probes would report only the first to exhaust it and the other two
-# would look resolved.
+# Compiled one at a time because the question is per column and a compilation answers per run. A
+# combined run over all three probes gives one exit code for the union of them, which is nonzero
+# while any single column still fails, so the one that had been fixed would be masked by the two
+# that had not. That is the whole point of the check, so it cannot be run in a form that cannot
+# express the answer. It is not about errors going unreported: this compiler names all three.
+#
+# The number of probes is asserted against what the carve script wrote, and each probe's output has
+# to actually contain TS2589. Both because "no news is good news" is how this check would otherwise
+# read an empty directory and an unrelated compile error alike: an unexpanded glob makes tsc fail
+# on a path that does not exist, and any nonzero exit used to count as proof the carve was earning
+# its place, so a genuinely broken column carved out of the main compile was certified by the
+# guard meant to police it.
+expected_probes=$(cat carve-manifest.txt)
+actual_probes=$(find src/carve-probe -name '*.ts' | wc -l)
+if [ "$actual_probes" != "$expected_probes" ]; then
+  echo "FAIL: $actual_probes carve probe(s) on disk, $expected_probes expected from CARVED." >&2
+  echo "      This check cannot report on a column it never compiled." >&2
+  exit 1
+fi
 carve_dead=0
-for probe in src/carve-probe/*.ts; do
-  if npx tsc --strict --noEmit --target es2022 --module nodenext --moduleResolution nodenext \
-      --skipLibCheck "$probe" >/dev/null 2>&1; then
-    echo "FAIL: $probe compiles, so that column no longer needs carving out of the typecheck." >&2
-    echo "      Delete it from CARVED above rather than leaving a column excluded for a defect" >&2
-    echo "      that has been fixed." >&2
-    carve_dead=1
-  fi
+for probe in $(find src/carve-probe -name '*.ts' | sort); do
+  out=$(npx tsc --strict --noEmit --target es2022 --module nodenext --moduleResolution nodenext \
+      --skipLibCheck "$probe" 2>&1 || true)
+  case "$out" in
+    *"error TS2589"*) ;;
+    '')
+      echo "FAIL: $probe compiles, so that column no longer needs carving out of the typecheck." >&2
+      echo "      Delete it from CARVED above rather than leaving a column excluded for a defect" >&2
+      echo "      that has been fixed." >&2
+      carve_dead=1
+      ;;
+    *)
+      echo "FAIL: $probe fails, but not with the TS2589 this carve-out exists for:" >&2
+      echo "$out" | head -5 >&2
+      echo "      That error is being hidden from the main typecheck by an exclusion written for" >&2
+      echo "      a different defect. Fix it, or carve it out deliberately and say so." >&2
+      carve_dead=1
+      ;;
+  esac
 done
 [ "$carve_dead" = 0 ] || exit 1
-echo "    each carved column still fails on its own, so the carve-out is still earning it"
+echo "    all $expected_probes carved column(s) still fail with TS2589, so the carve-out is earning it"
 
 cat > src/json-schema-valid.ts <<'JSON_SCHEMA_VALID'
 /**

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1043,12 +1043,11 @@ const ALLOWED: Record<string, string> = {
   // same hole on `c_bit` only because that column has a `minLength` an array cannot satisfy.
   'mysql/typebox/m_binary': 'official Type.RegExp accepts a non-string whose string form matches',
   'mysql/typebox/m_varbinary': 'as mysql/typebox/m_binary',
-  // ArkType states a bigint range through a narrow predicate built with its builder API. This
-  // generator emits one string per field, and the string DSL's comparators take numeric literals:
-  // `type('bigint >= -9223372036854775808n')` is a parse error, not a wider schema.
-  'pg/arktype/c_bigint_b': 'ArkType cannot bound a bigint in its string DSL',
-  'sqlite/arktype/s_blob_bigint': 'as pg/arktype/c_bigint_b',
-  'mysql/arktype/m_bigint_b': 'as pg/arktype/c_bigint_b',
+  // No arktype bigint entry. There were three, reading "ArkType cannot bound a bigint in its
+  // string DSL", and only half of that was true: the DSL cannot state the bound, but a narrow can,
+  // and this generator already used narrows for every character cap. It was the one place in this
+  // whole gate where DRZL was looser than the first-party module, waived on all three dialects.
+  // The generator now bounds bigint columns and all four agree.
 };
 
 const usedWaivers = new Set<string>();
@@ -1079,10 +1078,8 @@ const CROSS_ALLOWED: Record<string, string> = {
   'sqlite/s_text_json': 'as pg/c_json',
   'sqlite/s_blob_json': 'as pg/c_json',
   'sqlite/s_blob': 'as pg/c_json; a bare blob() is Drizzle json mode',
-  // As `pg/arktype/c_bigint_b` above: the three others bound the bigint, arktype cannot.
-  'pg/c_bigint_b': 'ArkType cannot bound a bigint in its string DSL',
-  'mysql/m_bigint_b': 'as pg/c_bigint_b',
-  'sqlite/s_blob_bigint': 'as pg/c_bigint_b',
+  // No bigint entry either, for the reason given in ALLOWED: arktype now bounds a bigint with a
+  // narrow, so the four generators agree about `c_bigint_b`, `m_bigint_b` and `s_blob_bigint`.
   // No `c_char` entry. There was one, reading "zod and valibot count code points; TypeBox and
   // ArkType count UTF-16 units", and it had been dead since arktype and typebox were changed to
   // count code points as well. All four now emit a `[...v].length` predicate and agree on every

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -710,6 +710,25 @@ export const defaulted = pgTable('defaulted', {
   d_enum: moodEnum().default('sad'),
 });
 
+/**
+ * Nullable arrays, which every array in `matrix` being `notNull` meant nothing had ever emitted.
+ *
+ * A nullable array renders differently enough to break code that assumed `T[]`: the arktype
+ * generator recovered an array's element by stripping a trailing `[]`, and `(T[] | null)` has
+ * none, so the whole union became the element and `.array()` wrapped it. That output refused
+ * `null` and `['ab']`, accepted `[['ab']]`, and for the bigint one did not compile at all. A
+ * capped or bounded element is what makes the shape reachable: an unconstrained column emits a
+ * plain DSL string and never goes near that code.
+ *
+ * Its own table rather than two more columns on `matrix`, because the arktype output for a
+ * 40-column table of narrowed fields is already at the edge of TS2589, and two more tipped it
+ * over. That defect is reported; provoking it here would only hide these columns behind it.
+ */
+export const arrays = pgTable('arrays', {
+  a_varchar_arr_null: varchar({ length: 10 }).array(),
+  a_bigint_arr_null: bigint({ mode: 'bigint' }).array(),
+});
+
 export const checked = pgTable('checked', {
   k_min: integer(),
   k_max: integer(),
@@ -1305,8 +1324,12 @@ PARITY_HARNESS
 # ajv and ajv-formats are the JSON Schema generator's own declared devDependency ranges, so the
 # packed artefact is read by the same validator its unit tests claim it is checked against. They
 # are not dependencies of anything DRZL publishes: JSON Schema output is data with no runtime.
+#
+# typescript, because this tree's generated output is now compiled as well as executed. It was
+# only ever run, and a nullable bigint array reached a released generator emitting `>=` against a
+# `bigint[]`, which no amount of running it can notice.
 npm install --no-audit --no-fund --loglevel=error \
-  "$TARS"/*.tgz drizzle-orm@1.0.0-rc.4 zod valibot arktype @sinclair/typebox tsx \
+  "$TARS"/*.tgz drizzle-orm@1.0.0-rc.4 zod valibot arktype @sinclair/typebox tsx typescript \
   ajv@^8.17.1 ajv-formats@^3.0.1 >/dev/null
 
 for dialect in pg mysql sqlite; do
@@ -1380,6 +1403,66 @@ CONFIG
     done
   fi
 done
+
+# ---------------------------------------------------------------------------------------------
+# Does the parity matrix output compile?
+#
+# The typecheck stage far above runs on a two-table users/posts schema with no arrays, no bigint
+# and no capped column, so the only generated code this script ever put through `tsc` was its
+# simplest. The 40-column matrix, which exists precisely to hold the awkward types, was generated,
+# executed and then thrown away without a compiler ever looking at it.
+#
+# What that hid: the arktype generator emitted `type("(bigint[] | null)").narrow((v, ctx) => ...
+# v >= -9223372036854775808n ...)` for a nullable bigint array, which is TS2365, `>=` cannot be
+# applied to `bigint[]`. Every runtime check in this file passed it, because a narrow that throws
+# is caught and read as a rejection, and rejection was the answer for most probe values anyway.
+# ---------------------------------------------------------------------------------------------
+echo "==> typechecking the parity matrix output"
+cat > tsconfig.gen.json <<'EOF'
+{
+  "compilerOptions": {
+    "strict": true, "noEmit": true, "target": "es2022",
+    "module": "nodenext", "moduleResolution": "nodenext", "skipLibCheck": true
+  },
+  "include": ["src/gen/**/*.ts", "src/schema.ts", "src/schema-mysql.ts", "src/schema-sqlite.ts"],
+  "exclude": [
+    "src/gen/pg/arktype/matrix.arktype.ts",
+    "src/gen/mysql/arktype/matrix.arktype.ts",
+    "src/gen/pg/arktype/index.ts",
+    "src/gen/mysql/arktype/index.ts"
+  ]
+}
+EOF
+# Four exclusions, named rather than silent, for one reported defect that predates this branch.
+#
+# The arktype output for the pg and mysql matrix tables each fail on their own with TS2589, "Type
+# instantiation is excessively deep and possibly infinite", at the `type({...})` call wrapping the
+# whole table. The sqlite one, 14 columns, is fine. What is known about it, each measured rather
+# than assumed:
+#
+#   - It is not this branch's doing. Rewriting the emitted pg file back to the exact form the
+#     generator produced before the bigint bound and before the array fix reproduces it at the
+#     identical position.
+#   - It is not the per-field `.narrow().narrow()` chain. Collapsing all fifteen double-narrow
+#     chains in the mysql file into single ones does not clear it.
+#   - It is the number of narrowed fields in one object literal, and the budget is global to the
+#     compilation: check the three arktype trees together and only the first file to exhaust it is
+#     reported, which is why this looked at first like a mysql-only problem.
+#
+# The barrels are excluded with them because `exclude` only filters the entry list: `index.ts`
+# re-exports the matrix module and would pull it back in.
+#
+# Nothing had ever compiled this output, and nothing had ever generated arktype for MySQL at all
+# until this branch widened the parity dialects, which is why a defect older than the branch
+# surfaced with it. Fixing it means changing how the generator emits a whole-table object, which
+# is a separate piece of work from anything here.
+if ! npx tsc -p tsconfig.gen.json; then
+  echo "FAIL: the parity matrix output does not compile under tsc --strict." >&2
+  echo "      Generated code that does not typecheck is not usable output, however it behaves" >&2
+  echo "      at runtime." >&2
+  exit 1
+fi
+echo "    every generator's matrix output compiles under --strict, module nodenext"
 
 cat > src/json-schema-valid.ts <<'JSON_SCHEMA_VALID'
 /**
@@ -1580,9 +1663,18 @@ size_fail=0
 # Raised once, when the fixture gained thirteen columns that each carry a CHECK. That is the
 # densest output the generators produce, so the per-column average rose without any generator
 # emitting more for the same input.
+#
+# Raised again for arktype only, 240 to 280, when the fixture gained the two-column `arrays`
+# table. Measured rather than guessed, because a budget raised to make a number fit is worth
+# nothing: on the original 62 columns arktype emits 223 bytes per column, up from 213, and those
+# ten bytes are the bigint bound and the array element walk, both of them constraints that were
+# missing. The two new columns cost about 750 bytes each, three times the average, because a
+# nullable capped array is the longest thing this generator emits and it is emitted three times,
+# once per mode. So the mixed average moved to 248 without any generator emitting more for the
+# same input, which is the same effect recorded above for the CHECK columns.
 report_size src/gen/pg/zod      zod      420  || size_fail=1
 report_size src/gen/pg/valibot  valibot  540  || size_fail=1
-report_size src/gen/pg/arktype  arktype  240  || size_fail=1
+report_size src/gen/pg/arktype  arktype  280  || size_fail=1
 report_size src/gen/pg/typebox  typebox  430  || size_fail=1
 [ "$size_fail" = 0 ] || exit 1
 


### PR DESCRIPTION
Plan items 10 and 11. Five fix rounds, each with an independent scoped re-review that reproduced
proofs rather than reading them. Every round found something real.

## The gap

```
pg)     libs="zod valibot arktype typebox"
mysql)  libs="zod"
sqlite) libs="zod"
```

**Valibot, arktype and typebox had never been compared against the official `drizzle-orm` modules
on two of three dialects.** Three generators x two dialects x three modes is eighteen combinations
with no differential coverage at all. Nothing structural prevented it; the line was never widened.

## Now

```
36 lines, all n/n cols compared   (was 18, of which 12 were pg)
all four pg generators agree with each other on every column and value
all four mysql generators agree with each other on every column and value
all four sqlite generators agree with each other on every column and value
every generator's matrix output compiles under --strict, module nodenext
```

## Widening the shell line alone would have compared nothing

`libs` generates the extra libraries. `DIALECTS[].libs`/`.mods` inside the harness is what compares
them. With only the first changed the run stays green having done no more work, which the review
confirmed by reverting the second half: **zero findings, exit 0**.

A task whose whole purpose was turning on comparisons that never ran would itself have run nothing.

## 41 findings, none a generator defect, and then one that was

| Category | Count | Mechanism |
| --- | ---: | --- |
| valibot's json check | 12 | DRZL stricter, the safe direction |
| official typebox accepts `[]` for a MySQL binary column | 6 | `Type.RegExp` uses `RegExp.test`, which stringifies |
| arktype json string widening | 20 | cross-generator pass only |
| arktype unbounded bigint | 3 | **the one place DRZL was looser** |

That last one had been waived for months on the grounds that "this generator emits one string per
field, and the string DSL's comparators take numeric literals". The second half is true. The first
is not: the generator already emits `type("string").narrow(...)` for every character cap.

So it was fixed rather than re-waived. ArkType now bounds bigint columns with a narrow, **closing
the only place in the entire gate where DRZL was looser than official.** The freshly-repaired
dead-waiver check then named all six now-obsolete waivers itself.

## Which broke nullable bigint arrays, and uncovered two silent siblings

The bound was attached after the element was extracted by stripping a trailing `[]`, so a nullable
array's whole `(T[] | null)` union became the element:

```
             null    [1n]    [[1n]]  [null]
before       false   false   true    true      TS2365 on all three modes
after        true    true    false   false     compiles clean
```

Both looser and stricter than official at once. The root cause was pre-existing with two further
instances nobody had named: a **nullable capped-string array** had the identical bug on master (it
compiled, so nothing noticed, but it rejected `null` and `['ab']` and accepted `[['ab']]`), and a
**two-dimensional capped array** came out a dimension too deep.

Fixed by keeping the narrow on the value and walking in with `.every` per dimension, so the depth
comes from the same `arrayDimensions` that adds the brackets and the two cannot disagree. Verified
against `drizzle-orm/arktype` across 13 columns x 18 probes: zero differing cells.

## The gate that let it through

The 40-column matrix's arktype output was **generated but never typechecked**. The tree that was
typechecked came from a simple users/posts schema with no arrays and no bigint. Every generator's
matrix output now compiles under the gate's own flags.

That exposed a pre-existing `TS2589`, and the reason first written for it was wrong: not the count
of narrowed fields, but **two columns** whose emitted DSL carries a 192-character regex ArkType
parses at the type level. Each fails alone. The carve-out is now per column, and guarded in both
directions: a renamed column fails, and a column that stops needing carving fails as dead.

## Five vacuous checks found

- `c_varchar_enum` and `m_year` had no accepted value in the pool, so both sides rejected all 55
  probes and were recorded as agreeing.
- The dead-waiver gate did not work for cross-generator waivers: the check ran before any
  disagreement was computed, so a key was marked used merely because the column existed.
- `pg/c_char`'s waiver was dead, and its stated reason was contradicted by all four generators.
- The dead-carve guard read any nonzero `tsc` exit as "still needed", so an unrelated compile error
  certified a carve while hiding a real defect.
- With no carved columns it printed success while excluding nothing.

## And a measurement problem worth naming

Two rounds of `TS2589` measurements were taken with the wrong compiler. The workspace has
TypeScript **5.9.3**; the packed parity tree runs `npx tsc` at **7.0.2**. They disagree on
reporting: 5.9.3 names one file, 7.0.2 names all three. It surfaced only because two agents got
different answers from the same experiment and one dug in. Every substantive conclusion was
re-tested under 7.0.2 and holds; only the sentence explaining it was wrong.

## Verification

870 tests across 101 files, typecheck and lint clean, full `verify:packed` green. Pre-existing
figures unmoved: 1400 Postgres probes, DRZL 1007, further on 0; CHECK probes DRZL 0 against
drizzle-orm's 22.
