### PR TITLE
fix(analyzer): type point and line as tuples on 0.4x, and take the float bounds from the database

### DIFF
--- a/.changeset/point-line-and-float-bounds-0-4x.md
+++ b/.changeset/point-line-and-float-bounds-0-4x.md
@@ -1,44 +1,91 @@
 ---
-'@drzl/analyzer': patch
-'@drzl/generator-zod': patch
-'@drzl/generator-valibot': patch
-'@drzl/generator-arktype': patch
-'@drzl/generator-typebox': patch
-'@drzl/generator-json-schema': patch
-'@drzl/generator-orpc': patch
-'@drzl/generator-service': patch
+'@drzl/analyzer': minor
+'@drzl/generator-zod': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-arktype': minor
+'@drzl/generator-typebox': minor
+'@drzl/generator-json-schema': minor
+'@drzl/generator-orpc': minor
+'@drzl/generator-service': minor
 ---
 
 Fixes two defects on drizzle-orm 0.4x, which is what `npm install drizzle-orm` still serves and
-what this workspace itself depends on. Both were filed by the cross-major analyzer diff and the
-0.4x parity pass and are now gone from both ledgers.
+what this workspace itself depends on, and corrects the bounds on inexact numeric columns on
+**both** majors.
 
-`point` and `line` were typed `string`. 0.4x carries no codec, so those columns reach the analyzer
-by class name, and a coarse `/Point|Line/i` answered `string` for a value the driver hands back as
-a tuple. A real Postgres settles it rather than the first-party module: drizzle 0.45.2 maps
-`[1, 2]` to the literal `(1,2)`, the column takes it and `mapFromDriverValue` returns `[1, 2]`;
-the string `"1,2"` is mapped to `(1,,)`, because `mapToDriverValue` indexes the value by position,
-and Postgres refuses it with `invalid input syntax for type point`. So a select schema generated
-on 0.4x rejected every row the column returned, and an insert schema accepted the one string shape
-the column cannot be given. `point()` is now `[number, number]` and `line()` `[number, number, number]`,
-matching what the analyzer already emitted on v1.
+**`minor`, not `patch`.** The emitted TypeScript type of a `point` column changes from `string` to
+`[number, number]`, and of a `line` from `string` to `[number, number, number]`. Code written
+against the old output does not compile against the new. `CONTRIBUTING.md` asks for a bump above
+patch to be called out, and this is the call-out.
 
-Inexact numeric columns carried no bounds. `real`, `double precision`, `numeric({ mode: 'number' })`
-on Postgres, `real`, `double` and `float` on MySQL and SingleStore, and `real` on SQLite all
-reached the same class-name path, where the only range table held integers. That left DRZL looser
-than `drizzle-zod@0.8.3`, the first-party validator for the very same major: its `real` schema
-refused 9000000, 2147483648 and 9007199254740993 where DRZL's took all three. Each column now
-carries the width drizzle states for it on v1, and `integer: false` with it, so a bounded float is
-not mistaken for an integer and does not start refusing `1.5`.
+**What changes for a user, in one sentence each.**
 
-The bounds are drizzle's, not the database's, and the difference is measured rather than assumed.
-Asked through PGlite, a `real` column accepts 8388608, 9000000, 2147483648, Infinity and NaN, and
-holds every integer exactly up to 16777216, twice the bound emitted for it; `double precision`
-returns every one of those unchanged. A `numeric(10,2)` runs the other way and refuses 2147483648
-outright with `numeric field overflow`, so the safe-integer bound is still looser than that column
-is. DRZL matches the first-party module on all of them, because a generated schema that disagreed
-with it about the same column would be the more surprising outcome.
+- A `point` or `line` column: your select schema stops rejecting every row and your insert schema
+  stops accepting a string the column cannot be given. On 0.4x only; v1 was already right.
+- A `real`, `double precision`, `float` or `double` column: your schema stops rejecting large
+  values the column holds. This is a change on **both** majors, and it widens rather than narrows,
+  so nothing that validated before stops validating.
+- A `numeric({ mode: 'number' })` column on 0.4x: newly bounded to the safe-integer range, which
+  is a narrowing. A value above 9007199254740991 that validated before is refused now. It could not
+  round-trip through a JS number anyway, and both drizzle majors and `drizzle-zod` emit the same
+  bound.
 
-Only the analyzer's source changes. The generators are listed because what they emit for these
-columns changes with it: a tuple where there was a string, and a range where there was none, in
-the validators, in the JSON Schema, and in the TypeScript the service and oRPC generators write.
+### point and line were typed `string` on 0.4x
+
+0.4x carries no codec, so those columns reach the analyzer by class name, and a coarse
+`/Point|Line/i` answered `string` for a value the driver hands back as a tuple. A real Postgres
+settles it rather than the first-party module: drizzle 0.45.2 maps `[1, 2]` to the literal `(1,2)`,
+the column takes it and `mapFromDriverValue` returns `[1, 2]`; the string `"1,2"` is mapped to
+`(1,,)`, because `mapToDriverValue` indexes the value by position, and Postgres refuses it with
+`invalid input syntax for type point`. `point()` is now `[number, number]` and `line()`
+`[number, number, number]`, matching what the analyzer already emitted on v1.
+
+### The bound on an inexact numeric column is the database's, not drizzle-zod's
+
+`real`, `double precision` and `numeric({ mode: 'number' })` on Postgres, `real`, `double` and
+`float` on MySQL and SingleStore, and `real` on SQLite carried no bound at all on 0.4x. The first
+pass at this adopted `drizzle-zod`'s numbers, and asking the database showed they are not limits of
+anything:
+
+- a `real` column stores 8388608, 9000000, 1e9 and 2147483648 and returns each unchanged, and holds
+  every integer exactly up to 16777216. `drizzle-zod` bounds it at +/-8388607, so that bound
+  refuses rows the column hands back.
+- a `double precision` column accepted every finite JavaScript number, measured to
+  `Number.MAX_VALUE`, and returned each identical. `drizzle-zod` bounds it at +/-140737488355327,
+  which refuses 1.75e15, an ordinary microsecond epoch.
+
+So the bounds are the database's now. A 4 byte float is bounded at the one magnitude Postgres does
+refuse, 3.4028234663852886e38, past which it answers `out of range for type real`. An 8 byte float
+carries no magnitude bound, and states `integer: false` on its own so a bounded float is never
+mistaken for an integer. `numeric({ mode: 'number' })` keeps the safe-integer range, which is about
+what a JS number can carry rather than about the column.
+
+Measured against this repository's ground-truth stages, which insert every probe into a real
+Postgres: DRZL's agreement with the database rose from 1007 to 1012 on the validator schemas and
+from 852 to 857 on the JSON Schema output, and the count of probes where DRZL disagrees with
+Postgres and the first-party module does not stayed at 0.
+
+This puts DRZL deliberately looser than `drizzle-orm/{zod,valibot,arktype,typebox}` on six columns.
+Every one is waived in both parity passes with the measurement attached.
+
+### Infinity and NaN are still refused, and that is not fixed
+
+Postgres stores and returns `Infinity`, `-Infinity` and `NaN` in `real` and `double precision`
+alike. No range admits any of them, and `z.number()` and `Type.Number()` refuse a non-finite number
+with no bound at all, so describing those columns honestly needs a union in every generator rather
+than a wider range. Filed, not fixed.
+
+One real consequence, stated because the first pass at this removed it silently: on 0.4x, valibot
+and arktype used to accept `Infinity` for these columns, because nothing bounded them. That is
+restored for every 8 byte float column, which now carries no bound again. For a 4 byte float it is
+not: the float4 magnitude bound excludes `Infinity`, so all four libraries refuse it there.
+
+### The service and oRPC generators
+
+Both map a column through a short allowlist and fall to `unknown` for anything else, so a tuple
+column became `unknown` in the emitted TypeScript and `z.unknown()` in an oRPC router's input
+schema, which accepts anything at all including a `null` payload the insert will not survive. Both
+now emit the tuple: `[number, number]` in the service types, `z.tuple([z.number(), z.number()])`
+and the valibot equivalent in oRPC. ArkType keeps `unknown` there, measured rather than assumed:
+that generator emits its field values as quoted string-DSL fragments, and ArkType's string DSL has
+no tuple form.

--- a/.changeset/point-line-and-float-bounds-0-4x.md
+++ b/.changeset/point-line-and-float-bounds-0-4x.md
@@ -23,8 +23,12 @@ patch to be called out, and this is the call-out.
 - A `point` or `line` column: your select schema stops rejecting every row and your insert schema
   stops accepting a string the column cannot be given. On 0.4x only; v1 was already right.
 - A `real`, `double precision`, `float` or `double` column: your schema stops rejecting large
-  values the column holds. This is a change on **both** majors, and it widens rather than narrows,
-  so nothing that validated before stops validating.
+  values the column holds. This is a change on **both** majors, and most of it widens: an 8 byte
+  float loses its bound entirely on both, and a 4 byte float on **v1** moves from `drizzle-zod`'s
+  `+/-8388607` to a far wider one. **On 0.4x a 4 byte float is a narrowing**, because it had no
+  bound there at all. `1e300` and `3.5e38` validated in a `real` before and are refused now, as is
+  `Infinity` in valibot and arktype, which is the one value in that set the column really holds and
+  which has its own section below. Nothing else that validated before stops validating.
 - A `numeric({ mode: 'number' })` column on 0.4x: newly bounded to the safe-integer range, which
   is a narrowing. A value above 9007199254740991 that validated before is refused now. It could not
   round-trip through a JS number anyway, and both drizzle majors and `drizzle-zod` emit the same
@@ -54,8 +58,15 @@ anything:
   `Number.MAX_VALUE`, and returned each identical. `drizzle-zod` bounds it at +/-140737488355327,
   which refuses 1.75e15, an ordinary microsecond epoch.
 
-So the bounds are the database's now. A 4 byte float is bounded at the one magnitude Postgres does
-refuse, 3.4028234663852886e38, past which it answers `out of range for type real`. An 8 byte float
+So the bounds are the database's now, and the 4 byte width has two of them, because the two
+databases that impose one do not agree on where it is. Both were bisected over the raw bit pattern
+of a double against a real server. Postgres accepts every double up to `3.4028235677973366e38` in a
+`real` and answers `out of range for type real` to the next one; MySQL 8.4 refuses everything past
+`3.4028234663852886e38`, the largest float32, which is 268435456 representable doubles lower, in
+strict mode and under the stock `sql_mode` alike. The gap is not academic: a `real` at full
+magnitude comes back over the text protocol as `3.4028235e+38`, which is inside Postgres's edge and
+outside the float32, so a schema bounded at the float32 refused a row the column had just handed
+back. An 8 byte float
 carries no magnitude bound, and states `integer: false` alongside, which is true of the column
 and is what keeps the *bounded* widths from being read as integers: `isIntegerColumn` falls back to
 "declares both bounds" when the flag is absent, so without it a `real` schema would call `.int()`
@@ -64,9 +75,13 @@ to fall back to. `numeric({ mode: 'number' })` keeps the safe-integer range, whi
 what a JS number can carry rather than about the column.
 
 Measured against this repository's ground-truth stages, which insert every probe into a real
-Postgres: DRZL's agreement with the database rose from 1007 to 1012 on the validator schemas and
-from 852 to 857 on the JSON Schema output, and the count of probes where DRZL disagrees with
-Postgres and the first-party module does not stayed at 0.
+Postgres. On the 1400 probes those stages carried before this release, DRZL's agreement with the
+database rose from 1007 to 1012 on the validator schemas and from 852 to 857 on the JSON Schema
+output. This release also adds the probe that would have caught the float32 mistake, the value a
+full-magnitude `real` returns, so the pool is 1440 probes now and the totals are not comparable
+across that line: DRZL agrees on 1048 of them against `drizzle-orm`'s 1013, is closer to the
+database on 35 and further on none. That last count, probes where DRZL disagrees with Postgres and
+the first-party module does not, stayed at 0 throughout.
 
 This puts DRZL deliberately looser than `drizzle-orm/{zod,valibot,arktype,typebox}` on six columns.
 Every one is waived in both parity passes with the measurement attached.

--- a/.changeset/point-line-and-float-bounds-0-4x.md
+++ b/.changeset/point-line-and-float-bounds-0-4x.md
@@ -56,8 +56,11 @@ anything:
 
 So the bounds are the database's now. A 4 byte float is bounded at the one magnitude Postgres does
 refuse, 3.4028234663852886e38, past which it answers `out of range for type real`. An 8 byte float
-carries no magnitude bound, and states `integer: false` on its own so a bounded float is never
-mistaken for an integer. `numeric({ mode: 'number' })` keeps the safe-integer range, which is about
+carries no magnitude bound, and states `integer: false` alongside, which is true of the column
+and is what keeps the *bounded* widths from being read as integers: `isIntegerColumn` falls back to
+"declares both bounds" when the flag is absent, so without it a `real` schema would call `.int()`
+and refuse 1.5. On the unbounded widths the flag decides nothing, since there is no pair of bounds
+to fall back to. `numeric({ mode: 'number' })` keeps the safe-integer range, which is about
 what a JS number can carry rather than about the column.
 
 Measured against this repository's ground-truth stages, which insert every probe into a real

--- a/.changeset/point-line-and-float-bounds-0-4x.md
+++ b/.changeset/point-line-and-float-bounds-0-4x.md
@@ -1,0 +1,44 @@
+---
+'@drzl/analyzer': patch
+'@drzl/generator-zod': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-arktype': patch
+'@drzl/generator-typebox': patch
+'@drzl/generator-json-schema': patch
+'@drzl/generator-orpc': patch
+'@drzl/generator-service': patch
+---
+
+Fixes two defects on drizzle-orm 0.4x, which is what `npm install drizzle-orm` still serves and
+what this workspace itself depends on. Both were filed by the cross-major analyzer diff and the
+0.4x parity pass and are now gone from both ledgers.
+
+`point` and `line` were typed `string`. 0.4x carries no codec, so those columns reach the analyzer
+by class name, and a coarse `/Point|Line/i` answered `string` for a value the driver hands back as
+a tuple. A real Postgres settles it rather than the first-party module: drizzle 0.45.2 maps
+`[1, 2]` to the literal `(1,2)`, the column takes it and `mapFromDriverValue` returns `[1, 2]`;
+the string `"1,2"` is mapped to `(1,,)`, because `mapToDriverValue` indexes the value by position,
+and Postgres refuses it with `invalid input syntax for type point`. So a select schema generated
+on 0.4x rejected every row the column returned, and an insert schema accepted the one string shape
+the column cannot be given. `point()` is now `[number, number]` and `line()` `[number, number, number]`,
+matching what the analyzer already emitted on v1.
+
+Inexact numeric columns carried no bounds. `real`, `double precision`, `numeric({ mode: 'number' })`
+on Postgres, `real`, `double` and `float` on MySQL and SingleStore, and `real` on SQLite all
+reached the same class-name path, where the only range table held integers. That left DRZL looser
+than `drizzle-zod@0.8.3`, the first-party validator for the very same major: its `real` schema
+refused 9000000, 2147483648 and 9007199254740993 where DRZL's took all three. Each column now
+carries the width drizzle states for it on v1, and `integer: false` with it, so a bounded float is
+not mistaken for an integer and does not start refusing `1.5`.
+
+The bounds are drizzle's, not the database's, and the difference is measured rather than assumed.
+Asked through PGlite, a `real` column accepts 8388608, 9000000, 2147483648, Infinity and NaN, and
+holds every integer exactly up to 16777216, twice the bound emitted for it; `double precision`
+returns every one of those unchanged. A `numeric(10,2)` runs the other way and refuses 2147483648
+outright with `numeric field overflow`, so the safe-integer bound is still looser than that column
+is. DRZL matches the first-party module on all of them, because a generated schema that disagreed
+with it about the same column would be the more surprising outcome.
+
+Only the analyzer's source changes. The generators are listed because what they emit for these
+columns changes with it: a tuple where there was a string, and a range where there was none, in
+the validators, in the JSON Schema, and in the TypeScript the service and oRPC generators write.

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -37,8 +37,13 @@ export type SelectpeopleOutput = Static<typeof SelectpeopleSchema>;
 | `varchar(255)`      | `Type.Intersect([Type.String(), <code-point cap>])`, see below          |
 | `uuid()`            | `Type.String({ pattern: '...' })`                                      |
 | `smallint()`        | `Type.Integer({ minimum: -32768, maximum: 32767 })`                    |
-| `real()`            | `Type.Number({ minimum: -8388608, maximum: 8388607 })`                 |
-| `doublePrecision()` | `Type.Number({ minimum: -140737488355328, maximum: 140737488355327 })` |
+| `real()`            | `Type.Number({ minimum: -3.4028234663852886e38, maximum: 3.4028234663852886e38 })`, written out in full |
+| `doublePrecision()` | `Type.Number()`, with no magnitude bound                               |
+
+The two float rows are the database's answer rather than `drizzle-orm/typebox`'s. Postgres stores
+`3.4028234663852886e38` in a `real` and answers `out of range for type real` to the next value up,
+and it stored `Number.MAX_VALUE` in a `double precision` and handed it back unchanged. See
+[Zod → What the column declares](/generators/zod#what-the-column-declares-is-what-the-schema-enforces).
 
 ### Why uuid is a pattern and not a format
 

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -37,12 +37,14 @@ export type SelectpeopleOutput = Static<typeof SelectpeopleSchema>;
 | `varchar(255)`      | `Type.Intersect([Type.String(), <code-point cap>])`, see below          |
 | `uuid()`            | `Type.String({ pattern: '...' })`                                      |
 | `smallint()`        | `Type.Integer({ minimum: -32768, maximum: 32767 })`                    |
-| `real()`            | `Type.Number({ minimum: -3.4028234663852886e38, maximum: 3.4028234663852886e38 })`, written out in full |
+| `real()`            | `Type.Number({ minimum: -3.4028235677973366e38, maximum: 3.4028235677973366e38 })`, written out in full |
 | `doublePrecision()` | `Type.Number()`, with no magnitude bound                               |
 
-The two float rows are the database's answer rather than `drizzle-orm/typebox`'s. Postgres stores
-`3.4028234663852886e38` in a `real` and answers `out of range for type real` to the next value up,
-and it stored `Number.MAX_VALUE` in a `double precision` and handed it back unchanged. See
+The two float rows are the database's answer rather than `drizzle-orm/typebox`'s. Postgres accepts
+every double up to `3.4028235677973366e38` in a `real` and answers `out of range for type real` to
+the next one, and it stored `Number.MAX_VALUE` in a `double precision` and handed it back unchanged.
+On MySQL a `float()` is bounded lower, at `3.4028234663852886e38`, because a real MySQL 8.4 refuses
+the next double after that one. See
 [Zod → What the column declares](/generators/zod#what-the-column-declares-is-what-the-schema-enforces).
 
 ### Why uuid is a pattern and not a format

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -45,10 +45,18 @@ Integer ranges follow the column width, and `bigint({ mode: 'number' })` is type
 with the JavaScript safe-integer bound rather than as a bigint, because that is what the value
 actually is.
 
-`real` is bounded at the one magnitude Postgres does refuse, `3.4028234663852886e38`, written out in
-full decimal. Postgres stores that value and answers `out of range for type real` to the next one
-up. `double precision` carries no magnitude bound at all: Postgres stored `Number.MAX_VALUE` in one
-and handed it back unchanged.
+`real` is bounded where Postgres stops accepting, `3.4028235677973366e38`, written out in full
+decimal. Postgres takes every double up to and including that one and answers `out of range for
+type real` to the next. That edge is above the largest float32 rather than at it: a `real` at full
+magnitude comes back over the text protocol as `3.4028235e+38`, which is already past the float32,
+so a schema bounded there would refuse the value the driver just handed you. `double precision`
+carries no magnitude bound at all: Postgres stored `Number.MAX_VALUE` in one and handed it back
+unchanged.
+
+MySQL's `float` is bounded lower, at `3.4028234663852886e38`, because MySQL is stricter here than
+Postgres: a real MySQL 8.4 refuses the very next double above the largest float32, in strict mode
+and under the stock `sql_mode` alike. Its `double` and `real` carry no bound, like Postgres's
+`double precision`.
 
 Those bounds are the database's rather than `drizzle-orm/zod`'s, which bounds the same two columns
 at `-8388608 .. 8388607` and `-140737488355328 .. 140737488355327`. Both refuse values the column

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -45,10 +45,16 @@ Integer ranges follow the column width, and `bigint({ mode: 'number' })` is type
 with the JavaScript safe-integer bound rather than as a bigint, because that is what the value
 actually is.
 
-`real` and `double precision` are bounded too, at the point past which a float stops being able
-to represent consecutive integers. That is narrower than the column, which holds far larger
-values, but a number above it comes back out of the database as a _different_ number.
-`drizzle-orm/zod` draws the line in the same place.
+`real` is bounded at the one magnitude Postgres does refuse, `3.4028234663852886e38`, written out in
+full decimal. Postgres stores that value and answers `out of range for type real` to the next one
+up. `double precision` carries no magnitude bound at all: Postgres stored `Number.MAX_VALUE` in one
+and handed it back unchanged.
+
+Those bounds are the database's rather than `drizzle-orm/zod`'s, which bounds the same two columns
+at `-8388608 .. 8388607` and `-140737488355328 .. 140737488355327`. Both refuse values the column
+hands back, `9000000` in a `real` and `1.75e15` in a `double precision`, so DRZL is deliberately
+wider on every 4 and 8 byte float column. Each one is waived in the parity gate with the measured
+divergence attached.
 
 ## Character limits count characters
 
@@ -110,10 +116,16 @@ every row the database returns:
 | `bytea()`                   | `Buffer`                   | `z.instanceof(Uint8Array)`              |
 | `json()`, `jsonb()`         | any JSON value             | `z.json()`                              |
 
-`bytea` is typed as `Uint8Array` rather than `Buffer`, which is the one place the output is
-deliberately wider than `drizzle-orm/zod`. A Buffer is a Uint8Array, so nothing official accepts
-is turned away; the wider check needs no `@types/node`, survives a runtime where `Buffer` is not
-defined, and makes a Postgres `bytea` and a SQLite `blob` validate the same way.
+`bytea` is typed as `Uint8Array` rather than `Buffer`, which is deliberately wider than
+`drizzle-orm/zod`. A Buffer is a Uint8Array, so nothing official accepts is turned away; the wider
+check needs no `@types/node`, survives a runtime where `Buffer` is not defined, and makes a
+Postgres `bytea` and a SQLite `blob` validate the same way.
+
+It is not the only place the output is wider. This page used to say it was, which the project's own
+parity gate had already contradicted: that gate waives each difference from the first-party module
+with the exact values measured, and prints on every run how many of them are DRZL accepting
+something official refuses. The float bounds described above are wider on six columns across the
+three dialects, and every one of those is waived too.
 
 A CHECK constraint naming an array or a structured column is skipped rather than folded in, since
 the comparison is against a scalar literal and describes neither.

--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -87,9 +87,9 @@ runs the emitted schemas against **three real databases** on every commit: Postg
 PGlite, SQLite via `node:sqlite`, and MySQL as a CI service container.
 
 ```
-    1400 probes against a real Postgres (40 columns)
-    agree with the database: DRZL 1007, drizzle-orm 979
-    DRZL closer than drizzle-orm on 28, further on 0
+    1440 probes against a real Postgres (40 columns)
+    agree with the database: DRZL 1048, drizzle-orm 1013
+    DRZL closer than drizzle-orm on 35, further on 0
 
     53 CHECK probes against a real Postgres (13 constrained columns)
     rows Postgres rejects and the validator accepts: DRZL 0, drizzle-orm 22

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -970,8 +970,14 @@ export class SchemaAnalyzer {
    * Only drizzle v1 states this outright, as a `float` or `double` semantic on `dataType`. On
    * 0.4x the same columns reach the analyzer by class name, `INT_RANGES` was the only range table
    * on that path, and so nothing said anything about them at all: not the range, and not that
-   * they are inexact. That made DRZL looser than the first-party validator for the same major on
-   * every one of these columns, which is what the parity gate exists to forbid.
+   * they are inexact. The parity gate measured seven of the ten classes below and reported DRZL
+   * differing from the first-party validator for the same major on all seven. The three
+   * SingleStore classes are in no fixture either pass carries and are covered by unit tests alone.
+   *
+   * Differing is what the gate reports, not what it forbids. Most of its waivers have DRZL
+   * accepting something official refuses and the run counts them; an earlier version of this
+   * sentence said the gate exists to forbid being looser, which the same commit's own success
+   * banner denies.
    *
    * `null` is a value in this table and is not the same as a class it does not name. It says the
    * column is inexact and that no finite magnitude bound is truthful for it, which is the case for

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -253,15 +253,61 @@ const MYSQL_TEXT_CAPS: Record<string, number> = {
 /**
  * Bounds `drizzle-orm/zod` puts on the inexact numeric types, matched deliberately.
  *
- * They are narrower than the column: Postgres `real` holds values up to ~3.4e38. The bound is
- * the point past which a float can no longer represent consecutive integers, so a value above
- * it round-trips through the database as a *different* number. Drizzle chose to reject that
- * rather than lose it silently, and a generated schema that disagreed with the first-party one
- * about the same column would be the more surprising outcome.
+ * Neither the column's range nor its precision limit, and the sentence that used to stand here
+ * said it was the second. Asked of a real Postgres through PGlite, on each column's own SQL type:
+ *
+ *   real              takes 8388608, 9000000, 2147483648, Infinity and NaN; holds every integer
+ *                     exactly up to 16777216, and gives 16777217 back as 16777216
+ *   double precision  takes all of the above and returns each one unchanged
+ *
+ * So `real` represents consecutive integers to twice the bound below and `double precision` to
+ * 2^53, and the database refuses none of it. Drizzle picked the signed 24 bit and 48 bit ranges
+ * instead, and DRZL matches them: a generated schema that disagreed with the first-party module
+ * about the same column would be the more surprising outcome. What that costs is stated rather
+ * than hidden, because it is a real cost: a schema built here turns away a value the column
+ * stores and returns unchanged, and Infinity is the plainest case of it.
+ *
+ * Used on both drizzle majors. v1 reaches it by `dataType` semantic; 0.4x has no codec to read
+ * and reaches it by class name through `INEXACT_RANGES`.
  */
-const V1_FLOAT_BOUNDS: Record<string, [string, string]> = {
+const FLOAT_BOUNDS: Record<string, [string, string]> = {
   float: ['-8388608', '8388607'], // real / float4, 2^23
   double: ['-140737488355328', '140737488355327'], // double precision / float8, 2^47
+};
+
+/**
+ * The range a JS number holds every integer of.
+ *
+ * What a `numeric`/`decimal` column in `{ mode: 'number' }` is bounded by, because the value
+ * arrives as a JS number and the column's own precision is wider than one can carry. Narrower
+ * than the database on that column too: PGlite refuses 2147483648 into a `numeric(10,2)` with
+ * `numeric field overflow`, so this admits values that column will not take. It is what both
+ * drizzle majors and `drizzle-zod` emit, and reading the declared precision instead would make
+ * DRZL disagree with all three.
+ */
+const JS_SAFE_INTEGER_BOUNDS: [string, string] = ['-9007199254740991', '9007199254740991'];
+
+/**
+ * Shapes the class-name fallback can state on its own.
+ *
+ * `shape` used to arrive from `describeV1Column` or from a json column and from nowhere else, so
+ * on drizzle-orm 0.4x, which carries no codec, a `point` had no way to say it was a tuple: a
+ * coarse `/Point|Line/i` over the class name answered `string`. That is wrong in both directions,
+ * measured against a real Postgres rather than against the first-party module. drizzle 0.45.2
+ * maps [1, 2] to the literal `(1,2)`, the column takes it and `mapFromDriverValue` hands back
+ * [1, 2]; it maps the string "1,2" to `(1,,)`, by indexing the string by position, and Postgres
+ * answers `invalid input syntax for type point`. Line behaves the same way, `{1,2,3}` against
+ * `{1,,,2}`.
+ *
+ * Only the tuple modes. `point({ mode: 'xy' })` is a `PgPointObject` and hands back `{ x, y }`,
+ * so neither a tuple nor a string describes it, and drizzle v1 calls that one a tuple too. It is
+ * left where it is rather than moved to a second wrong answer.
+ */
+const TUPLE_CLASS_SHAPES: Record<string, ColumnShape> = {
+  // `line()` is the trap here: its `drizzle:entityKind` is `PgLine` while its constructor is
+  // `PgLineTuple`, and this path matches on the constructor.
+  PgPointTuple: { kind: 'tuple', length: 2 },
+  PgLineTuple: { kind: 'tuple', length: 3 },
 };
 
 /**
@@ -349,7 +395,7 @@ export function describeV1Column(column: any): Partial<Column> | null {
       break;
     case 'float':
     case 'double': {
-      [out.min, out.max] = V1_FLOAT_BOUNDS[semantic]!;
+      [out.min, out.max] = FLOAT_BOUNDS[semantic]!;
       out.integer = false;
       out.tsType = 'number';
       out.dbType = semantic === 'float' ? 'REAL' : 'DOUBLE';
@@ -454,7 +500,7 @@ export function describeV1Column(column: any): Partial<Column> | null {
         out.tsType = 'number';
         out.dbType = 'NUMERIC';
         out.integer = false;
-        [out.min, out.max] = ['-9007199254740991', '9007199254740991'];
+        [out.min, out.max] = JS_SAFE_INTEGER_BOUNDS;
       } else if (js === 'string') {
         out.tsType = 'string';
         out.dbType = codec === 'varchar' ? 'VARCHAR' : codec === 'char' ? 'CHAR' : 'TEXT';
@@ -890,6 +936,41 @@ export class SchemaAnalyzer {
   };
 
   /**
+   * The same, for the numeric types that are not exact, keyed off the Drizzle column class.
+   *
+   * Only drizzle v1 states these outright, as a `float` or `double` semantic on `dataType`. On
+   * 0.4x the same columns reach the analyzer by class name, `INT_RANGES` was the only range table
+   * on that path, and so nothing bounded them at all: DRZL was looser than `drizzle-zod@0.8.3`,
+   * the first-party validator for that same major, which is the one direction this repository's
+   * parity gate exists to forbid. Measured, before the fix: DRZL's `real` schema accepted
+   * 9000000, 2147483648 and 9007199254740993 where official refused all three.
+   *
+   * `integer: false` travels with every entry and is not decoration. `isIntegerColumn` falls back
+   * to "declares both bounds" when the flag is absent, so a range arriving on its own turns the
+   * emitted schema into an integer one and it starts refusing 1.5.
+   *
+   * The widths are the type's, not the name's: MySQL and SingleStore `real` is a synonym for
+   * `double` unless REAL_AS_FLOAT is set, and SQLite `real` is an 8 byte IEEE float. Both are
+   * `number double` on drizzle v1, which is where these pairings come from.
+   */
+  private static readonly INEXACT_RANGES: Record<string, [string, string]> = {
+    // 24 bit: Postgres `real`/float4 and the MySQL family's `float`
+    PgReal: FLOAT_BOUNDS.float,
+    MySqlFloat: FLOAT_BOUNDS.float,
+    SingleStoreFloat: FLOAT_BOUNDS.float,
+    // 48 bit: everything backed by an 8 byte float
+    PgDoublePrecision: FLOAT_BOUNDS.double,
+    MySqlDouble: FLOAT_BOUNDS.double,
+    MySqlReal: FLOAT_BOUNDS.double,
+    SQLiteReal: FLOAT_BOUNDS.double,
+    SingleStoreDouble: FLOAT_BOUNDS.double,
+    SingleStoreReal: FLOAT_BOUNDS.double,
+    // `numeric({ mode: 'number' })`, which v1 reaches through the bare-number arm of
+    // `describeV1Column` and bounds by what a JS number can carry.
+    PgNumericNumber: JS_SAFE_INTEGER_BOUNDS,
+  };
+
+  /**
    * Constraints the column definition already carries, which the analysis used to throw away.
    *
    * Everything here is read off Drizzle's own column instance, so it states what the schema
@@ -911,6 +992,15 @@ export class SchemaAnalyzer {
     if (range) {
       [out.min, out.max] = range;
       out.integer = true;
+    }
+
+    // Disjoint from the table above by construction, and asserted as such by the analyzer tests
+    // rather than left to reading: no class appears in both, so the order of these two blocks
+    // cannot decide an answer.
+    const inexact = SchemaAnalyzer.INEXACT_RANGES[ctor];
+    if (inexact) {
+      [out.min, out.max] = inexact;
+      out.integer = false;
     }
 
     if (/^(Pg)?UUID$/i.test(ctor) || /Uuid$/i.test(ctor)) out.format = 'uuid';
@@ -992,10 +1082,26 @@ export class SchemaAnalyzer {
         // arbitrary precision. Typing them as numbers made the select validator reject every row
         // the database returned, and the insert validator reject the string the driver wants.
         return { tsType: 'string', dbType: 'NUMERIC' };
-      case 'PgFloat':
       case 'PgDoublePrecision':
         // These really are JS numbers.
         return { tsType: 'number', dbType: 'DOUBLE' };
+      // `real()` builds a `PgReal`, which matched no arm and fell through to the coarse
+      // `/Numeric|Float|Double|Real/i` below, so a real column was labelled NUMERIC while v1
+      // called it REAL. The arm above used to name `PgFloat` alongside `PgDoublePrecision`, and
+      // no such class exists in pg-core on either major: `float` is MySQL's spelling and Gel's
+      // is `GelReal`, both of which are matched elsewhere. Enumerated from the module's own
+      // exports on 0.45.2 and on 1.0.0-rc.4, which name only PgReal and PgDoublePrecision.
+      case 'PgReal':
+        return { tsType: 'number', dbType: 'REAL' };
+      // 0.4x names a point and a line by their mode. `point()` is a `PgPointTuple` and `line()` a
+      // `PgLineTuple`, whose entity kind is `PgLine` while its constructor is not, and both used
+      // to fall through to `/Point|Line/i` and come back `string`. The driver hands back [x, y]
+      // and [a, b, c], so a select schema built on 0.4x refused every row, and an insert schema
+      // took the one string form `mapToDriverValue` turns into something Postgres rejects.
+      case 'PgPointTuple':
+        return { tsType: '[number, number]', dbType: 'POINT' };
+      case 'PgLineTuple':
+        return { tsType: '[number, number, number]', dbType: 'LINE' };
       case 'PgJson':
       case 'PgJsonb':
         return { tsType: 'any', dbType: ctor === 'PgJsonb' ? 'JSONB' : 'JSON' };
@@ -1244,10 +1350,13 @@ export class SchemaAnalyzer {
           : undefined;
       const byteCap = sqlType ? MYSQL_TEXT_CAPS[sqlType] : undefined;
 
-      const jsonShape =
+      // The shape the class-name path can state for itself, which until now was only ever the
+      // json one. A `point` on 0.4x has no codec to read and needs a tuple here or the generators
+      // emit a scalar for a value that is not one.
+      const fallbackShape: ColumnShape | undefined =
         dbType === 'JSON' || dbType === 'JSONB' || (col as any)?.config?.mode === 'json'
-          ? ({ kind: 'json' } as const)
-          : undefined;
+          ? { kind: 'json' }
+          : TUPLE_CLASS_SHAPES[String((col as any)?.constructor?.name ?? '')];
 
       // A column with no type is how two real bugs looked from the outside: `.array()` and
       // `pgEnum` columns on drizzle-orm 0.4x came back `unknown`, every generator emitted a
@@ -1262,7 +1371,7 @@ export class SchemaAnalyzer {
       // The condition is "the emitted validator will be wide", not "tsType is unknown". A json
       // column is also `unknown` and is not wide: the generators emit the JSON value space for
       // it. A `custom` shape is wide, and is the one case where the user has a documented fix.
-      const shape = (v1?.shape ?? jsonShape)?.kind;
+      const shape = (v1?.shape ?? fallbackShape)?.kind;
       const finalTs = (v1?.tsType ?? tsType) as string;
       const wide = (finalTs === 'unknown' || finalTs === 'any') && (!shape || shape === 'custom');
       if (wide) {
@@ -1298,7 +1407,7 @@ export class SchemaAnalyzer {
         // that spread has nothing to say and this is the only source.
         ...(arrayDims ? { arrayDimensions: arrayDims } : {}),
         // Only where v1 did not already describe the value, so a shaped column keeps its shape.
-        ...(jsonShape && !v1?.shape ? { shape: jsonShape } : {}),
+        ...(fallbackShape && !v1?.shape ? { shape: fallbackShape } : {}),
         ...(byteCap && v1?.maxBytes === undefined ? { maxBytes: byteCap } : {}),
       });
     }

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -251,29 +251,49 @@ const MYSQL_TEXT_CAPS: Record<string, number> = {
 };
 
 /**
- * Bounds `drizzle-orm/zod` puts on the inexact numeric types, matched deliberately.
+ * The largest magnitude a 4 byte float column holds, which is the only bound the database draws.
  *
- * Neither the column's range nor its precision limit, and the sentence that used to stand here
- * said it was the second. Asked of a real Postgres through PGlite, on each column's own SQL type:
+ * Measured through PGlite, on a real `real` column, and it is a hard edge rather than a taste:
  *
- *   real              takes 8388608, 9000000, 2147483648, Infinity and NaN; holds every integer
- *                     exactly up to 16777216, and gives 16777217 back as 16777216
- *   double precision  takes all of the above and returns each one unchanged
+ *   3.4028234663852886e38   accepted, returned identical
+ *   3.4028236e38            refused, `"3.4028236e+38" is out of range for type real`
+ *   1e300                   refused, the same way
  *
- * So `real` represents consecutive integers to twice the bound below and `double precision` to
- * 2^53, and the database refuses none of it. Drizzle picked the signed 24 bit and 48 bit ranges
- * instead, and DRZL matches them: a generated schema that disagreed with the first-party module
- * about the same column would be the more surprising outcome. What that costs is stated rather
- * than hidden, because it is a real cost: a schema built here turns away a value the column
- * stores and returns unchanged, and Infinity is the plainest case of it.
+ * It is also exactly where JavaScript's own float32 rounding stops:
+ * `Math.fround(3.4028234663852886e38)` is itself and `Math.fround(3.4028236e38)` is `Infinity`.
+ * Both facts are asserted in floats-and-tuples-0.4x.spec.ts rather than left as this paragraph.
  *
- * Used on both drizzle majors. v1 reaches it by `dataType` semantic; 0.4x has no codec to read
- * and reaches it by class name through `INEXACT_RANGES`.
+ * Spelled in full decimal, like every other bound here, and not as `3.4028234663852886e38`. That
+ * is not a style choice: the generators paste these strings into their own syntax, and ArkType's
+ * string DSL cannot resolve an exponent literal. The parity stage crashed on
+ * `ParseError: '-3.4028234663852886e38' is unresolvable` before this was written out. The two
+ * spellings are the same double, asserted in the spec.
+ *
+ * `drizzle-orm/zod` bounds the same column at +/-8388607, and DRZL matched that for a release.
+ * The database was asked and disagreed: a `real` column stores 8388608, 9000000, 1e9 and
+ * 2147483648 and returns every one of them unchanged, and holds every integer exactly up to
+ * 16777216. A select schema is a description of what the column hands back, so a bound of
+ * 8388607 refused the column's own rows, which is the same defect as typing a `point` as a
+ * string and was introduced by the commit that fixed that one. The brief this work runs under
+ * says the database is the arbiter and official is only evidence that DRZL is wrong, so the
+ * bound is the database's and the divergence from official is waived in both parity passes with
+ * this measurement attached.
+ *
+ * There is deliberately no `double` entry. float8 is the JavaScript number's own format, so
+ * every finite JS number round-trips through it by construction, measured to
+ * `Number.MAX_VALUE`, and any finite bound on an 8 byte float column would refuse a value the
+ * column stores. `integer: false` is still stated for those columns, because an absent range is
+ * not a statement and `isIntegerColumn` reads a bare absence as "not bounded" rather than as
+ * "not an integer".
+ *
+ * What no range can express either way is `Infinity` and `NaN`. Postgres stores and returns both
+ * in `real` and in `double precision`; a `>=`/`<=` pair refuses them whatever the numbers are, and
+ * `z.number()` and `Type.Number()` refuse them with no bound at all. Describing that column
+ * honestly needs a union rather than a range, in every generator, which is filed rather than done
+ * here.
  */
-const FLOAT_BOUNDS: Record<string, [string, string]> = {
-  float: ['-8388608', '8388607'], // real / float4, 2^23
-  double: ['-140737488355328', '140737488355327'], // double precision / float8, 2^47
-};
+const FLOAT4_MAX = '340282346638528859811704183484516925440';
+const FLOAT4_RANGE: [string, string] = [`-${FLOAT4_MAX}`, FLOAT4_MAX];
 
 /**
  * The range a JS number holds every integer of.
@@ -395,7 +415,10 @@ export function describeV1Column(column: any): Partial<Column> | null {
       break;
     case 'float':
     case 'double': {
-      [out.min, out.max] = FLOAT_BOUNDS[semantic]!;
+      // Only the 4 byte width has a magnitude the database will refuse. Both majors take the same
+      // answer here on purpose: the bound moved off `drizzle-orm/zod`'s and onto the database's,
+      // and moving one major without the other is what the cross-major diff exists to catch.
+      if (semantic === 'float') [out.min, out.max] = FLOAT4_RANGE;
       out.integer = false;
       out.tsType = 'number';
       out.dbType = semantic === 'float' ? 'REAL' : 'DOUBLE';
@@ -936,37 +959,43 @@ export class SchemaAnalyzer {
   };
 
   /**
-   * The same, for the numeric types that are not exact, keyed off the Drizzle column class.
+   * The numeric column classes that are not exact, and the magnitude each one can really hold.
    *
-   * Only drizzle v1 states these outright, as a `float` or `double` semantic on `dataType`. On
+   * Only drizzle v1 states this outright, as a `float` or `double` semantic on `dataType`. On
    * 0.4x the same columns reach the analyzer by class name, `INT_RANGES` was the only range table
-   * on that path, and so nothing bounded them at all: DRZL was looser than `drizzle-zod@0.8.3`,
-   * the first-party validator for that same major, which is the one direction this repository's
-   * parity gate exists to forbid. Measured, before the fix: DRZL's `real` schema accepted
-   * 9000000, 2147483648 and 9007199254740993 where official refused all three.
+   * on that path, and so nothing said anything about them at all: not the range, and not that
+   * they are inexact, which left `isIntegerColumn` free to read a `CHECK`-derived pair of bounds
+   * as an integer column.
    *
-   * `integer: false` travels with every entry and is not decoration. `isIntegerColumn` falls back
-   * to "declares both bounds" when the flag is absent, so a range arriving on its own turns the
-   * emitted schema into an integer one and it starts refusing 1.5.
+   * `null` is a value in this table and is not the same as a class it does not name. It says the
+   * column is inexact and that no finite magnitude bound is truthful for it, which is the case for
+   * every 8 byte float: float8 is the JavaScript number's own format, so Postgres accepts every
+   * finite JS number into one, measured to `Number.MAX_VALUE`. Read with an own-property test for
+   * that reason, and because a plain object answers to `constructor` and `toString`.
+   *
+   * `integer: false` travels with every entry, bound or not, and is not decoration.
+   * `isIntegerColumn` falls back to "declares both bounds" when the flag is absent, so a range
+   * arriving on its own turns the emitted schema into an integer one and it starts refusing 1.5.
    *
    * The widths are the type's, not the name's: MySQL and SingleStore `real` is a synonym for
    * `double` unless REAL_AS_FLOAT is set, and SQLite `real` is an 8 byte IEEE float. Both are
    * `number double` on drizzle v1, which is where these pairings come from.
    */
-  private static readonly INEXACT_RANGES: Record<string, [string, string]> = {
-    // 24 bit: Postgres `real`/float4 and the MySQL family's `float`
-    PgReal: FLOAT_BOUNDS.float,
-    MySqlFloat: FLOAT_BOUNDS.float,
-    SingleStoreFloat: FLOAT_BOUNDS.float,
-    // 48 bit: everything backed by an 8 byte float
-    PgDoublePrecision: FLOAT_BOUNDS.double,
-    MySqlDouble: FLOAT_BOUNDS.double,
-    MySqlReal: FLOAT_BOUNDS.double,
-    SQLiteReal: FLOAT_BOUNDS.double,
-    SingleStoreDouble: FLOAT_BOUNDS.double,
-    SingleStoreReal: FLOAT_BOUNDS.double,
+  private static readonly INEXACT_RANGES: Record<string, [string, string] | null> = {
+    // 4 byte floats, whose magnitude Postgres does refuse past FLOAT4_MAX
+    PgReal: FLOAT4_RANGE,
+    MySqlFloat: FLOAT4_RANGE,
+    SingleStoreFloat: FLOAT4_RANGE,
+    // 8 byte floats, which hold every finite JS number
+    PgDoublePrecision: null,
+    MySqlDouble: null,
+    MySqlReal: null,
+    SQLiteReal: null,
+    SingleStoreDouble: null,
+    SingleStoreReal: null,
     // `numeric({ mode: 'number' })`, which v1 reaches through the bare-number arm of
-    // `describeV1Column` and bounds by what a JS number can carry.
+    // `describeV1Column`. This one is about what a JS number can carry rather than about the
+    // column, which Postgres caps far lower: it refuses 2147483648 into a `numeric(10,2)`.
     PgNumericNumber: JS_SAFE_INTEGER_BOUNDS,
   };
 
@@ -994,12 +1023,19 @@ export class SchemaAnalyzer {
       out.integer = true;
     }
 
-    // Disjoint from the table above by construction, and asserted as such by the analyzer tests
-    // rather than left to reading: no class appears in both, so the order of these two blocks
-    // cannot decide an answer.
-    const inexact = SchemaAnalyzer.INEXACT_RANGES[ctor];
-    if (inexact) {
-      [out.min, out.max] = inexact;
+    // The two tables must name no class in common, or the order of these two blocks would decide
+    // an answer. floats-and-tuples-0.4x.spec.ts intersects the two key sets directly, all 19 and
+    // 10 of them. An earlier comment here said the same thing and pointed at a test that built
+    // seven Postgres columns and touched neither table, which is the shape of false-mechanism
+    // comment this line of work keeps producing.
+    //
+    // An own-property test rather than a truthiness one, because `null` is a value in that table
+    // and means "inexact, and no finite bound on it is truthful". `hasOwnProperty` through
+    // `Object.prototype` rather than `Object.hasOwn`, which this package's `lib` setting does not
+    // have: it needs ES2022 and the build fails with TS2550.
+    if (Object.prototype.hasOwnProperty.call(SchemaAnalyzer.INEXACT_RANGES, ctor)) {
+      const inexact = SchemaAnalyzer.INEXACT_RANGES[ctor];
+      if (inexact) [out.min, out.max] = inexact;
       out.integer = false;
     }
 

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -988,9 +988,12 @@ export class SchemaAnalyzer {
    * `integer: false` travels with every entry, bound or not, and what it decides depends on which.
    * `isIntegerColumn` falls back to "declares both bounds" when the flag is absent, so on a bounded
    * entry the flag is the only thing stopping the emitted schema calling `.int()` and refusing 1.5.
-   * On an unbounded one it decides nothing, measured both ways in
-   * floats-and-tuples-0.4x.spec.ts. It is stated there because it is true of the column, not
-   * because it guards anything.
+   * On an unbounded one it decides nothing, measured both ways against the real function in
+   * `@drzl/validation-core`'s integer-column.spec.ts. It is stated there because it is true of the
+   * column, not because it guards anything. That spec is where the measurement moved when the
+   * analyzer's copy of it turned out to be a closed loop; this sentence went on naming
+   * floats-and-tuples-0.4x.spec.ts, which asserts the flag is present and nothing about what it
+   * decides.
    *
    * The widths are the type's, not the name's: MySQL and SingleStore `real` is a synonym for
    * `double` unless REAL_AS_FLOAT is set, and SQLite `real` is an 8 byte IEEE float. Both are

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -282,9 +282,15 @@ const MYSQL_TEXT_CAPS: Record<string, number> = {
  * There is deliberately no `double` entry. float8 is the JavaScript number's own format, so
  * every finite JS number round-trips through it by construction, measured to
  * `Number.MAX_VALUE`, and any finite bound on an 8 byte float column would refuse a value the
- * column stores. `integer: false` is still stated for those columns, because an absent range is
- * not a statement and `isIntegerColumn` reads a bare absence as "not bounded" rather than as
- * "not an integer".
+ * column stores.
+ *
+ * `integer: false` is still stated for those columns, and on an unbounded one it decides nothing:
+ * measured on a `doublePrecision` column carrying two bracketing CHECKs, `isIntegerColumn` answers
+ * false with the flag and false with the flag deleted, because a CHECK never becomes a column
+ * bound. The generators fold checks into the emitted range at emit time and nothing writes them
+ * back here. It is stated because it is true of the column and because the same flag is what
+ * decides the *bounded* case: on a `real`, deleting it flips `isIntegerColumn` to true and the
+ * emitted schema starts refusing 1.5.
  *
  * What no range can express either way is `Infinity` and `NaN`. Postgres stores and returns both
  * in `real` and in `double precision`; a `>=`/`<=` pair refuses them whatever the numbers are, and
@@ -964,8 +970,8 @@ export class SchemaAnalyzer {
    * Only drizzle v1 states this outright, as a `float` or `double` semantic on `dataType`. On
    * 0.4x the same columns reach the analyzer by class name, `INT_RANGES` was the only range table
    * on that path, and so nothing said anything about them at all: not the range, and not that
-   * they are inexact, which left `isIntegerColumn` free to read a `CHECK`-derived pair of bounds
-   * as an integer column.
+   * they are inexact. That made DRZL looser than the first-party validator for the same major on
+   * every one of these columns, which is what the parity gate exists to forbid.
    *
    * `null` is a value in this table and is not the same as a class it does not name. It says the
    * column is inexact and that no finite magnitude bound is truthful for it, which is the case for
@@ -973,9 +979,12 @@ export class SchemaAnalyzer {
    * finite JS number into one, measured to `Number.MAX_VALUE`. Read with an own-property test for
    * that reason, and because a plain object answers to `constructor` and `toString`.
    *
-   * `integer: false` travels with every entry, bound or not, and is not decoration.
-   * `isIntegerColumn` falls back to "declares both bounds" when the flag is absent, so a range
-   * arriving on its own turns the emitted schema into an integer one and it starts refusing 1.5.
+   * `integer: false` travels with every entry, bound or not, and what it decides depends on which.
+   * `isIntegerColumn` falls back to "declares both bounds" when the flag is absent, so on a bounded
+   * entry the flag is the only thing stopping the emitted schema calling `.int()` and refusing 1.5.
+   * On an unbounded one it decides nothing, measured both ways in
+   * floats-and-tuples-0.4x.spec.ts. It is stated there because it is true of the column, not
+   * because it guards anything.
    *
    * The widths are the type's, not the name's: MySQL and SingleStore `real` is a synonym for
    * `double` unless REAL_AS_FLOAT is set, and SQLite `real` is an 8 byte IEEE float. Both are

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -451,9 +451,14 @@ export function describeV1Column(column: any): Partial<Column> | null {
     case 'double': {
       // Only the 4 byte width has a magnitude the database will refuse, and the two databases that
       // have one refuse at different values, so the codec picks which. `float4` is Postgres's
-      // spelling and `float` is MySQL's. SingleStore states `number float` with no codec at all,
-      // measured on 1.0.0-rc.4, and so lands on MySQL's, which is the answer its class-name entry
-      // gives on 0.4x as well; the cross-major diff is what holds those two together.
+      // spelling and `float` is MySQL's. Three dialects state `number float` with no codec at all
+      // on 1.0.0-rc.4, measured: SingleStore, Cockroach and MSSQL. All three land on MySQL's bound
+      // by falling through, which is right for SingleStore and matches the answer its class-name
+      // entry gives on 0.4x, and is **wrong for Cockroach**, whose `real` is a Postgres `FLOAT4`
+      // over the Postgres wire. That is filed rather than fixed: Cockroach and MSSQL lose whole
+      // type families to `unknown` today, so a bound is not the defect worth fixing first, and
+      // neither dialect has a fixture in any gate that would prove a fix. The cross-major diff is
+      // what holds SingleStore's two answers together.
       //
       // Both majors take the same answer here on purpose: the bound moved off `drizzle-orm/zod`'s
       // and onto the database's, and moving one major without the other is what that diff catches.

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -251,19 +251,42 @@ const MYSQL_TEXT_CAPS: Record<string, number> = {
 };
 
 /**
- * The largest magnitude a 4 byte float column holds, which is the only bound the database draws.
+ * The largest magnitude a 4 byte float column accepts, which is the only bound the database draws.
  *
- * Measured through PGlite, on a real `real` column, and it is a hard edge rather than a taste:
+ * There are two of them, because the two databases that have a 4 byte float do not put the edge in
+ * the same place. Both were bisected over the raw bit pattern of a double, sending each value as a
+ * literal so the server parsed it itself rather than a driver.
  *
- *   3.4028234663852886e38   accepted, returned identical
- *   3.4028236e38            refused, `"3.4028236e+38" is out of range for type real`
+ * Postgres, PGlite on a `real` column, 62 steps:
+ *
+ *   3.4028234663852886e38   accepted, stored, read back identical   (the largest finite float32)
+ *   3.4028235677973366e38   accepted, and stored as 3.4028234663852886e38
+ *   3.402823567797337e38    refused, `... is out of range for type real`   (the next double up)
  *   1e300                   refused, the same way
  *
- * It is also exactly where JavaScript's own float32 rounding stops:
- * `Math.fround(3.4028234663852886e38)` is itself and `Math.fround(3.4028236e38)` is `Infinity`.
- * Both facts are asserted in floats-and-tuples-0.4x.spec.ts rather than left as this paragraph.
+ * MySQL 8.4 in `STRICT_ALL_TABLES`, on a `FLOAT` column, 61 steps, and again under the stock
+ * MySQL 8 `sql_mode`:
  *
- * Spelled in full decimal, like every other bound here, and not as `3.4028234663852886e38`. That
+ *   3.4028234663852886e38   accepted, stored, read back identical
+ *   3.402823466385289e38    refused, `Out of range value for column 'r' at row 1`
+ *   3.4028235e38            refused, the same way
+ *
+ * So MySQL's edge is the largest finite float32 exactly and Postgres's is 268435456 representable
+ * doubles above it. Postgres's number is `2 ** 128 - 2 ** 103`, the midpoint between the largest
+ * float32 and the first power of two past it, and it rounds that midpoint down: the row it stored
+ * for the edge value reads back as the largest float32.
+ *
+ * **Postgres's edge is not a float32, and the difference is a value users hit.** A `real` column at
+ * full magnitude comes back over the text protocol as `3.4028235e+38`, which every text-protocol
+ * driver parses into a double above the largest float32, so a select schema bounded at the float32
+ * refused a row that column had just handed back. That is the same defect as typing a `point` as a
+ * string, at the top of one type, and the parity probe pool now carries that exact value. Do not
+ * describe Postgres's bound as a float32 on the strength of the digits: `Math.fround` answers
+ * `Infinity` for it, because JavaScript rounds that midpoint to even and Postgres rounds it down.
+ * Every line above is asserted in floats-and-tuples-0.4x.spec.ts rather than left as this
+ * paragraph.
+ *
+ * Spelled in full decimal, like every other bound here, and not as `3.4028235677973366e38`. That
  * is not a style choice: the generators paste these strings into their own syntax, and ArkType's
  * string DSL cannot resolve an exponent literal. The parity stage crashed on
  * `ParseError: '-3.4028234663852886e38' is unresolvable` before this was written out. The two
@@ -279,10 +302,11 @@ const MYSQL_TEXT_CAPS: Record<string, number> = {
  * bound is the database's and the divergence from official is waived in both parity passes with
  * this measurement attached.
  *
- * There is deliberately no `double` entry. float8 is the JavaScript number's own format, so
- * every finite JS number round-trips through it by construction, measured to
- * `Number.MAX_VALUE`, and any finite bound on an 8 byte float column would refuse a value the
- * column stores.
+ * There is deliberately no `double` entry, on either database. float8 is the JavaScript number's
+ * own format, so every finite JS number round-trips through it by construction, measured to
+ * `Number.MAX_VALUE` in Postgres and again in MySQL's `DOUBLE`, which returned both that and
+ * 1e300 identical while refusing each of them in a `FLOAT` beside it. Any finite bound on an
+ * 8 byte float column would refuse a value the column stores.
  *
  * `integer: false` is still stated for those columns, and on an unbounded one it decides nothing:
  * measured on a `doublePrecision` column carrying two bracketing CHECKs, `isIntegerColumn` answers
@@ -298,8 +322,12 @@ const MYSQL_TEXT_CAPS: Record<string, number> = {
  * honestly needs a union rather than a range, in every generator, which is filed rather than done
  * here.
  */
-const FLOAT4_MAX = '340282346638528859811704183484516925440';
-const FLOAT4_RANGE: [string, string] = [`-${FLOAT4_MAX}`, FLOAT4_MAX];
+/** The largest finite float32, which is exactly where MySQL's `FLOAT` stops. */
+const FLOAT32_MAX = '340282346638528859811704183484516925440';
+/** `2 ** 128 - 2 ** 103`, the largest double Postgres takes in a `real`. Not a float32. */
+const PG_FLOAT4_INPUT_MAX = '340282356779733661637539395458142568448';
+const PG_FLOAT4_RANGE: [string, string] = [`-${PG_FLOAT4_INPUT_MAX}`, PG_FLOAT4_INPUT_MAX];
+const MYSQL_FLOAT_RANGE: [string, string] = [`-${FLOAT32_MAX}`, FLOAT32_MAX];
 
 /**
  * The range a JS number holds every integer of.
@@ -421,10 +449,16 @@ export function describeV1Column(column: any): Partial<Column> | null {
       break;
     case 'float':
     case 'double': {
-      // Only the 4 byte width has a magnitude the database will refuse. Both majors take the same
-      // answer here on purpose: the bound moved off `drizzle-orm/zod`'s and onto the database's,
-      // and moving one major without the other is what the cross-major diff exists to catch.
-      if (semantic === 'float') [out.min, out.max] = FLOAT4_RANGE;
+      // Only the 4 byte width has a magnitude the database will refuse, and the two databases that
+      // have one refuse at different values, so the codec picks which. `float4` is Postgres's
+      // spelling and `float` is MySQL's. SingleStore states `number float` with no codec at all,
+      // measured on 1.0.0-rc.4, and so lands on MySQL's, which is the answer its class-name entry
+      // gives on 0.4x as well; the cross-major diff is what holds those two together.
+      //
+      // Both majors take the same answer here on purpose: the bound moved off `drizzle-orm/zod`'s
+      // and onto the database's, and moving one major without the other is what that diff catches.
+      if (semantic === 'float')
+        [out.min, out.max] = codec === 'float4' ? PG_FLOAT4_RANGE : MYSQL_FLOAT_RANGE;
       out.integer = false;
       out.tsType = 'number';
       out.dbType = semantic === 'float' ? 'REAL' : 'DOUBLE';
@@ -1000,10 +1034,12 @@ export class SchemaAnalyzer {
    * `number double` on drizzle v1, which is where these pairings come from.
    */
   private static readonly INEXACT_RANGES: Record<string, [string, string] | null> = {
-    // 4 byte floats, whose magnitude Postgres does refuse past FLOAT4_MAX
-    PgReal: FLOAT4_RANGE,
-    MySqlFloat: FLOAT4_RANGE,
-    SingleStoreFloat: FLOAT4_RANGE,
+    // 4 byte floats, the one width a database refuses a magnitude for, and the two that have one
+    // refuse at different values. SingleStore is MySQL wire-compatible and unmeasured here, so it
+    // takes MySQL's rather than the wider of the two.
+    PgReal: PG_FLOAT4_RANGE,
+    MySqlFloat: MYSQL_FLOAT_RANGE,
+    SingleStoreFloat: MYSQL_FLOAT_RANGE,
     // 8 byte floats, which hold every finite JS number
     PgDoublePrecision: null,
     MySqlDouble: null,

--- a/packages/analyzer/test/column-constraints.spec.ts
+++ b/packages/analyzer/test/column-constraints.spec.ts
@@ -137,8 +137,9 @@ describe('numeric range', () => {
     // `doublePrecision` carries no range. float8 is the JavaScript number's own format, so
     // Postgres takes every finite JS number into one, measured through PGlite to
     // Number.MAX_VALUE and returned identical. Any finite bound would refuse a value the column
-    // stores. It still states `integer: false`, because an absent range is not a statement and
-    // `isIntegerColumn` would otherwise be free to read a CHECK-derived pair as an integer range.
+    // stores. It still states `integer: false`, and on this column that decides nothing: it is
+    // true of the column and it is what makes the *bounded* case work, which the flag test in
+    // floats-and-tuples-0.4x.spec.ts measures from both ends.
     //
     // `real` is bounded, at the one magnitude the database does refuse: PGlite takes
     // 3.4028234663852886e38 and answers `out of range for type real` to 3.4028236e38.

--- a/packages/analyzer/test/column-constraints.spec.ts
+++ b/packages/analyzer/test/column-constraints.spec.ts
@@ -131,26 +131,38 @@ describe('numeric range', () => {
     expect(String(Number(c.b.max))).not.toBe(c.b.max);
   });
 
-  it('bounds a float by its width and leaves a string numeric alone', async () => {
-    // This used to assert that neither carried a bound, on the reasoning that a float has no
-    // integer range. It has an inexact one, drizzle v1 states it, `drizzle-zod@0.8.3` emits it
-    // on this same major, and leaving it off made DRZL looser than the module it exists to
-    // improve on. A `numeric` in its default string mode really does stay unbounded: a min and a
-    // max on a string say nothing a validator can use, and its `format` carries the check.
+  it('states that a float is inexact, bounds only the width that has one', async () => {
+    // Three answers here, and the middle one is the point.
+    //
+    // `doublePrecision` carries no range. float8 is the JavaScript number's own format, so
+    // Postgres takes every finite JS number into one, measured through PGlite to
+    // Number.MAX_VALUE and returned identical. Any finite bound would refuse a value the column
+    // stores. It still states `integer: false`, because an absent range is not a statement and
+    // `isIntegerColumn` would otherwise be free to read a CHECK-derived pair as an integer range.
+    //
+    // `real` is bounded, at the one magnitude the database does refuse: PGlite takes
+    // 3.4028234663852886e38 and answers `out of range for type real` to 3.4028236e38.
+    //
+    // A `numeric` in its default string mode stays unbounded: a min and a max on a string say
+    // nothing a validator can use, and its `format` carries the check instead.
     const c = await columns(
       'cons-float',
       `
-      import { pgTable, doublePrecision, numeric } from 'drizzle-orm/pg-core';
+      import { pgTable, real, doublePrecision, numeric } from 'drizzle-orm/pg-core';
       export const t = pgTable('t', {
+        r: real('r'),
         d: doublePrecision('d'),
         n: numeric('n', { precision: 10, scale: 2 }),
       });
       `
     );
-    expect(c.d).toMatchObject({
+    expect(c.d).toMatchObject({ tsType: 'number', integer: false });
+    expect(c.d.min).toBeUndefined();
+    expect(c.d.max).toBeUndefined();
+    expect(c.r).toMatchObject({
       tsType: 'number',
-      min: '-140737488355328',
-      max: '140737488355327',
+      min: '-340282346638528859811704183484516925440',
+      max: '340282346638528859811704183484516925440',
       integer: false,
     });
     expect(c.n.tsType).toBe('string');

--- a/packages/analyzer/test/column-constraints.spec.ts
+++ b/packages/analyzer/test/column-constraints.spec.ts
@@ -139,7 +139,9 @@ describe('numeric range', () => {
     // Number.MAX_VALUE and returned identical. Any finite bound would refuse a value the column
     // stores. It still states `integer: false`, and on this column that decides nothing: it is
     // true of the column and it is what makes the *bounded* case work, which the flag test in
-    // floats-and-tuples-0.4x.spec.ts measures from both ends.
+    // validation-core's integer-column.spec.ts measures from both ends against the real
+    // `isIntegerColumn`. It named floats-and-tuples-0.4x.spec.ts until the measurement moved out
+    // of there, and that file now asserts the flag's presence alone.
     //
     // `real` is bounded, at the one magnitude the database does refuse: PGlite takes
     // 3.4028234663852886e38 and answers `out of range for type real` to 3.4028236e38.

--- a/packages/analyzer/test/column-constraints.spec.ts
+++ b/packages/analyzer/test/column-constraints.spec.ts
@@ -144,7 +144,10 @@ describe('numeric range', () => {
     // of there, and that file now asserts the flag's presence alone.
     //
     // `real` is bounded, at the one magnitude the database does refuse: PGlite takes
-    // 3.4028234663852886e38 and answers `out of range for type real` to 3.4028236e38.
+    // 3.4028235677973366e38 and answers `out of range for type real` to the next double up. That
+    // is above the largest float32 rather than at it, which is not a rounding of the digits; see
+    // the analyzer's own docstring for the bisection and for MySQL, whose edge is a different
+    // number.
     //
     // A `numeric` in its default string mode stays unbounded: a min and a max on a string say
     // nothing a validator can use, and its `format` carries the check instead.
@@ -164,8 +167,8 @@ describe('numeric range', () => {
     expect(c.d.max).toBeUndefined();
     expect(c.r).toMatchObject({
       tsType: 'number',
-      min: '-340282346638528859811704183484516925440',
-      max: '340282346638528859811704183484516925440',
+      min: '-340282356779733661637539395458142568448',
+      max: '340282356779733661637539395458142568448',
       integer: false,
     });
     expect(c.n.tsType).toBe('string');

--- a/packages/analyzer/test/column-constraints.spec.ts
+++ b/packages/analyzer/test/column-constraints.spec.ts
@@ -131,7 +131,12 @@ describe('numeric range', () => {
     expect(String(Number(c.b.max))).not.toBe(c.b.max);
   });
 
-  it('does not bound a float or a numeric, which have no integer range', async () => {
+  it('bounds a float by its width and leaves a string numeric alone', async () => {
+    // This used to assert that neither carried a bound, on the reasoning that a float has no
+    // integer range. It has an inexact one, drizzle v1 states it, `drizzle-zod@0.8.3` emits it
+    // on this same major, and leaving it off made DRZL looser than the module it exists to
+    // improve on. A `numeric` in its default string mode really does stay unbounded: a min and a
+    // max on a string say nothing a validator can use, and its `format` carries the check.
     const c = await columns(
       'cons-float',
       `
@@ -142,8 +147,15 @@ describe('numeric range', () => {
       });
       `
     );
-    expect(c.d.min).toBeUndefined();
+    expect(c.d).toMatchObject({
+      tsType: 'number',
+      min: '-140737488355328',
+      max: '140737488355327',
+      integer: false,
+    });
+    expect(c.n.tsType).toBe('string');
     expect(c.n.min).toBeUndefined();
+    expect(c.n.max).toBeUndefined();
   });
 });
 

--- a/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
+++ b/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
@@ -30,6 +30,9 @@ import { SchemaAnalyzer } from '../src/index';
 
 const dir = path.resolve(__dirname, 'fixtures');
 
+/** The largest finite float32, which is the only magnitude Postgres refuses on a `real` column. */
+const FLOAT4_MAX = '340282346638528859811704183484516925440';
+
 async function columnsOf(name: string, source: string) {
   await fs.mkdir(dir, { recursive: true });
   const file = path.join(dir, `${name}.mjs`);
@@ -105,15 +108,17 @@ describe('an inexact numeric column on 0.4x', () => {
     expect(cols.r).toMatchObject({
       tsType: 'number',
       dbType: 'REAL',
-      min: '-8388608',
-      max: '8388607',
+      min: `-${FLOAT4_MAX}`,
+      max: FLOAT4_MAX,
       integer: false,
     });
-    expect(cols.d).toMatchObject({
-      min: '-140737488355328',
-      max: '140737488355327',
-      integer: false,
-    });
+    // An 8 byte float carries no magnitude bound at all, because there is no finite one that is
+    // true: PGlite accepted every finite JS number into a `double precision` column up to
+    // Number.MAX_VALUE and returned each unchanged. Stated as an absence of a range plus a stated
+    // `integer: false`, which is not the same thing as the column being undescribed.
+    expect(cols.d).toMatchObject({ tsType: 'number', dbType: 'DOUBLE', integer: false });
+    expect(cols.d.min).toBeUndefined();
+    expect(cols.d.max).toBeUndefined();
     expect(cols.n).toMatchObject({
       min: '-9007199254740991',
       max: '9007199254740991',
@@ -130,10 +135,13 @@ describe('an inexact numeric column on 0.4x', () => {
       `
     );
     // MySQL's REAL is a synonym for DOUBLE unless REAL_AS_FLOAT is set, and drizzle v1 says
-    // `number double` for it, so it takes the wider pair.
-    expect(my.r).toMatchObject({ min: '-140737488355328', max: '140737488355327' });
-    expect(my.d).toMatchObject({ min: '-140737488355328', max: '140737488355327' });
-    expect(my.f).toMatchObject({ min: '-8388608', max: '8388607' });
+    // `number double` for it, so it is an 8 byte float and carries no bound.
+    for (const c of [my.r, my.d]) {
+      expect(c.integer).toBe(false);
+      expect(c.min).toBeUndefined();
+      expect(c.max).toBeUndefined();
+    }
+    expect(my.f).toMatchObject({ min: `-${FLOAT4_MAX}`, max: FLOAT4_MAX, integer: false });
 
     const sq = await columnsOf(
       'sqlite-floats-0.4x',
@@ -142,9 +150,10 @@ describe('an inexact numeric column on 0.4x', () => {
       export const t = sqliteTable('t', { r: real() });
       `
     );
-    // SQLite's REAL is an 8 byte IEEE float, which is why it takes the double pair and not the
-    // one its name suggests.
-    expect(sq.r).toMatchObject({ min: '-140737488355328', max: '140737488355327' });
+    // SQLite's REAL is an 8 byte IEEE float, which is why it is unbounded and not capped at the
+    // float4 magnitude its name suggests.
+    expect(sq.r).toMatchObject({ integer: false });
+    expect(sq.r.min).toBeUndefined();
 
     const ss = await columnsOf(
       'singlestore-floats-0.4x',
@@ -153,17 +162,34 @@ describe('an inexact numeric column on 0.4x', () => {
       export const t = singlestoreTable('t', { r: real(), d: double(), f: float() });
       `
     );
-    expect(ss.r).toMatchObject({ min: '-140737488355328', max: '140737488355327' });
-    expect(ss.d).toMatchObject({ min: '-140737488355328', max: '140737488355327' });
-    expect(ss.f).toMatchObject({ min: '-8388608', max: '8388607' });
+    expect(ss.r.min).toBeUndefined();
+    expect(ss.d.min).toBeUndefined();
+    expect(ss.f).toMatchObject({ min: `-${FLOAT4_MAX}`, max: FLOAT4_MAX, integer: false });
   });
 
-  it('is bounded by a table disjoint from the integer one', async () => {
-    // `columnConstraints` applies the integer table and then the inexact one, so a class in both
-    // would have its answer decided by the order of two blocks. Asserted over every class either
-    // table names rather than by reading them, since a later entry is exactly how that would
-    // creep in. Read off the analyzer's own output: an integer column keeps `integer: true` and
-    // an inexact one keeps `integer: false`, and no column can report both.
+  it('names no class in both range tables', () => {
+    // `columnConstraints` applies INT_RANGES and then INEXACT_RANGES, so a class named by both
+    // would have its answer decided by the order of two blocks rather than by anything true.
+    //
+    // Read off the two tables themselves, every key of both. The first version of this test built
+    // seven Postgres columns and carried a comment claiming it covered "every class either table
+    // names", which was false in two directions at once: it reached 7 of the 29 keys and it
+    // touched no MySQL, SQLite or SingleStore class at all. Review counted them. This is the
+    // assertion that comment described.
+    const tables = SchemaAnalyzer as unknown as {
+      INT_RANGES: Record<string, [string, string]>;
+      INEXACT_RANGES: Record<string, [string, string] | null>;
+    };
+    const ints = Object.keys(tables.INT_RANGES);
+    const inexact = Object.keys(tables.INEXACT_RANGES);
+    // A verification that can succeed by matching nothing is not one: an empty table would make
+    // the intersection trivially empty.
+    expect(ints.length, 'INT_RANGES is populated').toBeGreaterThan(10);
+    expect(inexact.length, 'INEXACT_RANGES is populated').toBeGreaterThan(5);
+    expect(ints.filter((k) => inexact.includes(k))).toEqual([]);
+  });
+
+  it('separates the two tables by what they say about a column', async () => {
     const cols = await columnsOf(
       'ranges-disjoint-0.4x',
       `
@@ -175,16 +201,18 @@ describe('an inexact numeric column on 0.4x', () => {
       });
       `
     );
-    const integers = ['i', 'si', 's', 'b'];
-    const inexact = ['r', 'd', 'n'];
-    for (const name of integers) expect(cols[name].integer, name).toBe(true);
-    for (const name of inexact) expect(cols[name].integer, name).toBe(false);
-    // And every one of them is bounded, so "disjoint" is not being satisfied by a class that
-    // neither table names.
-    for (const name of [...integers, ...inexact]) {
+    for (const name of ['i', 'si', 's', 'b']) {
+      expect(cols[name].integer, name).toBe(true);
       expect(cols[name].min, name).toBeDefined();
       expect(cols[name].max, name).toBeDefined();
     }
+    for (const name of ['r', 'd', 'n']) expect(cols[name].integer, name).toBe(false);
+    // `d` is the one that states inexactness with no range, which is a different thing from a
+    // column neither table names. Whether a consumer then reaches "not an integer" from the flag
+    // alone is `isIntegerColumn`'s job and is executed in generator-zod's structured-columns
+    // spec, since `@drzl/validation-core` is not a dependency of this package.
+    expect(cols.d.min, 'an 8 byte float carries no magnitude bound').toBeUndefined();
+    expect(cols.d.max).toBeUndefined();
   });
 
   it('is not an integer, so the bounds cannot be read as one', async () => {
@@ -200,13 +228,16 @@ describe('an inexact numeric column on 0.4x', () => {
     expect(cols.r.integer).toBe(false);
   });
 
-  it('carries the drizzle bound rather than the width the database can hold', async () => {
-    // Measured through PGlite on the column's own `real` type: it holds every integer up to
-    // 16777216 exactly, and 16777217 comes back as 16777216. The bound below is half that, so it
-    // is `drizzle-zod`'s choice and not the column's limit, and DRZL matches it deliberately so
-    // the two majors and the first-party module all agree about the same column. Asserted rather
-    // than described, because a sentence claiming a mechanism is how the last several of these
-    // went wrong.
+  it('carries the database limit, not drizzle-zod, and the limit is the largest float4', async () => {
+    // This bound is a measured database edge. PGlite, on a real `real` column: it accepted
+    // 3.4028234663852886e38 and returned it identical, and refused 3.4028236e38 with
+    // `"3.4028236e+38" is out of range for type real`.
+    //
+    // It used to be `drizzle-zod`'s +/-8388607, which is not a limit of anything: the same column
+    // stores 8388608, 9000000, 1e9 and 2147483648 and returns each unchanged, so that bound made
+    // the select schema refuse the column's own rows. The previous version of this test asserted
+    // `Number(max) < 16777216`, which pinned the wrong number as a requirement and would have had
+    // to be deleted rather than updated to adopt the right one. Review caught that.
     const cols = await columnsOf(
       'pg-float-bound-origin-0.4x',
       `
@@ -214,10 +245,41 @@ describe('an inexact numeric column on 0.4x', () => {
       export const t = pgTable('t', { r: real() });
       `
     );
-    expect(Number(cols.r.max)).toBeLessThan(16777216);
-    // And it is not a database limit in the other direction either: PGlite accepted Infinity and
-    // NaN into the same `real` column, which no finite bound admits. So the schema is narrower
-    // than the column on purpose, and this pins that it is narrow at all.
+    const max = Number(cols.r.max);
+    // Written out in full decimal rather than as 3.4028234663852886e38, and this asserts the two
+    // are the same double. The spelling is load-bearing: ArkType's string DSL cannot resolve an
+    // exponent literal, and the parity stage crashed with
+    // `ParseError: '-3.4028234663852886e38' is unresolvable` when the bound was written that way.
+    expect(cols.r.max, 'no exponent in the emitted bound').not.toMatch(/e/i);
+    expect(max).toBe(3.4028234663852886e38);
+    // The largest finite float32, asserted the way JavaScript can check it rather than described:
+    // it survives a round trip through float32, and the next float32 up is Infinity.
+    expect(Math.fround(max), 'is exactly representable as a float32').toBe(max);
+    expect(Math.fround(3.4028236e38), 'and is the last one that is').toBe(Infinity);
+    expect(Number.isFinite(max)).toBe(true);
+    // The value the old bound refused and the column holds exactly, so this cannot silently
+    // regress to a narrower one.
+    expect(max).toBeGreaterThan(1e9);
+  });
+
+  it('leaves Infinity and NaN outside every range, which the database does not', async () => {
+    // Filed, not fixed, and pinned here so it is measured rather than remembered. PGlite stores
+    // Infinity and NaN in both `real` and `double precision` and returns them unchanged. A
+    // `>=`/`<=` pair cannot admit either, whatever the numbers are, and `z.number()` and
+    // `Type.Number()` refuse both with no bound at all. Describing those columns honestly needs a
+    // union in every generator rather than a wider range.
+    //
+    // This asserts what the analyzer states, which is the input to that: a bounded float column
+    // has a finite range and no way to say "or Infinity", and an unbounded one says nothing about
+    // it either way.
+    const cols = await columnsOf(
+      'pg-float-inf-0.4x',
+      `
+      import { pgTable, real, doublePrecision } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', { r: real(), d: doublePrecision() });
+      `
+    );
     expect(Number.isFinite(Number(cols.r.max))).toBe(true);
+    expect(cols.d.max, 'nothing on the 8 byte column to admit or refuse it').toBeUndefined();
   });
 });

--- a/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
+++ b/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
@@ -19,9 +19,11 @@
  * accepted the one string shape the column cannot be given.
  *
  * The floats carried no bounds at all, because the class-name path reads its ranges from
- * `INT_RANGES` and nothing else. That left DRZL looser than `drizzle-zod@0.8.3`, the first-party
- * validator for this same major, which is the one direction this repository's parity gate exists
- * to forbid.
+ * `INT_RANGES` and nothing else, so DRZL described nothing where `drizzle-zod@0.8.3` described a
+ * range. What made that wrong is that the column has a magnitude and the schema claimed it did
+ * not, so the schema promised writes the database refuses. Not the direction of the difference:
+ * the parity gate counts the entries where DRZL accepts something official refuses and most of
+ * them do, several because the database backs DRZL, and these columns are among them now.
  */
 import { describe, it, expect } from 'vitest';
 import { promises as fs } from 'node:fs';
@@ -220,40 +222,25 @@ describe('an inexact numeric column on 0.4x', () => {
     expect(cols.d.max).toBeUndefined();
   });
 
-  it('states integer:false, which decides the bounded case and nothing on the unbounded one', () => {
-    // Three comments claimed `integer: false` was on the unbounded columns to stop
-    // `isIntegerColumn` reading a CHECK-derived pair of bounds as an integer range. Review asked
-    // for the experiment and it disproves the claim: a CHECK never becomes a column bound at all.
-    // The generators fold checks into the emitted range as they emit, and nothing writes them back
-    // onto the Column, so `min` and `max` on a `doublePrecision` carrying two bracketing CHECKs
-    // are still undefined.
-    //
-    // `isIntegerColumn` is reimplemented here in its three lines rather than imported, because
-    // `@drzl/validation-core` is not a dependency of this package. That is a real weakness of this
-    // test: it would not notice that function changing. What it does pin is the input, which is
-    // the half this package owns, and generator-zod's structured-columns spec runs the real one.
-    const isIntegerColumn = (c: {
-      integer?: boolean;
-      dbType?: string;
-      min?: string;
-      max?: string;
-    }) => {
-      if (typeof c.integer === 'boolean') return c.integer;
-      return c.dbType === 'INTEGER' || (c.min !== undefined && c.max !== undefined);
-    };
-    const bounded = { integer: false, dbType: 'REAL', min: `-${FLOAT4_MAX}`, max: FLOAT4_MAX };
-    const unbounded = { integer: false, dbType: 'DOUBLE' };
-    const without = <T extends object>(o: T) => {
-      const { integer: _drop, ...rest } = o as T & { integer?: boolean };
-      return rest;
-    };
-    // On the bounded column the flag is the whole answer: without it the two bounds are read as an
-    // integer range and the emitted schema starts refusing 1.5.
-    expect(isIntegerColumn(bounded)).toBe(false);
-    expect(isIntegerColumn(without(bounded)), 'the flag is load-bearing here').toBe(true);
-    // On the unbounded one it decides nothing, which is what the removed comments got wrong.
-    expect(isIntegerColumn(unbounded)).toBe(false);
-    expect(isIntegerColumn(without(unbounded)), 'and inert here').toBe(false);
+  it('states integer:false on both widths, bounded or not', async () => {
+    // What this package owns: the flag is present on every inexact column whether or not the
+    // column also carries a range. What that flag then decides is `isIntegerColumn`'s job, and it
+    // is asserted against the real function in validation-core's integer-column.spec.ts, which
+    // fails when the flag branch is deleted from it. The first version of this test reimplemented
+    // those three lines here, because `@drzl/validation-core` is not a dependency of this package,
+    // and review showed the loop was closed: deleting the branch from the real function left this
+    // suite green.
+    const cols = await columnsOf(
+      'pg-float-flag-0.4x',
+      `
+      import { pgTable, real, doublePrecision } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', { r: real(), d: doublePrecision() });
+      `
+    );
+    expect(cols.r.integer, 'bounded').toBe(false);
+    expect(cols.d.integer, 'unbounded').toBe(false);
+    expect(cols.r.max).toBe(FLOAT4_MAX);
+    expect(cols.d.max).toBeUndefined();
   });
 
   it('never turns a CHECK into a column bound, on a float or anything else', async () => {

--- a/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
+++ b/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
@@ -33,12 +33,17 @@ const dir = path.resolve(__dirname, 'fixtures');
 /** The largest finite float32, which is the only magnitude Postgres refuses on a `real` column. */
 const FLOAT4_MAX = '340282346638528859811704183484516925440';
 
-async function columnsOf(name: string, source: string) {
+async function tableOf(name: string, source: string) {
   await fs.mkdir(dir, { recursive: true });
   const file = path.join(dir, `${name}.mjs`);
   await fs.writeFile(file, source, 'utf8');
   const a = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
-  return Object.fromEntries((a.tables[0]?.columns ?? []).map((c) => [c.name, c]));
+  return a.tables[0];
+}
+
+async function columnsOf(name: string, source: string) {
+  const t = await tableOf(name, source);
+  return Object.fromEntries((t?.columns ?? []).map((c) => [c.name, c]));
 }
 
 describe('a postgres point or line column on 0.4x', () => {
@@ -215,17 +220,63 @@ describe('an inexact numeric column on 0.4x', () => {
     expect(cols.d.max).toBeUndefined();
   });
 
-  it('is not an integer, so the bounds cannot be read as one', async () => {
-    // `isIntegerColumn` falls back to "declares both bounds" when `integer` is absent, so a
-    // float that gained a range without the flag would start refusing 1.5.
-    const cols = await columnsOf(
-      'pg-float-not-integer-0.4x',
+  it('states integer:false, which decides the bounded case and nothing on the unbounded one', () => {
+    // Three comments claimed `integer: false` was on the unbounded columns to stop
+    // `isIntegerColumn` reading a CHECK-derived pair of bounds as an integer range. Review asked
+    // for the experiment and it disproves the claim: a CHECK never becomes a column bound at all.
+    // The generators fold checks into the emitted range as they emit, and nothing writes them back
+    // onto the Column, so `min` and `max` on a `doublePrecision` carrying two bracketing CHECKs
+    // are still undefined.
+    //
+    // `isIntegerColumn` is reimplemented here in its three lines rather than imported, because
+    // `@drzl/validation-core` is not a dependency of this package. That is a real weakness of this
+    // test: it would not notice that function changing. What it does pin is the input, which is
+    // the half this package owns, and generator-zod's structured-columns spec runs the real one.
+    const isIntegerColumn = (c: {
+      integer?: boolean;
+      dbType?: string;
+      min?: string;
+      max?: string;
+    }) => {
+      if (typeof c.integer === 'boolean') return c.integer;
+      return c.dbType === 'INTEGER' || (c.min !== undefined && c.max !== undefined);
+    };
+    const bounded = { integer: false, dbType: 'REAL', min: `-${FLOAT4_MAX}`, max: FLOAT4_MAX };
+    const unbounded = { integer: false, dbType: 'DOUBLE' };
+    const without = <T extends object>(o: T) => {
+      const { integer: _drop, ...rest } = o as T & { integer?: boolean };
+      return rest;
+    };
+    // On the bounded column the flag is the whole answer: without it the two bounds are read as an
+    // integer range and the emitted schema starts refusing 1.5.
+    expect(isIntegerColumn(bounded)).toBe(false);
+    expect(isIntegerColumn(without(bounded)), 'the flag is load-bearing here').toBe(true);
+    // On the unbounded one it decides nothing, which is what the removed comments got wrong.
+    expect(isIntegerColumn(unbounded)).toBe(false);
+    expect(isIntegerColumn(without(unbounded)), 'and inert here').toBe(false);
+  });
+
+  it('never turns a CHECK into a column bound, on a float or anything else', async () => {
+    // The other half of the same disproof, through the real analyzer: two bracketing CHECKs on a
+    // `doublePrecision` column leave its range untouched.
+    const table = await tableOf(
+      'pg-float-check-bounds-0.4x',
       `
-      import { pgTable, real } from 'drizzle-orm/pg-core';
-      export const t = pgTable('t', { r: real() });
+      import { pgTable, doublePrecision, real, check } from 'drizzle-orm/pg-core';
+      import { sql } from 'drizzle-orm';
+      export const t = pgTable('t', { d: doublePrecision(), r: real() }, (x) => [
+        check('lo', sql\`\${x.d} >= 0\`),
+        check('hi', sql\`\${x.d} <= 100\`),
+      ]);
       `
     );
-    expect(cols.r.integer).toBe(false);
+    // The checks were read, so an absent bound below is the analyzer's answer and not a fixture
+    // that quietly lost them. A verification that can succeed by matching nothing is not one.
+    expect(table.checks?.map((c) => c.expression)).toEqual(['d >= 0', 'd <= 100']);
+    const cols = Object.fromEntries(table.columns.map((c) => [c.name, c]));
+    expect(cols.d.min, 'a CHECK is not a column bound').toBeUndefined();
+    expect(cols.d.max).toBeUndefined();
+    expect(cols.d.integer).toBe(false);
   });
 
   it('carries the database limit, not drizzle-zod, and the limit is the largest float4', async () => {

--- a/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
+++ b/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * `point`, `line` and the inexact numeric types on drizzle-orm 0.4x, the major this package
+ * depends on and the one most users have installed.
+ *
+ * 0.4x carries no `codec`, so every column here reaches the analyzer through the class-name
+ * fallback rather than through `describeV1Column`, and that path got two things wrong.
+ *
+ * `point` and `line` were typed `string` by a coarse `/Point|Line/i` over the class name. They
+ * are not strings in either direction. Asked through PGlite, a real Postgres:
+ *
+ *   drizzle 0.45.2 maps [1, 2] to the literal "(1,2)", Postgres stores it, and
+ *   `mapFromDriverValue` hands back [1, 2]                                       accepted
+ *   the same column asked to insert the string "1,2" is handed "(1,,)", because
+ *   `mapToDriverValue` indexes the value by position, and Postgres answers
+ *   `invalid input syntax for type point: "(1,,)"`                               rejected
+ *   line, the same way: [1, 2, 3] becomes "{1,2,3}" and "1,2,3" becomes "{1,,,2}"
+ *
+ * So a select schema built on 0.4x refused every row the driver returned, and an insert schema
+ * accepted the one string shape the column cannot be given.
+ *
+ * The floats carried no bounds at all, because the class-name path reads its ranges from
+ * `INT_RANGES` and nothing else. That left DRZL looser than `drizzle-zod@0.8.3`, the first-party
+ * validator for this same major, which is the one direction this repository's parity gate exists
+ * to forbid.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function columnsOf(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const a = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  return Object.fromEntries((a.tables[0]?.columns ?? []).map((c) => [c.name, c]));
+}
+
+describe('a postgres point or line column on 0.4x', () => {
+  it('is the tuple the driver returns, not a string', async () => {
+    const cols = await columnsOf(
+      'pg-tuple-0.4x',
+      `
+      import { pgTable, point, line } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', { p: point(), l: line() });
+      `
+    );
+    expect(cols.p).toMatchObject({
+      tsType: '[number, number]',
+      dbType: 'POINT',
+      shape: { kind: 'tuple', length: 2 },
+    });
+    expect(cols.l).toMatchObject({
+      tsType: '[number, number, number]',
+      dbType: 'LINE',
+      shape: { kind: 'tuple', length: 3 },
+    });
+  });
+
+  it('reaches those classes by the names 0.4x actually uses', async () => {
+    // The fix is keyed on the constructor name, so the names are asserted rather than assumed.
+    // `line()` is the trap: its `drizzle:entityKind` is `PgLine` while its constructor is
+    // `PgLineTuple`, so a fix written against the entity kind would have missed it, and the
+    // fake `PgLine` class the older pg-types spec builds is a name drizzle never produces.
+    const { pgTable, point, line } = await import('drizzle-orm/pg-core');
+    const t = pgTable('t', { p: point(), l: line() });
+    const cols = t[Symbol.for('drizzle:Columns') as never] as Record<string, { constructor: { name: string } }>;
+    expect(cols.p.constructor.name).toBe('PgPointTuple');
+    expect(cols.l.constructor.name).toBe('PgLineTuple');
+  });
+
+  it('still calls the object modes strings, which is a filed defect and not the intent', async () => {
+    // What else `/Point|Line/i` catches. `point({ mode: 'xy' })` is a `PgPointObject` and
+    // `line({ mode: 'abc' })` a `PgLineABC`, and both hand back an object rather than a string
+    // or a tuple. Left alone here on purpose: drizzle v1 describes them as tuples too, so this
+    // is a defect on both majors and fixing it needs a shape the generators do not have yet.
+    // Pinned so the next change to that arm has to say what it did to them.
+    const cols = await columnsOf(
+      'pg-tuple-object-modes-0.4x',
+      `
+      import { pgTable, point, line } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', { p: point({ mode: 'xy' }), l: line({ mode: 'abc' }) });
+      `
+    );
+    expect(cols.p).toMatchObject({ tsType: 'string', dbType: 'TEXT' });
+    expect(cols.l).toMatchObject({ tsType: 'string', dbType: 'TEXT' });
+  });
+});
+
+describe('an inexact numeric column on 0.4x', () => {
+  it('bounds postgres real, double precision and numeric in number mode', async () => {
+    const cols = await columnsOf(
+      'pg-floats-0.4x',
+      `
+      import { pgTable, real, doublePrecision, numeric } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', {
+        r: real(),
+        d: doublePrecision(),
+        n: numeric({ precision: 10, scale: 2, mode: 'number' }),
+      });
+      `
+    );
+    expect(cols.r).toMatchObject({
+      tsType: 'number',
+      dbType: 'REAL',
+      min: '-8388608',
+      max: '8388607',
+      integer: false,
+    });
+    expect(cols.d).toMatchObject({
+      min: '-140737488355328',
+      max: '140737488355327',
+      integer: false,
+    });
+    expect(cols.n).toMatchObject({
+      min: '-9007199254740991',
+      max: '9007199254740991',
+      integer: false,
+    });
+  });
+
+  it('bounds the mysql, sqlite and singlestore spellings by their real width', async () => {
+    const my = await columnsOf(
+      'mysql-floats-0.4x',
+      `
+      import { mysqlTable, real, double, float } from 'drizzle-orm/mysql-core';
+      export const t = mysqlTable('t', { r: real(), d: double(), f: float() });
+      `
+    );
+    // MySQL's REAL is a synonym for DOUBLE unless REAL_AS_FLOAT is set, and drizzle v1 says
+    // `number double` for it, so it takes the wider pair.
+    expect(my.r).toMatchObject({ min: '-140737488355328', max: '140737488355327' });
+    expect(my.d).toMatchObject({ min: '-140737488355328', max: '140737488355327' });
+    expect(my.f).toMatchObject({ min: '-8388608', max: '8388607' });
+
+    const sq = await columnsOf(
+      'sqlite-floats-0.4x',
+      `
+      import { sqliteTable, real } from 'drizzle-orm/sqlite-core';
+      export const t = sqliteTable('t', { r: real() });
+      `
+    );
+    // SQLite's REAL is an 8 byte IEEE float, which is why it takes the double pair and not the
+    // one its name suggests.
+    expect(sq.r).toMatchObject({ min: '-140737488355328', max: '140737488355327' });
+
+    const ss = await columnsOf(
+      'singlestore-floats-0.4x',
+      `
+      import { singlestoreTable, real, double, float } from 'drizzle-orm/singlestore-core';
+      export const t = singlestoreTable('t', { r: real(), d: double(), f: float() });
+      `
+    );
+    expect(ss.r).toMatchObject({ min: '-140737488355328', max: '140737488355327' });
+    expect(ss.d).toMatchObject({ min: '-140737488355328', max: '140737488355327' });
+    expect(ss.f).toMatchObject({ min: '-8388608', max: '8388607' });
+  });
+
+  it('is bounded by a table disjoint from the integer one', async () => {
+    // `columnConstraints` applies the integer table and then the inexact one, so a class in both
+    // would have its answer decided by the order of two blocks. Asserted over every class either
+    // table names rather than by reading them, since a later entry is exactly how that would
+    // creep in. Read off the analyzer's own output: an integer column keeps `integer: true` and
+    // an inexact one keeps `integer: false`, and no column can report both.
+    const cols = await columnsOf(
+      'ranges-disjoint-0.4x',
+      `
+      import { pgTable, integer, smallint, serial, bigint, real, doublePrecision, numeric }
+        from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', {
+        i: integer(), si: smallint(), s: serial(), b: bigint({ mode: 'number' }),
+        r: real(), d: doublePrecision(), n: numeric({ precision: 10, scale: 2, mode: 'number' }),
+      });
+      `
+    );
+    const integers = ['i', 'si', 's', 'b'];
+    const inexact = ['r', 'd', 'n'];
+    for (const name of integers) expect(cols[name].integer, name).toBe(true);
+    for (const name of inexact) expect(cols[name].integer, name).toBe(false);
+    // And every one of them is bounded, so "disjoint" is not being satisfied by a class that
+    // neither table names.
+    for (const name of [...integers, ...inexact]) {
+      expect(cols[name].min, name).toBeDefined();
+      expect(cols[name].max, name).toBeDefined();
+    }
+  });
+
+  it('is not an integer, so the bounds cannot be read as one', async () => {
+    // `isIntegerColumn` falls back to "declares both bounds" when `integer` is absent, so a
+    // float that gained a range without the flag would start refusing 1.5.
+    const cols = await columnsOf(
+      'pg-float-not-integer-0.4x',
+      `
+      import { pgTable, real } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', { r: real() });
+      `
+    );
+    expect(cols.r.integer).toBe(false);
+  });
+
+  it('carries the drizzle bound rather than the width the database can hold', async () => {
+    // Measured through PGlite on the column's own `real` type: it holds every integer up to
+    // 16777216 exactly, and 16777217 comes back as 16777216. The bound below is half that, so it
+    // is `drizzle-zod`'s choice and not the column's limit, and DRZL matches it deliberately so
+    // the two majors and the first-party module all agree about the same column. Asserted rather
+    // than described, because a sentence claiming a mechanism is how the last several of these
+    // went wrong.
+    const cols = await columnsOf(
+      'pg-float-bound-origin-0.4x',
+      `
+      import { pgTable, real } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', { r: real() });
+      `
+    );
+    expect(Number(cols.r.max)).toBeLessThan(16777216);
+    // And it is not a database limit in the other direction either: PGlite accepted Infinity and
+    // NaN into the same `real` column, which no finite bound admits. So the schema is narrower
+    // than the column on purpose, and this pins that it is narrow at all.
+    expect(Number.isFinite(Number(cols.r.max))).toBe(true);
+  });
+});

--- a/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
+++ b/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
@@ -32,8 +32,18 @@ import { SchemaAnalyzer } from '../src/index';
 
 const dir = path.resolve(__dirname, 'fixtures');
 
-/** The largest finite float32, which is the only magnitude Postgres refuses on a `real` column. */
-const FLOAT4_MAX = '340282346638528859811704183484516925440';
+/**
+ * The two 4 byte float edges, which are not the same number.
+ *
+ * MySQL's `FLOAT` stops at the largest finite float32 exactly. Postgres's `real` takes every double
+ * up to `2 ** 128 - 2 ** 103`, 268435456 representable doubles further on, and stores the largest
+ * float32 for all of them. Both bisected against a real server; see the analyzer's own docstring
+ * for the runs, and the test at the bottom of this file for the consequence.
+ */
+const MYSQL_FLOAT_MAX = '340282346638528859811704183484516925440';
+const PG_FLOAT4_MAX = '340282356779733661637539395458142568448';
+/** What a `real` at full magnitude comes back as over the text protocol. */
+const FLOAT4_TEXT_ROUND_TRIP = 3.4028235e38;
 
 async function tableOf(name: string, source: string) {
   await fs.mkdir(dir, { recursive: true });
@@ -115,8 +125,8 @@ describe('an inexact numeric column on 0.4x', () => {
     expect(cols.r).toMatchObject({
       tsType: 'number',
       dbType: 'REAL',
-      min: `-${FLOAT4_MAX}`,
-      max: FLOAT4_MAX,
+      min: `-${PG_FLOAT4_MAX}`,
+      max: PG_FLOAT4_MAX,
       integer: false,
     });
     // An 8 byte float carries no magnitude bound at all, because there is no finite one that is
@@ -148,7 +158,12 @@ describe('an inexact numeric column on 0.4x', () => {
       expect(c.min).toBeUndefined();
       expect(c.max).toBeUndefined();
     }
-    expect(my.f).toMatchObject({ min: `-${FLOAT4_MAX}`, max: FLOAT4_MAX, integer: false });
+    // MySQL's own edge, not Postgres's. A real MySQL 8.4 in strict mode refuses the very next
+    // double above the largest float32, where Postgres takes another 268435456 of them, so a
+    // `FLOAT` column bounded at Postgres's number would promise a write MySQL answers
+    // `Out of range value for column` to.
+    expect(my.f).toMatchObject({ min: `-${MYSQL_FLOAT_MAX}`, max: MYSQL_FLOAT_MAX, integer: false });
+    expect(Number(my.f.max), 'narrower than the Postgres bound').toBeLessThan(Number(PG_FLOAT4_MAX));
 
     const sq = await columnsOf(
       'sqlite-floats-0.4x',
@@ -171,7 +186,9 @@ describe('an inexact numeric column on 0.4x', () => {
     );
     expect(ss.r.min).toBeUndefined();
     expect(ss.d.min).toBeUndefined();
-    expect(ss.f).toMatchObject({ min: `-${FLOAT4_MAX}`, max: FLOAT4_MAX, integer: false });
+    // SingleStore is MySQL wire-compatible and no server was measured for it here, so it takes
+    // MySQL's edge rather than the wider of the two.
+    expect(ss.f).toMatchObject({ min: `-${MYSQL_FLOAT_MAX}`, max: MYSQL_FLOAT_MAX, integer: false });
   });
 
   it('names no class in both range tables', () => {
@@ -239,7 +256,7 @@ describe('an inexact numeric column on 0.4x', () => {
     );
     expect(cols.r.integer, 'bounded').toBe(false);
     expect(cols.d.integer, 'unbounded').toBe(false);
-    expect(cols.r.max).toBe(FLOAT4_MAX);
+    expect(cols.r.max).toBe(PG_FLOAT4_MAX);
     expect(cols.d.max).toBeUndefined();
   });
 
@@ -266,10 +283,10 @@ describe('an inexact numeric column on 0.4x', () => {
     expect(cols.d.integer).toBe(false);
   });
 
-  it('carries the database limit, not drizzle-zod, and the limit is the largest float4', async () => {
-    // This bound is a measured database edge. PGlite, on a real `real` column: it accepted
-    // 3.4028234663852886e38 and returned it identical, and refused 3.4028236e38 with
-    // `"3.4028236e+38" is out of range for type real`.
+  it('carries the database limit, not drizzle-zod and not the float32 the digits look like', async () => {
+    // This bound is a measured database edge, bisected over the raw bit pattern of a double
+    // against PGlite on a real `real` column: 3.4028235677973366e38 is accepted and stored, and
+    // the next double up, 3.402823567797337e38, answers `... is out of range for type real`.
     //
     // It used to be `drizzle-zod`'s +/-8388607, which is not a limit of anything: the same column
     // stores 8388608, 9000000, 1e9 and 2147483648 and returns each unchanged, so that bound made
@@ -284,20 +301,37 @@ describe('an inexact numeric column on 0.4x', () => {
       `
     );
     const max = Number(cols.r.max);
-    // Written out in full decimal rather than as 3.4028234663852886e38, and this asserts the two
+    // Written out in full decimal rather than as 3.4028235677973366e38, and this asserts the two
     // are the same double. The spelling is load-bearing: ArkType's string DSL cannot resolve an
     // exponent literal, and the parity stage crashed with
     // `ParseError: '-3.4028234663852886e38' is unresolvable` when the bound was written that way.
     expect(cols.r.max, 'no exponent in the emitted bound').not.toMatch(/e/i);
-    expect(max).toBe(3.4028234663852886e38);
-    // The largest finite float32, asserted the way JavaScript can check it rather than described:
-    // it survives a round trip through float32, and the next float32 up is Infinity.
-    expect(Math.fround(max), 'is exactly representable as a float32').toBe(max);
-    expect(Math.fround(3.4028236e38), 'and is the last one that is').toBe(Infinity);
+    expect(max).toBe(3.4028235677973366e38);
     expect(Number.isFinite(max)).toBe(true);
-    // The value the old bound refused and the column holds exactly, so this cannot silently
-    // regress to a narrower one.
-    expect(max).toBeGreaterThan(1e9);
+    // It is `2 ** 128 - 2 ** 103`, the midpoint between the largest float32 and the first power of
+    // two past it, which is where Postgres's rounding stops bringing an input back into range.
+    expect(BigInt(cols.r.max!), 'the exact integer, not a rounded print of it').toBe(
+      2n ** 128n - 2n ** 103n
+    );
+    // Not a float32, whatever the leading digits suggest: JavaScript rounds that midpoint to even,
+    // which overflows, while Postgres rounds it down and stores the largest float32. Anyone
+    // "correcting" this bound to `Math.fround`'s idea of the edge reintroduces the defect below.
+    expect(Math.fround(max), 'JS rounds the midpoint up, Postgres rounds it down').toBe(Infinity);
+    // The defect this width exists to prevent, which the float32 bound had. A `real` at full
+    // magnitude is sent back over the text protocol as `3.4028235e+38`; every text-protocol driver
+    // parses that into a double above the largest float32, so a select schema bounded there
+    // refused a row the column had just handed back.
+    expect(Math.fround(FLOAT4_TEXT_ROUND_TRIP), 'is a full-magnitude float4 in text form').toBe(
+      3.4028234663852886e38
+    );
+    expect(FLOAT4_TEXT_ROUND_TRIP, 'which the float32 bound refused').toBeGreaterThan(
+      Number(MYSQL_FLOAT_MAX)
+    );
+    expect(max, 'and this bound takes').toBeGreaterThanOrEqual(FLOAT4_TEXT_ROUND_TRIP);
+    // Still narrow enough to catch the one genuine over-acceptance, and it cannot silently regress
+    // to `drizzle-zod`'s number either.
+    expect(max, 'refuses 1e300').toBeLessThan(1e300);
+    expect(max, 'and is nowhere near +/-8388607').toBeGreaterThan(1e9);
   });
 
   it('leaves Infinity and NaN outside every range, which the database does not', async () => {

--- a/packages/analyzer/test/pg-types.spec.ts
+++ b/packages/analyzer/test/pg-types.spec.ts
@@ -95,6 +95,11 @@ export { table as pg_table };
     expect(get('cidr')).toBe('string');
     expect(get('mac')).toBe('string');
     expect(get('mac8')).toBe('string');
+    // These two are the coarse `/Point|Line/i` fallback and not what drizzle builds. `point()`
+    // is a `PgPointTuple` and `line()` a `PgLineTuple` on both majors, both of which are tuples
+    // and are asserted against the installed drizzle in floats-and-tuples-0.4x.spec.ts. What is
+    // still reached through this arm is `point({ mode: 'xy' })` and `line({ mode: 'abc' })`,
+    // which hand back an object and are a filed defect on both majors.
     expect(get('p')).toBe('string');
     expect(get('l')).toBe('string');
     expect(get('j')).toBe('any');

--- a/packages/analyzer/test/v1-column-types.spec.ts
+++ b/packages/analyzer/test/v1-column-types.spec.ts
@@ -48,6 +48,33 @@ describe('numbers', () => {
     });
   });
 
+  it('takes the 4 byte float bound from the codec, because the two databases differ', () => {
+    // Postgres refuses a `real` past 3.4028235677973366e38 and MySQL refuses a `FLOAT` past
+    // 3.4028234663852886e38, both bisected against a real server, so one bound for `number float`
+    // would be wrong on one of them. The codec is what tells them apart on v1, and the answer has
+    // to match what the class-name table gives the same column on 0.4x or the cross-major diff in
+    // verify-packed.sh fails.
+    expect(describeV1Column(col('number float', 'float4'))).toMatchObject({
+      min: '-340282356779733661637539395458142568448',
+      max: '340282356779733661637539395458142568448',
+    });
+    expect(describeV1Column(col('number float', 'float'))).toMatchObject({
+      min: '-340282346638528859811704183484516925440',
+      max: '340282346638528859811704183484516925440',
+    });
+    // SingleStore states the semantic and no codec at all on 1.0.0-rc.4, measured on a real
+    // `singlestoreTable`, so it lands here. It is MySQL wire-compatible and was not measured
+    // itself, so it takes MySQL's edge rather than the wider one.
+    expect(describeV1Column({ dataType: 'number float', dimensions: 0 })).toMatchObject({
+      max: '340282346638528859811704183484516925440',
+    });
+    // 8 byte floats carry no magnitude bound on either database: MySQL's `DOUBLE` returned
+    // Number.MAX_VALUE and 1e300 identical while the `FLOAT` beside it refused both.
+    const d = describeV1Column(col('number double', 'float8'));
+    expect(d?.min).toBeUndefined();
+    expect(d?.max).toBeUndefined();
+  });
+
   it('marks the inexact types as non-integers even though they carry bounds', () => {
     // The generators used to read "declares both bounds" as "is an integer". That held only while
     // integers were the sole bounded type, so stating it outright is the whole point of the flag.

--- a/packages/analyzer/test/v1-column-types.spec.ts
+++ b/packages/analyzer/test/v1-column-types.spec.ts
@@ -88,6 +88,30 @@ describe('structured values', () => {
     });
   });
 
+  it('DEFECT: calls the object modes tuples too, and they are objects', () => {
+    // `point({ mode: 'xy' })` is `object point` with codec `point` on v1, and hands back
+    // `{ x, y }`; `line({ mode: 'abc' })` is `object line` and hands back `{ a, b, c }`. Both
+    // reach the same `case 'point'` and `case 'line'` arms above and come back as tuples, so a v1
+    // select schema for either rejects every row the driver returns. That is the same class of
+    // defect as typing a `point` as a string was, and it is worse than 0.4x's answer rather than
+    // better: 0.4x calls them strings, which is also wrong.
+    //
+    // Filed rather than fixed. Describing `{ x, y }` needs a `ColumnShape` no generator has, and
+    // no fixture in either parity pass carries an object-mode column, so there is no gate to turn
+    // red first. Pinned here so a change to those arms has to say what it did to these two: the
+    // 0.4x half is pinned in floats-and-tuples-0.4x.spec.ts and this is the v1 half, which had
+    // none.
+    expect(describeV1Column(col('object point', 'point'))?.shape).toEqual({
+      kind: 'tuple',
+      length: 2,
+    });
+    expect(describeV1Column(col('object line', 'line'))?.shape).toEqual({
+      kind: 'tuple',
+      length: 3,
+    });
+    expect(describeV1Column(col('object point', 'point'))?.tsType).toBe('[number, number]');
+  });
+
   it('carries the declared width of a vector and a bit string', () => {
     expect(describeV1Column(col('array vector', 'vector', { length: 3 }))?.shape).toEqual({
       kind: 'numberVector',

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -382,9 +382,11 @@ function atNarrow(c: Column, predicate: (v: string) => string, message: string):
  * `type('bigint >= -9223372036854775808n')` throws "Comparator >= must be followed by a
  * corresponding literal", and the same bound written as a number rounds: 9223372036854775807
  * is not representable as a double. So this generator emitted a bare `bigint` and accepted
- * `2n ** 70n`, which every other generator rejects and which no int64 column can hold. That is
- * the one direction this project says generated output must never take, looser than the
- * first-party validator, and the packed gate had it waived on all three dialects.
+ * `2n ** 70n`, which every other generator rejects and which no int64 column can hold, so the
+ * schema promised a write the database refuses. The packed gate had it waived on all three
+ * dialects. Being looser than the first-party validator is not what made it wrong, though an
+ * earlier version of this sentence said it was the one direction generated output must never
+ * take: that gate counts its looser entries and most of them run that way.
  *
  * A narrow can hold it, exactly as the character caps do. Null passes, matching SQL and matching
  * the cap narrows, so the guard belongs here rather than in a wrapping union.

--- a/packages/generator-arktype/test/bigint-range.spec.ts
+++ b/packages/generator-arktype/test/bigint-range.spec.ts
@@ -3,9 +3,14 @@
  *
  * This generator emitted a bare `bigint` and nothing else, so a `bigint({ mode: 'bigint' })`
  * column accepted `2n ** 70n`: a value no int64 column can hold, that zod, valibot and typebox
- * all reject, and that `drizzle-orm/arktype` rejects too. Looser than the first-party validator
- * is the one direction this project says generated output must never take, and it was waived on
- * all three dialects in the packed gate rather than fixed.
+ * all reject, and that `drizzle-orm/arktype` rejects too. It was waived on all three dialects in
+ * the packed gate rather than fixed.
+ *
+ * Being looser than the first-party validator is not by itself the thing that made it wrong, and
+ * an earlier version of this sentence said it was "the one direction this project says generated
+ * output must never take". The gate counts its looser waivers and most of them run that way, some
+ * because the database backs DRZL. What made this one wrong is that no `int64` column can hold
+ * `2n ** 70n`, so the schema promised a write the database refuses.
  *
  * The reason recorded for the waiver was half true. ArkType's *string DSL* genuinely cannot state
  * it: `type('bigint >= -9223372036854775808n')` throws "Comparator >= must be followed by a

--- a/packages/generator-orpc/src/index.ts
+++ b/packages/generator-orpc/src/index.ts
@@ -224,6 +224,17 @@ interface LibDialect {
   object: (body: string) => string;
   /** Same, on one line. A single-key lookup input reads better without the wrapping. */
   objectInline: (body: string) => string;
+  /**
+   * A fixed-length tuple of numbers: a `point`, a `line`, a `geometry`.
+   *
+   * Absent for ArkType, which is not an oversight. Its field values are emitted as quoted
+   * string-DSL fragments, and the DSL has no tuple: `type({ p: '[number, number]' })` throws
+   * `Expected an expression before '[number, number]'`, measured. The array-literal form
+   * `type({ p: ['number', 'number'] })` does work and does reject a third element, but it is not a
+   * string, so it composes with neither `nullable` nor `optional` here, both of which build DSL
+   * text around their argument. ArkType therefore keeps `unknown` for these columns.
+   */
+  tuple?: (length: number) => string;
   /** ArkType types are strings, so the field value is JSON-encoded rather than emitted bare. */
   fieldIsString?: boolean;
   /** Applied to the whole update schema, where the library has a shorthand for it. */
@@ -246,6 +257,7 @@ const LIBS: Record<Lib, LibDialect> = {
     boolean: 'z.boolean()',
     date: 'z.date()',
     unknown: 'z.unknown()',
+    tuple: (n) => `z.tuple([${Array.from({ length: n }, () => 'z.number()').join(', ')}])`,
     enum: (vals) => `z.enum([${vals.map(q).join(', ')}] as const)`,
     array: (e) => `z.array(${e})`,
     nullable: (b) => `${b}.nullable()`,
@@ -260,6 +272,7 @@ const LIBS: Record<Lib, LibDialect> = {
     boolean: 'v.boolean()',
     date: 'v.date()',
     unknown: 'v.unknown()',
+    tuple: (n) => `v.tuple([${Array.from({ length: n }, () => 'v.number()').join(', ')}])`,
     enum: (vals) => `v.picklist([${vals.map(q).join(', ')}] as const)`,
     array: (e) => `v.array(${e})`,
     nullable: (b) => `v.nullable(${b})`,
@@ -289,6 +302,10 @@ function mapExpr(column: Column, lib: Lib, mode: 'insert' | 'update' | 'select')
   const d = LIBS[lib];
   let base = (() => {
     if (column.enumValues && column.enumValues.length) return d.enum(column.enumValues);
+    // Before the analyzer described a `point` as a tuple this landed on `string` on drizzle-orm
+    // 0.4x, which refuses the value the driver returns, and then on `unknown`, which accepts
+    // anything at all including a null payload the insert will not survive. Neither is the column.
+    if (column.shape?.kind === 'tuple' && d.tuple) return d.tuple(column.shape.length);
     switch (column.tsType) {
       case 'number':
         return d.number;

--- a/packages/generator-orpc/test/tuple-columns.spec.ts
+++ b/packages/generator-orpc/test/tuple-columns.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * A `point` or `line` column in a generated router.
+ *
+ * This generator maps a column by `tsType` alone, through a switch of four scalar names, so a
+ * tuple column fell to `unknown`. On drizzle-orm 0.4x that was invisible until the analyzer began
+ * describing those columns correctly: the emitted input schema went from `z.string()`, which
+ * refuses the `[1, 2]` the driver returns and accepts a `"1,2"` the column cannot be given, to
+ * `z.unknown()`, which accepts anything at all including a null payload the insert will not
+ * survive. Neither one is the column. Review caught the second as a loosening that was shipping
+ * unmentioned.
+ *
+ * ArkType keeps `unknown`, measured rather than assumed: its field values are emitted as quoted
+ * string-DSL fragments, and `type({ p: '[number, number]' })` throws
+ * `Expected an expression before '[number, number]'`. The array-literal form does work and does
+ * reject a third element, but it is not a string and so composes with neither the `nullable` nor
+ * the `optional` wrapper this generator builds around every field.
+ *
+ * The option is `validation.library`. `enum-columns.spec.ts` passes `validation.lib`, which this
+ * generator does not read, and its docstring puts the resulting zod-only output down to "the
+ * standard template renders zod expressions regardless of the configured lib". That is not what is
+ * happening: with the key spelled `library` the same template renders valibot and arktype, which
+ * is what the three cases below show. Not fixed there, because changing which library that spec
+ * exercises is a different change from this one.
+ */
+import { describe, it, expect } from 'vitest';
+import { ORPCGenerator } from '../src';
+import type { Analysis } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const analysis: Analysis = {
+  dialect: 'postgres',
+  tables: [
+    {
+      name: 'places',
+      tsName: 'places',
+      columns: [
+        {
+          name: 'id',
+          tsType: 'number',
+          dbType: 'INTEGER',
+          nullable: false,
+          hasDefault: true,
+          isGenerated: true,
+        },
+        {
+          name: 'at',
+          tsType: '[number, number]',
+          dbType: 'POINT',
+          nullable: false,
+          hasDefault: false,
+          isGenerated: false,
+          shape: { kind: 'tuple', length: 2 },
+        },
+        {
+          name: 'edge',
+          tsType: '[number, number, number]',
+          dbType: 'LINE',
+          nullable: true,
+          hasDefault: false,
+          isGenerated: false,
+          shape: { kind: 'tuple', length: 3 },
+        },
+      ],
+      unique: [],
+      indexes: [],
+    } as never,
+  ],
+  enums: [],
+  relations: [],
+  issues: [],
+} as Analysis;
+
+async function generate(lib: 'zod' | 'valibot' | 'arktype') {
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-orpc-tuple-'));
+  try {
+    const { files } = await new ORPCGenerator(analysis).generate({
+      outputDir: outDir,
+      template: 'standard',
+      validation: { library: lib, importPath: './validation', useShared: false },
+    } as never);
+    const routerFile = files.find((f) => /places/i.test(path.basename(f))) ?? files[0];
+    return await fs.readFile(routerFile, 'utf8');
+  } finally {
+    await fs.rm(outDir, { recursive: true, force: true });
+  }
+}
+
+describe('@drzl/generator-orpc tuple columns', () => {
+  it('emits a two and a three number tuple for zod', async () => {
+    const content = await generate('zod');
+    expect(content).toContain('z.tuple([z.number(), z.number()])');
+    expect(content).toContain('z.tuple([z.number(), z.number(), z.number()])');
+    // The two answers this column has had, neither of which is the column.
+    expect(content).not.toContain('"at": z.string()');
+    expect(content).not.toContain('"at": z.unknown()');
+  });
+
+  it('emits the same for valibot, and keeps the nullable wrapper around it', async () => {
+    const content = await generate('valibot');
+    expect(content).toContain('v.tuple([v.number(), v.number()])');
+    expect(content).toContain('v.nullable(v.tuple([v.number(), v.number(), v.number()]))');
+  });
+
+  it('leaves arktype on unknown, because its string DSL has no tuple', async () => {
+    // Pinned rather than blessed. If the field emission ever stops JSON-encoding ArkType values,
+    // the array-literal form becomes available and this should change with it.
+    const content = await generate('arktype');
+    expect(content).toContain('unknown');
+    expect(content).not.toContain('[number, number]');
+  });
+});

--- a/packages/generator-service/src/index.ts
+++ b/packages/generator-service/src/index.ts
@@ -39,6 +39,15 @@ function singularize(s: string) {
 function tsTypeOf(c: Column): string {
   // basic mapping from analyzer tsType
   if (c.enumValues && c.enumValues.length) return c.enumValues.map((v) => `'${v}'`).join(' | ');
+  // A tuple column, built from the shape rather than pasted from `tsType`. The allowlist below is
+  // a list of scalar names and everything else falls to `unknown`, so a `point` was written as
+  // `unknown` here while the validators emitted a two-number tuple for the same column. Review
+  // measured it: on drizzle-orm 0.4x the emitted type went from `string`, which was wrong, to
+  // `unknown`, which is honest and says nothing. `[number, number]` is ordinary TypeScript and the
+  // analyzer already states the arity.
+  if (c.shape?.kind === 'tuple') {
+    return `[${Array.from({ length: c.shape.length }, () => 'number').join(', ')}]`;
+  }
   switch (c.tsType) {
     case 'number':
     case 'string':

--- a/packages/generator-service/test/tuple-types.spec.ts
+++ b/packages/generator-service/test/tuple-types.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * A `point` or `line` column in the generated service types.
+ *
+ * `tsTypeOf` maps a column through an allowlist of scalar names and everything else falls to
+ * `unknown`. On drizzle-orm 0.4x this was invisible while the analyzer typed a `point` as
+ * `string`: the field was wrong, but it was wrong in a way that looked like a type. Once the
+ * analyzer described those columns as tuples the same field became `unknown`, which is honest and
+ * says nothing, and the validation generators for the same column were emitting a two-number
+ * tuple. Review caught the gap.
+ *
+ * Built from `shape.length` rather than pasted from `tsType`. The analyzer states the arity, and a
+ * tuple of numbers is ordinary TypeScript, so there is nothing to guess.
+ */
+import { describe, it, expect } from 'vitest';
+import { ServiceGenerator } from '../src';
+import type { Analysis } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const analysis: Analysis = {
+  dialect: 'postgres',
+  tables: [
+    {
+      name: 'places',
+      tsName: 'places',
+      columns: [
+        {
+          name: 'id',
+          tsType: 'number',
+          dbType: 'INTEGER',
+          nullable: false,
+          hasDefault: true,
+          isGenerated: true,
+        },
+        {
+          name: 'at',
+          tsType: '[number, number]',
+          dbType: 'POINT',
+          nullable: false,
+          hasDefault: false,
+          isGenerated: false,
+          shape: { kind: 'tuple', length: 2 },
+        },
+        {
+          name: 'edge',
+          tsType: '[number, number, number]',
+          dbType: 'LINE',
+          nullable: true,
+          hasDefault: false,
+          isGenerated: false,
+          shape: { kind: 'tuple', length: 3 },
+        },
+        // The control. A column with no shape still falls to `unknown`, so this is not a blanket
+        // pass-through of whatever `tsType` happens to say.
+        {
+          name: 'blob',
+          tsType: 'Buffer',
+          dbType: 'BYTEA',
+          nullable: false,
+          hasDefault: false,
+          isGenerated: false,
+          shape: { kind: 'buffer' },
+        },
+      ],
+      primaryKey: { columns: ['id'] },
+      unique: [],
+      indexes: [],
+    },
+  ] as never,
+  enums: [],
+  relations: [],
+  issues: [],
+} as Analysis;
+
+async function emitted(): Promise<string> {
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-svc-tuple-'));
+  await new ServiceGenerator(analysis).generate({ outDir } as never);
+  return fs.readFile(path.join(outDir, 'types', 'places.ts'), 'utf8');
+}
+
+describe('a tuple column in the generated types', () => {
+  it('is a tuple of the declared arity, not unknown', async () => {
+    const src = await emitted();
+    expect(src).toContain('at: [number, number]');
+    expect(src).toContain('edge: [number, number, number] | null');
+    expect(src).not.toContain('at: unknown');
+  });
+
+  it('leaves a shape it cannot spell as unknown', async () => {
+    expect(await emitted()).toContain('blob: unknown');
+  });
+});

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -203,12 +203,20 @@ function shapeExpr(c: Column, typedJsonRef?: string): string | undefined {
       // all: it emits `z.any()`, losing both the type and the narrowing `unknown` would force.
       return typedJsonRef ? `z.custom<${typedJsonRef}>()` : 'z.unknown()';
     case 'buffer':
-      // `Uint8Array` rather than `Buffer`, which is the one place the output is deliberately
-      // wider than `drizzle-orm/zod`. A Buffer is a Uint8Array, so everything official accepts
-      // is accepted here; the reverse is not true. Reasons for the wider check: it needs no
-      // `@types/node` and so survives an edge or browser build, `Buffer` is not defined in those
-      // runtimes at all and `v instanceof Buffer` would throw rather than fail, and it makes a
-      // Postgres `bytea` and a SQLite `blob` validate identically instead of by dialect.
+      // `Uint8Array` rather than `Buffer`, which is deliberately wider than `drizzle-orm/zod`.
+      // A Buffer is a Uint8Array, so everything official accepts is accepted here; the reverse
+      // is not true. Both halves are asserted in test/structured-columns.spec.ts, which pushes a
+      // plain `Uint8Array` and a `Buffer` at the emitted field.
+      //
+      // It is not "the one place" the output is wider, which is what this sentence and the docs
+      // page both used to say. That is not a judgement, it is countable: `verify-packed.sh`
+      // counts the waivers where DRZL accepts something official refuses and prints the number
+      // on every run, and the float bounds released alongside this comment added six more.
+      //
+      // Reasons for the wider check: it needs no `@types/node` and so survives an edge or browser
+      // build, `Buffer` is not defined in those runtimes at all and `v instanceof Buffer` would
+      // throw rather than fail, and it makes a Postgres `bytea` and a SQLite `blob` validate
+      // identically instead of by dialect.
       return 'z.instanceof(Uint8Array)';
     case 'tuple':
       return `z.tuple([${Array.from({ length: s.length }, () => 'z.number()').join(', ')}])`;

--- a/packages/generator-zod/test/column-fidelity.spec.ts
+++ b/packages/generator-zod/test/column-fidelity.spec.ts
@@ -14,8 +14,11 @@
  *
  * DRZL emitted `z.string()` and `z.number().int()` for all of them, so a 300 character name and
  * a smallint of 40000 both passed validation and failed at the database. Being the codegen
- * alternative to a first-party runtime module is only defensible if the output is at least as
- * strict.
+ * alternative to a first-party runtime module is only defensible if every difference from it is
+ * known and accounted for. Not if the output is at least as strict, which this sentence used to
+ * say: `verify-packed.sh` counts the waivers where DRZL is the looser side and most of them are,
+ * several backed by the database. What is indefensible is a difference nobody has looked at, and
+ * a bound the column has and the schema does not is one of those.
  */
 import { describe, it, expect } from 'vitest';
 import { ZodGenerator } from '../src/index';

--- a/packages/generator-zod/test/structured-columns.spec.ts
+++ b/packages/generator-zod/test/structured-columns.spec.ts
@@ -137,6 +137,30 @@ describe('structured columns', () => {
     expect(accepts(f, 'abc'), 'a string').toBe(false);
   });
 
+  it('bounds an inexact numeric column without turning it into an integer', async () => {
+    // What the analyzer now emits for a `real` column on drizzle-orm 0.4x, where it used to emit
+    // no range at all and DRZL was looser than drizzle-zod@0.8.3 on the same major.
+    //
+    // `integer` has to travel with the bounds. `isIntegerColumn` falls back to "declares both
+    // bounds" when the flag is absent, so a range arriving on its own would make the emitted
+    // schema call `.int()` and start refusing 1.5, which is most of what a real column holds.
+    const m = await schemasFor([
+      col('ratio', {
+        tsType: 'number',
+        dbType: 'REAL',
+        min: '-8388608',
+        max: '8388607',
+        integer: false,
+      }),
+    ]);
+    const f = m.SelecttSchema.shape.ratio;
+    expect(accepts(f, 1.5), 'a fraction, which is the point of the column').toBe(true);
+    expect(accepts(f, 8388607), 'the bound itself').toBe(true);
+    expect(accepts(f, 8388608), 'one past the bound').toBe(false);
+    expect(accepts(f, -8388609), 'one below the bound').toBe(false);
+    expect(accepts(f, Infinity), 'a value Postgres takes and a finite bound cannot').toBe(false);
+  });
+
   it('holds a json column to values that survive a round trip', async () => {
     // `z.any()` accepted all of the rejections below, none of which come back out of the column
     // as they went in.

--- a/packages/generator-zod/test/structured-columns.spec.ts
+++ b/packages/generator-zod/test/structured-columns.spec.ts
@@ -137,9 +137,9 @@ describe('structured columns', () => {
     expect(accepts(f, 'abc'), 'a string').toBe(false);
   });
 
-  it('bounds an inexact numeric column without turning it into an integer', async () => {
-    // What the analyzer now emits for a `real` column on drizzle-orm 0.4x, where it used to emit
-    // no range at all and DRZL was looser than drizzle-zod@0.8.3 on the same major.
+  it('bounds a 4 byte float at the magnitude the database refuses', async () => {
+    // What the analyzer emits for a `real` column. The bound is a measured Postgres edge: PGlite
+    // takes 3.4028234663852886e38 and answers `out of range for type real` to 3.4028236e38.
     //
     // `integer` has to travel with the bounds. `isIntegerColumn` falls back to "declares both
     // bounds" when the flag is absent, so a range arriving on its own would make the emitted
@@ -148,17 +148,41 @@ describe('structured columns', () => {
       col('ratio', {
         tsType: 'number',
         dbType: 'REAL',
-        min: '-8388608',
-        max: '8388607',
+        min: '-340282346638528859811704183484516925440',
+        max: '340282346638528859811704183484516925440',
         integer: false,
       }),
     ]);
     const f = m.SelecttSchema.shape.ratio;
     expect(accepts(f, 1.5), 'a fraction, which is the point of the column').toBe(true);
-    expect(accepts(f, 8388607), 'the bound itself').toBe(true);
-    expect(accepts(f, 8388608), 'one past the bound').toBe(false);
-    expect(accepts(f, -8388609), 'one below the bound').toBe(false);
-    expect(accepts(f, Infinity), 'a value Postgres takes and a finite bound cannot').toBe(false);
+    expect(accepts(f, 3.4028234663852886e38), 'the bound itself').toBe(true);
+    expect(accepts(f, 3.4028236e38), 'past the largest float32').toBe(false);
+    expect(accepts(f, -3.4028236e38), 'and below the smallest').toBe(false);
+    // Values a shipped release refused and the column stores exactly. The bound used to be
+    // drizzle-zod's +/-8388607 and this is what that cost.
+    expect(accepts(f, 8388608)).toBe(true);
+    expect(accepts(f, 1e9)).toBe(true);
+    expect(accepts(f, 2147483648)).toBe(true);
+    // Filed, not fixed: Postgres stores Infinity and NaN in a real column and no range admits
+    // either. `z.number()` refuses both with no bound at all, so a range is not what would fix it.
+    expect(accepts(f, Infinity)).toBe(false);
+    expect(accepts(f, NaN)).toBe(false);
+  });
+
+  it('keeps an 8 byte float unbounded and still not an integer', async () => {
+    // The absence of a range is the statement here: float8 is the JavaScript number's own format,
+    // so Postgres takes every finite JS number into a `double precision` column, measured to
+    // Number.MAX_VALUE. `integer: false` is what stops `isIntegerColumn` reading the bare absence
+    // as anything, and this executes that rather than reading the three lines of it.
+    const m = await schemasFor([
+      col('reading', { tsType: 'number', dbType: 'DOUBLE', integer: false }),
+    ]);
+    const f = m.SelecttSchema.shape.reading;
+    expect(accepts(f, 1.5), 'a fraction, so no .int() was emitted').toBe(true);
+    expect(accepts(f, 1.75e15), 'a microsecond epoch, refused by the old bound').toBe(true);
+    expect(accepts(f, 1e300), 'refused by the old bound and stored by the column').toBe(true);
+    expect(accepts(f, Number.MAX_VALUE)).toBe(true);
+    expect(accepts(f, 'x'), 'still a number').toBe(false);
   });
 
   it('holds a json column to values that survive a round trip', async () => {

--- a/packages/generator-zod/test/structured-columns.spec.ts
+++ b/packages/generator-zod/test/structured-columns.spec.ts
@@ -138,8 +138,9 @@ describe('structured columns', () => {
   });
 
   it('bounds a 4 byte float at the magnitude the database refuses', async () => {
-    // What the analyzer emits for a `real` column. The bound is a measured Postgres edge: PGlite
-    // takes 3.4028234663852886e38 and answers `out of range for type real` to 3.4028236e38.
+    // What the analyzer emits for a Postgres `real` column. The bound is a measured edge, bisected
+    // against PGlite: it takes 3.4028235677973366e38 and answers `out of range for type real` to
+    // the next double up.
     //
     // `integer` has to travel with the bounds. `isIntegerColumn` falls back to "declares both
     // bounds" when the flag is absent, so a range arriving on its own would make the emitted
@@ -148,16 +149,20 @@ describe('structured columns', () => {
       col('ratio', {
         tsType: 'number',
         dbType: 'REAL',
-        min: '-340282346638528859811704183484516925440',
-        max: '340282346638528859811704183484516925440',
+        min: '-340282356779733661637539395458142568448',
+        max: '340282356779733661637539395458142568448',
         integer: false,
       }),
     ]);
     const f = m.SelecttSchema.shape.ratio;
     expect(accepts(f, 1.5), 'a fraction, which is the point of the column').toBe(true);
-    expect(accepts(f, 3.4028234663852886e38), 'the bound itself').toBe(true);
-    expect(accepts(f, 3.4028236e38), 'past the largest float32').toBe(false);
-    expect(accepts(f, -3.4028236e38), 'and below the smallest').toBe(false);
+    expect(accepts(f, 3.4028235677973366e38), 'the bound itself').toBe(true);
+    // The value a `real` at full magnitude comes back as over the text protocol. A bound at the
+    // largest float32, 3.4028234663852886e38, refused this and so refused the column's own row.
+    expect(accepts(f, 3.4028235e38), 'a full-magnitude float4 in text form').toBe(true);
+    expect(accepts(f, 3.402823567797337e38), 'the first double Postgres refuses').toBe(false);
+    expect(accepts(f, -3.402823567797337e38), 'and below the smallest').toBe(false);
+    expect(accepts(f, 1e300), 'still catches the one genuine over-acceptance').toBe(false);
     // Values a shipped release refused and the column stores exactly. The bound used to be
     // drizzle-zod's +/-8388607 and this is what that cost.
     expect(accepts(f, 8388608)).toBe(true);

--- a/packages/validation-core/test/integer-column.spec.ts
+++ b/packages/validation-core/test/integer-column.spec.ts
@@ -30,7 +30,8 @@ import { describe, it, expect } from 'vitest';
 import { isIntegerColumn } from '../src/index';
 import type { Column } from '@drzl/analyzer';
 
-const FLOAT4_MAX = '340282346638528859811704183484516925440';
+/** What the analyzer emits for a Postgres `real`: the largest double that column accepts. */
+const PG_FLOAT4_MAX = '340282356779733661637539395458142568448';
 
 const col = (over: Partial<Column>): Column =>
   ({
@@ -50,7 +51,7 @@ const withoutFlag = (c: Column): Column => {
 };
 
 describe('a bounded inexact column', () => {
-  const real = col({ dbType: 'REAL', min: `-${FLOAT4_MAX}`, max: FLOAT4_MAX, integer: false });
+  const real = col({ dbType: 'REAL', min: `-${PG_FLOAT4_MAX}`, max: PG_FLOAT4_MAX, integer: false });
 
   it('is not an integer, because the flag says so', () => {
     expect(isIntegerColumn(real)).toBe(false);

--- a/packages/validation-core/test/integer-column.spec.ts
+++ b/packages/validation-core/test/integer-column.spec.ts
@@ -8,8 +8,11 @@
  * measures the copy.
  *
  * So the assertion lives here, where the function does. Deleting
- * `if (typeof c.integer === 'boolean') return c.integer;` from `src/index.ts` fails the first two
- * cases below.
+ * `if (typeof c.integer === 'boolean') return c.integer;` from `src/index.ts` fails two cases, run
+ * rather than counted: `is not an integer, because the flag says so` and `lets an explicit true
+ * through as well, not only false`, which are the first and the last of the eight. An earlier
+ * version of this sentence said "the first two", and the second case is the control for the first:
+ * it asserts the fallback, which is all the deletion leaves, so it passes by construction.
  *
  * What the analyzer states, and why each case matters:
  *

--- a/packages/validation-core/test/integer-column.spec.ts
+++ b/packages/validation-core/test/integer-column.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * `isIntegerColumn`, against the real function rather than a copy of it.
+ *
+ * The analyzer's float work turned on a claim about this function, and the first attempt to assert
+ * that claim reimplemented its three lines inside `packages/analyzer/test`, because the analyzer
+ * does not depend on this package. Review showed what that cost: deleting the flag branch from the
+ * real function left the analyzer suite at 154 passed. A closed loop over a reimplementation
+ * measures the copy.
+ *
+ * So the assertion lives here, where the function does. Deleting
+ * `if (typeof c.integer === 'boolean') return c.integer;` from `src/index.ts` fails the first two
+ * cases below.
+ *
+ * What the analyzer states, and why each case matters:
+ *
+ *   real                bounded, integer: false   the flag is the only thing between the emitted
+ *                                                 schema and `.int()`, since "declares both
+ *                                                 bounds" is the fallback
+ *   double precision    unbounded, integer: false the flag decides nothing here, and is stated
+ *                                                 because it is true of the column
+ *
+ * Three comments in the analyzer used to say the flag was on the unbounded column to stop a
+ * CHECK-derived pair of bounds being read as an integer range. A CHECK never becomes a column
+ * bound at all, so that was false twice over, and the pair below is what is actually true.
+ */
+import { describe, it, expect } from 'vitest';
+import { isIntegerColumn } from '../src/index';
+import type { Column } from '@drzl/analyzer';
+
+const FLOAT4_MAX = '340282346638528859811704183484516925440';
+
+const col = (over: Partial<Column>): Column =>
+  ({
+    name: 'c',
+    tsType: 'number',
+    dbType: 'DOUBLE',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+/** The same column with the flag removed, which is the state a pre-1.7 analysis produces. */
+const withoutFlag = (c: Column): Column => {
+  const { integer: _drop, ...rest } = c;
+  return rest as Column;
+};
+
+describe('a bounded inexact column', () => {
+  const real = col({ dbType: 'REAL', min: `-${FLOAT4_MAX}`, max: FLOAT4_MAX, integer: false });
+
+  it('is not an integer, because the flag says so', () => {
+    expect(isIntegerColumn(real)).toBe(false);
+  });
+
+  it('and is read as one the moment the flag is gone, which is why it is stated', () => {
+    // The control for the case above. Without this, the first assertion passes for a function
+    // that ignores the flag entirely.
+    expect(isIntegerColumn(withoutFlag(real))).toBe(true);
+  });
+});
+
+describe('an unbounded inexact column', () => {
+  const double = col({ dbType: 'DOUBLE', integer: false });
+
+  it('is not an integer', () => {
+    expect(isIntegerColumn(double)).toBe(false);
+  });
+
+  it('and is not one without the flag either, so the flag decides nothing here', () => {
+    expect(isIntegerColumn(withoutFlag(double))).toBe(false);
+  });
+});
+
+describe('the fallback for an analysis that predates the flag', () => {
+  it('reads a declared integer dbType as an integer', () => {
+    expect(isIntegerColumn(withoutFlag(col({ dbType: 'INTEGER' })))).toBe(true);
+  });
+
+  it('reads a pair of bounds as an integer range', () => {
+    expect(isIntegerColumn(withoutFlag(col({ min: '-32768', max: '32767' })))).toBe(true);
+  });
+
+  it('needs both ends before it will', () => {
+    expect(isIntegerColumn(withoutFlag(col({ min: '-32768' })))).toBe(false);
+  });
+
+  it('lets an explicit true through as well, not only false', () => {
+    // Both branches of the flag, so a function that returned a constant false would fail here.
+    expect(isIntegerColumn(col({ dbType: 'DOUBLE', integer: true }))).toBe(true);
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -973,6 +973,28 @@ export const POOL: [string, unknown][] = [
 
 export type Lib = { field: (s: any, k: string) => any; ok: (f: any, x: unknown) => boolean };
 
+/**
+ * How each library's schema is taken apart into one field per column, and checked.
+ *
+ * Both passes compare a column by extracting its field from each side and pushing the pool through
+ * it, so anything a library keeps on the parent object rather than on the field is invisible here.
+ * One such thing is known and it is TypeBox's optionality. Measured on official's 0.4x update
+ * schema for `matrix`:
+ *
+ *   the property carries Symbol(TypeBox.Kind) and Symbol(TypeBox.Optional)
+ *   Value.Check(objectSchema, {}) with the key omitted   true
+ *   Value.Check(property, undefined)                     false
+ *   deleting Symbol(TypeBox.Optional) from the property  changes 0 of 59 pool verdicts
+ *
+ * So on TypeBox, and only on TypeBox, a required field and an optional one compare identically on
+ * every probe: this harness cannot tell them apart, in either direction, and would report parity
+ * on a DRZL update schema that omitted an optional marker official carries. zod, valibot and
+ * arktype put optionality on the field, where the `undefined` probe finds it, which is the whole
+ * reason update mode moves by one probe on those three and not on TypeBox.
+ *
+ * It is recorded rather than fixed: closing it means comparing modifiers as well as verdicts,
+ * which is a different comparison from the one this file makes.
+ */
 export const LIBS: Record<string, Lib> = {
   zod: { field: (s, k) => s.shape[k], ok: (f, x) => f.safeParse(x).success },
   valibot: { field: (s, k) => s.entries[k], ok: (f, x) => v.safeParse(f, x).success },
@@ -1360,14 +1382,17 @@ const recordThrow = (key: string, side: string, mode: string, value: string) => 
  *
  * `divergence` is keyed `<modes>/<libraries>`, `*` for all of them, and each value is the exact
  * signature measured for those pairings: `L: <labels DRZL accepts and official refuses> | T: <the
- * other way>`, in pool order. Three signatures are a property rather than a list:
- * `every probe official rejects (N of them)` says DRZL took the whole pool and states how many
- * official refused, and the two `has it, omits it` strings say one side produced no field at all.
- * The count is in the first of those because without it only DRZL's side was pinned: official
- * narrowing from 58 rejections to 2 left the signature unmoved, since it never mentioned official
- * at all. All three are what the run produces in those states, and no waiver declares any of them
- * today, since no waived column on this major is untyped or missing on one side. They are the
- * shape a future one would take, not a claim about the current list.
+ * other way>`, in pool order. Three signatures are stated from the other end rather than as a
+ * list: `every probe official rejects (N of them), and official accepts only: <labels>` says DRZL
+ * took the whole pool, how many official refused and exactly which ones it did not, and the two
+ * `has it, omits it` strings say one side produced no field at all. That first one carries both a
+ * count and a complement because each without the other is a shape: with neither, official
+ * narrowing from 58 rejections to 2 left the signature unmoved; with the count alone, official
+ * swapping which probes it refuses left it unmoved at the same 58. Both holes were measured on the
+ * 0.4x pass, where the six columns in that state live. All three are what the run produces in
+ * those states, and no waiver declares any of them today, since no waived column on this major is
+ * untyped or missing on one side. They are the shape a future one would take, not a claim about
+ * the current list.
  *
  * Until this existed a waiver asserted only that it suppressed something, and a real regression
  * walked through it: stripping every length cap from `m_tinytext` in all four generated modules
@@ -1394,10 +1419,14 @@ const LIB_NAMES = ['zod', 'valibot', 'arktype', 'typebox'];
 const MODE_NAMES = ['select', 'insert', 'update'];
 const WRITE = ['insert', 'update'];
 
-// A signature stating the divergence as a property rather than as a list, for a column DRZL
-// accepts every probe of. See the fuller note on the same constant in the 0.4x pass below, which
-// is where the six columns in that state live.
-const allProbes = (n: number) => `every probe official rejects (${n} of them)`;
+// A signature for a column DRZL accepts every probe of, stated as the count of official's
+// rejections plus the exact set it accepts instead. The complement is what makes it a set rather
+// than a shape, and it is one to three labels where the list it replaces is 56 to 58. See the
+// fuller note on the same constant in the 0.4x pass below, which is where the six columns in that
+// state live; no waiver in this pass is in that state today.
+const allProbes = (n: number, accepted: string[]) =>
+  `every probe official rejects (${n} of them), and official accepts only: ` +
+  (accepted.length ? accepted.join(', ') : 'nothing in the pool');
 
 /**
  * Does a declaration key such as `select,insert/zod` cover the pairing `select/zod`? A declaration
@@ -1801,6 +1830,9 @@ for (const d of DIALECTS) {
         compared++;
         const looser: string[] = [];
         const tighter: string[] = [];
+        // What official accepted, in pool order. Only read when DRZL accepted everything, where it
+        // is the complement of the divergence and so names it exactly.
+        const officialAccepted: string[] = [];
         let officialTook = false;
         let drzlTook = false;
         // Whether DRZL took the whole pool, which is what the derived signature rests on.
@@ -1821,6 +1853,7 @@ for (const d of DIALECTS) {
             recordCrashVerdict(`${d.name}/${libName}/${k}`, mode, label, b);
             continue;
           }
+          if (a === 'accept') officialAccepted.push(label);
           officialTook ||= a === 'accept';
           drzlTook ||= b === 'accept';
           if (b !== 'accept') drzlAll = false;
@@ -1841,7 +1874,7 @@ for (const d of DIALECTS) {
         }
         if (!looser.length && !tighter.length) continue;
         const signature = drzlAll
-          ? allProbes(looser.length)
+          ? allProbes(looser.length, officialAccepted)
           : `L: ${looser.join(', ')} | T: ${tighter.join(', ')}`;
         if (allowed(d.name, libName, k, mode, signature)) { waivedCount++; continue; }
         rows.push(
@@ -5064,7 +5097,9 @@ cat > parity-0-4x.ts <<'PARITY_0_4X'
  * The ledger is the part that makes this runnable rather than permanently red. Two maps:
  *
  *   ALLOWED  DRZL and the official 0.4x module really do differ here, deliberately.
- *   DEFECTS  DRZL is wrong or looser on 0.4x. Filed rather than fixed, and reported every run.
+ *   DEFECTS  DRZL is wrong on 0.4x, whichever way the difference runs. Filed rather than fixed,
+ *            and reported every run. Not "looser than official": six ALLOWED entries are looser
+ *            and right, because the database says so.
  *
  * Both are asserted exactly and in both directions. A difference in neither map fails the stage; an
  * entry that suppresses nothing fails it; and an entry whose libraries, modes, pairing count or
@@ -5143,12 +5178,14 @@ type Entry = {
    *
    * A signature is `L: <labels DRZL accepts and official refuses> | T: <the other way>`, in pool
    * order, and it has to match what the run measured character for character.
-   * `every probe official rejects (N of them)` says the same thing as a proof instead of a list:
-   * DRZL accepted every probe, so the divergence is exactly official's rejections, and N is how
-   * many those are. Both halves are needed. Without the count only DRZL's side was asserted, and
-   * the six entries using it would have stayed green through official narrowing from 58
-   * rejections to 2. The counts are not uniform either, which the shorthand hid: TypeBox refuses
-   * two fewer probes than the other three on `c_bit`.
+   * `every probe official rejects (N of them), and official accepts only: <labels>` states the
+   * same set from the other end, for the six columns DRZL accepts the whole pool of: the
+   * divergence is exactly official's rejections, N is how many those are, and the labels are the
+   * complement, which is one to three where the list they replace is 56 to 58. Naming the
+   * complement is what makes it a set. The count on its own was a shape, measured: with
+   * `c_vector` changed from `vector({ dimensions: 3 })` to `dimensions: 2`, official refuses
+   * `[1,2,3]` and accepts `[1,2]`, which is the opposite behaviour at the same count of 58, and
+   * the stage was green.
    *
    * This replaced a `direction` field, which named only which way the disagreement ran. That
    * closed a reversal and nothing else, and three sabotages walked through it: capping `c_char` at
@@ -5172,19 +5209,54 @@ type Entry = {
 };
 
 /**
- * A signature that states the divergence as a property instead of a list. DRZL accepted every
- * probe, so the set of differing probes is exactly the set official rejects, and there is nothing
- * to write down wrongly. Six columns are in that state and each would otherwise carry a list of
- * around 56 labels, which is a list nobody would read.
+ * A signature for a column DRZL accepts every probe of: official's rejection count, plus the exact
+ * set official accepts instead. Six columns are in that state, all six of them columns the
+ * class-name path cannot name at all, and the alternative is a list of 56 to 58 labels written out
+ * once per pairing group.
  *
- * The count is in the string because without it the shorthand was asserted in one direction only.
- * "DRZL accepts everything" is pinned by the phrase, and it fails the moment DRZL stops accepting
- * everything. What was not pinned was official's side: if official narrowed from refusing 26
- * probes to refusing 2, the divergence shrank by 24 and this signature did not move, because it
- * never mentioned official's rejections at all. It says how many now, so both halves of the
- * difference are asserted, which is what every other signature in these maps does.
+ * Naming what official accepts names the divergence exactly, from the other end. DRZL accepted
+ * every compared probe, so the probes that differ are exactly the ones official rejected, and that
+ * is every compared probe except the ones listed here. One to three labels instead of 56 to 58.
+ *
+ * Both halves are here because each closed a hole the other left open, and both holes were live.
+ *
+ *   the count       the phrase alone pinned DRZL's side only. "DRZL accepts everything" fails the
+ *                   moment DRZL stops accepting everything, but official was not mentioned, so
+ *                   official narrowing from 58 rejections to 2 left the signature unmoved.
+ *   the complement  the count pinned how many, not which. Measured: `c_vector` changed from
+ *                   `vector({ dimensions: 3 })` to `dimensions: 2` in src/matrix.ts makes official
+ *                   accept `[1,2]` and refuse `[1,2,3]`, the opposite behaviour, at the same count
+ *                   of 58 on all 12 pairings. The stage exited 0 and went on printing "official
+ *                   emits an array of exactly 3 numbers". With the complement declared the same
+ *                   edit exits 1 on all 12 pairings.
+ *
+ * Why the numbers are not uniform over the 72 pairings, measured on this run rather than reasoned,
+ * and now visible in the declarations themselves rather than only described here:
+ *
+ *   update on zod, valibot, arktype   one fewer rejection, always `undefined`. Official's update
+ *                                     schema marks the field optional, and in those three the
+ *                                     extracted field takes `undefined` on its own.
+ *   update on typebox                 no such move. TypeBox holds optionality as a modifier the
+ *                                     parent object consults, and this harness compares
+ *                                     `s.properties[k]`, where it is inert:
+ *                                     `Value.Check(prop, undefined)` is false with
+ *                                     `Symbol(TypeBox.Optional)` present on the property, and
+ *                                     deleting that symbol changes 0 of 59 pool verdicts.
+ *   valibot on c_geometry             one fewer in every mode: official builds a `v.tuple`, which
+ *                                     ignores extra items, so `[1,2,3]` and `[1,2,3,4]` both go
+ *                                     into a 2-tuple and `[1,2,3]` is accepted alongside `[1,2]`.
+ *   typebox on c_bit                  56 in all three modes, and not because it takes anything the
+ *                                     other three refuse. Official's TypeBox schema throws on
+ *                                     `null` and `undefined` for that column, so those two probes
+ *                                     are not compared at all: they go to the THREW ledger and are
+ *                                     arbitrated against a real Postgres. An earlier version of
+ *                                     this note called it "TypeBox refuses two fewer probes",
+ *                                     which reads as a rejection it never made, and which was also
+ *                                     wrong about update, where the other three are at 57.
  */
-const allProbes = (n: number) => `every probe official rejects (${n} of them)`;
+const allProbes = (n: number, accepted: string[]) =>
+  `every probe official rejects (${n} of them), and official accepts only: ` +
+  (accepted.length ? accepted.join(', ') : 'nothing in the pool');
 
 /**
  * Does a declaration key such as `select,insert/zod,typebox` cover the pairing `select/zod`?
@@ -5450,11 +5522,11 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/zod,arktype,typebox': allProbes(58),
-      'select,insert/valibot': allProbes(57),
-      'update/zod,arktype': allProbes(57),
-      'update/valibot': allProbes(56),
-      'update/typebox': allProbes(58),
+      'select,insert/zod,arktype,typebox': allProbes(58, ['[1,2]']),
+      'select,insert/valibot': allProbes(57, ['[1,2]', '[1,2,3]']),
+      'update/zod,arktype': allProbes(57, ['undefined', '[1,2]']),
+      'update/valibot': allProbes(56, ['undefined', '[1,2]', '[1,2,3]']),
+      'update/typebox': allProbes(58, ['[1,2]']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a tuple [number, number]',
@@ -5464,9 +5536,11 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/zod,valibot,arktype': allProbes(58),
-      'update/zod,valibot,arktype': allProbes(57),
-      '*/typebox': allProbes(56),
+      'select,insert/zod,valibot,arktype': allProbes(58, ["'010'"]),
+      'update/zod,valibot,arktype': allProbes(57, ['undefined', "'010'"]),
+      // Not "typebox refuses fewer": official's TypeBox schema throws on `null` and `undefined`
+      // here, so those two probes are not compared in any mode and the THREW ledger holds them.
+      '*/typebox': allProbes(56, ["'010'"]),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a string of at most 3 characters matching ^[01]*$',
@@ -5477,12 +5551,11 @@ const DEFECTS: Record<string, Entry> = {
     modes: MODE_NAMES,
     divergence: {
       // Per pairing, because official's own rejections are not the same everywhere and the bare
-      // shorthand hid that. TypeBox refuses two fewer probes than the rest on `c_bit`, valibot one
-      // fewer on `c_geometry`, and update mode refuses one fewer than select and insert wherever
-      // the column is optional there.
-      'select,insert/*': allProbes(58),
-      'update/zod,valibot,arktype': allProbes(57),
-      'update/typebox': allProbes(58),
+      // shorthand hid that. What each split measures is on `allProbes`, where it is measured
+      // rather than argued.
+      'select,insert/*': allProbes(58, ['[1,2,3]']),
+      'update/zod,valibot,arktype': allProbes(57, ['undefined', '[1,2,3]']),
+      'update/typebox': allProbes(58, ['[1,2,3]']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'an array of exactly 3 numbers',
@@ -5492,13 +5565,9 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      // Per pairing, because official's own rejections are not the same everywhere and the bare
-      // shorthand hid that. TypeBox refuses two fewer probes than the rest on `c_bit`, valibot one
-      // fewer on `c_geometry`, and update mode refuses one fewer than select and insert wherever
-      // the column is optional there.
-      'select,insert/*': allProbes(58),
-      'update/zod,valibot,arktype': allProbes(57),
-      'update/typebox': allProbes(58),
+      'select,insert/*': allProbes(58, ['Buffer']),
+      'update/zod,valibot,arktype': allProbes(57, ['undefined', 'Buffer']),
+      'update/typebox': allProbes(58, ['Buffer']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Buffer',
@@ -5508,13 +5577,9 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      // Per pairing, because official's own rejections are not the same everywhere and the bare
-      // shorthand hid that. TypeBox refuses two fewer probes than the rest on `c_bit`, valibot one
-      // fewer on `c_geometry`, and update mode refuses one fewer than select and insert wherever
-      // the column is optional there.
-      'select,insert/*': allProbes(58),
-      'update/zod,valibot,arktype': allProbes(57),
-      'update/typebox': allProbes(58),
+      'select,insert/*': allProbes(58, ['Buffer']),
+      'update/zod,valibot,arktype': allProbes(57, ['undefined', 'Buffer']),
+      'update/typebox': allProbes(58, ['Buffer']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Buffer',
@@ -5524,13 +5589,9 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      // Per pairing, because official's own rejections are not the same everywhere and the bare
-      // shorthand hid that. TypeBox refuses two fewer probes than the rest on `c_bit`, valibot one
-      // fewer on `c_geometry`, and update mode refuses one fewer than select and insert wherever
-      // the column is optional there.
-      'select,insert/*': allProbes(58),
-      'update/zod,valibot,arktype': allProbes(57),
-      'update/typebox': allProbes(58),
+      'select,insert/*': allProbes(58, ['Date']),
+      'update/zod,valibot,arktype': allProbes(57, ['undefined', 'Date']),
+      'update/typebox': allProbes(58, ['Date']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Date',
@@ -5907,6 +5968,9 @@ async function main() {
           compared++;
           const looser: string[] = [];
           const tighter: string[] = [];
+          // What official accepted, in pool order. Only read when DRZL accepted everything, where
+          // it is the complement of the divergence and so names it exactly.
+          const officialAccepted: string[] = [];
           let officialTook = false;
           let drzlTook = false;
           // Whether DRZL took the whole pool, which is what the derived signature rests on.
@@ -5927,6 +5991,7 @@ async function main() {
               recordCrashVerdict(`${d.name}/${libName}/${k}`, mode, label, b);
               continue;
             }
+            if (a === 'accept') officialAccepted.push(label);
             officialTook ||= a === 'accept';
             drzlTook ||= b === 'accept';
             if (b !== 'accept') drzlAll = false;
@@ -5954,7 +6019,9 @@ async function main() {
           seen.pairings++;
           seen.signatures.set(
             `${mode}/${libName}`,
-            drzlAll ? allProbes(looser.length) : `L: ${looser.join(', ')} | T: ${tighter.join(', ')}`
+            drzlAll
+              ? allProbes(looser.length, officialAccepted)
+              : `L: ${looser.join(', ')} | T: ${tighter.join(', ')}`
           );
           seen.detail.push(`${mode}/${libName} ${looser.length} looser ${tighter.length} tighter`);
           observed.set(key, seen);
@@ -6047,12 +6114,10 @@ async function main() {
         claimed.add(hits[0]);
         const want = entry.divergence[hits[0]];
         if (want === sig) continue;
-        if (want.startsWith('every probe official rejects')) {
-          ledgerProblems.push(
-            `${name}[${key}] on ${pairing} declares\n        ${want}\n      and measured\n        ${sig}`
-          );
-          continue;
-        }
+        // One message for both signature forms. The shorthand had a branch of its own here while
+        // it read `every probe official rejects` with no count and no complement, where printing
+        // it against a measured `L: ...` list said nothing; it carries both now and reads the same
+        // way round as any other signature, so the special case was byte identical to this one.
         ledgerProblems.push(
           `${name}[${key}] on ${pairing} declares\n        ${want}\n      and measured\n        ${sig}`
         );

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -4358,8 +4358,10 @@ const ALLOWED: Record<string, string> = {
  *
  * The gate that can is the 0.4x parity stage further down, which measures DRZL's emitted
  * validators against the first-party modules for 0.45.2 the way the stage near the top of this
- * file does for v1. It carries eight of these columns in its own DEFECTS map, so a fix has to
- * clear an entry there as well as here.
+ * file does for v1. It carries three of these columns in its own DEFECTS map, so a fix has to
+ * clear an entry there as well as here. That gate is what made the first fixes possible: the
+ * float bounds and the point and line tuples were filed here for a round because nothing could
+ * show that changing the 0.4x path was right, and both left this map through it.
  */
 const DEFECTS: Record<string, string> = {
   // ---- 0.4x names the SQL type coarsely, and once v1 does ------------------------------------
@@ -4371,10 +4373,12 @@ const DEFECTS: Record<string, string> = {
   // A label, and nothing more, on this fixture. `dbType` is read in exactly one place outside the
   // analyzer, `isIntegerColumn`, which prefers the `integer` flag and only falls back to
   // `dbType === 'INTEGER'`. Measured by changing it rather than by reading the output: setting all
-  // seventeen of these to the value v1 reports, in the analysis of the 0.4x tree, and regenerating
-  // all three fixtures with the zod and JSON Schema generators produces 29 byte-identical files.
-  // Reading the diff of the two majors' output instead would have been wrong here, since `c_real`
-  // sits in this group and in the float group below, and its output does change.
+  // seventeen of the labels this group then held to the value v1 reports, in the analysis of the
+  // 0.4x tree, and regenerating all three fixtures with the zod and JSON Schema generators
+  // produces 29 byte-identical files. Reading the diff of the two majors' output instead would
+  // have been wrong, and `matrix.c_real.dbType` is why: it sat in this group and in the float
+  // group, so its output did change, for the float bounds rather than for the label. It is gone
+  // from both now, because `PgReal` reaches an arm of its own and is named REAL on 0.4x too.
   'rows.small.dbType': 'label only: PgSmallInt is named INTEGER on 0.4x',
   'rows.name.dbType': 'as rows.small.dbType, PgVarchar as TEXT',
   'rows.code.dbType': 'as rows.small.dbType, PgChar as TEXT',
@@ -4384,7 +4388,6 @@ const DEFECTS: Record<string, string> = {
   'matrix.c_char.dbType': 'as rows.code.dbType',
   'matrix.c_smallint.dbType': 'as rows.small.dbType',
   'matrix.c_serial.dbType': 'label only, the other way: 0.4x says SERIAL and v1 says INTEGER',
-  'matrix.c_real.dbType': 'label only: PgReal is named NUMERIC on 0.4x',
   'matrix.c_date_d.dbType': 'as rows.day.dbType',
   'matrix.c_date_s.dbType': 'as rows.day.dbType',
   'matrix.c_varchar_arr.dbType': 'as rows.name.dbType',
@@ -4392,36 +4395,6 @@ const DEFECTS: Record<string, string> = {
   'matrix.c_cidr.dbType': 'as matrix.c_inet.dbType',
   'matrix.c_macaddr.dbType': 'as matrix.c_inet.dbType',
   'mtext.id.dbType': 'as rows.name.dbType, on MySQL: MySqlVarChar is named TEXT on 0.4x',
-
-  // ---- a float carries no bounds on 0.4x -----------------------------------------------------
-  // v1 reads `number float` and `number double` and bounds them at 2^23 and 2^47, the range each
-  // width represents exactly; 0.4x reaches the same columns through the class name and bounds
-  // nothing. Not a difference between the majors: drizzle-zod 0.8.3, the first-party validator
-  // for 0.45.2, emits the same two bounds this fixture's 0.4x side is missing. Measured: it
-  // rejects 8388608 for `real` and 140737488355328 for `double precision`, exactly as
-  // drizzle-orm/zod does on 1.0.0-rc.4.
-  //
-  // The `integer` half of each of these is the flag arriving with the bounds, and on its own it
-  // changes nothing: setting `integer: false` on all five without adding the bounds regenerates
-  // byte identical, because `isIntegerColumn` reaches the same answer from `dbType` and the
-  // absent bounds. Of the 54 fields in this map, those 5 and the 17 labels above are the ones
-  // with no measured effect on generated output; the other 32, on 17 columns, all have one.
-  'rows.ratio.min': 'no float bound on 0.4x, which official drizzle-zod does emit there',
-  'rows.ratio.max': 'as rows.ratio.min',
-  'rows.ratio.integer': 'as rows.ratio.min; the flag comes with the bounds',
-  'defaulted.d_real.min': 'as rows.ratio.min',
-  'defaulted.d_real.max': 'as rows.ratio.min',
-  'defaulted.d_real.integer': 'as rows.ratio.integer',
-  'matrix.c_real.min': 'as rows.ratio.min',
-  'matrix.c_real.max': 'as rows.ratio.min',
-  'matrix.c_real.integer': 'as rows.ratio.integer',
-  'matrix.c_double.min': 'as rows.ratio.min',
-  'matrix.c_double.max': 'as rows.ratio.min',
-  'matrix.c_double.integer': 'as rows.ratio.integer',
-  // `numeric({ mode: 'number' })` is a JS number, so v1 bounds it at the safe-integer range.
-  'matrix.c_numeric_n.min': 'as rows.ratio.min, at the safe-integer range',
-  'matrix.c_numeric_n.max': 'as matrix.c_numeric_n.min',
-  'matrix.c_numeric_n.integer': 'as rows.ratio.integer',
 
   // ---- a numeric column is unchecked on 0.4x -------------------------------------------------
   // The numeric pattern is DRZL's own, kept because a bare string accepts 'hello' for a column
@@ -4431,18 +4404,6 @@ const DEFECTS: Record<string, string> = {
   'rows.amount.format': 'the numeric pattern is attached on v1 only',
   'matrix.c_numeric.format': 'as rows.amount.format',
   'matrix.c_decimal.format': 'as rows.amount.format',
-
-  // ---- point and line are typed as strings on 0.4x -------------------------------------------
-  // The worst of these, because it is not looseness: `PgPointTuple` and `PgLineTuple` hand back
-  // [x, y] and [a, b, c], and the class-name path answers `string`, so a select schema built on
-  // 0.4x rejects every row the driver returns. Official drizzle-zod 0.8.3 on 0.45.2 parses
-  // [1, 2] and refuses '1,2' for the same column.
-  'matrix.c_point.tsType': 'typed `string` on 0.4x, where the driver returns [x, y]',
-  'matrix.c_point.dbType': 'as matrix.c_point.tsType',
-  'matrix.c_point.shape': 'as matrix.c_point.tsType',
-  'matrix.c_line.tsType': 'as matrix.c_point.tsType, for [a, b, c]',
-  'matrix.c_line.dbType': 'as matrix.c_point.tsType',
-  'matrix.c_line.shape': 'as matrix.c_point.tsType',
 
   // ---- geometry, bit and vector are unnamed on 0.4x ------------------------------------------
   // No arm for `PgGeometry`, `PgBinaryVector` or `PgVector` in the class-name path, so all three
@@ -5241,6 +5202,29 @@ const ALLOWED: Record<string, Entry> = {
   'mysql/m_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
   'sqlite/s_text_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
   'sqlite/s_blob_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
+  // Arrived here when `point` stopped being typed `string` on 0.4x and started being the tuple it
+  // is. The v1 pass has carried the same entry all along, for the same reason: DRZL emits
+  // `v.strictTuple` and official emits `v.tuple`, which ignores anything past the declared
+  // members. The other three libraries reject a third element on both sides.
+  //
+  // Postgres is what makes DRZL the right one, rather than a preference for strictness. Asked
+  // through PGlite on a real `point` column, `[1, 2, 3]` is handed to the driver as `(1,2)`,
+  // because drizzle's `mapToDriverValue` reads `value[0]` and `value[1]` and nothing else. The
+  // insert succeeds, the column stores `(1,2)`, and the row reads back as `[1, 2]`. So the value
+  // official accepts is one the database silently truncates.
+  //
+  // `c_line` is not here, and not because it behaves differently. The longest array in the pool
+  // is `[1,2,3]`, which both a strict and a lax 3-tuple accept, so nothing in it separates the two
+  // at that arity. The run asserts every entry's libs and divergence, so listing `c_line` on a
+  // difference nothing measures would fail this stage rather than pass quietly.
+  'pg/c_point': {
+    libs: ['valibot'],
+    modes: MODE_NAMES,
+    divergence: { '*/*': `L:  | T: [1,2,3]` },
+    drzl: 'a strict tuple of exactly two numbers',
+    official: 'v.tuple, which ignores a third element the column then drops',
+    filed: 'not a defect: DRZL is stricter, and Postgres truncates what official accepts',
+  },
 };
 
 /**
@@ -5249,10 +5233,18 @@ const ALLOWED: Record<string, Entry> = {
  * `filed: 'AC: ...'` names the fields the cross-major stage above already carries for the same
  * column. The two sets do not line up one to one and were never going to: that map records the
  * analyzer describing a column differently per major, and this one records the emitted validator
- * behaving differently from the first-party one. Eight of these columns were already filed there.
- * The other fourteen are new, and they are new mostly because the cross-major fixture is Postgres
- * plus four MySQL text columns, so no MySQL float, no MySQL binary, no MySQL year and no SQLite
- * column of any kind had ever been described under both majors.
+ * behaving differently from the first-party one. Three of these columns are also filed there.
+ * The other ten are new, and they are new mostly because the cross-major fixture is Postgres
+ * plus four MySQL text columns, so no MySQL binary, no MySQL year and no SQLite column of any
+ * kind had ever been described under both majors.
+ *
+ * Nine entries have left this map, which is what it is for. `pg/c_real`, `pg/c_double`,
+ * `pg/c_numeric_n`, `mysql/m_real`, `mysql/m_double`, `mysql/m_float` and `sqlite/s_real` were
+ * the class-name path carrying no bound at all for an inexact numeric column, and `pg/c_point`
+ * and `pg/c_line` were it answering `string` for a value the driver hands back as a tuple. Both
+ * are fixed in the analyzer rather than filed now, and removing an entry before the fix is what
+ * showed the entry was covering the defect: taking these nine out on their own failed this stage
+ * with 108 parity findings naming exactly those nine columns.
  *
  * Two kinds of filed defect are not in this map, and they are not there for different reasons.
  *
@@ -5278,112 +5270,6 @@ const ALLOWED: Record<string, Entry> = {
  * rather than effort, and the run says so out loud.
  */
 const DEFECTS: Record<string, Entry> = {
-  // ---- a float carries no bounds on 0.4x -----------------------------------------------------
-  // v1 reads `number float` and `number double` and bounds them at the range each width
-  // represents exactly; 0.4x reaches the same columns through the class name and bounds nothing.
-  'pg/c_real': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      '*/zod,typebox': `L: 9000000, 2147483648, 9007199254740993 | T: `,
-      '*/valibot,arktype': `L: 9000000, 2147483648, 9007199254740993, Infinity | T: `,
-    },
-    drzl: 'an unbounded number',
-    official: 'a number within +/-8388607',
-    filed: 'AC: matrix.c_real.min, .max, .integer',
-  },
-  'pg/c_double': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      '*/zod,typebox': `L: 9007199254740993 | T: `,
-      '*/valibot,arktype': `L: 9007199254740993, Infinity | T: `,
-    },
-    drzl: 'an unbounded number',
-    official: 'a number within +/-140737488355327',
-    filed: 'AC: matrix.c_double.min, .max, .integer',
-  },
-  'pg/c_numeric_n': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      '*/zod,typebox': `L: 9007199254740993 | T: `,
-      '*/valibot,arktype': `L: 9007199254740993, Infinity | T: `,
-    },
-    drzl: 'an unbounded number',
-    official: 'a number within the safe-integer range',
-    filed: 'AC: matrix.c_numeric_n.min, .max, .integer',
-  },
-  'mysql/m_real': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      '*/zod,typebox': `L: 9007199254740993 | T: `,
-      '*/valibot,arktype': `L: 9007199254740993, Infinity | T: `,
-    },
-    drzl: 'an unbounded number',
-    official: 'a number within +/-140737488355327',
-    filed: 'new: the same float defect, on a dialect the cross-major fixture cannot reach',
-  },
-  'mysql/m_double': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      '*/zod,typebox': `L: 9007199254740993 | T: `,
-      '*/valibot,arktype': `L: 9007199254740993, Infinity | T: `,
-    },
-    drzl: 'an unbounded number',
-    official: 'a number within +/-140737488355327',
-    filed: 'new: as mysql/m_real',
-  },
-  'mysql/m_float': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      '*/zod,typebox': `L: 9000000, 2147483648, 9007199254740993 | T: `,
-      '*/valibot,arktype': `L: 9000000, 2147483648, 9007199254740993, Infinity | T: `,
-    },
-    drzl: 'an unbounded number',
-    official: 'a number within +/-8388607',
-    filed: 'new: as mysql/m_real',
-  },
-  'sqlite/s_real': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      '*/zod,typebox': `L: 9007199254740993 | T: `,
-      '*/valibot,arktype': `L: 9007199254740993, Infinity | T: `,
-    },
-    drzl: 'an unbounded number',
-    official: 'a number within +/-140737488355327',
-    filed: 'new: as mysql/m_real, on SQLite',
-  },
-
-  // ---- point and line are typed as strings on 0.4x -------------------------------------------
-  // Not looseness but a wrong type: `PgPointTuple` and `PgLineTuple` hand back [x, y] and
-  // [a, b, c], and the class-name path answers `string`, so a select schema built on 0.4x rejects
-  // every row the driver returns. That shows up here as the one direction a wrong type takes:
-  // DRZL accepts 24 strings official refuses, and refuses the tuple official takes.
-  'pg/c_point': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      '*/zod,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: [1,2]`,
-      '*/valibot': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: [1,2], [1,2,3]`,
-    },
-    drzl: 'a string',
-    official: 'a tuple [number, number]',
-    filed: 'AC: matrix.c_point.tsType, .dbType, .shape',
-  },
-  'pg/c_line': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: { '*/*': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: [1,2,3]` },
-    drzl: 'a string',
-    official: 'a tuple [number, number, number]',
-    filed: 'AC: matrix.c_line.tsType, .dbType, .shape',
-  },
-
   // ---- columns the class-name path cannot name at all ----------------------------------------
   // No arm for the class, so the column comes back `unknown` and every generator emits a validator
   // that accepts anything. The three Postgres ones are also named in check-old.ts, as an absolute

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -927,6 +927,21 @@ export const POOL: [string, unknown][] = [
   ["'x'", 'x'],
   ['0', 0], ['1', 1], ['1.5', 1.5], ['-1', -1], ['200', 200], ['40000', 40000],
   ['9000000', 9000000], ['2147483648', 2147483648], ['9007199254740993', 9007199254740993],
+  // What a Postgres `real` at full magnitude comes back as over the text protocol, and the reason
+  // the two 4 byte float columns below no longer carry the same bound.
+  //
+  // Every other number here is orders of magnitude away from a float4 edge, so nothing in this
+  // pool could tell a bound at the largest float32 from one at the largest double Postgres
+  // accepts. Those are different numbers: Postgres takes 268435456 representable doubles past the
+  // float32 and stores the float32 for all of them, and this is one of them. A select schema
+  // bounded at the float32 refused the row a `real` column had just handed back, which is the
+  // defect this branch exists to remove, and it survived a green run of both parity passes and
+  // 1400 ground-truth probes because no probe was within 30 orders of magnitude of the edge.
+  //
+  // It separates the two dialects as well as the two bounds: `pg/c_real` accepts it and
+  // `mysql/m_float` does not, because a real MySQL 8.4 refuses it with
+  // `Out of range value for column`.
+  ['3.4028235e38', 3.4028235e38],
   // 1900 and 2500 sit either side of MySQL's YEAR range and nothing sat inside it, so `m_year`
   // was the same vacuous agreement as the enum above: rejected by both, proving nothing.
   ['1900', 1900], ['2000', 2000], ['2500', 2500], ['NaN', NaN], ['Infinity', Infinity],
@@ -1026,7 +1041,7 @@ export type Lib = { field: (s: any, k: string) => any; ok: (f: any, x: unknown) 
  *   the property carries Symbol(TypeBox.Kind) and Symbol(TypeBox.Optional)
  *   Value.Check(objectSchema, {}) with the key omitted   true
  *   Value.Check(property, undefined)                     false
- *   deleting Symbol(TypeBox.Optional) from the property  changes 0 of 57 pool verdicts
+ *   deleting Symbol(TypeBox.Optional) from the property  changes 0 of 58 pool verdicts
  *
  * So on TypeBox, and only on TypeBox, a required field and an optional one compare identically on
  * every probe: this harness cannot tell them apart, in either direction, and would report parity
@@ -1463,7 +1478,7 @@ const WRITE = ['insert', 'update'];
 
 // A signature for a column DRZL accepts every probe of, stated as the count of official's
 // rejections plus the exact set it accepts instead. The complement is what makes it a set rather
-// than a shape, and it is one to three labels where the list it replaces is 54 to 56. See the
+// than a shape, and it is one to three labels where the list it replaces is 55 to 57. See the
 // fuller note on the same constant in the 0.4x pass below, which is where the six columns in that
 // state live; no waiver in this pass is in that state today.
 const allProbes = (n: number, accepted: string[]) =>
@@ -1630,10 +1645,17 @@ const ALLOWED: Record<string, Waiver> = {
   // `real` / float4. Official bounds it at +/-8388607, and the column stores 8388608, 9000000,
   // 1e9 and 2147483648 and returns every one of them unchanged, and holds every integer exactly
   // to 16777216. So official's bound refuses rows the column hands back, and a select schema that
-  // did the same refused its own rows. DRZL bounds it where the database does instead:
-  // 3.4028234663852886e38 is accepted and 3.4028236e38 answers
-  // `"3.4028236e+38" is out of range for type real`. That is why 9007199254740993 is in the
-  // signature and 1e300 is not: the first is inside the float4 magnitude and the second is not.
+  // did the same refused its own rows. DRZL bounds it where the database does instead, bisected
+  // over the raw bit pattern of a double: 3.4028235677973366e38 is accepted and the next double
+  // up answers `... is out of range for type real`. That is why 9007199254740993 and
+  // 3.4028235e38 are in the signature and 1e300 is not.
+  //
+  // `pg/c_real` and `mysql/m_float` are the same width and do not have the same bound, which is
+  // why they no longer share a signature. Postgres takes 268435456 representable doubles past the
+  // largest float32 and stores the float32 for each; MySQL 8.4 refuses the very next double,
+  // measured in `STRICT_ALL_TABLES` and again under the stock MySQL 8 `sql_mode`. The probe that
+  // separates them is `3.4028235e38`, which is what a full-magnitude float4 looks like coming
+  // back over the text protocol.
   //
   // `double precision` / float8 and everything else backed by an 8 byte float. No bound at all,
   // because there is no finite one that is true: float8 is the JavaScript number's own format and
@@ -1656,12 +1678,12 @@ const ALLOWED: Record<string, Waiver> = {
   //                      only valibot and arktype do, because `z.number()` and `Type.Number()`
   //                      refuse it with no bound at all. Filed: describing that column honestly
   //                      needs a union in every generator rather than a range.
-  'pg/c_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'bounded at the float4 magnitude Postgres refuses rather than at drizzle-zod +/-8388607, which refuses rows the column returns', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` } },
-  'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_real; MySQL FLOAT is the same 4 byte width', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` } },
-  'pg/c_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'no finite bound is true of an 8 byte float, which holds every finite JS number', divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` } },
-  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; MySQL REAL is a synonym for DOUBLE', divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` } },
-  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double', divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` } },
-  'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; SQLite REAL is an 8 byte IEEE float', divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` } },
+  'pg/c_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'bounded where Postgres stops accepting rather than at drizzle-zod +/-8388607, which refuses rows the column returns', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38 | T: ` } },
+  'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_real, but at MySQL edge: a real MySQL 8.4 refuses 3.4028235e38 where Postgres takes it', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` } },
+  'pg/c_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'no finite bound is true of an 8 byte float, which holds every finite JS number', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
+  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; MySQL REAL is a synonym for DOUBLE', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
+  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
+  'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; SQLite REAL is an 8 byte IEEE float', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   // Official emits `Type.RegExp`, whose check runs `RegExp.prototype.test` against the raw value,
   // and `test` stringifies what it is given: `[]` becomes '' and matches `^[01]*$`. So official
   // accepts an empty array for a binary column. This generator emits a `string` carrying a
@@ -3126,6 +3148,11 @@ cat > src/probes.ts <<'PROBES'
 export const MATRIX_POOL: [string, unknown][] = [
   ['0', 0], ['1.5', 1.5], ['-1', -1], ['40000', 40000], ['2147483648', 2147483648],
   ['1e9', 1e9], ['1e300', 1e300], ['9007199254740993', 9007199254740993],
+  // A `real` at full magnitude, as the text protocol returns it. Postgres accepts it and stores
+  // the largest float32; a schema bounded at that float32 refuses it, which is a schema refusing
+  // its own column's rows. Nothing else here is within 30 orders of magnitude of that edge, so
+  // this stage asked 1400 questions and none of them was about it.
+  ['3.4028235e38', 3.4028235e38],
   ['NaN', NaN], ['Infinity', Infinity],
   ["''", ''], ["'hello'", 'hello'], ['300-char', 'x'.repeat(300)],
   ['3 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}'],
@@ -3291,7 +3318,7 @@ GROUND_TRUTH
 # @electric-sql/pglite is installed with the rest of this tree, far above, because the parity pass
 # needs a Postgres too now. It had its own install line here, which was a second install of the
 # same package into the same tree.
-if ! npx tsx src/ground-truth.ts; then
+if ! npx tsx src/ground-truth.ts | tee -a "$WORK/printed.log"; then
   echo "FAIL: a generated schema disagrees with Postgres itself." >&2
   exit 1
 fi
@@ -3879,7 +3906,7 @@ console.log(
 await db.close();
 CHECKS_TRUTH
 
-if ! npx tsx src/checks-truth.ts; then
+if ! npx tsx src/checks-truth.ts | tee -a "$WORK/printed.log"; then
   echo "FAIL: a generated CHECK disagrees with Postgres." >&2
   exit 1
 fi
@@ -3955,7 +3982,7 @@ if (diffs.length) {
 await db.close();
 DEFAULTS_TRUTH
 
-if ! npx tsx src/defaults-truth.ts; then
+if ! npx tsx src/defaults-truth.ts | tee -a "$WORK/printed.log"; then
   echo "FAIL: applyDefaults does not reproduce the database's defaults." >&2
   exit 1
 fi
@@ -4106,7 +4133,7 @@ if (loose.length) {
 await db.end();
 MYSQL_TRUTH
 
-if ! npx tsx src/mysql-truth.ts; then
+if ! npx tsx src/mysql-truth.ts | tee -a "$WORK/printed.log"; then
   echo "FAIL: a generated schema disagrees with MySQL." >&2
   exit 1
 fi
@@ -4214,10 +4241,69 @@ db.close();
 SQLITE_TRUTH
 
 # `node:sqlite` is still flagged experimental, and its warning is not news here.
-if ! npx tsx --disable-warning=ExperimentalWarning src/sqlite-truth.ts; then
+if ! npx tsx --disable-warning=ExperimentalWarning src/sqlite-truth.ts | tee -a "$WORK/printed.log"; then
   echo "FAIL: a generated CHECK disagrees with SQLite." >&2
   exit 1
 fi
+
+# ---------------------------------------------------------------------------------------------
+# The numbers the published documentation quotes, against the run that produced them.
+#
+# Until this existed nothing in the project checked a number in the documentation. Measured rather
+# than assumed: `9.9999999999999999e42` substituted for the float4 bound in the shipped TypeBox
+# page left `pnpm lint`, `pnpm typecheck`, every package test, `pnpm -C docs build` and
+# `scripts/extract-doc-configs.mjs` all at exit 0, and that last one is the only docs-aware stage
+# in the whole gate: it reads runnable config blocks and cannot see a table or a paragraph.
+#
+# It is not a documentation test framework, and it does not try to be. It covers exactly one
+# thing, the block in benchmarks.md that quotes this script's own output, which is the only prose
+# in the docs whose numbers this run also computes. That block was stale when this check was
+# written: it claimed `DRZL 1007, drizzle-orm 979` and `closer on 28` for a run that had been
+# printing 1012 and 33 since the commit that changed the float bounds, and five rounds of review
+# had read the same branch without noticing. Every other number in the docs is still unchecked and
+# still has nothing behind it.
+#
+# The comparison is line by line and literal, so a fabricated digit fails rather than a fabricated
+# sentence. Lines about MySQL are skipped, by name and out loud, when no MYSQL_URL is set: that
+# stage did not run, so this run has nothing to compare them with.
+#
+# Both controls were run against a captured run log before this shipped. `DRZL 1048` changed to
+# `DRZL 9999` in the page exits 1 naming that line. The vacuity control matters more, because this
+# check finds its block by a phrase in the prose above it: editing "three real databases" to
+# "three actual databases" makes the extraction return nothing, and the count guard below exits 1
+# rather than reporting that everything matched.
+echo "==> the numbers the documentation quotes, against this run"
+DOC_BENCH="$ROOT/docs/guide/benchmarks.md"
+doc_missing=0
+doc_checked=0
+doc_skipped=0
+while IFS= read -r doc_line; do
+  doc_trim="$(printf '%s' "$doc_line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  [ -z "$doc_trim" ] && continue
+  if [ -z "${MYSQL_URL:-}" ] && printf '%s' "$doc_trim" | grep -q 'MySQL'; then
+    doc_skipped=$((doc_skipped + 1))
+    echo "    not compared, that stage did not run without MYSQL_URL: $doc_trim"
+    continue
+  fi
+  doc_checked=$((doc_checked + 1))
+  if ! grep -Fq -- "$doc_trim" "$WORK/printed.log"; then
+    if [ "$doc_missing" -eq 0 ]; then
+      echo "    FAIL: docs/guide/benchmarks.md quotes this script's output, and this run did not"
+      echo "          print these lines. Paste what the run printed, or say what changed:"
+    fi
+    echo "      $doc_trim"
+    doc_missing=$((doc_missing + 1))
+  fi
+done < <(awk '/three real databases/{found=1} found && /^```$/{n++; next} found && n==1' "$DOC_BENCH")
+if [ "$doc_checked" -eq 0 ]; then
+  echo "    FAIL: found no quoted lines to compare, so this check measured nothing." >&2
+  exit 1
+fi
+if [ "$doc_missing" -gt 0 ]; then
+  echo "FAIL: the documentation quotes numbers this run did not produce." >&2
+  exit 1
+fi
+echo "    $doc_checked line(s) of docs/guide/benchmarks.md matched this run's output, $doc_skipped not compared"
 
 cd "$APP"
 
@@ -5223,7 +5309,7 @@ type Entry = {
    * `every probe official rejects (N of them), and official accepts only: <labels>` states the
    * same set from the other end, for the six columns DRZL accepts the whole pool of: the
    * divergence is exactly official's rejections, N is how many those are, and the labels are the
-   * complement, which is one to three where the list they replace is 54 to 56. Naming the
+   * complement, which is one to three where the list they replace is 55 to 57. Naming the
    * complement is what makes it a set. The count on its own was a shape, measured: with
    * `c_vector` changed from `vector({ dimensions: 3 })` to `dimensions: 2`, official refuses
    * `[1,2,3]` and accepts `[1,2]`, which is the opposite behaviour at the same count of 56, and
@@ -5253,22 +5339,22 @@ type Entry = {
 /**
  * A signature for a column DRZL accepts every probe of: official's rejection count, plus the exact
  * set official accepts instead. Six columns are in that state, all six of them columns the
- * class-name path cannot name at all, and the alternative is a list of 54 to 56 labels written out
+ * class-name path cannot name at all, and the alternative is a list of 55 to 57 labels written out
  * once per pairing group.
  *
  * Naming what official accepts names the divergence exactly, from the other end. DRZL accepted
  * every compared probe, so the probes that differ are exactly the ones official rejected, and that
- * is every compared probe except the ones listed here. One to three labels instead of 54 to 56.
+ * is every compared probe except the ones listed here. One to three labels instead of 55 to 57.
  *
  * Both halves are here because each closed a hole the other left open, and both holes were live.
  *
  *   the count       the phrase alone pinned DRZL's side only. "DRZL accepts everything" fails the
  *                   moment DRZL stops accepting everything, but official was not mentioned, so
- *                   official narrowing from 56 rejections to 2 left the signature unmoved.
+ *                   official narrowing from 57 rejections to 2 left the signature unmoved.
  *   the complement  the count pinned how many, not which. Measured: `c_vector` changed from
  *                   `vector({ dimensions: 3 })` to `dimensions: 2` in src/matrix.ts makes official
  *                   accept `[1,2]` and refuse `[1,2,3]`, the opposite behaviour, at the same count
- *                   of 56 on all 12 pairings. The stage exited 0 and went on printing "official
+ *                   of 57 on all 12 pairings. The stage exited 0 and went on printing "official
  *                   emits an array of exactly 3 numbers". With the complement declared the same
  *                   edit exits 1 on all 12 pairings.
  *
@@ -5283,18 +5369,18 @@ type Entry = {
  *                                     `s.properties[k]`, where it is inert:
  *                                     `Value.Check(prop, undefined)` is false with
  *                                     `Symbol(TypeBox.Optional)` present on the property, and
- *                                     deleting that symbol changes 0 of 57 pool verdicts.
+ *                                     deleting that symbol changes 0 of 58 pool verdicts.
  *   valibot on c_geometry             one fewer in every mode: official builds a `v.tuple`, which
  *                                     ignores extra items, so `[1,2,3]` and `[1,2,3,4]` both go
  *                                     into a 2-tuple and `[1,2,3]` is accepted alongside `[1,2]`.
- *   typebox on c_bit                  54 in all three modes, and not because it takes anything the
+ *   typebox on c_bit                  55 in all three modes, and not because it takes anything the
  *                                     other three refuse. Official's TypeBox schema throws on
  *                                     `null` and `undefined` for that column, so those two probes
  *                                     are not compared at all: they go to the THREW ledger and are
  *                                     arbitrated against a real Postgres. An earlier version of
  *                                     this note called it "TypeBox refuses two fewer probes",
  *                                     which reads as a rejection it never made, and which was also
- *                                     wrong about update, where the other three are at 55.
+ *                                     wrong about update, where the other three are at 56.
  */
 const allProbes = (n: number, accepted: string[]) =>
   `every probe official rejects (${n} of them), and official accepts only: ` +
@@ -5476,23 +5562,25 @@ const ALLOWED: Record<string, Entry> = {
   'pg/c_real': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` },
-    drzl: 'a number within the float4 magnitude Postgres accepts',
+    divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38 | T: ` },
+    drzl: 'a number within the magnitude Postgres accepts into a real',
     official: 'a number within +/-8388607, which refuses rows the column returns',
     filed: 'not a defect: the database is the arbiter, see the same key in the v1 pass',
   },
-  'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` }, drzl: 'as pg/c_real', official: 'as pg/c_real', filed: 'as pg/c_real' },
+  // Not `as pg/c_real` in the signature, which it was until MySQL was measured: the two 4 byte
+  // floats have different edges, and `3.4028235e38` is the probe that says so.
+  'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` }, drzl: 'as pg/c_real, at the narrower MySQL edge', official: 'as pg/c_real', filed: 'as pg/c_real' },
   'pg/c_double': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` },
+    divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` },
     drzl: 'an unbounded number, because no finite bound is true of an 8 byte float',
     official: 'a number within +/-140737488355327, which refuses an ordinary microsecond epoch',
     filed: 'not a defect: as pg/c_real',
   },
-  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
-  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
-  'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
 };
 
 /**
@@ -5564,11 +5652,11 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/zod,arktype,typebox': allProbes(56, ['[1,2]']),
-      'select,insert/valibot': allProbes(55, ['[1,2]', '[1,2,3]']),
-      'update/zod,arktype': allProbes(55, ['undefined', '[1,2]']),
-      'update/valibot': allProbes(54, ['undefined', '[1,2]', '[1,2,3]']),
-      'update/typebox': allProbes(56, ['[1,2]']),
+      'select,insert/zod,arktype,typebox': allProbes(57, ['[1,2]']),
+      'select,insert/valibot': allProbes(56, ['[1,2]', '[1,2,3]']),
+      'update/zod,arktype': allProbes(56, ['undefined', '[1,2]']),
+      'update/valibot': allProbes(55, ['undefined', '[1,2]', '[1,2,3]']),
+      'update/typebox': allProbes(57, ['[1,2]']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a tuple [number, number]',
@@ -5578,11 +5666,11 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/zod,valibot,arktype': allProbes(56, ["'010'"]),
-      'update/zod,valibot,arktype': allProbes(55, ['undefined', "'010'"]),
+      'select,insert/zod,valibot,arktype': allProbes(57, ["'010'"]),
+      'update/zod,valibot,arktype': allProbes(56, ['undefined', "'010'"]),
       // Not "typebox refuses fewer": official's TypeBox schema throws on `null` and `undefined`
       // here, so those two probes are not compared in any mode and the THREW ledger holds them.
-      '*/typebox': allProbes(54, ["'010'"]),
+      '*/typebox': allProbes(55, ["'010'"]),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a string of at most 3 characters matching ^[01]*$',
@@ -5595,9 +5683,9 @@ const DEFECTS: Record<string, Entry> = {
       // Per pairing, because official's own rejections are not the same everywhere and the bare
       // shorthand hid that. What each split measures is on `allProbes`, where it is measured
       // rather than argued.
-      'select,insert/*': allProbes(56, ['[1,2,3]']),
-      'update/zod,valibot,arktype': allProbes(55, ['undefined', '[1,2,3]']),
-      'update/typebox': allProbes(56, ['[1,2,3]']),
+      'select,insert/*': allProbes(57, ['[1,2,3]']),
+      'update/zod,valibot,arktype': allProbes(56, ['undefined', '[1,2,3]']),
+      'update/typebox': allProbes(57, ['[1,2,3]']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'an array of exactly 3 numbers',
@@ -5607,9 +5695,9 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/*': allProbes(56, ['Buffer']),
-      'update/zod,valibot,arktype': allProbes(55, ['undefined', 'Buffer']),
-      'update/typebox': allProbes(56, ['Buffer']),
+      'select,insert/*': allProbes(57, ['Buffer']),
+      'update/zod,valibot,arktype': allProbes(56, ['undefined', 'Buffer']),
+      'update/typebox': allProbes(57, ['Buffer']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Buffer',
@@ -5619,9 +5707,9 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/*': allProbes(56, ['Buffer']),
-      'update/zod,valibot,arktype': allProbes(55, ['undefined', 'Buffer']),
-      'update/typebox': allProbes(56, ['Buffer']),
+      'select,insert/*': allProbes(57, ['Buffer']),
+      'update/zod,valibot,arktype': allProbes(56, ['undefined', 'Buffer']),
+      'update/typebox': allProbes(57, ['Buffer']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Buffer',
@@ -5631,9 +5719,9 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/*': allProbes(56, ['Date']),
-      'update/zod,valibot,arktype': allProbes(55, ['undefined', 'Date']),
-      'update/typebox': allProbes(56, ['Date']),
+      'select,insert/*': allProbes(57, ['Date']),
+      'update/zod,valibot,arktype': allProbes(56, ['undefined', 'Date']),
+      'update/typebox': allProbes(57, ['Date']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Date',
@@ -5649,18 +5737,18 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'insert/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'insert/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'insert/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'insert/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'select/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'select/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'select/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'select/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'update/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, NaN, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'update/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'update/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'update/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'insert/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'insert/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'insert/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'insert/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'select/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'select/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'select/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'select/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'update/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500, NaN, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'update/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'update/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'update/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
     },
     drzl: 'a number',
     official: 'a string',
@@ -5707,7 +5795,7 @@ const DEFECTS: Record<string, Entry> = {
     modes: MODE_NAMES,
     divergence: {
       '*/zod': `L: -1 | T: `,
-      '*/valibot,arktype,typebox': `L: -1, 9007199254740993 | T: `,
+      '*/valibot,arktype,typebox': `L: -1, 9007199254740993, 3.4028235e38 | T: `,
     },
     drzl: 'an unbounded integer, so it takes -1 for an auto-increment column',
     official: 'an integer within 0..9007199254740991',
@@ -5718,7 +5806,7 @@ const DEFECTS: Record<string, Entry> = {
     modes: MODE_NAMES,
     divergence: {
       '*/zod': `L: 0, 1, -1, 200, 40000, 9000000, 2147483648, 1900, 2500 | T: `,
-      '*/valibot,arktype,typebox': `L: 0, 1, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2500 | T: `,
+      '*/valibot,arktype,typebox': `L: 0, 1, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 3.4028235e38, 1900, 2500 | T: `,
     },
     drzl: 'an unbounded integer',
     official: 'an integer within 1901..2155',

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -910,13 +910,13 @@ import { Value } from '@sinclair/typebox/value';
 export const POOL: [string, unknown][] = [
   ['null', null], ['undefined', undefined], ['""', ''], ["'hello'", 'hello'],
   ['300-char', 'x'.repeat(300)], ['70k-char', 'x'.repeat(70000)], ['5-char', 'xxxxx'],
-  // Astral-plane characters, which tell a code-point count from a UTF-16 `.length`. Without them
-  // the pool cannot see the difference, which is exactly how the `varchar(n)` bug survived.
-  ['3 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}'],
-  ['5 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}'],
-  // Astral-plane characters, where a code-point count and a UTF-16 `.length` disagree.
-  // Postgres counts characters for `varchar(n)`, so a 3-emoji string fits in a varchar(5)
-  // that every library's `.max(5)` refuses.
+  // Astral-plane characters, where a code-point count and a UTF-16 `.length` disagree. Without
+  // them the pool cannot see the difference, which is exactly how the `varchar(n)` bug survived:
+  // Postgres counts characters for `varchar(n)`, so a 3-emoji string fits in a varchar(5) that
+  // every library's `.max(5)` refuses.
+  //
+  // Both of these were once listed twice, under two comments saying that in two ways. See the
+  // duplicate check below the pool.
   ['3 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}'],
   ['5 emoji', '\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}\u{1F44D}'],
   ["'not-a-uuid'", 'not-a-uuid'], ['uuid', '3f2504e0-4f89-11d3-9a0c-0305e82c3301'],
@@ -971,6 +971,48 @@ export const POOL: [string, unknown][] = [
   ['{x:1,y:2}', { x: 1, y: 2 }], ["'12.5'", '12.5'], ["'0101'", '0101'], ["'010'", '010'],
 ];
 
+/**
+ * The pool holds each probe once, enforced rather than asserted.
+ *
+ * `3 emoji` and `5 emoji` were each listed twice, added under two comments that say the same thing
+ * two ways, so `POOL.length` read 59 over 57 distinct values. Nothing failed and nothing could:
+ * two entries carrying the same value get the same verdict from every schema on every side, so a
+ * duplicate cannot produce a disagreement. What it does instead is inflate the counts a ledger
+ * declares, each of which is the length of a list built by walking this pool, and put a label into
+ * an `L:` or `T:` list twice, where that reads as two different probes.
+ *
+ * Measured by removing the two and re-running both passes against the declarations they had:
+ * 168 declared-against-measured mismatches on the 0.4x pass over 17 entries, 102 on the v1 pass
+ * over 12, every one of them a count two lower or a list with a repeat gone. No verdict moved and
+ * no summary count moved on either pass.
+ *
+ * Both halves are checked. A duplicate label makes two entries indistinguishable in a printed
+ * signature even when their values differ, and a duplicate value is the inflation above even when
+ * the labels differ.
+ */
+const poolKey = (x: unknown): string => {
+  if (typeof x === 'bigint') return `bigint:${x}`;
+  if (typeof x === 'number') return `number:${Object.is(x, -0) ? '-0' : String(x)}`;
+  if (typeof x === 'string') return `string:${x}`;
+  if (x instanceof Date) return `date:${x.getTime()}`;
+  if (ArrayBuffer.isView(x)) return `bytes:${Array.from(x as Uint8Array).join(',')}`;
+  return `${typeof x}:${JSON.stringify(x) ?? String(x)}`;
+};
+const repeated = (keys: string[]): string[] => [
+  ...new Set(keys.filter((k, i) => keys.indexOf(k) !== i)),
+];
+{
+  const labels = repeated(POOL.map(([label]) => label));
+  const values = repeated(POOL.map(([, value]) => poolKey(value)));
+  if (labels.length > 0 || values.length > 0) {
+    throw new Error(
+      `POOL holds duplicate entries, so every count taken off it is inflated. ` +
+        `Repeated label(s): ${labels.join(', ') || 'none'}. ` +
+        `Repeated value(s): ${values.map((k) => k.slice(0, 40)).join(', ') || 'none'}.`,
+    );
+  }
+}
+
 export type Lib = { field: (s: any, k: string) => any; ok: (f: any, x: unknown) => boolean };
 
 /**
@@ -984,7 +1026,7 @@ export type Lib = { field: (s: any, k: string) => any; ok: (f: any, x: unknown) 
  *   the property carries Symbol(TypeBox.Kind) and Symbol(TypeBox.Optional)
  *   Value.Check(objectSchema, {}) with the key omitted   true
  *   Value.Check(property, undefined)                     false
- *   deleting Symbol(TypeBox.Optional) from the property  changes 0 of 59 pool verdicts
+ *   deleting Symbol(TypeBox.Optional) from the property  changes 0 of 57 pool verdicts
  *
  * So on TypeBox, and only on TypeBox, a required field and an optional one compare identically on
  * every probe: this harness cannot tell them apart, in either direction, and would report parity
@@ -1387,8 +1429,8 @@ const recordThrow = (key: string, side: string, mode: string, value: string) => 
  * took the whole pool, how many official refused and exactly which ones it did not, and the two
  * `has it, omits it` strings say one side produced no field at all. That first one carries both a
  * count and a complement because each without the other is a shape: with neither, official
- * narrowing from 58 rejections to 2 left the signature unmoved; with the count alone, official
- * swapping which probes it refuses left it unmoved at the same 58. Both holes were measured on the
+ * narrowing from 56 rejections to 2 left the signature unmoved; with the count alone, official
+ * swapping which probes it refuses left it unmoved at the same 56. Both holes were measured on the
  * 0.4x pass, where the six columns in that state live. All three are what the run produces in
  * those states, and no waiver declares any of them today, since no waived column on this major is
  * untyped or missing on one side. They are the shape a future one would take, not a claim about
@@ -1421,7 +1463,7 @@ const WRITE = ['insert', 'update'];
 
 // A signature for a column DRZL accepts every probe of, stated as the count of official's
 // rejections plus the exact set it accepts instead. The complement is what makes it a set rather
-// than a shape, and it is one to three labels where the list it replaces is 56 to 58. See the
+// than a shape, and it is one to three labels where the list it replaces is 54 to 56. See the
 // fuller note on the same constant in the 0.4x pass below, which is where the six columns in that
 // state live; no waiver in this pass is in that state today.
 const allProbes = (n: number, accepted: string[]) =>
@@ -1466,7 +1508,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'coerceDates accepts a date string or epoch number on write',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
     },
   },
   'pg/c_ts_d': {
@@ -1475,7 +1517,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
     },
   },
   'mysql/m_date': {
@@ -1484,7 +1526,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
     },
   },
   'mysql/m_datetime': {
@@ -1493,7 +1535,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
     },
   },
   'mysql/m_ts': {
@@ -1502,7 +1544,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
     },
   },
   'sqlite/s_int_ts': {
@@ -1511,7 +1553,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
     },
   },
   'sqlite/s_int_ts_ms': {
@@ -1520,7 +1562,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
     },
   },
   // Official emits `Type.String({ format: 'uuid' })`, and TypeBox fails a format it has no entry
@@ -1530,8 +1572,8 @@ const ALLOWED: Record<string, Waiver> = {
   // A character limit counts *characters*; official counts `.length`, which is UTF-16 units, so
   // it refuses three emoji in a `char(4)` the database accepts. Measured against Postgres: three
   // emoji insert into a `char(4)` and read back as four code points, which are seven UTF-16 units.
-  'pg/c_char': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'character limit counts code points; official counts UTF-16 units', divergence: { '*/*': `L: 3 emoji, 3 emoji | T: ` } },
-  'mysql/m_char': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_char', divergence: { '*/*': `L: 3 emoji, 3 emoji | T: ` } },
+  'pg/c_char': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'character limit counts code points; official counts UTF-16 units', divergence: { '*/*': `L: 3 emoji | T: ` } },
+  'mysql/m_char': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_char', divergence: { '*/*': `L: 3 emoji | T: ` } },
   // MySQL's TEXT family is capped in bytes and official caps it in UTF-16 units, so official takes
   // a 100 emoji string that is 200 units and 400 bytes into a `tinytext` whose budget is 255. DRZL
   // emits the byte check and refuses it. A real MySQL 8 on a utf8mb4 client is the authority and
@@ -1557,9 +1599,9 @@ const ALLOWED: Record<string, Waiver> = {
   // Stricter than official, and verified against Postgres itself through PGlite: a `numeric`
   // column is a string, and a bare string schema accepts 'hello' where the database rejects it.
   // Official accepts all of these; the database does not.
-  'pg/c_numeric': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'numeric format enforced; official accepts any string, Postgres does not', divergence: { '*/*': `L:  | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1'` } },
-  'pg/c_decimal': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_numeric', divergence: { '*/*': `L:  | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1'` } },
-  'mysql/m_decimal': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_numeric', divergence: { '*/*': `L:  | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1'` } },
+  'pg/c_numeric': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'numeric format enforced; official accepts any string, Postgres does not', divergence: { '*/*': `L:  | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1'` } },
+  'pg/c_decimal': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_numeric', divergence: { '*/*': `L:  | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1'` } },
+  'mysql/m_decimal': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_numeric', divergence: { '*/*': `L:  | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1'` } },
   // Stricter than official, in DRZL's favour.
   'pg/valibot/c_json': { libs: ['valibot'], modes: MODE_NAMES, why: 'DRZL rejects Infinity and non-plain objects; official accepts both', divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` } },
   'pg/valibot/c_jsonb': { libs: ['valibot'], modes: MODE_NAMES, why: 'as pg/valibot/c_json', divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` } },
@@ -5181,10 +5223,10 @@ type Entry = {
    * `every probe official rejects (N of them), and official accepts only: <labels>` states the
    * same set from the other end, for the six columns DRZL accepts the whole pool of: the
    * divergence is exactly official's rejections, N is how many those are, and the labels are the
-   * complement, which is one to three where the list they replace is 56 to 58. Naming the
+   * complement, which is one to three where the list they replace is 54 to 56. Naming the
    * complement is what makes it a set. The count on its own was a shape, measured: with
    * `c_vector` changed from `vector({ dimensions: 3 })` to `dimensions: 2`, official refuses
-   * `[1,2,3]` and accepts `[1,2]`, which is the opposite behaviour at the same count of 58, and
+   * `[1,2,3]` and accepts `[1,2]`, which is the opposite behaviour at the same count of 56, and
    * the stage was green.
    *
    * This replaced a `direction` field, which named only which way the disagreement ran. That
@@ -5211,22 +5253,22 @@ type Entry = {
 /**
  * A signature for a column DRZL accepts every probe of: official's rejection count, plus the exact
  * set official accepts instead. Six columns are in that state, all six of them columns the
- * class-name path cannot name at all, and the alternative is a list of 56 to 58 labels written out
+ * class-name path cannot name at all, and the alternative is a list of 54 to 56 labels written out
  * once per pairing group.
  *
  * Naming what official accepts names the divergence exactly, from the other end. DRZL accepted
  * every compared probe, so the probes that differ are exactly the ones official rejected, and that
- * is every compared probe except the ones listed here. One to three labels instead of 56 to 58.
+ * is every compared probe except the ones listed here. One to three labels instead of 54 to 56.
  *
  * Both halves are here because each closed a hole the other left open, and both holes were live.
  *
  *   the count       the phrase alone pinned DRZL's side only. "DRZL accepts everything" fails the
  *                   moment DRZL stops accepting everything, but official was not mentioned, so
- *                   official narrowing from 58 rejections to 2 left the signature unmoved.
+ *                   official narrowing from 56 rejections to 2 left the signature unmoved.
  *   the complement  the count pinned how many, not which. Measured: `c_vector` changed from
  *                   `vector({ dimensions: 3 })` to `dimensions: 2` in src/matrix.ts makes official
  *                   accept `[1,2]` and refuse `[1,2,3]`, the opposite behaviour, at the same count
- *                   of 58 on all 12 pairings. The stage exited 0 and went on printing "official
+ *                   of 56 on all 12 pairings. The stage exited 0 and went on printing "official
  *                   emits an array of exactly 3 numbers". With the complement declared the same
  *                   edit exits 1 on all 12 pairings.
  *
@@ -5241,18 +5283,18 @@ type Entry = {
  *                                     `s.properties[k]`, where it is inert:
  *                                     `Value.Check(prop, undefined)` is false with
  *                                     `Symbol(TypeBox.Optional)` present on the property, and
- *                                     deleting that symbol changes 0 of 59 pool verdicts.
+ *                                     deleting that symbol changes 0 of 57 pool verdicts.
  *   valibot on c_geometry             one fewer in every mode: official builds a `v.tuple`, which
  *                                     ignores extra items, so `[1,2,3]` and `[1,2,3,4]` both go
  *                                     into a 2-tuple and `[1,2,3]` is accepted alongside `[1,2]`.
- *   typebox on c_bit                  56 in all three modes, and not because it takes anything the
+ *   typebox on c_bit                  54 in all three modes, and not because it takes anything the
  *                                     other three refuse. Official's TypeBox schema throws on
  *                                     `null` and `undefined` for that column, so those two probes
  *                                     are not compared at all: they go to the THREW ledger and are
  *                                     arbitrated against a real Postgres. An earlier version of
  *                                     this note called it "TypeBox refuses two fewer probes",
  *                                     which reads as a rejection it never made, and which was also
- *                                     wrong about update, where the other three are at 57.
+ *                                     wrong about update, where the other three are at 55.
  */
 const allProbes = (n: number, accepted: string[]) =>
   `every probe official rejects (${n} of them), and official accepts only: ` +
@@ -5299,7 +5341,7 @@ const ALLOWED: Record<string, Entry> = {
   'pg/c_char': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `L: "", 3 emoji, 3 emoji, 'zzz', 'a', 'x', '010' | T: ` },
+    divergence: { '*/*': `L: "", 3 emoji, 'zzz', 'a', 'x', '010' | T: ` },
     drzl: 'a string of at most 4 code points',
     official: 'a string of exactly 4 UTF-16 units',
     filed: 'not a defect: two deliberate differences, see the note above',
@@ -5307,7 +5349,7 @@ const ALLOWED: Record<string, Entry> = {
   'mysql/m_char': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `L: "", 3 emoji, 3 emoji, 'zzz', 'a', 'x', '010' | T: ` },
+    divergence: { '*/*': `L: "", 3 emoji, 'zzz', 'a', 'x', '010' | T: ` },
     drzl: 'as pg/c_char',
     official: 'as pg/c_char',
     filed: 'as pg/c_char',
@@ -5356,17 +5398,17 @@ const ALLOWED: Record<string, Entry> = {
     modes: WRITE,
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
     },
     drzl: 'a Date, or a string or number coerced to one',
     official: 'a Date only',
     filed: 'not a defect: coerceDates',
   },
-  'pg/c_ts_d': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'mysql/m_date': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'mysql/m_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'mysql/m_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'sqlite/s_int_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'pg/c_ts_d': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_date': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'sqlite/s_int_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010' | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   // TypeBox fails a format it has no entry for rather than ignoring it, so official's schema
   // rejects every valid uuid in any project that has not populated `FormatRegistry` first.
   'pg/c_uuid': {
@@ -5522,11 +5564,11 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/zod,arktype,typebox': allProbes(58, ['[1,2]']),
-      'select,insert/valibot': allProbes(57, ['[1,2]', '[1,2,3]']),
-      'update/zod,arktype': allProbes(57, ['undefined', '[1,2]']),
-      'update/valibot': allProbes(56, ['undefined', '[1,2]', '[1,2,3]']),
-      'update/typebox': allProbes(58, ['[1,2]']),
+      'select,insert/zod,arktype,typebox': allProbes(56, ['[1,2]']),
+      'select,insert/valibot': allProbes(55, ['[1,2]', '[1,2,3]']),
+      'update/zod,arktype': allProbes(55, ['undefined', '[1,2]']),
+      'update/valibot': allProbes(54, ['undefined', '[1,2]', '[1,2,3]']),
+      'update/typebox': allProbes(56, ['[1,2]']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a tuple [number, number]',
@@ -5536,11 +5578,11 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/zod,valibot,arktype': allProbes(58, ["'010'"]),
-      'update/zod,valibot,arktype': allProbes(57, ['undefined', "'010'"]),
+      'select,insert/zod,valibot,arktype': allProbes(56, ["'010'"]),
+      'update/zod,valibot,arktype': allProbes(55, ['undefined', "'010'"]),
       // Not "typebox refuses fewer": official's TypeBox schema throws on `null` and `undefined`
       // here, so those two probes are not compared in any mode and the THREW ledger holds them.
-      '*/typebox': allProbes(56, ["'010'"]),
+      '*/typebox': allProbes(54, ["'010'"]),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a string of at most 3 characters matching ^[01]*$',
@@ -5553,9 +5595,9 @@ const DEFECTS: Record<string, Entry> = {
       // Per pairing, because official's own rejections are not the same everywhere and the bare
       // shorthand hid that. What each split measures is on `allProbes`, where it is measured
       // rather than argued.
-      'select,insert/*': allProbes(58, ['[1,2,3]']),
-      'update/zod,valibot,arktype': allProbes(57, ['undefined', '[1,2,3]']),
-      'update/typebox': allProbes(58, ['[1,2,3]']),
+      'select,insert/*': allProbes(56, ['[1,2,3]']),
+      'update/zod,valibot,arktype': allProbes(55, ['undefined', '[1,2,3]']),
+      'update/typebox': allProbes(56, ['[1,2,3]']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'an array of exactly 3 numbers',
@@ -5565,9 +5607,9 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/*': allProbes(58, ['Buffer']),
-      'update/zod,valibot,arktype': allProbes(57, ['undefined', 'Buffer']),
-      'update/typebox': allProbes(58, ['Buffer']),
+      'select,insert/*': allProbes(56, ['Buffer']),
+      'update/zod,valibot,arktype': allProbes(55, ['undefined', 'Buffer']),
+      'update/typebox': allProbes(56, ['Buffer']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Buffer',
@@ -5577,9 +5619,9 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/*': allProbes(58, ['Buffer']),
-      'update/zod,valibot,arktype': allProbes(57, ['undefined', 'Buffer']),
-      'update/typebox': allProbes(58, ['Buffer']),
+      'select,insert/*': allProbes(56, ['Buffer']),
+      'update/zod,valibot,arktype': allProbes(55, ['undefined', 'Buffer']),
+      'update/typebox': allProbes(56, ['Buffer']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Buffer',
@@ -5589,9 +5631,9 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'select,insert/*': allProbes(58, ['Date']),
-      'update/zod,valibot,arktype': allProbes(57, ['undefined', 'Date']),
-      'update/typebox': allProbes(58, ['Date']),
+      'select,insert/*': allProbes(56, ['Date']),
+      'update/zod,valibot,arktype': allProbes(55, ['undefined', 'Date']),
+      'update/typebox': allProbes(56, ['Date']),
     },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Date',
@@ -5607,18 +5649,18 @@ const DEFECTS: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
     divergence: {
-      'insert/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'insert/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'insert/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'insert/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'select/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'select/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'select/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'select/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'update/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, NaN, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'update/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'update/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
-      'update/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'insert/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'insert/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'insert/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'insert/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'select/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'select/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'select/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'select/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'update/arktype': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, NaN, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'update/typebox': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'update/valibot': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500, Infinity | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
+      'update/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 9007199254740993, 1900, 2000, 2500 | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'`,
     },
     drzl: 'a number',
     official: 'a string',
@@ -5641,7 +5683,7 @@ const DEFECTS: Record<string, Entry> = {
   'mysql/m_binary': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `L: Buffer, Uint8Array | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'` },
+    divergence: { '*/*': `L: Buffer, Uint8Array | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'` },
     drzl: 'a Uint8Array',
     official: "a bare string on 0.4x, where official v1 emits ^[01]*$ capped at 4",
     filed: "new: drizzle-orm declares dataType 'string' on both majors",
@@ -5649,7 +5691,7 @@ const DEFECTS: Record<string, Entry> = {
   'mysql/m_varbinary': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `L: Buffer, Uint8Array | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'` },
+    divergence: { '*/*': `L: Buffer, Uint8Array | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'` },
     drzl: 'a Uint8Array',
     official: "a bare string on 0.4x, where official v1 emits ^[01]*$ capped at 16",
     filed: 'new: as mysql/m_binary',

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -601,11 +601,17 @@ fi
 echo "    all $doc_total documented configs generate and typecheck"
 
 echo "==> differential parity against the official drizzle-orm validators"
-# The claim DRZL makes is that its generated schemas are at least as strict as the first-party
-# `drizzle-orm/{zod,valibot,arktype}` modules. That is a claim about behaviour, so it is measured
-# by behaviour: generate for the same table, then push the same pool of values through both
-# schemas column by column and compare the verdicts. Reading the emitted source cannot do this,
-# because a schema that parses and a schema that validates look identical as text.
+# What DRZL claims is that every difference between its generated schemas and the first-party
+# `drizzle-orm/{zod,valibot,arktype,typebox}` modules is known and named. Not that it is at least as
+# strict: this comment said that for a long time and it was never true, since Postgres takes three
+# emoji into a `char(3)` and a Uint8Array into a `bytea` and official refuses both. Where the two
+# disagree the database decides which is right, and the answer goes in ALLOWED with its
+# measurement.
+#
+# That is a claim about behaviour, so it is measured by behaviour: generate for the same table,
+# then push the same pool of values through both schemas column by column and compare the verdicts.
+# Reading the emitted source cannot do this, because a schema that parses and a schema that
+# validates look identical as text.
 #
 # Three dialects and all three modes, because the gaps cluster in the corners: MySQL owns the
 # narrow integer widths and the text/blob caps, SQLite owns the blob modes, and insert and update
@@ -1532,9 +1538,17 @@ const ALLOWED: Record<string, Waiver> = {
   'sqlite/valibot/s_blob': { libs: ['valibot'], modes: MODE_NAMES, why: 'as pg/valibot/c_json; a bare blob() is Drizzle json mode', divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` } },
   'pg/valibot/c_point': { libs: ['valibot'], modes: MODE_NAMES, why: 'v.strictTuple rejects a third element; official v.tuple ignores extras', divergence: { '*/*': `L:  | T: [1,2,3]` } },
   'pg/valibot/c_geometry': { libs: ['valibot'], modes: MODE_NAMES, why: 'as pg/valibot/c_point', divergence: { '*/*': `L:  | T: [1,2,3]` } },
-  // Looser than official on purpose, and the only entries in either pass that run that way, so
-  // they are the ones to read carefully. The database is the arbiter here, not the first-party
-  // module, and it was asked directly through PGlite on each column's own SQL type.
+  // Looser than official on purpose. An earlier version of this sentence called these the only
+  // entries in either pass that run that way, and the map around it refutes that: the run prints
+  // how many waivers have DRZL accepting something official refuses, and it is most of them.
+  // `pg/c_char` takes three emoji into a `char(3)`, `pg/c_bytea` takes a Uint8Array, `pg/c_uuid`
+  // takes a uuid TypeBox refuses without a FormatRegistry, and Postgres accepts all three.
+  //
+  // What is unusual about these six is narrower and worth reading for: they are looser on a
+  // *numeric range*, which is the kind of divergence this gate was built to catch, and they got
+  // that way by moving off the first-party module's numbers rather than by never having had any.
+  // The database is the arbiter here, not the first-party module, and it was asked directly
+  // through PGlite on each column's own SQL type.
   //
   // `real` / float4. Official bounds it at +/-8388607, and the column stores 8388608, 9000000,
   // 1e9 and 2147483648 and returns every one of them unchanged, and holds every integer exactly
@@ -1551,11 +1565,11 @@ const ALLOWED: Record<string, Waiver> = {
   // microsecond epoch.
   //
   // DRZL was on official's numbers for one release and this is the correction. The failure text
-  // this gate prints for an unwaived difference, "a generated schema looser than the first-party
-  // module accepts rows the database will reject", is exactly the equivalence that does not hold
+  // this gate prints for an unwaived difference used to gloss "looser than the first-party module"
+  // as "accepts rows the database will reject", which is exactly the equivalence that does not hold
   // for these six: the database accepts every value in these signatures except the ones noted
-  // below. That is what makes them ALLOWED rather than DEFECTS, and the note is here because the
-  // sentence would otherwise read as an admission.
+  // below. That sentence has been rewritten rather than caveated, because it was already false of
+  // five waived columns before these six arrived.
   //
   // Two values in these signatures the database is not on DRZL's side about:
   //   9007199254740993   the JS literal is 9007199254740992, which a float8 holds exactly and a
@@ -2091,6 +2105,27 @@ if (totalCompared !== EXPECTED_COMPARISONS) {
 }
 console.log(`    ${totalCompared} column comparisons`);
 
+/**
+ * How many waivers run each way, counted from the map rather than stated in a sentence.
+ *
+ * `L:` is the half of a signature listing what DRZL accepts and official refuses, so a non-empty
+ * one is a waiver where DRZL is the looser side. Three comments in this file have now claimed a
+ * number for that, and the count is printed here instead so a claim about it cannot go stale: the
+ * float waivers added when the bounds moved to the database's were described as "the only entries
+ * in either pass that run that way", and they are not, by an order of magnitude.
+ *
+ * Being looser than official is not by itself a defect and this line is not a warning. Postgres
+ * takes three emoji into a `char(3)`, a Uint8Array into a `bytea` and a uuid into a `uuid`, and
+ * official refuses all three. What the gate holds is the sentence at the end of this file.
+ */
+const looserSide = (e: { divergence: Record<string, string> }) =>
+  Object.values(e.divergence).some((s) => s.split('|')[0].replace(/^L:/, '').trim() !== '');
+const looserWaivers = Object.values(ALLOWED).filter(looserSide).length;
+console.log(
+  `    ${Object.keys(ALLOWED).length} documented divergence(s), ${looserWaivers} of them with ` +
+    `DRZL accepting something official refuses`
+);
+
 // A waiver that suppresses nothing is not harmless. It is a sentence claiming a divergence exists
 // and is fine, sitting next to the divergences that really do, and the next person to widen this
 // file reads it as covered ground. Every key above has to earn its place on this run or be
@@ -2362,8 +2397,12 @@ if (deadWaivers.length) {
 }
 
 if (findings) {
-  console.error(`FAIL: ${findings} parity finding(s). A generated schema looser than the`);
-  console.error('      first-party module accepts rows the database will reject.');
+  console.error(`FAIL: ${findings} parity finding(s): a generated schema differs from the`);
+  console.error('      first-party module on a value, and no waiver names that difference.');
+  console.error('      Looser is not automatically wrong and this sentence used to say it was:');
+  console.error('      Postgres takes three emoji into a char(3) and a Uint8Array into a bytea,');
+  console.error('      and official refuses both. Ask the database which side is right, then put');
+  console.error('      the answer in ALLOWED with its measurement, or fix the generator.');
 }
 
 // Counted separately and exited on together, so one run reports both rather than hiding the
@@ -5277,10 +5316,13 @@ const ALLOWED: Record<string, Entry> = {
     official: 'v.tuple, which ignores a third element the column then drops',
     filed: 'not a defect: DRZL is stricter, and Postgres truncates what official accepts',
   },
-  // Looser than official, on purpose, and these six are the only entries in either pass that run
-  // that way. The reasoning, the PGlite measurements and the two caveats are written out once at
-  // the same six keys in the v1 pass near the top of this file, because both majors now take the
-  // database's answer and moving one without the other is what the cross-major diff catches.
+  // Looser than official, on purpose, and looser on a numeric range rather than on a format or a
+  // length, which is the part worth reading for. An earlier version of this sentence called these
+  // six the only entries in either pass running that way; they are not, and the run now counts and
+  // prints how many waivers do. The reasoning, the PGlite measurements and the two caveats are
+  // written out once at the same six keys in the v1 pass near the top of this file, because both
+  // majors now take the database's answer and moving one without the other is what the cross-major
+  // diff catches.
   //
   // They were in DEFECTS below for one release, filed as "DRZL emits an unbounded number, official
   // emits a number within +/-8388607". The fix that closed that filed the wrong way: it adopted
@@ -5871,9 +5913,14 @@ async function main() {
   }
 
   const filedAlready = Object.values(DEFECTS).filter((e) => e.filed.startsWith('AC:')).length;
+  // As in the v1 pass: which side each waiver runs on, counted rather than asserted.
+  const looserWaivers = Object.values(ALLOWED).filter((e) =>
+    Object.values(e.divergence).some((s) => s.split('|')[0].replace(/^L:/, '').trim() !== '')
+  ).length;
   console.log(`    ${totalCompared} column comparisons across ${pairings} pairings`);
   console.log(
-    `    ${Object.keys(ALLOWED).length} documented divergence(s); ` +
+    `    ${Object.keys(ALLOWED).length} documented divergence(s), ${looserWaivers} of them with ` +
+      `DRZL accepting something official refuses; ` +
       `${Object.keys(DEFECTS).length} known-defect column(s), ${filedAlready} already filed and ` +
       `${Object.keys(DEFECTS).length - filedAlready} first seen by this stage`
   );
@@ -6383,8 +6430,11 @@ async function main() {
     for (const c of capProblems) console.error(`      ${c}`);
   }
   if (findings.length) {
-    console.error(`    FAIL: ${findings.length} parity finding(s). A generated schema looser than`);
-    console.error('          the first-party module accepts rows the database will reject.');
+    console.error(`    FAIL: ${findings.length} parity finding(s): a generated schema differs from`);
+    console.error('          the first-party module on a value, and no waiver names that');
+    console.error('          difference. Looser is not automatically wrong, which is what this');
+    console.error('          sentence used to claim. Ask the database which side is right, then');
+    console.error('          put the answer in ALLOWED with its measurement, or fix the generator.');
   }
   if (
     findings.length ||
@@ -6612,9 +6662,13 @@ fi
 cd "$APP"
 
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
-echo "    typechecks under bundler, node16 and nodenext, and validates at least as strictly as"
-echo "    all four first-party drizzle-orm validator modules on each of three dialects and three"
-echo "    modes, with the four generators cross-checked against each other on every dialect,"
+echo "    typechecks under bundler, node16 and nodenext, and is compared column by column and value"
+echo "    by value against all four first-party drizzle-orm validator modules on each of three"
+echo "    dialects and three modes. Every difference either fails this run or is waived by name,"
+echo "    and each waiver pins the exact set of probes it covers, in both directions. That"
+echo "    comparison is the guarantee, and it is not \"at least as strict\": most waivers have DRZL"
+echo "    accepting something official refuses, the run counts them above, and each says why."
+echo "    The four generators are cross-checked against each other on every dialect,"
 echo "    checked against a real Postgres, a real SQLite and, where MYSQL_URL is set, a real"
 echo "    MySQL, with applyDefaults compared against what the database writes, and described the"
 echo "    same way by the analyzer under both drizzle-orm majors, bar the differences that stage"

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1360,12 +1360,14 @@ const recordThrow = (key: string, side: string, mode: string, value: string) => 
  *
  * `divergence` is keyed `<modes>/<libraries>`, `*` for all of them, and each value is the exact
  * signature measured for those pairings: `L: <labels DRZL accepts and official refuses> | T: <the
- * other way>`, in pool order. Three signatures are a property rather than a list, so they cannot be
- * written down wrongly: `every probe official rejects` says DRZL took the whole pool, and the two
- * `has it, omits it` strings say one side produced no field at all. All three are what the run
- * produces in those states, and no waiver declares any of them today, since no waived column on
- * this major is untyped or missing on one side. They are the shape a future one would take, not a
- * claim about the current list.
+ * other way>`, in pool order. Three signatures are a property rather than a list:
+ * `every probe official rejects (N of them)` says DRZL took the whole pool and states how many
+ * official refused, and the two `has it, omits it` strings say one side produced no field at all.
+ * The count is in the first of those because without it only DRZL's side was pinned: official
+ * narrowing from 58 rejections to 2 left the signature unmoved, since it never mentioned official
+ * at all. All three are what the run produces in those states, and no waiver declares any of them
+ * today, since no waived column on this major is untyped or missing on one side. They are the
+ * shape a future one would take, not a claim about the current list.
  *
  * Until this existed a waiver asserted only that it suppressed something, and a real regression
  * walked through it: stripping every length cap from `m_tinytext` in all four generated modules
@@ -1392,7 +1394,10 @@ const LIB_NAMES = ['zod', 'valibot', 'arktype', 'typebox'];
 const MODE_NAMES = ['select', 'insert', 'update'];
 const WRITE = ['insert', 'update'];
 
-const ALL_PROBES = 'every probe official rejects';
+// A signature stating the divergence as a property rather than as a list, for a column DRZL
+// accepts every probe of. See the fuller note on the same constant in the 0.4x pass below, which
+// is where the six columns in that state live.
+const allProbes = (n: number) => `every probe official rejects (${n} of them)`;
 
 /**
  * Does a declaration key such as `select,insert/zod` cover the pairing `select/zod`? A declaration
@@ -1541,8 +1546,9 @@ const ALLOWED: Record<string, Waiver> = {
   // Looser than official on purpose. An earlier version of this sentence called these the only
   // entries in either pass that run that way, and the map around it refutes that: the run prints
   // how many waivers have DRZL accepting something official refuses, and it is most of them.
-  // `pg/c_char` takes three emoji into a `char(3)`, `pg/c_bytea` takes a Uint8Array, `pg/c_uuid`
-  // takes a uuid TypeBox refuses without a FormatRegistry, and Postgres accepts all three.
+  // `pg/c_char` takes three emoji into a `char(3)`, `pg/c_bytea` takes a Uint8Array, and
+  // `pg/typebox/c_uuid` takes a uuid TypeBox refuses until a FormatRegistry is populated. Postgres
+  // accepts all three. The uuid one is keyed by library because only TypeBox has it.
   //
   // What is unusual about these six is narrower and worth reading for: they are looser on a
   // *numeric range*, which is the kind of divergence this gate was built to catch, and they got
@@ -1594,9 +1600,14 @@ const ALLOWED: Record<string, Waiver> = {
   'mysql/typebox/m_varbinary': { libs: ['typebox'], modes: MODE_NAMES, why: 'as mysql/typebox/m_binary', divergence: { '*/*': `L:  | T: []` } },
   // No arktype bigint entry. There were three, reading "ArkType cannot bound a bigint in its
   // string DSL", and only half of that was true: the DSL cannot state the bound, but a narrow can,
-  // and this generator already used narrows for every character cap. It was the one place in this
-  // whole gate where DRZL was looser than the first-party module, waived on all three dialects.
-  // The generator now bounds bigint columns and all four agree.
+  // and this generator already used narrows for every character cap. The generator now bounds
+  // bigint columns and all four agree.
+  //
+  // That trio used to be described here as the one place in this whole gate where DRZL was looser
+  // than the first-party module. It never was: the run counts the waivers where DRZL accepts
+  // something official refuses and prints the number, and it is most of them. What made those
+  // three worth fixing rather than waiving is that no int64 column can hold the value they let
+  // through.
 };
 
 const usedWaivers = new Set<string>();
@@ -1829,7 +1840,9 @@ for (const d of DIALECTS) {
           continue;
         }
         if (!looser.length && !tighter.length) continue;
-        const signature = drzlAll ? ALL_PROBES : `L: ${looser.join(', ')} | T: ${tighter.join(', ')}`;
+        const signature = drzlAll
+          ? allProbes(looser.length)
+          : `L: ${looser.join(', ')} | T: ${tighter.join(', ')}`;
         if (allowed(d.name, libName, k, mode, signature)) { waivedCount++; continue; }
         rows.push(
           `        ${k}:` +
@@ -2112,7 +2125,9 @@ console.log(`    ${totalCompared} column comparisons`);
  * one is a waiver where DRZL is the looser side. Three comments in this file have now claimed a
  * number for that, and the count is printed here instead so a claim about it cannot go stale: the
  * float waivers added when the bounds moved to the database's were described as "the only entries
- * in either pass that run that way", and they are not, by an order of magnitude.
+ * in either pass that run that way", and they are not: the counts printed below are 18 of 35 here
+ * and 15 of 24 in the 0.4x pass, against the six. An earlier version of this sentence said "by an
+ * order of magnitude", which is 3x and 2.5x.
  *
  * Being looser than official is not by itself a defect and this line is not a warning. Postgres
  * takes three emoji into a `char(3)`, a Uint8Array into a `bytea` and a uuid into a `uuid`, and
@@ -4523,8 +4538,9 @@ const DEFECTS: Record<string, string> = {
   // own validators do not differ here. drizzle-zod 0.8.3 on drizzle-orm 0.45.2 emits `max_length`
   // 255 / 65535 / 16777215 / 4294967295 on all four, off the text subtype (`column.textType`)
   // rather than off `length`, which is the same place DRZL's own 0.4x path gets `maxBytes` from.
-  // So DRZL on 0.4x is looser than official on 0.4x, the one direction this map exists to
-  // record. Same evidence as the float group above.
+  // So DRZL on 0.4x is looser than official on 0.4x here, and that is worth recording because the
+  // column has a cap and DRZL's 0.4x answer claims it does not, not because looser is a direction
+  // this map forbids: the parity passes count their looser entries and most run that way.
   //
   // Measured on the emitted files, since ALLOWED also claimed nothing was accepted on one side
   // and refused on the other. All five generators emit different source, and one differs in
@@ -5126,10 +5142,13 @@ type Entry = {
    * The exact divergence this entry covers, keyed `<modes>/<libraries>` with `*` for all of them.
    *
    * A signature is `L: <labels DRZL accepts and official refuses> | T: <the other way>`, in pool
-   * order, and it has to match what the run measured character for character. The literal
-   * `every probe official rejects` says the same thing as a proof instead of a list: DRZL accepted
-   * every probe, so the divergence is exactly official's rejections and cannot be written down
-   * wrongly.
+   * order, and it has to match what the run measured character for character.
+   * `every probe official rejects (N of them)` says the same thing as a proof instead of a list:
+   * DRZL accepted every probe, so the divergence is exactly official's rejections, and N is how
+   * many those are. Both halves are needed. Without the count only DRZL's side was asserted, and
+   * the six entries using it would have stayed green through official narrowing from 58
+   * rejections to 2. The counts are not uniform either, which the shorthand hid: TypeBox refuses
+   * two fewer probes than the other three on `c_bit`.
    *
    * This replaced a `direction` field, which named only which way the disagreement ran. That
    * closed a reversal and nothing else, and three sabotages walked through it: capping `c_char` at
@@ -5157,8 +5176,15 @@ type Entry = {
  * probe, so the set of differing probes is exactly the set official rejects, and there is nothing
  * to write down wrongly. Six columns are in that state and each would otherwise carry a list of
  * around 56 labels, which is a list nobody would read.
+ *
+ * The count is in the string because without it the shorthand was asserted in one direction only.
+ * "DRZL accepts everything" is pinned by the phrase, and it fails the moment DRZL stops accepting
+ * everything. What was not pinned was official's side: if official narrowed from refusing 26
+ * probes to refusing 2, the divergence shrank by 24 and this signature did not move, because it
+ * never mentioned official's rejections at all. It says how many now, so both halves of the
+ * difference are asserted, which is what every other signature in these maps does.
  */
-const ALL_PROBES = 'every probe official rejects';
+const allProbes = (n: number) => `every probe official rejects (${n} of them)`;
 
 /**
  * Does a declaration key such as `select,insert/zod,typebox` cover the pairing `select/zod`?
@@ -5356,7 +5382,11 @@ const ALLOWED: Record<string, Entry> = {
 };
 
 /**
- * Where DRZL is wrong or looser than the official module on 0.4x.
+ * Where DRZL is wrong on 0.4x, whichever way the difference runs.
+ *
+ * Not "looser than official", which is the neighbouring map's business as often as this one's:
+ * ALLOWED above holds six columns where DRZL is looser and right, because the database says so.
+ * What puts an entry here is that DRZL's answer is wrong about the column.
  *
  * `filed: 'AC: ...'` names the fields the cross-major stage above already carries for the same
  * column. The two sets do not line up one to one and were never going to: that map records the
@@ -5419,7 +5449,13 @@ const DEFECTS: Record<string, Entry> = {
   'pg/c_geometry': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `every probe official rejects` },
+    divergence: {
+      'select,insert/zod,arktype,typebox': allProbes(58),
+      'select,insert/valibot': allProbes(57),
+      'update/zod,arktype': allProbes(57),
+      'update/valibot': allProbes(56),
+      'update/typebox': allProbes(58),
+    },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a tuple [number, number]',
     filed: 'AC: matrix.c_geometry.tsType, .dbType, .shape, and check-old.ts KNOWN_UNNAMED',
@@ -5427,7 +5463,11 @@ const DEFECTS: Record<string, Entry> = {
   'pg/c_bit': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `every probe official rejects` },
+    divergence: {
+      'select,insert/zod,valibot,arktype': allProbes(58),
+      'update/zod,valibot,arktype': allProbes(57),
+      '*/typebox': allProbes(56),
+    },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a string of at most 3 characters matching ^[01]*$',
     filed: 'AC: matrix.c_bit.tsType, .dbType, .shape, and check-old.ts KNOWN_UNNAMED',
@@ -5435,7 +5475,15 @@ const DEFECTS: Record<string, Entry> = {
   'pg/c_vector': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `every probe official rejects` },
+    divergence: {
+      // Per pairing, because official's own rejections are not the same everywhere and the bare
+      // shorthand hid that. TypeBox refuses two fewer probes than the rest on `c_bit`, valibot one
+      // fewer on `c_geometry`, and update mode refuses one fewer than select and insert wherever
+      // the column is optional there.
+      'select,insert/*': allProbes(58),
+      'update/zod,valibot,arktype': allProbes(57),
+      'update/typebox': allProbes(58),
+    },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'an array of exactly 3 numbers',
     filed: 'AC: matrix.c_vector.tsType, .dbType, .shape, and check-old.ts KNOWN_UNNAMED',
@@ -5443,7 +5491,15 @@ const DEFECTS: Record<string, Entry> = {
   'sqlite/s_blob': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `every probe official rejects` },
+    divergence: {
+      // Per pairing, because official's own rejections are not the same everywhere and the bare
+      // shorthand hid that. TypeBox refuses two fewer probes than the rest on `c_bit`, valibot one
+      // fewer on `c_geometry`, and update mode refuses one fewer than select and insert wherever
+      // the column is optional there.
+      'select,insert/*': allProbes(58),
+      'update/zod,valibot,arktype': allProbes(57),
+      'update/typebox': allProbes(58),
+    },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Buffer',
     filed: 'new: no SQLiteBlobBuffer arm in the class-name path',
@@ -5451,7 +5507,15 @@ const DEFECTS: Record<string, Entry> = {
   'sqlite/s_blob_buf': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `every probe official rejects` },
+    divergence: {
+      // Per pairing, because official's own rejections are not the same everywhere and the bare
+      // shorthand hid that. TypeBox refuses two fewer probes than the rest on `c_bit`, valibot one
+      // fewer on `c_geometry`, and update mode refuses one fewer than select and insert wherever
+      // the column is optional there.
+      'select,insert/*': allProbes(58),
+      'update/zod,valibot,arktype': allProbes(57),
+      'update/typebox': allProbes(58),
+    },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Buffer',
     filed: 'new: as sqlite/s_blob',
@@ -5459,7 +5523,15 @@ const DEFECTS: Record<string, Entry> = {
   'sqlite/s_int_ts_ms': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `every probe official rejects` },
+    divergence: {
+      // Per pairing, because official's own rejections are not the same everywhere and the bare
+      // shorthand hid that. TypeBox refuses two fewer probes than the rest on `c_bit`, valibot one
+      // fewer on `c_geometry`, and update mode refuses one fewer than select and insert wherever
+      // the column is optional there.
+      'select,insert/*': allProbes(58),
+      'update/zod,valibot,arktype': allProbes(57),
+      'update/typebox': allProbes(58),
+    },
     drzl: 'unknown, which accepts every value in the pool',
     official: 'a Date',
     filed: 'new: integer({ mode: timestamp_ms }) is unnamed on 0.4x',
@@ -5882,7 +5954,7 @@ async function main() {
           seen.pairings++;
           seen.signatures.set(
             `${mode}/${libName}`,
-            drzlAll ? ALL_PROBES : `L: ${looser.join(', ')} | T: ${tighter.join(', ')}`
+            drzlAll ? allProbes(looser.length) : `L: ${looser.join(', ')} | T: ${tighter.join(', ')}`
           );
           seen.detail.push(`${mode}/${libName} ${looser.length} looser ${tighter.length} tighter`);
           observed.set(key, seen);
@@ -5975,10 +6047,9 @@ async function main() {
         claimed.add(hits[0]);
         const want = entry.divergence[hits[0]];
         if (want === sig) continue;
-        if (want === ALL_PROBES) {
+        if (want.startsWith('every probe official rejects')) {
           ledgerProblems.push(
-            `${name}[${key}] declares that DRZL accepts every probe on ${pairing}, and it does ` +
-              `not. Measured: ${sig}`
+            `${name}[${key}] on ${pairing} declares\n        ${want}\n      and measured\n        ${sig}`
           );
           continue;
         }
@@ -6664,10 +6735,14 @@ cd "$APP"
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
 echo "    typechecks under bundler, node16 and nodenext, and is compared column by column and value"
 echo "    by value against all four first-party drizzle-orm validator modules on each of three"
-echo "    dialects and three modes. Every difference either fails this run or is waived by name,"
-echo "    and each waiver pins the exact set of probes it covers, in both directions. That"
-echo "    comparison is the guarantee, and it is not \"at least as strict\": most waivers have DRZL"
-echo "    accepting something official refuses, the run counts them above, and each says why."
+echo "    dialects and three modes. Every difference either fails this run or is in one of two"
+echo "    ledgers by name: ALLOWED, where the difference is deliberate, or DEFECTS, where DRZL is"
+echo "    wrong and it is filed rather than fixed and named on every run with what each side"
+echo "    emits. Both ledgers are asserted the same way and in both directions, each entry"
+echo "    pinning the exact set of probes it covers, so a stale entry fails as loudly as an"
+echo "    unledgered difference. That comparison is the guarantee, and it is not \"at least as"
+echo "    strict\": most ledger entries have DRZL accepting something official refuses, the run"
+echo "    counts them above, and each says why."
 echo "    The four generators are cross-checked against each other on every dialect,"
 echo "    checked against a real Postgres, a real SQLite and, where MYSQL_URL is set, a real"
 echo "    MySQL, with applyDefaults compared against what the database writes, and described the"

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1532,6 +1532,45 @@ const ALLOWED: Record<string, Waiver> = {
   'sqlite/valibot/s_blob': { libs: ['valibot'], modes: MODE_NAMES, why: 'as pg/valibot/c_json; a bare blob() is Drizzle json mode', divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` } },
   'pg/valibot/c_point': { libs: ['valibot'], modes: MODE_NAMES, why: 'v.strictTuple rejects a third element; official v.tuple ignores extras', divergence: { '*/*': `L:  | T: [1,2,3]` } },
   'pg/valibot/c_geometry': { libs: ['valibot'], modes: MODE_NAMES, why: 'as pg/valibot/c_point', divergence: { '*/*': `L:  | T: [1,2,3]` } },
+  // Looser than official on purpose, and the only entries in either pass that run that way, so
+  // they are the ones to read carefully. The database is the arbiter here, not the first-party
+  // module, and it was asked directly through PGlite on each column's own SQL type.
+  //
+  // `real` / float4. Official bounds it at +/-8388607, and the column stores 8388608, 9000000,
+  // 1e9 and 2147483648 and returns every one of them unchanged, and holds every integer exactly
+  // to 16777216. So official's bound refuses rows the column hands back, and a select schema that
+  // did the same refused its own rows. DRZL bounds it where the database does instead:
+  // 3.4028234663852886e38 is accepted and 3.4028236e38 answers
+  // `"3.4028236e+38" is out of range for type real`. That is why 9007199254740993 is in the
+  // signature and 1e300 is not: the first is inside the float4 magnitude and the second is not.
+  //
+  // `double precision` / float8 and everything else backed by an 8 byte float. No bound at all,
+  // because there is no finite one that is true: float8 is the JavaScript number's own format and
+  // Postgres accepted every finite JS number into one, measured to Number.MAX_VALUE and returned
+  // identical. Official bounds it at +/-140737488355327, which refuses 1.75e15, an ordinary
+  // microsecond epoch.
+  //
+  // DRZL was on official's numbers for one release and this is the correction. The failure text
+  // this gate prints for an unwaived difference, "a generated schema looser than the first-party
+  // module accepts rows the database will reject", is exactly the equivalence that does not hold
+  // for these six: the database accepts every value in these signatures except the ones noted
+  // below. That is what makes them ALLOWED rather than DEFECTS, and the note is here because the
+  // sentence would otherwise read as an admission.
+  //
+  // Two values in these signatures the database is not on DRZL's side about:
+  //   9007199254740993   the JS literal is 9007199254740992, which a float8 holds exactly and a
+  //                      float4 rounds. Postgres stores it in both. It is here because no bound
+  //                      excludes it, not because a bound was chosen to admit it.
+  //   Infinity           Postgres stores and returns it in both types, so accepting it is right;
+  //                      only valibot and arktype do, because `z.number()` and `Type.Number()`
+  //                      refuse it with no bound at all. Filed: describing that column honestly
+  //                      needs a union in every generator rather than a range.
+  'pg/c_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'bounded at the float4 magnitude Postgres refuses rather than at drizzle-zod +/-8388607, which refuses rows the column returns', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` } },
+  'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_real; MySQL FLOAT is the same 4 byte width', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` } },
+  'pg/c_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'no finite bound is true of an 8 byte float, which holds every finite JS number', divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` } },
+  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; MySQL REAL is a synonym for DOUBLE', divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` } },
+  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double', divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` } },
+  'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; SQLite REAL is an 8 byte IEEE float', divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` } },
   // Official emits `Type.RegExp`, whose check runs `RegExp.prototype.test` against the raw value,
   // and `test` stringifies what it is given: `[]` becomes '' and matches `^[01]*$`. So official
   // accepts an empty array for a binary column. This generator emits a `string` carrying a
@@ -1584,6 +1623,19 @@ const CROSS_ALLOWED: Record<string, { why: string; divergence: string }> = {
   'sqlite/s_text_json': { why: 'as pg/c_json', divergence: `NaN: arktype accept, zod/valibot/typebox reject; Infinity: arktype accept, zod/valibot/typebox reject; Date: arktype accept, zod/valibot/typebox reject; Buffer: arktype accept, zod/valibot/typebox reject; Uint8Array: arktype accept, zod/valibot/typebox reject` },
   'sqlite/s_blob_json': { why: 'as pg/c_json', divergence: `NaN: arktype accept, zod/valibot/typebox reject; Infinity: arktype accept, zod/valibot/typebox reject; Date: arktype accept, zod/valibot/typebox reject; Buffer: arktype accept, zod/valibot/typebox reject; Uint8Array: arktype accept, zod/valibot/typebox reject` },
   'sqlite/s_blob': { why: 'as pg/c_json; a bare blob() is Drizzle json mode', divergence: `NaN: arktype accept, zod/valibot/typebox reject; Infinity: arktype accept, zod/valibot/typebox reject; Date: arktype accept, zod/valibot/typebox reject; Buffer: arktype accept, zod/valibot/typebox reject; Uint8Array: arktype accept, zod/valibot/typebox reject` },
+  // The four generators split on `Infinity` for every 8 byte float column, and only since those
+  // columns stopped carrying a magnitude bound. That is not a difference in what DRZL asked for:
+  // all four are handed the same column, with `integer: false` and no range, and `z.number()` and
+  // `Type.Number()` refuse a non-finite number on their own while `v.number()` and arktype's
+  // `number` accept one. Postgres stores and returns Infinity in `real` and `double precision`
+  // alike, so valibot and arktype are the two that agree with the database here.
+  //
+  // No `real` entry: the float4 bound refuses Infinity in all four, so they agree there for a
+  // reason that has nothing to do with the libraries.
+  'pg/c_double': { why: 'z.number() and Type.Number() refuse a non-finite number with no bound; v.number() and arktype number accept one, as Postgres does', divergence: `Infinity: valibot/arktype accept, zod/typebox reject` },
+  'mysql/m_real': { why: 'as pg/c_double', divergence: `Infinity: valibot/arktype accept, zod/typebox reject` },
+  'mysql/m_double': { why: 'as pg/c_double', divergence: `Infinity: valibot/arktype accept, zod/typebox reject` },
+  'sqlite/s_real': { why: 'as pg/c_double', divergence: `Infinity: valibot/arktype accept, zod/typebox reject` },
   // No bigint entry either, for the reason given in ALLOWED: arktype now bounds a bigint with a
   // narrow, so the four generators agree about `c_bigint_b`, `m_bigint_b` and `s_blob_bigint`.
   // No `c_char` entry. There was one, reading "zod and valibot count code points; TypeBox and
@@ -5225,6 +5277,40 @@ const ALLOWED: Record<string, Entry> = {
     official: 'v.tuple, which ignores a third element the column then drops',
     filed: 'not a defect: DRZL is stricter, and Postgres truncates what official accepts',
   },
+  // Looser than official, on purpose, and these six are the only entries in either pass that run
+  // that way. The reasoning, the PGlite measurements and the two caveats are written out once at
+  // the same six keys in the v1 pass near the top of this file, because both majors now take the
+  // database's answer and moving one without the other is what the cross-major diff catches.
+  //
+  // They were in DEFECTS below for one release, filed as "DRZL emits an unbounded number, official
+  // emits a number within +/-8388607". The fix that closed that filed the wrong way: it adopted
+  // official's bound, which refuses 8388608, 9000000, 1e9 and 2147483648 on a column that stores
+  // and returns all four. Review measured the cost against the ground-truth pool at ten probes
+  // Postgres stores and both DRZL and official refused. The bound is the database's now.
+  //
+  // `pg/c_numeric_n` is deliberately not among them. Its bound is the safe-integer range, which is
+  // about what a JS number can carry rather than about the column, official emits the same one,
+  // and Postgres is stricter than both: it refuses 2147483648 into a `numeric(10,2)`.
+  'pg/c_real': {
+    libs: LIB_NAMES,
+    modes: MODE_NAMES,
+    divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` },
+    drzl: 'a number within the float4 magnitude Postgres accepts',
+    official: 'a number within +/-8388607, which refuses rows the column returns',
+    filed: 'not a defect: the database is the arbiter, see the same key in the v1 pass',
+  },
+  'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` }, drzl: 'as pg/c_real', official: 'as pg/c_real', filed: 'as pg/c_real' },
+  'pg/c_double': {
+    libs: LIB_NAMES,
+    modes: MODE_NAMES,
+    divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` },
+    drzl: 'an unbounded number, because no finite bound is true of an 8 byte float',
+    official: 'a number within +/-140737488355327, which refuses an ordinary microsecond epoch',
+    filed: 'not a defect: as pg/c_real',
+  },
+  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993 | T: `, '*/valibot,arktype': `L: 9007199254740993, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
 };
 
 /**
@@ -5238,13 +5324,21 @@ const ALLOWED: Record<string, Entry> = {
  * plus four MySQL text columns, so no MySQL binary, no MySQL year and no SQLite column of any
  * kind had ever been described under both majors.
  *
- * Nine entries have left this map, which is what it is for. `pg/c_real`, `pg/c_double`,
- * `pg/c_numeric_n`, `mysql/m_real`, `mysql/m_double`, `mysql/m_float` and `sqlite/s_real` were
- * the class-name path carrying no bound at all for an inexact numeric column, and `pg/c_point`
- * and `pg/c_line` were it answering `string` for a value the driver hands back as a tuple. Both
- * are fixed in the analyzer rather than filed now, and removing an entry before the fix is what
- * showed the entry was covering the defect: taking these nine out on their own failed this stage
- * with 108 parity findings naming exactly those nine columns.
+ * Nine entries have left this map, which is what it is for, and they left by two different doors.
+ *
+ * `pg/c_point` and `pg/c_line` were the class-name path answering `string` for a value the driver
+ * hands back as a tuple. Fixed in the analyzer, and gone from both maps except for the valibot
+ * strict-tuple entry above, which is DRZL being the stricter one.
+ *
+ * `pg/c_real`, `pg/c_double`, `mysql/m_real`, `mysql/m_double`, `mysql/m_float` and
+ * `sqlite/s_real` were an inexact numeric column carrying no bound at all. They are in ALLOWED
+ * above now rather than gone: they are still divergences, in the opposite direction, because the
+ * bound DRZL adopted is the database's and not official's. `pg/c_numeric_n` is the one that is
+ * simply gone, since its safe-integer bound is what official emits too.
+ *
+ * Removing an entry before the fix is what showed the entry was covering the defect: taking the
+ * nine out on their own failed this stage with 108 parity findings naming exactly those nine
+ * columns.
  *
  * Two kinds of filed defect are not in this map, and they are not there for different reasons.
  *


### PR DESCRIPTION
## A `point` column rejected every row the driver returns

On `drizzle-orm@0.4x`, the major nearly every user runs, the analyzer typed `point` and `line` as
`string`. `packages/analyzer/src/index.ts` had a coarse fallback:

```ts
if (/Point|Line/i.test(ctor)) return { tsType: 'string', dbType: 'TEXT' };
```

So the emitted schema rejected `[1, 2]`, which is what `mapFromDriverValue` returns, and accepted
`"1,2"`, which it never produces. On insert too, where `mapToDriverValue` then received a value it
could not index. The codec path used on v1 got both right, which is why the cross-major diff could
see it.

The database settles it independently of what any validator says:

```
[1,2]  maps to (1,2)   accepted, reads back as [1,2]
"1,2"  maps to (1,,)   Postgres refuses it
```

## The float bounds were `drizzle-zod`'s heuristic, not the column's limit

The same fallback left floats unbounded, so DRZL accepted values official rejected. The obvious fix
was to copy official's bounds. That was wrong, and the first attempt at this shipped it: measured
against a real Postgres, **official's bounds reject values the database stores**.

```
before  probes where Postgres stores the value and both DRZL and official refuse it: 10
after                                                                                  5
        DRZL alone refuses it: 0
```

The five that remain are `Infinity` and `NaN`, described below.

**The bound is now split by dialect, because two databases disagree.** Both edges were found by
bisecting the raw bit pattern of a double against a real server, with values sent as literals so the
server parsed them rather than a driver:

| | edge | doubles above the largest float32 |
| --- | --- | --- |
| Postgres `real` | `3.4028235677973366e38` (`2**128 - 2**103`) | 268435456 |
| MySQL 8.4 `FLOAT` | the largest float32 exactly | 0 |

Widening every 4 byte float to Postgres's number would have promised a write MySQL answers
`Out of range value for column` to. `MySqlFloat` and `SingleStoreFloat` keep the narrower bound, now
measured rather than inherited.

That distinction is not academic: the old bound refused `3.4028235e+38`, which is the value a
text-protocol driver hands back for a full-magnitude float4. Refusing what the driver returns is the
same defect as the `point` typing above. A probe for exactly that value is now in both pools, inside
`ALLOWED[pg/c_real]`'s signature and outside `mysql/m_float`'s, so a regression either way fails by
name.

## Measured against the databases

| | before | after |
| --- | --- | --- |
| ground-truth probes | 1400 | 1440 |
| DRZL agrees with Postgres | 1012 | **1048** |
| `drizzle-orm` agrees | 979 | 1013 |
| DRZL closer than `drizzle-orm` | 33 | **35** |
| DRZL further | 0 | **0** |
| JSON Schema agrees | 857 of 1221 | 890 of 1258 |

Ledgers shrank as the defects were fixed: the cross-major map went from 54 fields on 33 columns to
32 on 26, and the 0.4x parity ledger from 22 known-defect columns to 13.

## What stops validating

Stated plainly because this ships. On `drizzle-orm@0.4x` a 4 byte float goes from unbounded to
bounded, so values above the float4 range that validated before are refused now, and `Infinity` is
refused by valibot and arktype where it was accepted before. `NaN` was never accepted by any
generator in any state. The changeset carries the same detail.

## Things this found and did not fix

Each is filed with its measurement rather than carried quietly:

- **Views are invisible to the analyzer on 0.4x**, so every view generates nothing at all.
- **Nothing in the parity comparison is nullable**: 0 of 40 Postgres columns, 0 of 29 MySQL, 0 of 14
  SQLite. Every generator's nullable path is emitted by every run and compared by nothing.
- **Both passes are blind to TypeBox optionality**, in either direction, because the harness reads
  `s.properties[k]` and TypeBox's `Optional` modifier is inert on an extracted property.
- **`point({mode:'xy'})` is typed `string` on both majors**, not only 0.4x. It needs a new
  `ColumnShape`, and no fixture in any gate contains an object-mode column.
- **Cockroach and MSSQL** state `number float` with no codec, so both take MySQL's narrower bound;
  that is wrong for Cockroach. Both dialects already lose whole type families to `unknown`.

## A gate for numbers in the documentation

Four user-facing numbers on this branch turned out to be false, and the fourth was found only after
five review rounds: `docs/guide/benchmarks.md` claimed `DRZL 1007 / closer on 28` for a run printing
1012 and 33. In every case the comment next to the code was right and only the prose away from the
code had drifted.

The benchmarks block is now compared line by line against a log the database stages write. Both
controls run: a fabricated digit fails naming the line, and breaking the anchor fails rather than
passing vacuously. The general case, numbers in prose with nothing behind them, is filed.

## Verification

`pnpm build`, `pnpm -r test` (918 tests across 12 packages), `pnpm typecheck`, `pnpm lint`,
`pnpm verify:packed` and `pnpm -C docs build` all pass.

Every control quoted here was run, reverted, and the tree verified byte identical afterwards.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
