### PR TITLE
fix(cli): read the printed version from the manifest instead of a literal

### DIFF
--- a/.changeset/cli-version-from-manifest.md
+++ b/.changeset/cli-version-from-manifest.md
@@ -1,0 +1,39 @@
+---
+'@drzl/cli': patch
+---
+
+`drzl --version` and `drzl -V` report the version you actually installed.
+
+Both printed `0.0.1` on every release the CLI has ever had. The registry lists 29 versions of
+`@drzl/cli` and 28 of them were wrong, so every version number in every bug report filed against
+this CLI has been `0.0.1` and none of them identified anything.
+
+**Where it came from.** `program.version('0.0.1')` in `src/cli.ts`, a literal written when the CLI
+was scaffolded. It was accurate for the first publish and for nothing after it. There was no
+manifest lookup to go wrong and no bundling involved: the number was simply typed into the source
+and left there while `package.json` moved on to `4.14.1`.
+
+**What it does now.** The version comes from the `version` field of the package's own
+`package.json`, read at startup from beside the running build. That file is the one the registry
+took the version from, so the two cannot disagree, including for anyone running a build from a
+branch or a tarball.
+
+Nothing falls back. If the manifest is missing, belongs to another package, or has no `version`,
+the CLI throws and names the path it looked at, because a placeholder standing in for a failed
+lookup is exactly what made this defect survive 28 releases.
+
+**Verified from an installed tarball**, not from the source tree: `pnpm pack`, `npm install` of the
+resulting `.tgz` into an empty directory, then the installed `drzl` binary, which prints `4.14.1`
+for `--version` and for `-V`. The published `@drzl/cli@4.14.1` prints `0.0.1` for both.
+
+The bin test in `packages/cli/test/every-entry-loads.spec.ts` ran the built binary throughout and
+asserted only that it printed something, which `0.0.1` did. It now asserts equality with the
+manifest, for `--version` and `-V`, from the ESM and CommonJS builds alike.
+
+One build change comes with this. `src/version.ts` locates the manifest through `import.meta.url`,
+which esbuild rewrites to `undefined` in a CommonJS output while warning `empty-import-meta`. The
+new `packages/cli/tsup.config.ts` gives the CommonJS build a real value for it, derived from
+`__filename`, rather than silencing the warning: that is the same shape as the
+`createRequire(import.meta.url)` defect in `@drzl/validation-core`, and leaving it silenced would
+have left the next unguarded use in this package resolving to `undefined` with nothing printed to
+say so. The banner repeats `"use strict"` so that the CommonJS bundles stay in strict mode.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,9 +17,10 @@ import {
 } from './config.js';
 import { diffSnapshots, restoreSnapshot, snapshotAll } from './drift.js';
 import { maybeShowSponsorMessage } from './sponsor.js';
+import { CLI_VERSION } from './version.js';
 
 const program = new Command();
-program.name('drzl').description('DRZL - Drizzle Developer Toolkit').version('0.0.1');
+program.name('drzl').description('DRZL - Drizzle Developer Toolkit').version(CLI_VERSION);
 program.addHelpText(
   'afterAll',
   `\nNeed a template, adapter, or generator DRZL doesn't ship yet?\n→ DM @omardulaimidev on X: https://x.com/omardulaimidev\n`

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,76 @@
+/**
+ * The version `drzl --version` prints, read from the manifest that ships beside the build.
+ *
+ * It used to be the literal `'0.0.1'`, passed to `program.version()` when the CLI was scaffolded
+ * and never touched again. That was true of exactly one release, the first: the registry lists 29
+ * versions of `@drzl/cli`, and the other 28 printed `0.0.1` as well. Reading the manifest is the
+ * only form that cannot drift, because it is the same file the registry took the version from.
+ *
+ * Nothing here falls back. A build that cannot find its own manifest, or finds someone else's, has
+ * resolved somewhere it did not intend to, and a placeholder standing in for that is how the
+ * original defect stayed invisible for 28 releases.
+ */
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** The name the manifest beside this build must carry, which is what makes it ours. */
+const PACKAGE_NAME = '@drzl/cli';
+
+/**
+ * The directory holding the file this code ends up in, in every form it is reached.
+ *
+ * Three of them: `dist/cli.js`, `dist/cli.cjs`, and this file unbundled under ts-node, all three
+ * run and checked. Only the CommonJS bundle has no `import.meta`; `tsup.config.ts` gives that
+ * build a real value for `import.meta.url` rather than esbuild's empty one, so this needs no
+ * branch. If that config is ever dropped, `fileURLToPath(undefined)` throws on load, so the
+ * CommonJS bundle stops working loudly instead of reporting the wrong directory.
+ */
+function moduleDir(): string {
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+
+/**
+ * The `version` a named manifest declares, or a throw naming what was wrong with it.
+ *
+ * Split out from the caller below only so the three ways it refuses can be exercised without a
+ * build. Nothing in the CLI passes a path.
+ */
+export function readVersionFrom(manifestPath: string): string {
+  let raw: string;
+  try {
+    raw = readFileSync(manifestPath, 'utf8');
+  } catch (e: any) {
+    throw new Error(
+      `${PACKAGE_NAME} cannot read its own version: no manifest at ${manifestPath} ` +
+        `(${e?.message ?? String(e)}).`
+    );
+  }
+
+  const manifest = JSON.parse(raw) as { name?: unknown; version?: unknown };
+
+  if (manifest.name !== PACKAGE_NAME) {
+    throw new Error(
+      `${PACKAGE_NAME} looked for its own version in ${manifestPath} and found ` +
+        `${JSON.stringify(manifest.name)}, so this build is not sitting where it thinks it is.`
+    );
+  }
+
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    throw new Error(`${manifestPath} declares no version, so there is nothing to report.`);
+  }
+
+  return manifest.version;
+}
+
+/**
+ * The `version` field of this package's own manifest.
+ *
+ * Both bundles sit one level below it, in `dist/`, and so does `src/` when this file is run
+ * unbundled, so one `..` covers every way it is reached. All three were run.
+ */
+export function readCliVersion(): string {
+  return readVersionFrom(path.join(moduleDir(), '..', 'package.json'));
+}
+
+export const CLI_VERSION = readCliVersion();

--- a/packages/cli/test/every-entry-loads.spec.ts
+++ b/packages/cli/test/every-entry-loads.spec.ts
@@ -45,6 +45,7 @@ const packagesDir = path.join(repoRoot, 'packages');
 
 interface Manifest {
   name: string;
+  version: string;
   private?: boolean;
   main?: string;
   bin?: Record<string, string>;
@@ -192,7 +193,12 @@ function requireBuilt(dir: string, file: string, declared: boolean) {
 }
 
 const cases = publishable.flatMap(({ dir, manifest }) =>
-  entryPoints(manifest).map((entry) => ({ dir, name: manifest.name, entry }))
+  entryPoints(manifest).map((entry) => ({
+    dir,
+    name: manifest.name,
+    version: manifest.version,
+    entry,
+  }))
 );
 
 it('found every publishable package', () => {
@@ -239,26 +245,34 @@ it('advertises a Node floor older than require(esm) everywhere', () => {
 
 const entriesOf = (dir: string) => entryPoints(publishable.find((p) => p.dir === dir)!.manifest);
 
-describe.each(cases)('$name $entry.subpath', ({ dir, entry }) => {
+describe.each(cases)('$name $entry.subpath', ({ dir, version, entry }) => {
   it('emits both an ESM entry and its CommonJS twin', () => {
     requireBuilt(dir, entry.esm, true);
     requireBuilt(dir, entry.cjs, entry.cjsDeclared);
   });
 
   if (entry.isBin) {
-    it.each(['esm', 'cjs'] as const)('runs as a program from the %s build', (format) => {
-      const abs = requireBuilt(dir, entry[format], format === 'esm' || entry.cjsDeclared);
-      // A bin cannot be imported for its exports: this one parses argv at module scope. Running
-      // it is what a consumer does and is the only thing that catches a bundle that cannot start.
-      const out = execFileSync(process.execPath, [abs, '--version'], {
-        cwd: probeDir,
-        encoding: 'utf8',
-        timeout: 60_000,
-      });
-      expect(
-        out.trim().length,
-        `${dir} ${format} bin printed nothing for --version`
-      ).toBeGreaterThan(0);
+    // A bin cannot be imported for its exports: this one parses argv at module scope. Running it
+    // is what a consumer does and is the only thing that catches a bundle that cannot start.
+    //
+    // The assertion is equality with the manifest, not merely that something was printed. For
+    // every one of the 29 published versions of @drzl/cli this printed the literal `0.0.1`,
+    // hardcoded in the `program.version()` call, while the manifest said otherwise; a
+    // non-empty check passed on all of them, so every version report ever filed was `0.0.1`.
+    it.each(['--version', '-V'])('prints the manifest version for %s, from both builds', (flag) => {
+      for (const format of ['esm', 'cjs'] as const) {
+        const abs = requireBuilt(dir, entry[format], format === 'esm' || entry.cjsDeclared);
+        const out = execFileSync(process.execPath, [abs, flag], {
+          cwd: probeDir,
+          encoding: 'utf8',
+          timeout: 60_000,
+        });
+        expect(
+          out.trim(),
+          `${dir} ${format} bin printed the wrong version for ${flag}; packages/${dir}/package.json ` +
+            `says ${version}. A stale dist is one cause, so try 'pnpm build' before reading further.`
+        ).toBe(version);
+      }
     });
     return;
   }

--- a/packages/cli/test/version.spec.ts
+++ b/packages/cli/test/version.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * What `drzl --version` reports, and what it does instead of reporting a wrong number.
+ *
+ * The CLI announced `0.0.1` for all 29 of its published versions, because `program.version()` was
+ * handed that literal at scaffolding time and the manifest moved on without it. The bin test in
+ * `every-entry-loads.spec.ts` ran the built binary the whole time and only asked whether anything
+ * came out, which `0.0.1` satisfies; that assertion is now equality, and this file covers the
+ * refusals, which running a correct build cannot reach.
+ *
+ * These load the source rather than `dist`, so they say nothing about the bundles. That is the
+ * other file's job, and the packed artefact's.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readCliVersion, readVersionFrom } from '../src/version';
+
+const manifestPath = path.join(import.meta.dirname, '..', 'package.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+  name: string;
+  version: string;
+};
+
+/** A manifest written where `readVersionFrom` will be pointed at it. */
+function manifestAt(body: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'drzl-version-'));
+  const file = path.join(dir, 'package.json');
+  fs.writeFileSync(file, JSON.stringify(body), 'utf8');
+  return file;
+}
+
+describe('readCliVersion', () => {
+  it('reports the version in its own manifest', () => {
+    expect(readCliVersion()).toBe(manifest.version);
+  });
+
+  it('does not report the scaffolded placeholder', () => {
+    // Belt and braces on the assertion above: if @drzl/cli is ever legitimately at 0.0.1 again the
+    // equality check would pass while the defect was back, and this is the version every report
+    // that has ever been filed against this CLI carried.
+    expect(manifest.version).not.toBe('0.0.1');
+    expect(readCliVersion()).not.toBe('0.0.1');
+  });
+});
+
+describe('readVersionFrom refuses rather than substituting', () => {
+  it('throws when there is no manifest where one was expected', () => {
+    const missing = path.join(os.tmpdir(), 'drzl-version-absent', 'package.json');
+    expect(() => readVersionFrom(missing)).toThrow(/cannot read its own version/);
+  });
+
+  it('throws when the manifest it found belongs to some other package', () => {
+    // The failure mode a bundler causes: the file resolves, so a read succeeds, and the number
+    // that comes back is someone else's.
+    const foreign = manifestAt({ name: 'not-drzl', version: '9.9.9' });
+    expect(() => readVersionFrom(foreign)).toThrow(/found "not-drzl"/);
+  });
+
+  it('throws when the manifest declares no version', () => {
+    const versionless = manifestAt({ name: manifest.name });
+    expect(() => readVersionFrom(versionless)).toThrow(/declares no version/);
+  });
+
+  it('throws on an empty version rather than printing an empty line', () => {
+    const blank = manifestAt({ name: manifest.name, version: '' });
+    expect(() => readVersionFrom(blank)).toThrow(/declares no version/);
+  });
+});

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'tsup';
+
+/**
+ * Entry points, formats and flags stay in the `build` script; this file exists for the one thing
+ * a tsup CLI flag cannot express.
+ *
+ * `src/version.ts` reads `import.meta.url` to find the manifest sitting beside the build. esbuild
+ * has no such thing in a CommonJS output: it rewrites `import.meta` to `{}`, warns
+ * `empty-import-meta`, and leaves `import.meta.url` as `undefined` at runtime. That is the same
+ * shape as the `createRequire(import.meta.url)` defect in `@drzl/validation-core`, where the CJS
+ * bundle got `createRequire(undefined)` and a `catch {}` hid it.
+ *
+ * So the CommonJS build gets a real value instead of a silenced warning: a banner computes the
+ * module URL from `__filename`, which CommonJS does have, and `define` points `import.meta.url` at
+ * it. Silencing the warning would have worked equally well for `version.ts`, which throws rather
+ * than reads `undefined`, and would have left the next unguarded `import.meta.url` in this package
+ * resolving to `undefined` with nothing on stdout to say so.
+ *
+ * The banner repeats `"use strict"` because it lands above esbuild's own copy, and a `var` ahead of
+ * that directive ends the prologue and drops the whole bundle into sloppy mode. Checked by running
+ * a file shaped that way, not inferred: an assignment to an undeclared name succeeded.
+ *
+ * esbuild hoists the hashbang above the banner, so `dist/cli.cjs` still starts with
+ * `#!/usr/bin/env node`.
+ */
+export default defineConfig({
+  esbuildOptions(options, context) {
+    if (context.format !== 'cjs') return;
+    options.banner = {
+      js: `"use strict";var __drzlModuleUrl = require("node:url").pathToFileURL(__filename).href;`,
+    };
+    options.define = { ...options.define, 'import.meta.url': '__drzlModuleUrl' };
+  },
+});


### PR DESCRIPTION
## Every version report ever filed against this CLI said `0.0.1`

`drzl --version` and `drzl -V` printed `0.0.1` at package version `4.14.1`. The registry lists 29
versions of `@drzl/cli`; the literal was accurate for the first one and for nothing after it.

The cause is the dullest available:

```ts
program.version('0.0.1')   // packages/cli/src/cli.ts:22
```

No manifest lookup to go wrong, no bundling involved. The number was typed in when the CLI was
scaffolded and never touched while `package.json` moved on.

## Why it survived 28 releases

A test already ran the built binary with `--version` on every build, and asserted:

```ts
expect(out.trim().length).toBeGreaterThan(0)
```

which `0.0.1` satisfies perfectly. The command was right, the assertion was about nothing. That test
now compares against the manifest, across `--version` and `-V` and both the ESM and CJS builds, and
it was confirmed to go red by putting the literal back:

```
× prints the manifest version for --version, from both builds
× prints the manifest version for -V, from both builds
AssertionError: expected '0.0.1' to be '4.14.1'
```

## Nothing falls back

A build that cannot find its own manifest, or finds someone else's, has resolved somewhere it did
not intend to, and a placeholder standing in for that is how the original defect stayed invisible.
All three refusals name the path:

```
missing  -> @drzl/cli cannot read its own version: no manifest at /nope/package.json (ENOENT ...)
foreign  -> @drzl/cli looked for its own version in <path> and found "drzl", so this build is not
            sitting where it thinks it is
empty    -> <path> declares no version, so there is nothing to report
```

## Verified from an installed tarball, not from source

```
packed + npm install     drzl --version -> 4.14.1     drzl -V -> 4.14.1
dist/cli.cjs directly                   -> 4.14.1
published @drzl/cli@4.14.1              -> 0.0.1      (control: the harness can tell them apart)
```

`src/version.ts` resolves the manifest through `import.meta.url`, which esbuild rewrites to
`undefined` in CJS output while warning `empty-import-meta`. Rather than silence that warning, the
new `tsup.config.ts` gives the CJS build a real value derived from `__filename`, so a future
unguarded `import.meta.url` in this package fails loudly rather than silently becoming `undefined`.
The emitted bundle keeps its shebang first and its directive prologue intact.

## Verification

`pnpm build` (0 warnings), `pnpm -r test` (924 tests across 12 packages), `pnpm typecheck` and
`pnpm lint` all pass. `verify:packed` was not run because another branch is editing it; it never
invokes `drzl --version`, and it checks that `pkg.bin` entries exist and that the bin resolves after
a real install, neither of which this touches.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
