### PR TITLE
fix(analyzer): see views on 0.x, type mssql/cockroach and gel columns, and cap JSON Schema by bytes

### DIFF
--- a/.changeset/gel-column-types.md
+++ b/.changeset/gel-column-types.md
@@ -1,0 +1,45 @@
+---
+'@drzl/analyzer': patch
+---
+
+Seven Gel column types are described from what a live Gel server actually returns.
+
+`boolean()` had no case in the analyzer's Gel arm at all and fell off the end to `unknown`, so every
+generator emitted a field that refused nothing. The six `cal::` and duration columns were typed
+`string`, which is worse: a wrong type rejects every row rather than accepting every value.
+
+Measured on a live Gel 7.1 (`geldata/gel:7`, `sys::get_version_as_str()` -> `7.1+08db576`) through
+`drizzle-orm/gel` 0.45.2 on `gel@2.2.0`, writing one row and reading it back:
+
+```
+column        gel-core declares        SELECT hands back    INSERT accepts
+boolean       boolean                  boolean  true        -
+timestamp     LocalDateTime            LocalDateTime        LocalDateTime
+localDate     LocalDate                LocalDate            LocalDate
+localTime     LocalTime                LocalTime            LocalTime
+dateDuration  DateDuration             RelativeDuration     DateDuration
+relDuration   RelativeDuration         RelativeDuration     RelativeDuration
+duration      Duration                 RelativeDuration     Duration
+timestamptz   Date        (control)    Date                 -
+decimal       string      (control)    string  '12.34'      -
+```
+
+A string is refused on insert by all six and returned by none, so `string` was wrong in both
+directions, not merely loose. `dateDuration` and `duration` contradict drizzle's own `.d.ts` on the
+way out and agree with it on the way in; the server is the arbiter for both halves.
+
+**What changes for you.** A Gel `boolean()` column now emits a real boolean check: `'yes'`, `12345`
+and `{ a: 1 }` were accepted before and are rejected now. The six temporal columns now report
+`tsType: 'unknown'`, so their emitted field goes from a string check that rejected every row to one
+that accepts the value the driver hands back, and each raises a `DRZL_ANL_UNKNOWN_COLUMN` warning
+naming its Gel type (`cal::local_datetime`, `cal::local_date`, `cal::local_time`, `dateDuration`,
+`edgedbt.relative_duration_t`, `duration`).
+
+**Why `unknown` and not a class name.** The value is an instance of a class from the `gel` package,
+which DRZL cannot import, so no generator can emit a check for it. A tsType naming the class would
+also suppress the unknown-column warning, which fires on `unknown`. Stating nothing and saying so is
+the honest answer; the check itself stays open and is tracked separately.
+
+**What does not change.** `integer`, `smallint`, `bigintT`, `bigint`, `text`, `uuid`, `json`, `real`,
+`doublePrecision`, `decimal`, `bytes`, `timestamptz` and `.array()` are all unaffected, and every one
+of them was read out of the same row.

--- a/.changeset/json-schema-byte-caps.md
+++ b/.changeset/json-schema-byte-caps.md
@@ -1,0 +1,38 @@
+---
+'@drzl/generator-json-schema': patch
+---
+
+A MySQL TEXT column now carries its cap in the emitted JSON Schema, and says what the format cannot
+express.
+
+The analyzer reports a MySQL `tinytext`, `text`, `mediumtext` or `longtext` column with `maxBytes`,
+the budget the column type itself imposes. The four validation generators encode the string and
+count the bytes. This one ignored the field, so on drizzle-orm 0.4x, where such a column carries no
+declared length either, the emitted schema was `{ "type": "string" }` and a document validated
+against it could still be refused by the database.
+
+Asked of a real MySQL 8 on utf8mb4 in `STRICT_TRANS_TABLES`, on a `TINYTEXT` column whose budget is
+255 bytes, with the emitted module compiled by ajv:
+
+```
+                       MySQL     before    after
+255 ascii, 255 bytes   accepts   accepts   accepts
+256 ascii, 256 bytes   REFUSES   accepts   REFUSES
+ 63 emoji, 252 bytes   accepts   accepts   accepts
+ 64 emoji, 256 bytes   REFUSES   accepts   accepts
+```
+
+**What changes for you.** A string column with a byte budget gains `maxLength` holding that number,
+and a `description` naming the budget. If you were sending values over the cap, the database was
+already refusing the write. `varchar(n)` columns are untouched: that limit really is characters, and
+it already had one.
+
+**What it still cannot do.** JSON Schema has no byte-length keyword in any draft, and inventing one
+produces a document that either fails to compile in a strict validator or is silently ignored by a
+lax one. `maxLength` counts characters, and UTF-8 spends at least one byte per character, so the cap
+refuses nothing the column accepts and catches every overflow made of one-byte characters. It cannot
+catch a multi-byte string that fits the count and not the budget, which is the last row of the table
+above, so that is what the `description` says.
+
+Binary columns are unaffected, because they travel as base64 and a character cap taken from a byte
+budget would refuse a legal value.

--- a/.changeset/mssql-cockroach-boolean-and-string.md
+++ b/.changeset/mssql-cockroach-boolean-and-string.md
@@ -1,0 +1,45 @@
+---
+'@drzl/analyzer': patch
+---
+
+`mssql` and `cockroach` columns no longer lose their boolean and string families to `unknown`.
+
+Both cores arrived with Drizzle v1 and neither had a fixture anywhere in this repository. Measured
+by running the real analyzer over a real `mssqlTable` and a real `cockroachTable` on
+drizzle-orm 1.0.0-rc.4: **7 of 23 mssql columns and 6 of 27 cockroach columns came back
+`tsType: 'unknown'`**, and all thirteen were booleans or strings.
+
+```
+mssql       flag(bit) name(varchar) nname(nvarchar) code(char) ncode(nchar) body(text) nbody(ntext)
+cockroach   flag(boolean) name(varchar) code(char) body(text) str(string) tags(text[])
+```
+
+`describeV1Column` recognised a v1 column by its `codec` or by the semantic half of its `dataType`.
+Swept across every column builder the two cores export, 22 and 27 of them, **not one states a
+codec**, and those thirteen state a bare `dataType` with no semantic half either: a `bit` says
+`boolean`, and `varchar`/`nvarchar`/`char`/`nchar`/`text`/`ntext`/`string` all say `string`. That is
+indistinguishable from a Drizzle 0.4x column, so all thirteen fell to the class-name path, which has
+arms for Pg, MySql, SingleStore and Gel and none for these two. `drizzle:entityKind` is now a third
+v1 marker, sound for exactly these two because `mssql-core` and `cockroach-core` ship only on v1:
+the strings `MsSql` and `Cockroach` appear nowhere in the installed 0.45.2 package.
+
+The emitted validators accepted every value for those columns. Executed, not read, across all five
+generators, against values two real servers handed back or refused: 25 of 50 mssql probes and 25 of
+60 cockroach probes were wrong before, and 0 of each after. SQL Server 2022 refuses `'yes'` for a
+`bit` and refuses a 121st character in a `varchar(120)`; CockroachDB v24.3 refuses `1` for a `bool`
+and refuses a bare string for a `string[]`. Every one of those was accepted by the generated select
+and insert schemas in zod, valibot, arktype, typebox and JSON Schema.
+
+A cockroach `real` is also now bounded where Postgres bounds one rather than where MySQL does.
+`information_schema` reports its `crdb_sql_type` as `FLOAT4` and it speaks the Postgres wire
+protocol, so it carries the Postgres read-back this package already records: measured on v24.3,
+inserting the largest finite float32 makes the column hand back `3.4028235e+38`, a *larger* double,
+so the MySQL bound refused a row the column had just returned. MSSQL keeps MySQL's bound, which is
+where falling through already put it and which SQL Server 2022 confirms: a `real` stores
+`3.4028234663852886e38` and refuses the next candidate up with an arithmetic overflow.
+
+**What changes for you.** If you generate from an mssql or cockroach schema, those columns now
+produce a real validator instead of one that accepts anything, and the `DRZL_ANL_UNKNOWN_COLUMN`
+warning they raised is gone. Input that only ever validated because nothing was checking it will
+now be rejected, which is the point. No other dialect is affected: the new marker only matches
+class names those two cores own.

--- a/.changeset/views-on-drizzle-0-4x.md
+++ b/.changeset/views-on-drizzle-0-4x.md
@@ -1,0 +1,48 @@
+---
+'@drzl/analyzer': minor
+---
+
+A view in your schema now produces schemas on drizzle-orm 0.x, as it already did on 1.0.0.
+
+On every 0.x release a view answers `undefined` to `drizzle:Columns`, `drizzle:Name` and
+`drizzle:Schema`; its columns and its name live only in `Symbol.for('drizzle:ViewBaseConfig')`. On
+1.0.0 `View` declares all three as getters over that same config. The analyzer identifies a
+table-like export by asking for `drizzle:Columns`, so on 0.x it skipped every view, and said
+nothing about it. `@drzl/analyzer` and `@drzl/cli` both depend on `drizzle-orm@^0.45.2`, so the
+broken major was the default one.
+
+Probed with a fresh install of each: invisible on 0.29.5, 0.33.0, 0.36.4, 0.39.3, 0.44.7, 0.45.0
+and 0.45.2; visible on 1.0.0-beta.1, beta.24, rc.1 and rc.4. Every dialect with a view API is
+affected: `pgView`, `pgMaterializedView`, `mysqlView` and `sqliteView`, in their query-builder,
+explicit-column-list, `.existing()` and schema-qualified forms alike.
+
+**What changes for you.** On 0.x, a schema file with views now emits a module per view and a line
+per view in the barrel, where it emitted nothing before. A fixture of 2 tables and 7 views went
+from 3 emitted files to 10. A file of nothing but views also stops reporting
+`dialect: unknown` with a spurious `DRZL_ANL_DIALECT` warning, because the loop that identifies
+the dialect read the raw symbol rather than going through the resolver, and was the one read site
+a fallback in the resolver did not reach.
+
+The measured target was parity, and it is met: on a fixture covering join, aggregate, `.existing()`,
+schema-qualified and materialized views, 0.45.2's analysis is byte-identical to 1.0.0-rc.4's, and
+so is the emitted zod. 1.0.0-rc.4's own analysis is unchanged by this release.
+
+**A SQLite view is now read-only.** SQLite refuses every write to a view, measured with
+`node:sqlite`: `insert`, `update` and `delete` all fail with `cannot modify <name> because it is a
+view`. That is the argument `readOnly` already makes for a materialized view, so a `sqliteView` now
+carries it too and gets a select schema and nothing else. Postgres and MySQL both accept a write to
+a simple auto-updatable view, verified against a real server on each, so their plain views are
+unchanged.
+
+**Two things a view inherits from Drizzle that the server does not agree with**, both already
+present on 1.0.0 and neither addressed here. A view's columns keep the base column's `notNull` and
+its `primary`, because that is what Drizzle records in `selectedFields`. Postgres reports every view
+column nullable, so `SelectuserOrdersSchema` rejects `{"userId":2,"userName":"bob","total":null}`,
+a row PGlite really returned from a `LEFT JOIN` view. MySQL agrees for the join column and disagrees
+for the simple view's, computing nullability per column. Neither reports a primary key on a view,
+while DRZL reports one for the join view and the service and oRPC generators build by-id, update and
+delete endpoints on it. Both are filed.
+
+New export: `isDrizzleView(val)`, which asks `drizzle:ViewBaseConfig` rather than
+`drizzle:IsDrizzleView`; the latter looks like the obvious question and was only introduced in
+drizzle-orm 0.39.0.

--- a/.superpowers/sdd/2026-08-03-top-100/mssql-cockroach-report.md
+++ b/.superpowers/sdd/2026-08-03-top-100/mssql-cockroach-report.md
@@ -1,0 +1,340 @@
+# mssql and cockroach lose their boolean and string families to `unknown`
+
+Branch `fix/mssql-cockroach-types`. Status: **fixed**, with two further defects measured and filed
+rather than fixed.
+
+There was no salvaged measurement for this one, so everything below was measured first. Two real
+servers were run in Docker and asked directly: **SQL Server 2022** (`mcr.microsoft.com/mssql/server:2022-latest`)
+and **CockroachDB v24.3** (`cockroachdb/cockroach:latest-v24.3`). Both dialects exist only on
+drizzle-orm v1, so the tables were built against `drizzle-orm@1.0.0-rc.4`.
+
+---
+
+## 1. The measurement, before any change
+
+A real `mssqlTable` with 23 columns and a real `cockroachTable` with 27 columns, run through the
+real `SchemaAnalyzer`. Every field the analyzer states is recorded; fields it does not state are
+omitted rather than shown as absent.
+
+### mssql, 23 columns, **7 `unknown`**
+
+| column | builder | tsType | dbType | nullable | other |
+|---|---|---|---|---|---|
+| i | `int` | number | INTEGER | true | min -2147483648, max 2147483647, integer true |
+| ti | `tinyint` | number | NUMERIC | true | min -9007199254740991, max 9007199254740991, **integer false** |
+| si | `smallint` | number | SMALLINT | true | min -32768, max 32767, integer true |
+| b53 | `bigint({mode:'number'})` | number | BIGINT | true | min -9007199254740991, max 9007199254740991, integer true |
+| b64 | `bigint({mode:'bigint'})` | bigint | BIGINT | true | min -9223372036854775808, max 9223372036854775807, integer true |
+| **flag** | `bit` | **unknown** | **UNKNOWN** | true | |
+| price | `decimal` | string | NUMERIC | true | format numeric |
+| num | `numeric` | string | NUMERIC | true | format numeric |
+| fl | `float` | number | DOUBLE | true | integer false |
+| rl | `real` | number | REAL | true | min/max +/-340282346638528859811704183484516925440, integer false |
+| **name** | `varchar(120)` | **unknown** | **UNKNOWN** | true | maxLength 120 |
+| **nname** | `nvarchar(120)` | **unknown** | **UNKNOWN** | true | maxLength 120 |
+| **code** | `char(4)` | **unknown** | **UNKNOWN** | true | maxLength 4 |
+| **ncode** | `nchar(4)` | **unknown** | **UNKNOWN** | true | maxLength 4 |
+| **body** | `text` | **unknown** | **UNKNOWN** | true | |
+| **nbody** | `ntext` | **unknown** | **UNKNOWN** | true | |
+| d | `date` | Date | DATE | true | |
+| dt | `datetime` | Date | DATE | true | |
+| dt2 | `datetime2` | Date | DATE | true | |
+| dto | `datetimeoffset` | Date | DATE | true | |
+| tm | `time` | Date | DATE | true | |
+| bin | `binary(16)` | Buffer | BYTEA | true | shape `{kind:'buffer'}` |
+| vbin | `varbinary(32)` | Buffer | BYTEA | true | shape `{kind:'buffer'}` |
+
+No column carries `arrayDimensions` or `enumValues`; `mssql-core` exports no array or enum builder.
+Seven `DRZL_ANL_UNKNOWN_COLUMN` warnings were raised, one per unknown column.
+
+### cockroach, 27 columns, **6 `unknown`**
+
+| column | builder | tsType | dbType | nullable | other |
+|---|---|---|---|---|---|
+| i | `int4` | number | INTEGER | true | min -2147483648, max 2147483647, integer true |
+| si | `smallint` | number | SMALLINT | true | min -32768, max 32767, integer true |
+| b53 | `bigint({mode:'number'})` | number | BIGINT | true | min/max safe-integer, integer true |
+| b64 | `bigint({mode:'bigint'})` | bigint | BIGINT | true | min/max 64 bit, integer true |
+| **flag** | `boolean` | **unknown** | **UNKNOWN** | true | |
+| dec | `decimal` | string | NUMERIC | true | format numeric |
+| num | `numeric` | string | NUMERIC | true | format numeric |
+| rl | `real` | number | REAL | true | min/max +/-340282346638528859811704183484516925440, integer false |
+| fl | `float` | number | DOUBLE | true | integer false |
+| dp | `doublePrecision` | number | DOUBLE | true | integer false |
+| **name** | `varchar(120)` | **unknown** | **UNKNOWN** | true | maxLength 120 |
+| **code** | `char(4)` | **unknown** | **UNKNOWN** | true | maxLength 4 |
+| **body** | `text` | **unknown** | **UNKNOWN** | true | |
+| **str** | `string` | **unknown** | **UNKNOWN** | true | |
+| u | `uuid` | string | UUID | true | format uuid |
+| payload | `jsonb` | any | JSON | true | shape `{kind:'json'}` |
+| d | `date` | string | DATE | true | |
+| ts | `timestamp` | Date | DATE | true | |
+| tm | `time` | string | TIME | true | |
+| iv | `interval` | string | INTERVAL | true | |
+| ip | `inet` | string | INET | true | |
+| bt | `bit({dimensions:3})` | string | BINARY | true | shape `{kind:'bitstring',length:1,exact:false}` |
+| vb | `varbit({dimensions:8})` | string | BINARY | true | shape `{kind:'bitstring',exact:false}` |
+| g | `geometry({type:'point'})` | [number, number] | GEOMETRY | true | shape `{kind:'tuple',length:2}` |
+| vec | `vector({dimensions:3})` | number[] | VECTOR | true | shape `{kind:'numberVector',length:3}` |
+| m | `cockroachEnum` | string | TEXT | true | enumValues ['sad','ok','happy'] |
+| **tags** | `text().array()` | **unknown** | **UNKNOWN** | true | arrayDimensions 1 |
+
+Six `DRZL_ANL_UNKNOWN_COLUMN` warnings. Dialect detection worked on both: `mssql` and `cockroach`.
+
+**13 unknown columns, all of them booleans or strings.** `tags` is the string hole wearing an
+array: its element is the same `CockroachString` that `body` is.
+
+---
+
+## 2. Why
+
+`describeV1Column` recognised a v1 column two ways, `codec` or the semantic half of `dataType`, and
+mssql and cockroach columns have neither. Swept across **every column builder both cores export**,
+22 for mssql and 27 for cockroach:
+
+- **Not one states a `codec`.** Zero of 49.
+- Thirteen state a bare `dataType` with no semantic half: `bit` says `boolean`; `varchar`,
+  `nvarchar`, `char`, `nchar`, `text`, `ntext`, `string`, `bool`, `boolean` all say `boolean` or
+  `string`.
+
+`{ dataType: 'string' }` with no codec is exactly what a Drizzle 0.4x column looks like, so the gate
+sent all thirteen to the class-name fallback, which carries arms for `Pg*`, `MySql*`,
+`SingleStore*` and `Gel*` and none for these two. They fell off the end to `unknown`/`UNKNOWN`.
+
+Every other dataType in both cores carries a semantic half and already passed the gate, which is
+why the failure is exactly the boolean and string families and nothing else.
+
+---
+
+## 3. Ground truth, from the servers
+
+Rows inserted through drizzle's own drivers (`drizzle-orm/node-mssql`, `drizzle-orm/cockroach`) and
+read back.
+
+### SQL Server 2022
+
+```
+bit           -> JS true / false                  ('yes' refused: "Conversion failed when
+                                                    converting the varchar value 'yes' to bit")
+varchar(120)  -> JS string   'hello'              (121 chars refused: "String or binary data
+                                                    would be truncated", 120 accepted)
+nvarchar(120) -> JS string
+char(4)       -> JS string   'ab  '  (space padded to the declared width)
+nchar(4)      -> JS string   'cd  '
+text / ntext  -> JS string
+tinyint       -> JS number   0..255               (256 refused, -1 refused, both "Arithmetic
+                                                    overflow error for data type tinyint")
+real          -> 3.4028234663852886e38 stored and returned exactly;
+                 3.4028235677973366e38 refused, "Arithmetic overflow error for type real"
+```
+
+### CockroachDB v24.3
+
+```
+bool          -> JS true / false                  (1 refused: "value type int doesn't match
+                                                    type bool of column")
+varchar(120)  -> JS string                        (121 chars refused: "value too long for
+                                                    type VARCHAR(120)")
+char(4)       -> JS string   'ab  '
+string / text -> JS string
+string[]      -> JS string[]  ['a','b'] and []    ('a' refused: "could not parse \"a\" as
+                                                    type string[]")
+real          -> information_schema crdb_sql_type FLOAT4.
+                 Insert 340282346638528859811704183484516925440 (the largest finite float32)
+                 and the column hands back 3.4028235e+38, which as a double is
+                 3.4028235e38 > 3.4028234663852886e38. Larger magnitudes are not refused;
+                 the column saturates to infinity.
+```
+
+---
+
+## 4. What the generated validators did, executed
+
+All five generators, run over the analyzer's real output, emitted module imported and executed.
+Each probe value is one a server returned or refused.
+
+| | probes | wrong before | wrong after |
+|---|---|---|---|
+| mssql, 5 generators x (flag, name, body) | 50 | **25** | **0** |
+| cockroach, 5 generators x (flag, name, tags) | 60 | **25** | **0** |
+
+Identical five ways: zod, valibot, arktype, typebox and JSON Schema (compiled and run under ajv)
+each accepted `'yes'` for a `bit`, `1` for a `bool`, a 121-character string for a `varchar(120)`,
+`12345` for a `varchar`, `{a:1}` for a `text` and `[1,2]` for a `string[]`. The JSON Schema
+generator emitted the property as literally `{}`, which is a valid schema that accepts every
+instance.
+
+The array wrapper was the one thing already working: `arrayDimensions` was read even while the
+element type was not, so a bare `'a'` was refused for `tags` before the fix. Only the element was
+open.
+
+---
+
+## 5. The fix
+
+`packages/analyzer/src/index.ts`, three hunks inside `describeV1Column` and its preamble.
+
+1. A third v1 marker, `V1_ONLY_ENTITY_KINDS = /^(?:MsSql|Cockroach)/`, checked on
+   `drizzle:entityKind`. Sound for exactly these two because `mssql-core` and `cockroach-core` ship
+   only on v1: grepping the whole installed `drizzle-orm@0.45.2` package finds the strings `MsSql`
+   and `Cockroach` in none of its files, so no 0.4x column can reach it. `drizzle:entityKind`
+   rather than `constructor.name` because it survives minification, which is what the rest of this
+   function already uses.
+2. The gate becomes `if (typeof codec !== 'string' && !semantic && !V1_ONLY_ENTITY_KINDS.test(entityKind)) return null;`.
+   Past it, the existing `default:` arm already handles `js === 'boolean'` and `js === 'string'`
+   correctly, and `maxLength` was already arriving from `columnConstraints`.
+3. The `float` arm picks Postgres's 4 byte bound for cockroach, keeping MySQL's for mssql and
+   singlestore. See addendum V below.
+
+Everything the fix did **not** need to touch stayed untouched: the `default:` arm's body, the
+`numeric` arm and the class-name fallback are unchanged, so the diff does not overlap the regions
+other agents are working in.
+
+The 13 columns now read:
+
+```
+mssql       flag boolean/BOOLEAN;  name nname string maxLength 120;  code ncode string maxLength 4;
+            body nbody string, no maxBytes (MySQL's TEXT caps are a MySQL fact; SQL Server's
+            text holds 2 GB, so borrowing 65535 would refuse rows this server stores)
+cockroach   flag boolean/BOOLEAN;  name string maxLength 120;  code string maxLength 4;
+            body str string;  tags string + arrayDimensions 1
+```
+
+`dbType` for the string family is `TEXT` rather than `VARCHAR`/`CHAR`, because those two spellings
+are keyed off a codec neither dialect states. That matches what a Postgres `varchar` already
+reports on the class-name path (`case 'PgVarchar': return { tsType: 'string', dbType: 'TEXT' }`),
+and `dbType` feeds exactly one decision anywhere in the repo, `isIntegerColumn`'s
+`dbType === 'INTEGER'` fallback, which a string column never reaches.
+
+Unknown counts after: **0 of 23 and 0 of 27**, and zero `DRZL_ANL_UNKNOWN_COLUMN` issues.
+
+## 6. The test
+
+`packages/generator-zod/test/mssql-cockroach-types.spec.ts`, 14 tests. Written first; all 10
+substantive ones failed for the right reasons before the fix (the 3 that passed are the dialect
+name, the column counts and the mssql float bound, which the fix must not move).
+
+It builds real `mssqlTable` and `cockroachTable` modules, runs the **real** `SchemaAnalyzer` over
+them, feeds the **real** analysis to the **real** `ZodGenerator`, then imports the emitted module
+and executes it. Nothing reads emitted text.
+
+Reaching drizzle v1 needed a dependency: `packages/generator-zod` gains a devDependency
+`"drizzle-orm-v1": "npm:drizzle-orm@1.0.0-rc.4"`. Aliased, so `import 'drizzle-orm'` everywhere
+else still resolves to the 0.45.2 the workspace measures against, and devDependencies are not
+published. It lives in `generator-zod` rather than `analyzer` because the analyzer cannot import a
+generator (the dependency runs the other way), and this file needs both halves in one process.
+
+The fourteenth test guards the near-miss the new marker creates: `MySqlVarChar` and `MsSqlVarChar`
+differ by one letter, and a 0.45.2 MySQL column presents the exact shape the marker was added to
+admit, `dataType: 'string'` with no codec. Catching it would send every 0.4x MySQL string and
+boolean down the v1 path and past the byte caps the class-name path applies. Checked against the
+real package rather than reasoned about: a real `varchar`, `boolean` and `text` from
+`drizzle-orm@0.45.2/mysql-core` all still return `null` from `describeV1Column`.
+
+Both the test and the fix were mutation-checked rather than trusted:
+
+| mutation | result |
+|---|---|
+| the fix removed entirely (the branch base) | 10 of the 13 fail, each naming its column |
+| `/^(?:MsSql\|Cockroach)/` -> `/Sql\|Cockroach/` | the near-miss test fails, **and** so does `analyzer/test/floats-and-tuples-0.4x.spec.ts` independently |
+| `/^(?:MsSql\|Cockroach)/` -> the same with `/i` | **nothing fails, and nothing should**: `MsSql` and `MySql` differ at position 1 in the letter itself, not in its case, so that edit changes no answer. Recorded because it was the first mutation tried and a green run on it would have looked like a vacuous test |
+
+## 7. Verification
+
+```
+pnpm build           pass
+pnpm -r test         pass, 945 tests across 12 packages, 0 failures. 14 of those are new here.
+pnpm typecheck       pass
+pnpm lint            pass
+pnpm verify:packed   pass, exit 0, and byte-identical to the same run on the branch base
+```
+
+`scripts/verify-packed.sh` was not touched and was run read-only, from this worktree.
+
+**No count and no ledger in it moved, measured rather than reasoned.** It was run twice: once with
+the analyzer reverted to the branch base and once with the fix, and the two logs were compared line
+by line. Both exit 0. Ignoring the shell echoes, timings and temp paths that differ between any two
+runs, the two are **424 lines each and identical**, the only difference being the exit marker this
+branch appended to each log to tell them apart. All **144 parity lines match one for one**, same
+dialects, same generators, same modes, same `n/n cols compared`, same waived counts.
+
+That is what should have happened: the script contains no reference to `mssql` or `cockroach`
+anywhere, so it has no fixture that can reach either dialect, and the new marker matches only class
+names those two cores own. The point of running it both ways is that "cannot reach" is an argument
+and this is a measurement.
+
+Its opening stage still prints its standing WARN about four comment blocks in `verify-packed.sh`
+itself that state a quantity in the idiom a restated one is written in. That WARN is identical in
+both runs. The stage reads only `scripts/verify-packed.sh`, which this branch did not edit, so
+those four are that file's to settle and the controller's to touch. Read by hand for this branch's
+own prose instead: the counts in the new comments and in the changeset are measurements taken
+against the servers and the builder sweep, not restatements of a declaration sitting beside them.
+
+Its opening stage still prints its standing WARN about four comment blocks in `verify-packed.sh`
+itself that state a quantity in the idiom a restated one is written in. That stage reads only
+`scripts/verify-packed.sh`, which this branch did not edit, so those four are exactly the four that
+were there before; they are that file's to settle and the controller's to touch. Read for this
+branch's own prose: the counts in the new comments and in the changeset are measurements taken
+against the servers and the sweep, not restatements of a declaration sitting beside them.
+
+---
+
+## 8. Filed, not fixed
+
+### Addendum V, closed: cockroach `real` bound. **Fixed here.**
+
+The filing was right and is now measured. CockroachDB's `real` is a `FLOAT4`
+(`information_schema.columns.crdb_sql_type`) spoken over the Postgres wire, so it carries the
+Postgres read-back this package already documents at `PG_FLOAT4_RANGE`: insert the largest finite
+float32 and the column hands back `3.4028235e+38`, a *larger* double, so a select schema bounded at
+MySQL's edge, which is that float32 exactly, refused a row the column had just returned. Now
+bounded at `PG_FLOAT4_RANGE`.
+
+MSSQL, which the same filing grouped with it, turns out to be right where it was. SQL Server 2022
+stops a `real` exactly at the largest finite float32 and refuses the next candidate up with an
+arithmetic overflow, which is MySQL's bound, which is where falling through already put it. That is
+now asserted so a future cockroach change cannot drag it along.
+
+One thing no range describes either way: CockroachDB does not refuse a magnitude at all, saturating
+to infinity instead. That is the same open `Infinity`/`NaN` gap this package already records for
+Postgres.
+
+### New: mssql `tinyint` is unsigned, and DRZL calls it a wide non-integer
+
+`tinyint` states `dataType: 'number uint8'`, and `uint8` is not in the width table in
+`describeV1Column` (`int8` through `int64` plus `uint53` are). It falls through to the bare-number
+arm and comes out `dbType: 'NUMERIC'`, `integer: false`, `min: '-9007199254740991'`,
+`max: '9007199254740991'`.
+
+Measured on SQL Server 2022: the column takes 0 and 255, and refuses 256 and -1, both with
+"Arithmetic overflow error for data type tinyint". It is unsigned, 0..255, and it is an integer.
+Fractions are truncated rather than refused, measured on the same server:
+
+```
+insert 1.5  -> stored 1
+insert 2.5  -> stored 2
+insert 2.4  -> stored 2
+```
+
+so a select never returns a fraction either. The emitted schema today accepts `-1`, `256`, `1e15`
+and `1.5` for a column that stores none of them.
+
+The fix is two lines, `uint8: ['0', '255']` in the same range map plus its `dbType`, but it is a
+different defect from the one this branch was given and the map is a region other agents are
+editing. Filed with the measurement rather than folded in.
+
+### Not a defect, checked: mssql `time` typed as `Date`
+
+`MsSqlTime` states `dataType: 'object date'`, so the analyzer answers `tsType: 'Date'`, where every
+other dialect in this repo types a `time` column as a string. That looked like an inconsistency
+worth filing, so it was probed instead of assumed. Inserting `'13:45:30'` into a `time` column on
+SQL Server 2022 and reading it back through the `mssql` driver returns a real `Date` instance
+(epoch day, time of day set), so `Date` is the correct type and the difference from the other
+dialects is a real difference in the drivers. The offset the driver applies to the time of day is a
+separate question this branch did not investigate.
+
+### Not a defect, checked: the `char(n)` cap
+
+Both servers space-pad a `char(4)` to exactly four characters, so `maxLength: 4` and a
+code-point-count check accept what comes back. Probed through the emitted schema with the exact
+padded strings both servers returned.

--- a/.superpowers/sdd/2026-08-03-top-100/views-0-4x-report.md
+++ b/.superpowers/sdd/2026-08-03-top-100/views-0-4x-report.md
@@ -1,0 +1,258 @@
+# views-not-relations-0-4x: fixed
+
+Branch `fix/views-on-0-4x`, one commit on top of `b0822df`. Status: **done**, with two inherited
+defects filed rather than fixed and one pre-existing generator gap filed.
+
+## What was wrong
+
+A drizzle-orm 0.x view answers `undefined` to all three of `drizzle:Columns`, `drizzle:Name` and
+`drizzle:Schema`. Its columns and its name live only in `Symbol.for('drizzle:ViewBaseConfig')`. On
+1.0.0 the `View` class declares those three as prototype getters over that same config
+(`node_modules/drizzle-orm/sql/sql.js`, the `View` class: `[TableName]`, `[TableSchema]` and
+`[TableColumns]` return `this[ViewBaseConfig].name / .schema / .selectedFields`), so a view answers
+exactly as a table does. It is prototype getters, not a Proxy as the salvaged measurement said; the
+observable behaviour is the same.
+
+The analyzer identifies a table-like export by asking for `drizzle:Columns`, so on 0.x it skipped
+every view and raised no issue. `packages/analyzer/package.json` and `packages/cli/package.json`
+both pin `drizzle-orm@^0.45.2`, so the broken major was the default one.
+
+## The read sites: the measurement named four, and four is the number
+
+Verified by enumerating every `drizzle:Columns`, `drizzle:Name` and `drizzle:Schema` read in
+`packages/analyzer/src/index.ts`, and every `Symbol.for(` read in every other package.
+
+| site | before | reached by a resolver-only fix |
+| --- | --- | --- |
+| discovery gate, `analyze()` | `this.getSymbol(val, 'drizzle:Columns')` | yes |
+| `analyzeTable` columnsObj | `this.getSymbol(tbl, 'drizzle:Columns')` | yes |
+| `analyzeTable` name and schema | `this.getSymbol(tbl, 'drizzle:Name' / 'drizzle:Schema')` | yes |
+| dialect loop | `(val)[Symbol.for('drizzle:Columns')]` **direct** | **no** |
+
+There is no fifth. `grep -n "Symbol.for(" packages/analyzer/src/index.ts` returns exactly one other
+`drizzle:Columns` read, which is the dialect loop above; the remaining hits are
+`drizzle:entityKind` on a column's constructor, which a view's columns answer normally because they
+are the base table's column objects. `grep -rn "Symbol.for(" packages/*/src/*.ts` outside the
+analyzer returns nothing at all: no other package reads a Drizzle symbol. The enum capture inside
+the discovery loop reads the `cols` local the gate produced, so it follows the gate.
+
+`getSymbolOf` at `:704`/`:717`/`:718` (relations v2) and `this.getSymbol` at `:841`/`:895` (foreign
+tables, `relations()` objects) share the resolver and are unaffected either way, as the measurement
+said.
+
+### The partial-fix experiment, run rather than argued
+
+With the resolver fixed and the dialect loop left as it was, on a file of nothing but two pg views:
+
+```
+dialect=unknown  relations=2  issues=["DRZL_ANL_DIALECT"]
+```
+
+and with both fixed, `dialect=postgres relations=2 issues=[]`. So the fourth site is load-bearing
+and is now guarded by a test.
+
+**The measurement's stated consequence of that state is wrong.** It says `dialect: unknown` "drops
+every column to its coarse default". Measured in exactly that state, the columns are untouched:
+
+```
+id -> number/INTEGER   label -> string/TEXT   live -> boolean/BOOLEAN   seen -> Date/TIMESTAMP
+```
+
+`analyzeTable` reads each column object directly and never consults the dialect, and the dialect is
+computed after every table has already been analysed. The real cost of the missed site is that
+`analysis.dialect` is wrong in the CLI's `analyze --json` output and in the public `Analysis` type,
+plus a spurious `DRZL_ANL_DIALECT` warning whose hint ("Column types will fall back to their coarse
+defaults") does not apply to that case. No generator reads `analysis.dialect` at all
+(`grep -rn "\.dialect\b" packages/*/src/*.ts` outside the analyzer: no hits). The comment in the
+source now says the measured thing.
+
+## A version fact the salvaged measurement did not have
+
+Sweeping 11 published versions with a fresh `npm i` each, probing own symbols as well as lookups:
+
+```
+0.29.5   viewOwn ["drizzle:ViewBaseConfig","drizzle:PgViewConfig"]                          IsDrizzleView: ABSENT
+0.33.0   same                                                                               IsDrizzleView: ABSENT
+0.36.4   same                                                                               IsDrizzleView: ABSENT
+0.39.3   viewOwn ["drizzle:ViewBaseConfig","drizzle:IsDrizzleView","drizzle:PgViewConfig"]  IsDrizzleView: present
+0.44.7 / 0.45.0 / 0.45.2                                                                    IsDrizzleView: present
+1.0.0-beta.1 / beta.24 / rc.1 / rc.4                                                        IsDrizzleView: present
+```
+
+`drizzle:IsDrizzleView` was introduced in 0.39.0. It reads like the obvious way to recognise a view
+and it is not there to be asked on three of the seven 0.x releases probed. `drizzle:ViewBaseConfig`
+is an own symbol on all eleven, so `isDrizzleView()` asks that instead. The first draft of this fix
+used `IsDrizzleView` and would have silently not marked a `sqliteView` read-only on drizzle < 0.39.
+
+`drizzle:Columns`, `drizzle:Name` and `drizzle:Schema` are undefined on all seven 0.x and answered
+on all four 1.0.0, matching the salvaged measurement exactly.
+
+## The fix
+
+`packages/analyzer/src/index.ts`, five small regions:
+
+1. `getSymbolOf` gains a fallback: when a lookup misses, and the key is one of the three a view
+   holds in its config, read `drizzle:ViewBaseConfig` and take `selectedFields` / `name` / `schema`.
+   Own-symbol scanning is split into `ownSymbolOf` so the fallback cannot recur. The analyzer still
+   does not import drizzle-orm.
+2. The class's private `getSymbol` was a second, identical copy of that resolver. It now delegates,
+   so the two cannot drift and a fallback added to either reaches every caller of both.
+3. New export `isDrizzleView(val)`, asking `drizzle:ViewBaseConfig`.
+4. The dialect loop reads through the resolver.
+5. A SQLite view is marked `readOnly` once the dialect is known.
+
+## Parity, which was the success criterion
+
+Harness: the analyzer **source** loaded with jiti from two trees, one with `drizzle-orm@0.45.2` and
+one with `1.0.0-rc.4`, over the same 9-export fixture (2 tables, a simple view, a `LEFT JOIN` view,
+an aggregate view with a raw `sql` alias, an `.existing()` view with an explicit column list, a
+materialized view, a schema-qualified view and a schema-qualified materialized view). Tables and
+relations sorted, then `JSON.stringify(..., null, 2)`.
+
+```
+md5 4b495a36680e2bb3e729045955c61a49  v1 before the fix
+md5 4b495a36680e2bb3e729045955c61a49  v1 after the fix
+md5 4b495a36680e2bb3e729045955c61a49  0.45.2 after the fix
+md5 8e56c016cc109cd19db1e0f0cd5bd745  0.45.2 before the fix   (2 relations, not 9)
+```
+
+Byte-identical three ways, and v1's own output is untouched by this change. The emitted zod is
+byte-identical too: `diff -r out-d04 out-v1` is empty over 10 files. Before the fix that directory
+held 3 files (`index.ts`, `orders.zod.ts`, `users.zod.ts`).
+
+The same check on the fixture the committed test builds (8 exports, no aggregate view): identical,
+`issues: []` on both majors.
+
+The readOnly rule survives: `reportMv.zod.ts` exports `SelectreportMvSchema` and nothing else, on
+both majors, because `drizzle:PgMaterializedViewConfig` is an own symbol on all eleven releases.
+
+Degradation is identical on both majors too: the aggregate view's `sql` alias becomes one `unknown`
+column with `DRZL_ANL_UNKNOWN_COLUMN`, on 0.45.2 and on rc.4 alike.
+
+## What the databases said
+
+**SQLite** (`node:sqlite`, Node 22):
+
+```
+FAIL insert into active_users  -> cannot modify active_users because it is a view
+FAIL update active_users       -> cannot modify active_users because it is a view
+FAIL delete from active_users  -> cannot modify active_users because it is a view
+pragma table_info(active_users): every column notnull=0, pk=0
+```
+
+So a `sqliteView` insert or update schema describes an operation SQLite always refuses, and that is
+the same argument the code already makes for a materialized view. `sqliteView` is now `readOnly`.
+
+**Postgres** (PGlite 0.5.4, PostgreSQL 18):
+
+```
+OK   insert into simple view     -> the row really appears in users
+OK   update simple view
+FAIL insert into join view       -> cannot insert into view "user_orders"
+FAIL update join view            -> cannot update view "user_orders"
+FAIL delete from join view       -> cannot delete from view "user_orders"
+FAIL insert into matview         -> cannot change materialized view "user_stats"
+FAIL update matview              -> cannot change materialized view "user_stats"
+is_nullable: every column of every view = YES, including active_users.name whose base is NOT NULL
+pg_class/pg_index: active_users v/0 pks, user_orders v/0 pks, user_stats m/0 pks, users r/1 pk
+select * from user_orders -> {"userId":2,"userName":"bob","total":null}
+```
+
+**MySQL 8.4.11** (my own container, started and removed; the other agents' containers untouched):
+
+```
+OK   insert into simple view     -> the row really appears in users
+OK   update simple view
+FAIL insert into user_orders     -> ERROR 1471 not insertable-into
+FAIL update/delete user_orders   -> ERROR 1288 not updatable
+FAIL insert into order_totals    -> ERROR 1471
+information_schema.views is_updatable: active_users YES, user_orders NO, order_totals NO
+is_nullable: user_orders.total = YES although orders.total is NOT NULL;
+             active_users.id and .name = NO
+no PRIMARY constraint on any view
+```
+
+Postgres and MySQL both accept a write to a simple auto-updatable view, so leaving their plain views
+writable stays right for the simple case and over-permissive for the join case. That is unchanged
+and is not made worse here.
+
+**One correction to the salvaged measurement.** It says "no database gives a view column a
+NOT NULL". MySQL does: `active_users.id` and `active_users.name` are `is_nullable=NO`. Postgres
+reports YES for everything, MySQL computes it per column. So the nullability defect below is
+dialect-dependent, not universal.
+
+## Tests
+
+Both were written first and watched fail for the right reason.
+
+`packages/analyzer/test/views-0.4x.spec.ts`, 8 cases, all 8 red before the fix. The reds were the
+real ones: `expected 'unknown' to be 'postgres'` for the views-only dialect case, and
+`Cannot read properties of undefined` everywhere a view should have been a table.
+
+`packages/cli/test/views.e2e.spec.ts`, 4 cases, all 4 red before the fix with
+`no activeUsers.zod.ts was emitted; got: index.ts, schema.mjs, users.zod.ts`. This one builds a real
+Drizzle schema, runs the real analyzer, emits with the real generator, **imports the emitted
+module**, and hands its schema a row a real SQLite returned from a real view; it also executes the
+insert SQLite refuses and asserts on the message before asserting that no insert schema was emitted.
+It lives in `packages/cli` because that is the only package with both `drizzle-orm` and the
+generators.
+
+The pre-existing `packages/analyzer/test/materialized-views.spec.ts` is left alone. It hand-builds
+objects and calls `isReadOnlyRelation` directly, so it passes on both majors while the feature is
+dead on one; the two new files are the ones that can fail.
+
+Full run, all green: **943 tests / 110 files** (`pnpm -r test`), up from 931/108. `pnpm build`,
+`pnpm typecheck` and `pnpm lint` all clean.
+
+## verify-packed
+
+`pnpm verify:packed` was run **read-only** and passed, ending on its `OK: 12 packages packed, ...`
+banner under `set -euo pipefail`. `git diff -- scripts/verify-packed.sh` is empty.
+
+**No count and no ledger in it moves.** Its fixtures contain no view of any kind
+(`grep -n "pgView\|sqliteView\|mysqlView\|MaterializedView" scripts/verify-packed.sh` returns one
+hit, and it is a word inside the comment quoted below), so nothing it measures is touched by this
+change.
+
+**One hand-off for whoever owns that file.** The comment at `scripts/verify-packed.sh:5781-5785`
+says `readOnly` is outside the cross-major field coverage because "`pgMaterializedView` answers a
+`drizzle:Columns` lookup on 1.0.0-rc.4 and returns undefined on 0.45.2, so the analyzer sees no
+0.4x view of any kind as a relation ... Covering `readOnly` means dealing with that first." That is
+now dealt with. Adding a `pgMaterializedView` to the cross-major parity fixture makes `readOnly`
+land on both sides and closes the one field that stage names as uncovered. Left alone here.
+
+## Filed, not fixed
+
+**1. A view's columns keep the base column's `notNull`.** Drizzle's `selectedFields` clone the base
+columns, so DRZL reports `user_orders.total` as `nullable: false` and emits
+`total: z.number().int()...`, which **rejects** `{"userId":2,"userName":"bob","total":null}`, a row
+PGlite really returned. Postgres reports every view column nullable; MySQL widens only the ones the
+outer join makes optional. Already wrong on 1.0.0 today; this change makes it reachable on 0.x too.
+Fixing it means deciding whether a view's nullability follows the server (which differs by dialect)
+or the query, and it changes every view's emitted select schema on both majors. Too large for this
+commit; stated in the changeset.
+
+**2. A view is reported with a primary key it does not have.** The cloned base column carries
+`primary: true`, so the analysis says `user_orders.primaryKey = {columns: ['userId']}`. No catalog
+agrees: `pg_index.indisprimary` gives 0 primary keys for relkind `v` and `m`, MySQL has no `PRIMARY`
+constraint on any view, and SQLite's pragma reports `pk=0`. Generated, the consequence is real:
+`userOrderService.getById(id) / update(id, ...) / delete(id)` and oRPC `create/update/delete` on a
+view Postgres refuses to update or delete. Removing it changes the shape of the service and oRPC
+output for every view on both majors. Filed.
+
+**3. Six of seven generators ignore `readOnly`.** `grep -rn "readOnly" packages/*/src/*.ts` finds it
+only in `@drzl/analyzer` and `@drzl/generator-zod`. Verified by generating: for the materialized view
+`reportMv`, zod correctly emits `SelectreportMvSchema` alone, while `generator-service` emits
+`create`, `update` and `delete` methods and `generator-orpc` emits `create/update/delete` procedures.
+Neither breaks a build (service emits its own `types/` and oRPC inlines its schemas, so nothing
+imports the insert schema zod withholds), but both offer a call the database always refuses. Already
+true on 1.0.0; newly reachable on 0.x. Filed rather than fixed: it is a change in six packages.
+
+## Files
+
+- `packages/analyzer/src/index.ts` (+74/-15, five regions)
+- `packages/analyzer/test/views-0.4x.spec.ts` (new, 8 cases)
+- `packages/cli/test/views.e2e.spec.ts` (new, 4 cases, executes the emitted module)
+- `docs/generators/zod.md` (the unconditional "views get schemas too" promise is now true, plus the
+  SQLite read-only fact and a warning naming defects 1 and 2)
+- `.changeset/views-on-drizzle-0-4x.md` (`@drzl/analyzer`: minor)

--- a/docs/generators/json-schema.md
+++ b/docs/generators/json-schema.md
@@ -110,6 +110,40 @@ nothing pretends to enforce it:
 The four validation generators do enforce these. See
 [the ArkType generator](/generators/arktype) or [the valibot generator](/generators/valibot).
 
+### A byte budget
+
+MySQL's TEXT family is capped by the type in **bytes**, not by a declared length in characters:
+`tinytext` holds 255 bytes, `text` 65535, `mediumtext` 16777215, `longtext` 4294967295. No draft of
+JSON Schema has a byte-length keyword, and an invented one is not a constraint: a strict validator
+refuses to compile it and a lax one ignores it.
+
+So the budget is emitted as `maxLength`, which counts characters, with the part it cannot carry
+written beside it:
+
+```json
+{
+  "type": "string",
+  "maxLength": 255,
+  "description": "At most 255 bytes of UTF-8, which JSON Schema has no keyword for. maxLength counts characters: it refuses nothing the column accepts, and a string of multi-byte characters can satisfy it and still be too long for the column."
+}
+```
+
+UTF-8 spends at least one byte per character, so that cap **never refuses a value the column
+accepts**, and it catches every overflow made of one-byte characters. What it cannot catch is a
+string that fits the character count and not the budget. Asked of a real MySQL 8 on utf8mb4, on a
+`tinytext` column:
+
+| Value | Bytes | Characters | MySQL | This schema |
+| --- | --- | --- | --- | --- |
+| 255 ascii | 255 | 255 | accepts | accepts |
+| 256 ascii | 256 | 256 | refuses | refuses |
+| 63 emoji | 252 | 63 | accepts | accepts |
+| 64 emoji | 256 | 64 | refuses | accepts |
+
+The four validation generators encode the string and count the bytes, so they get the last row
+right. `varchar(n)` is genuinely characters in the same database and is unaffected: it keeps
+`maxLength` from its declared length.
+
 ## Values as they survive JSON
 
 The schema describes the value **after** `JSON.stringify`, which is not always what the TypeScript

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -469,9 +469,23 @@ A **materialized view** gets a select schema and nothing else. `INSERT INTO mv .
 `cannot change materialized view`, so an insert or update schema for one describes an operation
 the database will always refuse.
 
-An ordinary view keeps all three. Postgres accepts an `INSERT` into a simple auto-updatable view,
-and whether a given view qualifies depends on its query rather than on anything the schema file
-states, so refusing them all would take away something that works.
+An ordinary view keeps all three on Postgres and MySQL. Both accept an `INSERT` into a simple
+auto-updatable view, verified against a real server on each, and whether a given view qualifies
+depends on its query rather than on anything the schema file states, so refusing them all would
+take away something that works.
+
+A **SQLite view** gets a select schema and nothing else, materialized or not. SQLite refuses
+every write to a view: `insert`, `update` and `delete` all fail with
+`cannot modify <name> because it is a view`.
+
+::: warning A view's columns follow Drizzle, not the server
+The nullability and the primary key of a view's columns are inherited from the base columns the
+view selects, because that is what Drizzle records. No server agrees in full: Postgres reports
+every view column nullable, MySQL widens the nullable ones a join makes optional, and neither
+reports a primary key on a view. So a select schema for a view can reject a row the database
+really returns, and the service and oRPC generators build by-id endpoints on views that have no
+key to look up by.
+:::
 
 ## Custom names
 

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -365,6 +365,28 @@ const TUPLE_CLASS_SHAPES: Record<string, ColumnShape> = {
 };
 
 /**
+ * Column families that arrived with Drizzle v1 and exist on no earlier release, by
+ * `drizzle:entityKind`.
+ *
+ * The third v1 marker, after the `codec` and the semantic half of `dataType`. Both of those are
+ * properties of a column, and mssql and cockroach columns have neither: swept across every column
+ * builder the two cores export, 22 and 27 of them, **not one states a codec**, and thirteen state
+ * a bare `dataType` with no semantic half either (`bit` says `boolean`; `varchar`, `nvarchar`,
+ * `char`, `nchar`, `text`, `ntext`, `string` all say `string`). Those thirteen are exactly the two
+ * dialects' boolean and string families, and they were indistinguishable from a 0.4x column, so
+ * every one of them fell to the class-name path, which has arms for Pg, MySql, SingleStore and Gel
+ * and none for these two, and came back `unknown`.
+ *
+ * The class name is the marker of last resort here rather than the first choice, and it is sound
+ * for exactly these two: `mssql-core` and `cockroach-core` ship only on v1. Checked rather than
+ * assumed, by grepping the whole installed 0.45.2 package: the strings `MsSql` and `Cockroach`
+ * appear in none of its files, so no 0.4x column can reach this.
+ *
+ * `drizzle:entityKind` rather than `constructor.name`, because it survives minification.
+ */
+const V1_ONLY_ENTITY_KINDS = /^(?:MsSql|Cockroach)/;
+
+/**
  * Everything Drizzle v1 states about a column outright, or `null` on an older Drizzle.
  *
  * v1 stamps each column with a `dataType` of the form `"<js type> <semantic>"` (`"number
@@ -393,12 +415,17 @@ export function describeV1Column(column: any): Partial<Column> | null {
     };
   }
 
+  const entityKind = String(column?.constructor?.[Symbol.for('drizzle:entityKind')] ?? '');
   const [js, semantic = ''] = dataType.split(' ');
   // SQLite columns carry a `dataType` but no `codec` at all, so gating on the codec alone left
   // the whole dialect on the class-name path: its json text and blob modes stayed `any`, its
   // buffer mode stayed `unknown`, and its bigint blob mode lost its range. A semantic half is
   // just as good a v1 marker, since 0.4x spells every dataType as a single bare word.
-  if (typeof codec !== 'string' && !semantic) return null;
+  //
+  // mssql and cockroach state neither, on their boolean and string families, so the two markers
+  // above left thirteen columns looking exactly like 0.4x ones. Their class names are the third
+  // marker; see `V1_ONLY_ENTITY_KINDS`.
+  if (typeof codec !== 'string' && !semantic && !V1_ONLY_ENTITY_KINDS.test(entityKind)) return null;
 
   const out: Partial<Column> = {};
 
@@ -449,21 +476,33 @@ export function describeV1Column(column: any): Partial<Column> | null {
       break;
     case 'float':
     case 'double': {
-      // Only the 4 byte width has a magnitude the database will refuse, and the two databases that
-      // have one refuse at different values, so the codec picks which. `float4` is Postgres's
-      // spelling and `float` is MySQL's. Three dialects state `number float` with no codec at all
-      // on 1.0.0-rc.4, measured: SingleStore, Cockroach and MSSQL. All three land on MySQL's bound
-      // by falling through, which is right for SingleStore and matches the answer its class-name
-      // entry gives on 0.4x, and is **wrong for Cockroach**, whose `real` is a Postgres `FLOAT4`
-      // over the Postgres wire. That is filed rather than fixed: Cockroach and MSSQL lose whole
-      // type families to `unknown` today, so a bound is not the defect worth fixing first, and
-      // neither dialect has a fixture in any gate that would prove a fix. The cross-major diff is
-      // what holds SingleStore's two answers together.
+      // Only the 4 byte width has a magnitude the database will refuse, and the databases that
+      // have one do not put the edge in the same place, so the codec picks which. `float4` is
+      // Postgres's spelling and `float` is MySQL's. Three dialects state `number float` with no
+      // codec at all on 1.0.0-rc.4, measured: SingleStore, Cockroach and MSSQL, so each needs
+      // deciding on something else.
+      //
+      // SingleStore and MSSQL take MySQL's, which is where falling through already put them.
+      // SingleStore is MySQL wire-compatible and matches the answer its class-name entry gives on
+      // 0.4x, which the cross-major diff holds together. MSSQL was measured on SQL Server 2022:
+      // a `real` column stores 3.4028234663852886e38, the largest finite float32 and MySQL's exact
+      // edge, and refuses the next candidate up with "Arithmetic overflow error for type real".
+      //
+      // Cockroach takes Postgres's, and falling through was wrong for it. `information_schema`
+      // reports its `real` as crdb_sql_type FLOAT4 and it speaks the Postgres wire protocol, so it
+      // inherits the Postgres defect this file already records at PG_FLOAT4_RANGE: measured on
+      // v24.3, inserting the largest finite float32 makes the column hand back 3.4028235e+38,
+      // which is a *larger* double, so a schema bounded at MySQL's edge refused a row the column
+      // had just returned. It does not refuse a magnitude at all, saturating to infinity instead,
+      // which no finite range can describe either way; the bound is set by what comes back.
       //
       // Both majors take the same answer here on purpose: the bound moved off `drizzle-orm/zod`'s
       // and onto the database's, and moving one major without the other is what that diff catches.
       if (semantic === 'float')
-        [out.min, out.max] = codec === 'float4' ? PG_FLOAT4_RANGE : MYSQL_FLOAT_RANGE;
+        [out.min, out.max] =
+          codec === 'float4' || entityKind.startsWith('Cockroach')
+            ? PG_FLOAT4_RANGE
+            : MYSQL_FLOAT_RANGE;
       out.integer = false;
       out.tsType = 'number';
       out.dbType = semantic === 'float' ? 'REAL' : 'DOUBLE';

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -635,15 +635,61 @@ function declaredLength(column: any): number | undefined {
   return typeof n === 'number' && Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
-/** `getSymbol` as a free function, for the readers that live outside the class. */
-function getSymbolOf(target: any, key: string): unknown {
-  if (!target) return undefined;
+/**
+ * The three lookups a view answers on drizzle-orm 1.0.0 and on no 0.x release, and the field of
+ * `drizzle:ViewBaseConfig` each one comes from.
+ *
+ * On 1.0.0 `View` declares `drizzle:Name`, `drizzle:Schema` and `drizzle:Columns` as prototype
+ * getters over its `drizzle:ViewBaseConfig`, so a view answers all three exactly as a table does.
+ * On 0.x those getters do not exist and the config is the only place a view's columns and name
+ * are recorded, so every one of the three comes back undefined and a view looks like nothing.
+ *
+ * Probed with a fresh install of each: all three undefined on 0.29.5, 0.33.0, 0.36.4, 0.39.3,
+ * 0.44.7, 0.45.0 and 0.45.2, all three answered on 1.0.0-beta.1, beta.24, rc.1 and rc.4. The
+ * config itself is an own symbol on all eleven.
+ */
+const VIEW_CONFIG_FIELDS: Record<string, string> = {
+  'drizzle:Columns': 'selectedFields',
+  'drizzle:Name': 'name',
+  'drizzle:Schema': 'schema',
+};
+
+/** An own symbol by description. Separate from `getSymbolOf` so the view fallback cannot recur. */
+function ownSymbolOf(target: any, key: string): unknown {
   try {
     for (const sym of Object.getOwnPropertySymbols(target)) {
       if ((sym as any).description === key) return (target as any)[sym];
     }
   } catch {}
-  return (target as any)[Symbol.for(key)];
+  return undefined;
+}
+
+/** `getSymbol` as a free function, for the readers that live outside the class. */
+function getSymbolOf(target: any, key: string): unknown {
+  if (!target) return undefined;
+  const own = ownSymbolOf(target, key);
+  if (own !== undefined) return own;
+  const direct = (target as any)[Symbol.for(key)];
+  if (direct !== undefined) return direct;
+  // A 0.x view, whose columns and name are only in its config.
+  const field = VIEW_CONFIG_FIELDS[key];
+  if (!field) return undefined;
+  const cfg = ownSymbolOf(target, 'drizzle:ViewBaseConfig') as any;
+  return cfg ? cfg[field] : undefined;
+}
+
+/**
+ * Whether an export is a Drizzle view, of any dialect and on either major.
+ *
+ * Asked of `drizzle:ViewBaseConfig` rather than of `drizzle:IsDrizzleView`, which reads like the
+ * obvious question and is not there to be asked: the marker was introduced in 0.39.0, and a view
+ * built on 0.29.5, 0.33.0 or 0.36.4 answers undefined to it. The config is an own symbol on all
+ * eleven releases probed and on every view form measured, on both majors: the query-builder and
+ * explicit-column-list forms of pg view, pg materialized view, mysql view and sqlite view,
+ * `.existing()`, and the schema-qualified pg view and materialized view.
+ */
+export function isDrizzleView(val: any): boolean {
+  return !!val && typeof val === 'object' && !!getSymbolOf(val, 'drizzle:ViewBaseConfig');
 }
 
 /**
@@ -728,16 +774,9 @@ export class SchemaAnalyzer {
   constructor(private readonly schemaPath: string) {}
 
   private getSymbol(table: any, key: string) {
-    if (!table) return undefined;
-    try {
-      const syms = Object.getOwnPropertySymbols(table);
-      for (const s of syms) {
-        if ((s as any).description === key) {
-          return (table as any)[s];
-        }
-      }
-    } catch {}
-    return (table as any)[Symbol.for(key)];
+    // One resolver rather than two identical ones, so a fallback added to either is reached by
+    // every caller of both.
+    return getSymbolOf(table, key);
   }
 
   /**
@@ -1666,6 +1705,8 @@ export class SchemaAnalyzer {
     const enums: Enum[] = [];
     // Enums seen on a column, resolved against the exported ones once the loop below ends.
     const columnEnums: Enum[] = [];
+    // Views, held aside for the read-only pass that runs once the dialect is known.
+    const viewTables: Table[] = [];
 
     // Identify table-like exports by presence of Drizzle symbols
     for (const [name, val] of Object.entries(exportsObj)) {
@@ -1674,6 +1715,7 @@ export class SchemaAnalyzer {
         if (cols && typeof cols === 'object') {
           const table = this.analyzeTable(name, val, issues);
           tables.push(table);
+          if (isDrizzleView(val)) viewTables.push(table);
 
           // Enum capture is deliberately outside any relations guard. It used to sit inside
           // `if (opts.includeRelations)`, so a caller that only wanted tables silently lost
@@ -1751,7 +1793,13 @@ export class SchemaAnalyzer {
     let dialect: Dialect = 'unknown';
     const marks = new Set<string>();
     for (const [_, val] of Object.entries(exportsObj)) {
-      const cols = (val as any)?.[Symbol.for('drizzle:Columns')];
+      // Through the resolver, not `val[Symbol.for('drizzle:Columns')]`. This loop read the
+      // symbol itself, so it was the one site a fallback added to the resolver did not reach.
+      // Measured with the resolver fixed and this line left as it was, on a file of nothing but
+      // pg views: both views analysed, `dialect: unknown`, and a DRZL_ANL_DIALECT warning whose
+      // hint does not apply. The columns keep their types either way, since `analyzeTable` reads
+      // each column object and never consults the dialect.
+      const cols = this.getSymbol(val, 'drizzle:Columns');
       if (!cols) continue;
       for (const c of Object.values(cols) as any[]) {
         const kind = c?.constructor?.[Symbol.for('drizzle:entityKind')] as string | undefined;
@@ -1770,6 +1818,23 @@ export class SchemaAnalyzer {
     else if (/MySql|Mysql/i.test(names)) dialect = 'mysql';
     else if (/Pg|Postgres/i.test(names)) dialect = 'postgres';
     else if (/Gel/i.test(names)) dialect = 'gel';
+
+    // SQLite refuses every write to a view, so an insert or update schema for one describes an
+    // operation the database will always refuse. Measured with node:sqlite: insert, update and
+    // delete against a plain `create view` all fail with "cannot modify <name> because it is a
+    // view". That is the same argument `isReadOnlyRelation` already makes for a materialized
+    // view, and it holds for every SQLite view rather than for one construction of one.
+    //
+    // Only SQLite. Postgres and MySQL both accept a write to a simple auto-updatable view, and
+    // whether a given view qualifies depends on its query rather than on anything the schema
+    // file states.
+    //
+    // Decided here rather than in `isReadOnlyRelation` because the dialect is a fact about the
+    // schema and not about the export: a view selecting nothing but `sql` aliases carries no
+    // column that names a dialect, so asking the export alone gets no answer for it.
+    if (dialect === 'sqlite') {
+      for (const view of viewTables) view.readOnly = true;
+    }
 
     // No guessing from column storage classes. That fallback asked "does any column look like a
     // SQLite type", and every unrecognised column returns dbType UNKNOWN while the `/At$/`

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1329,12 +1329,46 @@ export class SchemaAnalyzer {
           // Bytes
           if (/Bytes/i.test(ctor)) return { tsType: 'Uint8Array', dbType: 'BLOB' };
 
+          // Boolean. There was no case for one at all, so `GelBoolean` fell off the end of this
+          // arm to `unknown` and every generator emitted a field that refused nothing: measured
+          // through the emitted zod schema, a `boolean()` column accepted 'yes', 12345 and
+          // { a: 1 }. A live Gel 7.1 hands back a JS `true`.
+          if (/Bool/i.test(ctor)) return { tsType: 'boolean', dbType: 'BOOLEAN' };
+
           // Temporal and calendar types
           if (/TimestampTz/i.test(ctor)) return { tsType: 'Date', dbType: 'TIMESTAMPTZ' };
-          if (/Timestamp/i.test(ctor)) return { tsType: 'string', dbType: 'TIMESTAMP' };
-          if (/LocalDateString|LocalTime/i.test(ctor)) return { tsType: 'string', dbType: 'TEXT' };
-          if (/DateDuration|RelDuration|Duration/i.test(ctor))
-            return { tsType: 'string', dbType: 'TEXT' };
+
+          // The `cal::` and duration family, whose value is an instance of a class from the
+          // `gel` package. These said `string`, which the server refuses in both directions.
+          //
+          // Measured on a live Gel 7.1 (`geldata/gel:7`) through `drizzle-orm/gel` 0.45.2 on
+          // `gel@2.2.0`, one row written and read back:
+          //
+          //   column        gel-core declares        SELECT returns      INSERT accepts
+          //   timestamp     data: LocalDateTime      LocalDateTime       LocalDateTime
+          //   localDate     data: LocalDate          LocalDate           LocalDate
+          //   localTime     data: LocalTime          LocalTime           LocalTime
+          //   dateDuration  data: DateDuration       RelativeDuration    DateDuration
+          //   relDuration   data: RelativeDuration   RelativeDuration    RelativeDuration
+          //   duration      data: Duration           RelativeDuration    Duration
+          //
+          // The bottom two lines are the server contradicting drizzle's own `.d.ts`, and the
+          // server is the arbiter. A string was rejected outright on insert by all six and
+          // returned by none.
+          //
+          // `unknown` rather than a class name: DRZL cannot import `gel`, so no generator can
+          // emit a check for these, and a tsType no generator handles would also lose the
+          // `DRZL_ANL_UNKNOWN_COLUMN` warning, which fires on `unknown` and carries
+          // `getSQLType()`. Saying nothing and saying so is the honest answer; saying `string`
+          // was a guess that turned every one of these columns into a validator that rejected
+          // every row.
+          //
+          // This arm returns what falling off the end of the block returns, verified by deleting
+          // it and rerunning `gel-types.spec.ts` and `uncovered-dialects.spec.ts`, both of which
+          // stayed green. It is here so the six read as measured and decided rather than
+          // forgotten, which is how they came to be `string`.
+          if (/Timestamp|LocalDateString|LocalTime|DateDuration|RelDuration|Duration/i.test(ctor))
+            return { tsType: 'unknown', dbType: 'UNKNOWN' };
         }
         return { tsType: 'unknown', dbType: 'UNKNOWN' };
     }

--- a/packages/analyzer/test/gel-types.spec.ts
+++ b/packages/analyzer/test/gel-types.spec.ts
@@ -1,3 +1,15 @@
+/**
+ * The `/^Gel/i` name-matching arm, driven by hand-written classes.
+ *
+ * This file is deliberately NOT the coverage that matters. It builds a table out of
+ * `class GelInteger {}` and friends, so all it can ever show is that the arm agrees with a class
+ * list someone typed out, and a type drizzle ships that nobody thought to type out is invisible
+ * to it: `GelBoolean` was missing here for exactly that reason, and a real `boolean()` column
+ * came back `unknown`. `uncovered-dialects.spec.ts` runs the same arm against a real `gelTable`
+ * and is where an expectation traced to a live server lives. What is left here is the ordering
+ * of the regexes, which a class list does exercise: `GelTimestampTz` must not be caught by the
+ * `Timestamp` case, and `GelLocalDateString` must not be caught by the `Text` one.
+ */
 import { describe, it, expect } from 'vitest';
 import { SchemaAnalyzer } from '../src/index';
 import { promises as fs } from 'node:fs';
@@ -20,6 +32,7 @@ class GelReal {}
 class GelDoublePrecision {}
 class GelDecimal {}
 class GelBytes {}
+class GelBoolean {}
 class GelTimestamp {}
 class GelTimestampTz {}
 class GelLocalDateString {}
@@ -42,6 +55,7 @@ table[Symbol.for('drizzle:Columns')] = {
   dp: new GelDoublePrecision(),
   dec: new GelDecimal(),
   b: new GelBytes(),
+  flag: new GelBoolean(),
   ts: new GelTimestamp(),
   tstz: new GelTimestampTz(),
   ld: new GelLocalDateString(),
@@ -70,13 +84,19 @@ export { table as gel_table };
     expect(get('dp')).toBe('number');
     expect(get('dec')).toBe('string');
     expect(get('b')).toBe('Uint8Array');
-    expect(get('ts')).toBe('string');
+    expect(get('flag')).toBe('boolean');
+    // `GelTimestampTz` is a `Date` and must be matched before the `Timestamp` case, which is why
+    // both are here and not just one.
     expect(get('tstz')).toBe('Date');
-    expect(get('ld')).toBe('string');
-    expect(get('lt')).toBe('string');
-    expect(get('dd')).toBe('string');
-    expect(get('rd')).toBe('string');
-    expect(get('d')).toBe('string');
+    // The `cal::` and duration family. Each one's value is an instance of a class from the `gel`
+    // package, which DRZL cannot import and therefore cannot check; see the live-server
+    // measurement in `uncovered-dialects.spec.ts` for what each one really returns.
+    expect(get('ts')).toBe('unknown');
+    expect(get('ld')).toBe('unknown');
+    expect(get('lt')).toBe('unknown');
+    expect(get('dd')).toBe('unknown');
+    expect(get('rd')).toBe('unknown');
+    expect(get('d')).toBe('unknown');
   });
 });
 

--- a/packages/analyzer/test/uncovered-dialects.spec.ts
+++ b/packages/analyzer/test/uncovered-dialects.spec.ts
@@ -276,11 +276,14 @@ describe('Gel, against a real gelTable', () => {
     expect(analysis.dialect).toBe('gel');
   });
 
-  it('types every column it is given except the boolean', async () => {
-    // 20 columns tried, 1 `unknown`.
+  it('types every column whose JavaScript type it can state', async () => {
+    // 20 columns tried. The six `unknown` ones are the `cal::` and duration family, whose value
+    // is an instance of a class from the `gel` package: see the test below for the measurement
+    // and for why stating nothing is the honest answer there. `flag` used to be a seventh, for
+    // no reason at all.
     const { analysis, unknowns } = await columnsOf('real-gel', GEL_SOURCE);
     expect(analysis.tables[0].columns).toHaveLength(20);
-    expect(unknowns).toEqual(['flag']);
+    expect(unknowns).toEqual(['ts', 'ld', 'lt', 'dd', 'rd', 'd']);
   });
 
   it('describes the scalar families correctly', async () => {
@@ -301,40 +304,72 @@ describe('Gel, against a real gelTable', () => {
     expect(ts('tstz')).toBe('Date'); // timestamptz.d.ts data: Date
   });
 
-  it('DEFECT: types the whole cal:: and duration family as string, which the driver never returns', async () => {
-    // Six columns, all of the same species as the SingleStore `decimal` defect below: the
-    // analyzer states a JS type the driver does not produce, so a select validator rejects
-    // every row the database returns.
+  it('states nothing for the cal:: and duration family, whose value is a gel class', async () => {
+    // Six columns whose value is an instance of a class from the `gel` package. DRZL cannot
+    // import that package, so it cannot express the check, and it says so rather than guessing.
+    // The guess it used to make was `string`, which is refused in both directions.
     //
-    // Drizzle declares each one's `data` as a class from the `gel` package, and none of these
-    // six defines a `mapFromDriverValue`, so the instance reaches the caller untouched. Only
-    // `bigintT`, `custom` and `doublePrecision` define one anywhere in `gel-core/columns`.
+    // GROUND TRUTH, a live Gel 7.1 (`geldata/gel:7`, sys::get_version_as_str() -> 7.1+08db576)
+    // read and written through `drizzle-orm/gel` 0.45.2 on `gel@2.2.0`:
     //
-    //   column        gel-core declares          DRZL says   correct answer
-    //   timestamp     data: LocalDateTime        string      LocalDateTime
-    //   localDate     data: LocalDate            string      LocalDate
-    //   localTime     data: LocalTime            string      LocalTime
-    //   dateDuration  data: DateDuration         string      DateDuration
-    //   relDuration   data: RelativeDuration     string      RelativeDuration
-    //   duration      data: Duration             string      Duration
+    //   column        gel-core declares        SELECT hands back    INSERT accepts
+    //   timestamp     data: LocalDateTime      LocalDateTime        LocalDateTime
+    //   localDate     data: LocalDate          LocalDate            LocalDate
+    //   localTime     data: LocalTime          LocalTime            LocalTime
+    //   dateDuration  data: DateDuration       RelativeDuration     DateDuration
+    //   relDuration   data: RelativeDuration   RelativeDuration     RelativeDuration
+    //   duration      data: Duration           RelativeDuration     Duration
     //
-    // Measured against real instances from `gel@2.2.0` through the emitted schemas: all six
-    // are rejected by all five generators, and all six accept a string the driver never hands
-    // back. `timestamptz` and `decimal` were probed the same way in the same run and are
-    // correct, which is why they stay in the test above.
+    // The last two lines are the server disagreeing with drizzle's own `.d.ts`, and the server
+    // is the arbiter: `dateDuration` and `duration` come back as a `RelativeDuration` and take a
+    // `DateDuration`/`Duration` on the way in, refusing a `RelativeDuration` there. An earlier
+    // version of this comment recorded `DateDuration` and `Duration` as the SELECT answers,
+    // taken from `gel-core/columns/*.d.ts` rather than from a server.
     //
-    // The first version of this file asserted all six as correct under a test named
-    // "describes the scalar and temporal families correctly", with a comment claiming
-    // `timestamp` "arrives as a string". That was a type assumption written down as a
-    // measurement, and `string` is exactly what the `/^Gel/i` arm happens to return.
-    const { byName } = await columnsOf('real-gel', GEL_SOURCE);
+    // A string is refused by that server on INSERT for all six ('2020-01-01T12:00:00',
+    // '2020-01-01', '01:02:03', 'P1Y', 'P1Y', 'PT1H' each rejected outright) and returned by it
+    // for none, so `string` was not a loose answer here, it was a wrong one in both directions.
+    //
+    // `timestamptz` and `decimal` were read from the same row and really are a `Date` and a
+    // string, which is why they stay in the test above.
+    const { byName, analysis } = await columnsOf('real-gel', GEL_SOURCE);
     const ts = (n: string) => byName.get(n)?.tsType;
-    expect(ts('ts')).toBe('string');
-    expect(ts('ld')).toBe('string');
-    expect(ts('lt')).toBe('string');
-    expect(ts('dd')).toBe('string');
-    expect(ts('rd')).toBe('string');
-    expect(ts('d')).toBe('string');
+    for (const n of ['ts', 'ld', 'lt', 'dd', 'rd', 'd']) {
+      expect(ts(n), n).toBe('unknown');
+      // Not silent. The analyzer's own warning names the column and carries `getSQLType()`, so
+      // the absence is reported as an absence rather than papered over.
+      expect(
+        analysis.issues.some(
+          (i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN' && i.message.includes(`"${n}"`)
+        ),
+        `no unknown-column warning for ${n}`
+      ).toBe(true);
+    }
+    expect(
+      analysis.issues.find((i) => i.message.includes('"ts"'))?.message,
+      'the warning identifies the Gel type, not just the column'
+    ).toContain('cal::local_datetime');
+  });
+
+  it('DEFECT: the "ends in At" heuristic turns one of those six into a Date', async () => {
+    // Pre-existing and not introduced here, but newly reachable: `analyzeTable` rewrites any
+    // `unknown` column whose name ends in `At` to `Date`, and a Gel `timestamp('createdAt')` is
+    // now `unknown` where it used to be `string`. Both answers are refused by the same server
+    // (it hands back a `LocalDateTime` and takes one), so nothing got worse; what is lost is the
+    // unknown-column warning, which the heuristic suppresses by supplying a value for an
+    // absence. Pinned so the day the heuristic is scoped, this test names the consequence.
+    const { byName, analysis } = await columnsOf(
+      'real-gel-at',
+      GEL_SOURCE.replace(
+        "ts: timestamp('ts'),",
+        "ts: timestamp('ts'), createdAt: timestamp('createdAt'),"
+      )
+    );
+    expect(byName.get('createdAt')?.tsType).toBe('Date');
+    expect(
+      analysis.issues.some((i) => i.message.includes('"createdAt"')),
+      'the heuristic suppresses the warning the other five get'
+    ).toBe(false);
   });
 
   it('gives a uuid column its format', async () => {
@@ -355,57 +390,57 @@ describe('Gel, against a real gelTable', () => {
     expect(byName.get('tags')).toMatchObject({ tsType: 'string', arrayDimensions: 1 });
   });
 
-  it('DEFECT: seven holes in total, and a partial fix must not look green', async () => {
-    // The boolean plus the six temporal columns, each pinned to the type DRZL returns today
-    // and commented with the type drizzle declares. Keyed by column rather than counted, so
-    // fixing any single one fails this test naming that column.
+  it('answers every one of the seven that used to be wrong, and no others', async () => {
+    // Every column of the fixture, keyed by name rather than counted, so a fix that repairs one
+    // and breaks another fails here naming both. The seven that changed are marked.
     //
-    // The first version of this test was `wrong.filter((n) => byName.has(n))`, which reads
-    // only whether the fixture still defines those seven columns and never looks at a type at
-    // all. Its comment claimed it was the thing stopping a partial fix from looking green.
-    // Measured: applying the full gel fix, a boolean case plus all six temporal arms, failed
-    // three tests in this file and left that one passing. A vacuous assertion, an expectation
-    // traced to the fixture's own column list instead of to ground truth, and a comment
-    // promising a property the code did not provide, in six lines.
-    const TODAY: Record<string, string> = {
-      flag: 'unknown', // boolean.d.ts             data: boolean
-      ts: 'string', //    timestamp.d.ts           data: LocalDateTime
-      ld: 'string', //    localdate.d.ts           data: LocalDate
-      lt: 'string', //    localtime.d.ts           data: LocalTime
-      dd: 'string', //    date-duration.d.ts       data: DateDuration
-      rd: 'string', //    relative-duration.d.ts   data: RelativeDuration
-      d: 'string', //     duration.d.ts            data: Duration
+    // An earlier version of this test was `wrong.filter((n) => byName.has(n))`, which reads only
+    // whether the fixture still defines those columns and never looks at a type at all, while
+    // its comment claimed it was the thing stopping a partial fix from looking green. Measured
+    // at the time: applying the full gel fix failed three tests in this file and left that one
+    // passing.
+    const EXPECTED: Record<string, string> = {
+      i: 'number',
+      si: 'number',
+      b64: 'bigint',
+      i53: 'number',
+      flag: 'boolean', // was `unknown`;  boolean.d.ts  data: boolean, and the server returns one
+      name: 'string',
+      u: 'string',
+      payload: 'any',
+      r: 'number',
+      dp: 'number',
+      dec: 'string',
+      b: 'Uint8Array',
+      ts: 'unknown', // was `string`;  the server returns a LocalDateTime
+      tstz: 'Date',
+      ld: 'unknown', // was `string`;  the server returns a LocalDate
+      lt: 'unknown', // was `string`;  the server returns a LocalTime
+      dd: 'unknown', // was `string`;  the server returns a RelativeDuration
+      rd: 'unknown', // was `string`;  the server returns a RelativeDuration
+      d: 'unknown', //  was `string`;  the server returns a RelativeDuration
+      tags: 'string', // the element type; `arrayDimensions` carries the rest
     };
     const { byName } = await columnsOf('real-gel', GEL_SOURCE);
-    const actual = Object.fromEntries(
-      Object.keys(TODAY).map((n) => [n, byName.get(n)?.tsType])
-    );
-    expect(actual).toEqual(TODAY);
-
-    // And "seven" is the whole count, not just seven of an unknown number: no column outside
-    // that list comes back `unknown` either.
-    const named = new Set(Object.keys(TODAY));
-    const otherUnknowns = [...byName.values()]
-      .filter((c) => !named.has(c.name) && c.tsType === 'unknown')
-      .map((c) => c.name);
-    expect(otherUnknowns).toEqual([]);
+    const actual = Object.fromEntries([...byName.values()].map((c) => [c.name, c.tsType]));
+    expect(actual).toEqual(EXPECTED);
   });
 
-  it('DEFECT: types a boolean column as unknown, so its validator refuses nothing', async () => {
-    // The `/^Gel/i` arm has cases for integers, floats, decimal, uuid, json, text, bytes and
-    // the whole temporal family, and no case for a boolean at all, so `GelBoolean` falls off
-    // the end to `unknown`. Measured through the emitted zod schema: this column accepts
-    // 'yes', 12345 and { a: 1 }. All four validator generators and the JSON Schema generator
-    // behave the same way.
+  it('types a boolean column as a boolean, so its validator refuses what is not one', async () => {
+    // The `/^Gel/i` arm had cases for integers, floats, decimal, uuid, json, text, bytes and the
+    // whole temporal family, and no case for a boolean at all, so `GelBoolean` fell off the end
+    // to `unknown` and the emitted field was `z.unknown()`: measured through the emitted zod
+    // schema, the column accepted 'yes', 12345 and { a: 1 }. All four validator generators and
+    // the JSON Schema generator behaved the same way. A live Gel 7.1 hands back a JS `true`.
     //
-    // `gel-types.spec.ts` does not catch it because its hand-written class list has no
+    // `gel-types.spec.ts` did not catch it because its hand-written class list has no
     // `GelBoolean` in it. A boolean is the least exotic type a schema can have, which is the
     // point: a fixture written from the implementation can only ever confirm the implementation.
     const { byName, analysis } = await columnsOf('real-gel', GEL_SOURCE);
-    expect(byName.get('flag')?.tsType).toBe('unknown');
-    expect(byName.get('flag')?.dbType).toBe('UNKNOWN');
+    expect(byName.get('flag')?.tsType).toBe('boolean');
+    expect(byName.get('flag')?.dbType).toBe('BOOLEAN');
     expect(
       analysis.issues.some((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN' && /"flag"/.test(i.message))
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/packages/analyzer/test/views-0.4x.spec.ts
+++ b/packages/analyzer/test/views-0.4x.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Views, on the drizzle-orm major this package depends on.
+ *
+ * Drizzle changed how a view answers for itself between majors. On 1.0.0 a view is a Proxy that
+ * maps `drizzle:Columns` to its selected fields, `drizzle:Name` to the view's name and
+ * `drizzle:Schema` to its schema, exactly as a table does. On every 0.x release it is a plain
+ * object carrying three own symbols and none of those three: the columns live only in
+ * `Symbol.for('drizzle:ViewBaseConfig').selectedFields`.
+ *
+ * The analyzer identifies a table-like export by asking for `drizzle:Columns`, so on 0.4x every
+ * view was skipped, with no issue raised. Measured on the pg fixture below before the fix: 2
+ * relations on 0.45.2 against 8 on 1.0.0-rc.4, `issues: []` on both. A views-only file came back
+ * `tables: 0, dialect: unknown, issues: []`. With the fix the two majors' analyses of that same
+ * fixture are byte-identical.
+ *
+ * These tests build against the installed 0.4x, so they fail on the version users actually have
+ * rather than only on the one the release gate installs.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function analyze(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  return new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({ includeRelations: true });
+}
+
+const byName = (a: { tables: { name: string }[] }) =>
+  Object.fromEntries(a.tables.map((t) => [t.name, t])) as Record<string, any>;
+
+const PG = `
+import { pgTable, pgView, pgMaterializedView, pgSchema, integer, text, boolean } from 'drizzle-orm/pg-core';
+import { eq } from 'drizzle-orm';
+
+export const users = pgTable('users', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+  active: boolean('active'),
+});
+export const orders = pgTable('orders', {
+  id: integer('id').primaryKey(),
+  userId: integer('user_id').references(() => users.id),
+  total: integer('total').notNull(),
+});
+export const activeUsers = pgView('active_users').as((qb) =>
+  qb.select().from(users).where(eq(users.active, true)));
+export const userOrders = pgView('user_orders').as((qb) =>
+  qb.select({ userId: users.id, userName: users.name, total: orders.total })
+    .from(users).leftJoin(orders, eq(orders.userId, users.id)));
+export const legacyView = pgView('legacy_view', {
+  id: integer('id'),
+  label: text('label'),
+}).existing();
+export const userStats = pgMaterializedView('user_stats').as((qb) =>
+  qb.select({ id: users.id, name: users.name }).from(users));
+
+const reporting = pgSchema('reporting');
+export const reportView = reporting.view('report_view', { id: integer('id') }).existing();
+export const reportMv = reporting.materializedView('report_mv', { id: integer('id') }).existing();
+`;
+
+describe('a postgres view', () => {
+  it('is analysed, under its database name', async () => {
+    const a = await analyze('views-pg', PG);
+    expect(a.tables.map((t) => t.name).sort()).toEqual([
+      'active_users',
+      'legacy_view',
+      'orders',
+      'report_mv',
+      'report_view',
+      'user_orders',
+      'user_stats',
+      'users',
+    ]);
+  });
+
+  it('carries the columns it selects', async () => {
+    const t = byName(await analyze('views-pg', PG));
+    expect(t.active_users.columns.map((c: any) => c.name)).toEqual(['id', 'name', 'active']);
+    expect(t.user_orders.columns.map((c: any) => c.name)).toEqual(['userId', 'userName', 'total']);
+    // An explicit column list on a view declared elsewhere is the same shape.
+    expect(t.legacy_view.columns.map((c: any) => c.name)).toEqual(['id', 'label']);
+  });
+
+  it('keeps each column typed rather than falling back to unknown', async () => {
+    const t = byName(await analyze('views-pg', PG));
+    const cols = Object.fromEntries(t.user_orders.columns.map((c: any) => [c.name, c]));
+    expect(cols.userId).toMatchObject({ tsType: 'number', dbType: 'INTEGER' });
+    expect(cols.userName).toMatchObject({ tsType: 'string', dbType: 'TEXT' });
+  });
+
+  it('reports the schema a qualified view was declared in', async () => {
+    const t = byName(await analyze('views-pg', PG));
+    expect(t.report_view.schema).toBe('reporting');
+    expect(t.report_mv.schema).toBe('reporting');
+    expect(t.active_users.schema).toBeUndefined();
+  });
+
+  it('marks a materialized view read-only and leaves a plain view writable', async () => {
+    // Postgres refuses every write to a materialized view ("cannot change materialized view"),
+    // and accepts an INSERT into a simple auto-updatable view.
+    const t = byName(await analyze('views-pg', PG));
+    expect(t.user_stats.readOnly).toBe(true);
+    expect(t.report_mv.readOnly).toBe(true);
+    expect(t.active_users.readOnly).toBeUndefined();
+    expect(t.users.readOnly).toBeUndefined();
+  });
+});
+
+describe('a schema file of nothing but views', () => {
+  it('names the dialect', async () => {
+    // The dialect loop read `Symbol.for('drizzle:Columns')` directly rather than through the
+    // resolver every other site uses, so a fallback living only in the resolver leaves it
+    // answering `unknown`. Measured in exactly that state: both views analysed, `dialect:
+    // unknown`, and a DRZL_ANL_DIALECT warning on a schema whose dialect is not in doubt.
+    const a = await analyze(
+      'views-only-pg',
+      `
+      import { pgView, integer, text } from 'drizzle-orm/pg-core';
+      export const a = pgView('a', { id: integer('id'), label: text('label') }).existing();
+      export const b = pgView('b', { id: integer('id') }).existing();
+      `
+    );
+    expect(a.dialect).toBe('postgres');
+    expect(a.tables.map((t) => t.name)).toEqual(['a', 'b']);
+    expect(a.issues).toEqual([]);
+    const id = a.tables[0].columns.find((c) => c.name === 'id');
+    expect(id).toMatchObject({ tsType: 'number', dbType: 'INTEGER' });
+  });
+});
+
+describe('a sqlite view', () => {
+  it('is analysed and marked read-only', async () => {
+    // SQLite refuses every write to a view, insert, update and delete alike, with
+    // "cannot modify <name> because it is a view". Measured with node:sqlite; an insert or update
+    // schema for one describes an operation the database will always refuse.
+    const a = await analyze(
+      'views-sqlite',
+      `
+      import { sqliteTable, sqliteView, integer, text } from 'drizzle-orm/sqlite-core';
+      export const users = sqliteTable('users', {
+        id: integer('id').primaryKey(),
+        name: text('name').notNull(),
+      });
+      export const activeUsers = sqliteView('active_users').as((qb) => qb.select().from(users));
+      `
+    );
+    expect(a.dialect).toBe('sqlite');
+    const t = byName(a);
+    expect(t.active_users.columns.map((c: any) => c.name)).toEqual(['id', 'name']);
+    expect(t.active_users.readOnly).toBe(true);
+    expect(t.users.readOnly).toBeUndefined();
+  });
+});
+
+describe('a mysql view', () => {
+  it('is analysed and stays writable', async () => {
+    // MySQL accepts inserts and updates through a simple view (information_schema.views reports
+    // is_updatable=YES for one), so it keeps all three schemas.
+    const a = await analyze(
+      'views-mysql',
+      `
+      import { mysqlTable, mysqlView, int, varchar } from 'drizzle-orm/mysql-core';
+      export const users = mysqlTable('users', {
+        id: int('id').primaryKey(),
+        name: varchar('name', { length: 40 }).notNull(),
+      });
+      export const activeUsers = mysqlView('active_users').as((qb) => qb.select().from(users));
+      `
+    );
+    expect(a.dialect).toBe('mysql');
+    const t = byName(a);
+    expect(t.active_users.columns.map((c: any) => c.name)).toEqual(['id', 'name']);
+    expect(t.active_users.readOnly).toBeUndefined();
+  });
+});

--- a/packages/cli/test/gel-emitted-schemas.spec.ts
+++ b/packages/cli/test/gel-emitted-schemas.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Gel columns, from a real `gelTable` through the real analyzer and the real zod generator into
+ * an emitted module that is imported and run.
+ *
+ * It lives in this package because this is the only one where `drizzle-orm` and `zod` both
+ * resolve, so the whole chain can be exercised in one file rather than split across a
+ * hand-written `Column[]` in the generator package and a type assertion in the analyzer package.
+ * Requires a build, like the other end-to-end files here: CI builds before testing.
+ *
+ * GROUND TRUTH. A live Gel 7.1 (`geldata/gel:7`, `sys::get_version_as_str()` -> `7.1+08db576`),
+ * with a `T` object type carrying one property per Gel scalar, read back through
+ * `drizzle-orm/gel` 0.45.2 on `gel@2.2.0`. `constructor.name` of every value in the row:
+ *
+ *   column  gel-core/columns/*.d.ts declares   the server hands back
+ *   flag    boolean                            boolean            true
+ *   name    string                             string             'hello'
+ *   dec     string                             string             '12.34'
+ *   ts      LocalDateTime                      LocalDateTime      2020-01-01T12:00:00
+ *   tstz    Date                               Date               2020-01-01T12:00:00.000Z
+ *   ld      LocalDate                          LocalDate          2020-01-01
+ *   lt      LocalTime                          LocalTime          12:00:00
+ *   dd      DateDuration                       RelativeDuration   P1Y2M3D
+ *   rd      RelativeDuration                   RelativeDuration   P1Y2M3DT4H
+ *   d       Duration                           RelativeDuration   PT4H5M
+ *
+ * The last two lines are the server disagreeing with drizzle's own declaration, and the server
+ * is the arbiter. Insert goes the other way on the same two: the same server took a
+ * `DateDuration` into `dd` and a `Duration` into `d` and refused a `RelativeDuration` for
+ * either, so the round trip is genuinely asymmetric.
+ *
+ * The string DRZL used to demand is refused on insert by all six, measured on that server:
+ * `'2020-01-01T12:00:00'`, `'2020-01-01'`, `'01:02:03'`, `'P1Y'`, `'P1Y'` and `'PT1H'` were each
+ * rejected outright, and the matching class instance accepted. So `string` was not merely a
+ * loose answer for these six, it was refused in both directions.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs, existsSync } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer, type Analysis } from '@drzl/analyzer';
+import { ZodGenerator } from '@drzl/generator-zod';
+
+const DIR = path.join(__dirname, '.tmp-gel');
+
+const SCHEMA = `
+import {
+  gelTable, boolean, text, decimal, timestamp, timestamptz,
+  localDate, localTime, dateDuration, relDuration, duration,
+} from 'drizzle-orm/gel-core';
+export const t = gelTable('t', {
+  flag: boolean('flag').notNull(),
+  name: text('name').notNull(),
+  dec: decimal('dec').notNull(),
+  ts: timestamp('ts').notNull(),
+  tstz: timestamptz('tstz').notNull(),
+  ld: localDate('ld').notNull(),
+  lt: localTime('lt').notNull(),
+  dd: dateDuration('dd').notNull(),
+  rd: relDuration('rd').notNull(),
+  d: duration('d').notNull(),
+});
+`;
+
+/**
+ * A stand-in for one of the `gel` classes above.
+ *
+ * `gel` is a peer of `drizzle-orm` and is not a dependency of this repo, so the real class is
+ * not importable here. What an emitted schema can observe about the real value is that it is an
+ * object and not a string, which is exactly what this reproduces; the class identity is recorded
+ * in the header, where the server that produced it is named. Constructed through a computed key
+ * so `constructor.name` really is the name passed in, rather than a comment claiming it is.
+ */
+function driverInstance(className: string, printed: string): object {
+  const holder = {
+    [className]: class {
+      toString() {
+        return printed;
+      }
+      toJSON() {
+        return printed;
+      }
+    },
+  };
+  return new holder[className]!();
+}
+
+/** One value per column, as the live server handed it back. */
+const FROM_SERVER: Record<string, unknown> = {
+  flag: true,
+  name: 'hello',
+  dec: '12.34',
+  tstz: new Date('2020-01-01T12:00:00Z'),
+  ts: driverInstance('LocalDateTime', '2020-01-01T12:00:00'),
+  ld: driverInstance('LocalDate', '2020-01-01'),
+  lt: driverInstance('LocalTime', '12:00:00'),
+  dd: driverInstance('RelativeDuration', 'P1Y2M3D'),
+  rd: driverInstance('RelativeDuration', 'P1Y2M3DT4H'),
+  d: driverInstance('RelativeDuration', 'PT4H5M'),
+};
+
+/** The six whose value is a class instance from the `gel` package. */
+const INSTANCE_COLUMNS = ['ts', 'ld', 'lt', 'dd', 'rd', 'd'] as const;
+
+let analysis: Analysis;
+let mod: Record<string, any>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  const schemaFile = path.join(DIR, 'schema.ts');
+  await fs.writeFile(schemaFile, SCHEMA, 'utf8');
+
+  analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schemaFile)).analyze({});
+  expect(analysis.dialect, 'a real gelTable is analyzed as gel').toBe('gel');
+
+  await new ZodGenerator(analysis).generate({ outDir: DIR } as never);
+  const emitted = path.join(DIR, 't.zod.ts');
+  expect(existsSync(emitted), `no module was emitted at ${emitted}`).toBe(true);
+  // Imported under a unique name so a rerun is never served from the module cache, the same
+  // guard `structured-columns.spec.ts` uses.
+  const unique = path.join(DIR, `t-${process.pid}.zod.ts`);
+  await fs.rename(emitted, unique);
+  mod = await import(unique);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const accepts = (schema: any, v: unknown) => schema.safeParse(v).success;
+
+describe('a Gel boolean column', () => {
+  it('is a boolean, and refuses what a boolean is not', () => {
+    // `GelBoolean` matched no case in the analyzer's `/^Gel/i` arm and fell off the end to
+    // `unknown`, so the emitted field was `z.unknown()` and the column that a database can only
+    // ever put `true` or `false` in accepted every one of the values below.
+    const f = mod.SelecttSchema.shape.flag;
+    expect(accepts(f, true), 'true').toBe(true);
+    expect(accepts(f, false), 'false').toBe(true);
+    expect(accepts(f, 'yes'), "'yes'").toBe(false);
+    expect(accepts(f, 12345), '12345').toBe(false);
+    expect(accepts(f, { a: 1 }), 'an object').toBe(false);
+    expect(accepts(f, null), 'null on a NOT NULL column').toBe(false);
+  });
+});
+
+describe('the six Gel columns whose value is a class from the gel package', () => {
+  it.each(INSTANCE_COLUMNS)('accepts the value the server returns for %s', (name) => {
+    // Before: `z.string()`, so the select schema refused every row the database returned.
+    const f = mod.SelecttSchema.shape[name];
+    expect(accepts(f, FROM_SERVER[name])).toBe(true);
+  });
+
+  it.each(INSTANCE_COLUMNS)('accepts the value the server takes on insert for %s', (name) => {
+    // The same class instance is what the server accepted on INSERT, and the string DRZL asked
+    // for was refused. Both halves measured; see the header.
+    const f = mod.InserttSchema.shape[name];
+    expect(accepts(f, FROM_SERVER[name])).toBe(true);
+  });
+
+  it('says outright that it cannot type them, naming the Gel type', () => {
+    // The honest half of the fix. DRZL has no way to state "an instance of a class from a
+    // package I cannot import", so it states nothing and warns, and the warning carries
+    // `getSQLType()` so the column is identifiable. An absence reported as an absence.
+    const warned = analysis.issues
+      .filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN')
+      .map((i) => i.message);
+    for (const name of INSTANCE_COLUMNS) {
+      expect(
+        warned.some((m) => m.includes(`"${name}"`)),
+        `no unknown-column warning for ${name}`
+      ).toBe(true);
+    }
+    // And the boolean is no longer among them, because it is now typed.
+    expect(warned.some((m) => m.includes('"flag"'))).toBe(false);
+    // The Gel type reaches the message, so the warning identifies the column type rather than
+    // only the column name.
+    expect(warned.join('\n')).toContain('cal::local_datetime');
+  });
+});
+
+describe('the Gel columns that were already right', () => {
+  // A control. Widening everything would pass every assertion above, and these fail if it does.
+  it('keeps timestamptz a Date and refuses a string for it', () => {
+    const f = mod.SelecttSchema.shape.tstz;
+    expect(accepts(f, FROM_SERVER.tstz), 'a Date').toBe(true);
+    expect(accepts(f, '2020-01-01T12:00:00Z'), 'a string').toBe(false);
+  });
+
+  it('keeps decimal a string and refuses a number for it', () => {
+    // Gel's `decimal` really does arrive as a string, measured in the same row.
+    const f = mod.SelecttSchema.shape.dec;
+    expect(accepts(f, '12.34'), "'12.34'").toBe(true);
+    expect(accepts(f, 12.34), '12.34').toBe(false);
+  });
+
+  it('keeps text a string and refuses a number for it', () => {
+    const f = mod.SelecttSchema.shape.name;
+    expect(accepts(f, 'hello'), "'hello'").toBe(true);
+    expect(accepts(f, 42), '42').toBe(false);
+  });
+});

--- a/packages/cli/test/views.e2e.spec.ts
+++ b/packages/cli/test/views.e2e.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * A view, generated and then run against the database it describes.
+ *
+ * On drizzle-orm 0.4x a view answers no `drizzle:Columns` and no `drizzle:Name`, so the analyzer
+ * saw none of them and the generators emitted nothing at all for one: no module, no export in the
+ * barrel, and no issue saying so. The repo pins ^0.45.2 for itself, so that was the default.
+ *
+ * Every other view test in this repo hand-builds an `Analysis` object, which passes on both
+ * majors while the feature is dead on one. This one builds a real Drizzle schema, runs the real
+ * analyzer over it, emits with the real generator, imports what was emitted, and hands it a row
+ * SQLite actually returned.
+ *
+ * Requires a build, like the other e2e specs here: it imports `@drzl/analyzer` and
+ * `@drzl/generator-zod` as packages, which resolve to their `dist`. CI builds before testing;
+ * locally, run `pnpm build` first.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ZodGenerator } from '@drzl/generator-zod';
+
+// Under this package rather than os.tmpdir(): the schema imports drizzle-orm and the emitted
+// module imports zod, and Node resolves both by walking parents for node_modules.
+const workdir = path.join(__dirname, '.tmp-views-e2e');
+
+const SCHEMA = `
+import { sqliteTable, sqliteView, integer, text } from 'drizzle-orm/sqlite-core';
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+});
+
+export const activeUsers = sqliteView('active_users').as((qb) => qb.select().from(users));
+`;
+
+/** The same objects, in a real SQLite, plus the row the view really returns. */
+function realRow() {
+  const db = new DatabaseSync(':memory:');
+  db.exec(`create table users (id integer primary key, name text not null)`);
+  db.exec(`insert into users values (1, 'ann')`);
+  db.exec(`create view active_users as select id, name from users`);
+  const row = db.prepare('select * from active_users').get() as Record<string, unknown>;
+  let writeError = '';
+  try {
+    db.exec(`insert into active_users values (2, 'bob')`);
+  } catch (e) {
+    writeError = (e as Error).message;
+  }
+  db.close();
+  return { row, writeError };
+}
+
+let emitted: Record<string, any> | undefined;
+let barrel: string;
+let files: string[];
+
+/** The emitted module, or a failure naming the file that was never written. */
+function moduleUnderTest(): Record<string, any> {
+  if (!emitted) throw new Error(`no activeUsers.zod.ts was emitted; got: ${files.join(', ')}`);
+  return emitted;
+}
+
+beforeAll(async () => {
+  await fs.rm(workdir, { recursive: true, force: true });
+  await fs.mkdir(workdir, { recursive: true });
+  const schemaFile = path.join(workdir, 'schema.mjs');
+  await fs.writeFile(schemaFile, SCHEMA, 'utf8');
+
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schemaFile)).analyze({});
+  await new ZodGenerator(analysis).generate({ outDir: workdir } as never);
+
+  files = (await fs.readdir(workdir)).sort();
+  barrel = await fs.readFile(path.join(workdir, 'index.ts'), 'utf8');
+  // Renamed so a rerun cannot be served the previous parse out of the module cache. Absent when
+  // the view was never analysed, which is the defect; the cases below say so rather than every
+  // one of them dying in here.
+  if (files.includes('activeUsers.zod.ts')) {
+    const stable = path.join(workdir, `activeUsers-${process.pid}.ts`);
+    await fs.rename(path.join(workdir, 'activeUsers.zod.ts'), stable);
+    emitted = await import(stable);
+  }
+}, 120_000);
+
+describe('a view reaches the emitted output at all', () => {
+  it('gets its own module and a line in the barrel', async () => {
+    // Before the fix this directory held index.ts and users.zod.ts, and nothing else.
+    expect(files).toContain('activeUsers.zod.ts');
+    expect(files).toContain('users.zod.ts');
+    expect(barrel).toContain('activeUsers.zod');
+  });
+});
+
+describe('the emitted schema, run against what SQLite returns', () => {
+  it('accepts the row the view really produced', () => {
+    const { row } = realRow();
+    expect(row).toEqual({ id: 1, name: 'ann' });
+    const parsed = moduleUnderTest().SelectactiveUsersSchema.safeParse(row);
+    expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+  });
+
+  it('describes the columns rather than waving them through', () => {
+    // A column the analyzer cannot describe comes out `unknown` and is emitted as `z.unknown()`,
+    // which accepts everything, so an emitted module proves nothing by existing. Handing it a
+    // value of the wrong type is what separates a described column from a waved-through one.
+    const bad = moduleUnderTest().SelectactiveUsersSchema.safeParse({ id: 'one', name: 'ann' });
+    expect(bad.success).toBe(false);
+  });
+
+  it('offers no way to write to it, because SQLite refuses every write to a view', () => {
+    const { writeError } = realRow();
+    expect(writeError).toMatch(/cannot modify active_users because it is a view/);
+    expect(moduleUnderTest().InsertactiveUsersSchema).toBeUndefined();
+    expect(moduleUnderTest().UpdateactiveUsersSchema).toBeUndefined();
+    // The base table keeps all three; only the view is refused.
+    expect(moduleUnderTest().SelectactiveUsersSchema).toBeDefined();
+  });
+});

--- a/packages/generator-json-schema/src/index.ts
+++ b/packages/generator-json-schema/src/index.ts
@@ -133,6 +133,7 @@ function baseSchema(
       if (c.format === 'uuid') out.format = UUID_FORMAT;
       else if (c.format && COLUMN_FORMATS[c.format]) out.pattern = COLUMN_FORMATS[c.format];
       if (c.maxLength !== undefined) out.maxLength = c.maxLength;
+      applyByteCap(out, c);
       applyLengths(out, c, lengths);
       return out;
     }
@@ -155,6 +156,46 @@ function baseSchema(
     default:
       return {};
   }
+}
+
+/**
+ * A byte budget, as the strongest thing this format can say about one.
+ *
+ * MySQL's TEXT family is capped by the type in bytes rather than by a declared length in
+ * characters, so the analyzer carries it as `maxBytes` and the four validation generators encode
+ * the string and count the result. There is no keyword for that here. No draft has a byte length,
+ * and inventing one is worse than saying nothing: ajv in strict mode throws on `maxBytes`, and
+ * with strict mode off it ignores the keyword and takes a thousand byte string into a 255 byte
+ * column, which is a document that looks enforced and is not.
+ *
+ * `maxLength` counts characters, which is a different measurement of the same string. It is a
+ * true statement about a byte budget in one direction only: UTF-8 spends at least one byte per
+ * character, so a string inside the budget is always inside a character cap of the same number.
+ * The cap emitted here therefore refuses nothing the column accepts, and it catches every
+ * overflow made of one-byte characters. It cannot catch a multi-byte string that fits the count
+ * and not the budget, so that is written into `description` rather than left unsaid.
+ *
+ * Measured against a real MySQL 8 on utf8mb4 in STRICT_TRANS_TABLES, on `TINYTEXT`, over the same
+ * 150 seeded random strings before and after. Made of one-byte characters, the uncapped document
+ * took 20 strings the server refused and the capped one takes none. Made of mixed one, two, three
+ * and four byte characters, 88 becomes 68: what is left is the part the paragraph above says
+ * cannot be expressed. Neither document refused anything the server took.
+ * `test/byte-caps.spec.ts` has the targeted probes.
+ *
+ * The minimum rather than an assignment, so the smaller of the two caps a column carries is the
+ * one that survives. The two forms agree on every column the analyzer produces today, and not by
+ * luck: where a declared length and a byte budget arrive together the budget is the smaller of
+ * them or equal to it, which `scripts/verify-packed.sh` asserts per column on both drizzle-orm
+ * majors. The test asserting this one uses a column with a smaller character limit, where
+ * assignment would widen the cap and take an eleventh character.
+ *
+ * Before `applyLengths`, so a `CHECK (length(col) <= n)` narrower than the budget still wins:
+ * that one is reachable from a real schema, and it is asserted too.
+ */
+function applyByteCap(out: Schema, c: Column) {
+  if (!c.maxBytes) return;
+  out.maxLength = Math.min(Number(out.maxLength ?? Infinity), c.maxBytes);
+  out.description = `At most ${c.maxBytes} bytes of UTF-8, which JSON Schema has no keyword for. maxLength counts characters: it refuses nothing the column accepts, and a string of multi-byte characters can satisfy it and still be too long for the column.`;
 }
 
 /** `length(col) >= n` as `minLength` and `maxLength`, which count characters as SQL does. */

--- a/packages/generator-json-schema/test/byte-caps.spec.ts
+++ b/packages/generator-json-schema/test/byte-caps.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * A MySQL TEXT column is capped in bytes, and JSON Schema has no keyword for a byte length.
+ *
+ * The four validation generators encode the string and count the result. This one cannot: no
+ * draft has a byte-length keyword, and inventing one would produce a document that validates as a
+ * schema and means nothing, since an unknown keyword is not an error in JSON Schema, it is
+ * ignored.
+ *
+ * What the format can say is `maxLength`, which counts characters. UTF-8 spends at least one byte
+ * per character, so every string inside a byte budget is inside a character cap of the same
+ * number: the cap emitted from `maxBytes` refuses nothing the column accepts, and it catches every
+ * overflow made of one-byte characters, which is the ordinary one. What it cannot catch is a
+ * multi-byte string that fits the character count and not the budget, and that is written into
+ * `description` rather than left unsaid.
+ *
+ * Measured against a real MySQL 8 on utf8mb4 in STRICT_TRANS_TABLES, on `TINYTEXT`, whose budget
+ * is 255 bytes. The emitted document is the one this generator produced from drizzle-orm 0.45.2
+ * column objects, transpiled and imported, and read by ajv:
+ *
+ *   bytes  chars  MySQL     before    after
+ *     255    255  accepts   accepts   accepts     255 ascii
+ *     256    256  REFUSES   accepts   REFUSES     256 ascii
+ *     254    127  accepts   accepts   accepts     127 e-acute
+ *     256    128  REFUSES   accepts   accepts     128 e-acute
+ *     255     85  accepts   accepts   accepts     85 cjk
+ *     258     86  REFUSES   accepts   accepts     86 cjk
+ *     252     63  accepts   accepts   accepts     63 emoji
+ *     256     64  REFUSES   accepts   accepts     64 emoji
+ *     800    200  REFUSES   accepts   accepts     200 emoji
+ *
+ * Four of those stay wrong, and they are the four a character count cannot see: a string can be
+ * over the budget and under the count. Every one of them is over the budget by multi-byte text.
+ *
+ * The same 150 seeded random strings against the same server, before and after:
+ *
+ *   alphabet                 refused by MySQL and taken by the document   the other way
+ *   mixed 1/2/3/4-byte       88 -> 68                                     0 -> 0
+ *   one-byte characters      20 -> 0                                      0 -> 0
+ *
+ * `varchar(n)` is genuinely characters in the same database and keeps `maxLength` from its
+ * declared length: the server took 10 emoji into a `varchar(10)` and refused 11.
+ *
+ * The column shape here is what `@drzl/analyzer` reports for a real `tinytext()` on drizzle-orm
+ * 0.45.2, asserted in packages/analyzer/test/mysql-byte-caps.spec.ts: `maxBytes` set and
+ * `maxLength` undefined.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import type { Analysis, Column, Table } from '@drzl/analyzer';
+import { JsonSchemaGenerator, type JsonSchemaTarget } from '../src/index';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (over: Partial<Column> = {}): Column =>
+  ({
+    name: 'n',
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+/**
+ * The emitted module, imported and read rather than matched against.
+ *
+ * The generator writes a `.ts` file holding the schema as data. Importing it is the only way to
+ * be sure the thing a consumer installs carries the constraint, since a JSON Schema is data all
+ * the way down and a keyword that never reached the file looks exactly like one that did until
+ * something reads it.
+ */
+async function emitted(
+  c: Column,
+  opts: { target?: JsonSchemaTarget; checks?: { name?: string; expression?: string }[] } = {}
+) {
+  const table: Table = {
+    name: 't',
+    tsName: 't',
+    columns: [c],
+    unique: [],
+    indexes: [],
+    checks: opts.checks ?? [],
+  } as never;
+  const analysis: Analysis = {
+    dialect: 'mysql',
+    tables: [table],
+    enums: [],
+    relations: [],
+    issues: [],
+  } as never;
+  const dir = path.join(__dirname, '.tmp-bytecaps');
+  await fs.mkdir(dir, { recursive: true });
+  await new JsonSchemaGenerator(analysis).generate({
+    outDir: dir,
+    ...(opts.target ? { target: opts.target } : {}),
+  } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.schema.ts'), file);
+  const mod = await import(file);
+  return mod.SelecttSchema.properties.n as Record<string, unknown>;
+}
+
+/** Compiled in strict mode, so a keyword that does not exist fails here rather than being ignored. */
+function compile(schema: unknown) {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  return ajv.compile(schema as never);
+}
+
+const EMOJI = '\u{1F44D}'; // one code point, four bytes in UTF-8
+const CJK = '好'; // one code point, three bytes
+const ACUTE = 'é'; // one code point, two bytes
+
+describe('a byte budget in a format with no byte-length keyword', () => {
+  it('caps a column that carries only a byte budget, which is every TEXT column on 0.4x', async () => {
+    // On drizzle-orm 0.4x a `tinytext` states no length at all, so `maxBytes` is the only cap the
+    // column has. Ignoring it left `{ type: 'string' }`, which took a megabyte into a 255 byte
+    // column. MySQL refuses 256 ascii with ERROR 1406, and so does official drizzle-zod 0.8.3.
+    const v = compile(await emitted(col({ maxBytes: 255 })));
+    expect(v('a'.repeat(255)), '255 bytes, which MySQL takes').toBe(true);
+    expect(v('a'.repeat(256)), '256 bytes, which MySQL refuses').toBe(false);
+  });
+
+  it('refuses nothing the column accepts, whatever the text is made of', async () => {
+    // The one direction that breaks working code. UTF-8 spends at least one byte per character,
+    // so a character cap of the same number can never be the stricter of the two. Each of these
+    // was accepted by a real MySQL 8 in the same run.
+    const v = compile(await emitted(col({ maxBytes: 255 })));
+    expect(v('a'.repeat(255)), '255 ascii, 255 bytes').toBe(true);
+    expect(v(ACUTE.repeat(127)), '127 two-byte characters, 254 bytes').toBe(true);
+    expect(v(CJK.repeat(85)), '85 three-byte characters, 255 bytes').toBe(true);
+    expect(v(EMOJI.repeat(63)), '63 four-byte characters, 252 bytes').toBe(true);
+  });
+
+  it('says in prose what it cannot enforce, rather than pretending', async () => {
+    // 64 emoji is 64 characters and 256 bytes: MySQL refuses the row and no character count can
+    // say so. The schema takes it, and names the budget it cannot check.
+    const s = await emitted(col({ maxBytes: 255 }));
+    expect(String(s.description)).toContain('255 bytes');
+    const v = compile(s);
+    expect(v(EMOJI.repeat(64)), '256 bytes, and 64 characters, so the count cannot see it').toBe(
+      true
+    );
+    expect(v(EMOJI.repeat(256)), '1024 bytes, and 256 characters, which it can').toBe(false);
+  });
+
+  it('keeps the smaller cap when a character limit is smaller', async () => {
+    // A byte budget is not licence to widen a character limit: `varchar(10)` refuses an eleventh
+    // character whatever it costs in bytes.
+    const v = compile(await emitted(col({ maxLength: 10, maxBytes: 255 })));
+    expect(v('a'.repeat(10))).toBe(true);
+    expect(v('a'.repeat(11)), 'over the character limit').toBe(false);
+  });
+
+  it('is one cap when the two agree, which is the v1 shape of the same column', async () => {
+    // v1's MySqlText states `length` equal to the type's budget, recorded in the 0.4x ledger in
+    // scripts/verify-packed.sh, so on that major the column arrives carrying both. The emitted
+    // document is the same one either way, which is the point: the two majors describe the same
+    // column and now the two documents say the same thing about it.
+    const s = await emitted(col({ maxLength: 255, maxBytes: 255 }));
+    expect(s.maxLength).toBe(255);
+    const v = compile(s);
+    expect(v('a'.repeat(255))).toBe(true);
+    expect(v('a'.repeat(256))).toBe(false);
+  });
+
+  it('narrows to a CHECK that is smaller still', async () => {
+    const v = compile(
+      await emitted(col({ maxBytes: 255 }), { checks: [{ expression: 'length(n) <= 100' }] })
+    );
+    expect(v('a'.repeat(100))).toBe(true);
+    expect(v('a'.repeat(101))).toBe(false);
+  });
+
+  it('leaves a base64 column alone, where a character cap would refuse a legal value', async () => {
+    // Not hypothetical: MYSQL_TEXT_CAPS covers the blob family too, and scripts/verify-packed.sh
+    // records that on drizzle-orm 1.0.0-rc.4 a `tinyblob` column comes back carrying maxBytes
+    // 255. Binary travels as base64, which is four characters for every three bytes, so a
+    // character cap taken from a byte budget would refuse a full column: 255 bytes is 340 base64
+    // characters. That is the one direction this must never take, and the shape is what keeps it
+    // out, so the assertion is on the emitted keyword rather than on the guard.
+    const s = await emitted(
+      col({
+        tsType: 'Uint8Array',
+        dbType: 'BLOB',
+        maxBytes: 255,
+        shape: { kind: 'buffer' } as never,
+      })
+    );
+    expect(s.maxLength, 'no character cap on an encoded string').toBeUndefined();
+    const v = compile(s);
+    expect(v('A'.repeat(340)), 'a full 255 byte value, base64 encoded').toBe(true);
+  });
+
+  it('carries the cap into the OpenAPI 3.0 spelling too', async () => {
+    // `maxLength` and `description` mean the same thing in 3.0, so nothing changes but the draft.
+    const s = await emitted(col({ maxBytes: 255 }), { target: 'openapi-3.0' });
+    expect(s.maxLength).toBe(255);
+    expect(String(s.description)).toContain('255 bytes');
+  });
+});

--- a/packages/generator-zod/package.json
+++ b/packages/generator-zod/package.json
@@ -20,6 +20,7 @@
     "@drzl/validation-core": "workspace:^"
   },
   "devDependencies": {
+    "drizzle-orm-v1": "npm:drizzle-orm@1.0.0-rc.4",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "zod": "^4.1.13"

--- a/packages/generator-zod/test/mssql-cockroach-types.spec.ts
+++ b/packages/generator-zod/test/mssql-cockroach-types.spec.ts
@@ -1,0 +1,358 @@
+/**
+ * The mssql and cockroach dialects, end to end: a real drizzle table, the real analyzer, and the
+ * emitted zod module executed against values two real servers handed back or refused.
+ *
+ * Both cores arrived with Drizzle v1 and neither has ever had a fixture anywhere in this
+ * repository. `packages/analyzer/test/uncovered-dialects.spec.ts` says so outright and stops
+ * there, because the workspace resolves `drizzle-orm` to 0.45.2, which has no `mssql-core` or
+ * `cockroach-core` at all. This file gets at them through `drizzle-orm-v1`, an alias of
+ * 1.0.0-rc.4 held as a devDependency of this package alone, so the 0.45.2 every other suite
+ * measures against is untouched.
+ *
+ * Measured before the fix, by running the real analyzer over the two tables below: 7 of 23 mssql
+ * columns and 6 of 27 cockroach columns came back `tsType: 'unknown'`, and all thirteen were
+ * booleans or strings. Neither dialect states a `codec`, and `describeV1Column` was gated on
+ * "a codec, or a semantic half on the dataType". A `bit` states `boolean` and a `varchar` states
+ * `string`, both bare, so both failed that gate and fell to the class-name path, which has arms
+ * for Pg, MySql, SingleStore and Gel and none for these two.
+ *
+ * Ground truth is the servers, not drizzle's declarations. SQL Server 2022 and CockroachDB
+ * v24.3 were run in Docker, the tables created, rows inserted and read back through drizzle's
+ * own drivers; every literal asserted below is a value one of them returned or refused, and the
+ * measurement is recorded in `.superpowers/sdd/2026-08-03-top-100/mssql-cockroach-report.md`.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer, describeV1Column, type Analysis, type Column } from '@drzl/analyzer';
+import { ZodGenerator } from '../src/index';
+
+const dir = path.join(__dirname, '.tmp-mssql-cockroach');
+
+/**
+ * Every mssql column family the core exports a builder for, so a hole cannot hide in a type
+ * nobody thought to list. `nvarchar`/`nchar`/`ntext` are separate builders from their non-N
+ * counterparts and are kept apart here for that reason.
+ */
+const MSSQL_SOURCE = `
+  import {
+    mssqlTable, bigint, binary, bit, char, date, datetime, datetime2, datetimeoffset,
+    decimal, float, int, nchar, ntext, numeric, nvarchar, real, smallint, text, time,
+    tinyint, varbinary, varchar,
+  } from 'drizzle-orm-v1/mssql-core';
+  export const t = mssqlTable('t', {
+    i: int('i'),
+    ti: tinyint('ti'),
+    si: smallint('si'),
+    b53: bigint('b53', { mode: 'number' }),
+    b64: bigint('b64', { mode: 'bigint' }),
+    flag: bit('flag'),
+    price: decimal('price', { precision: 10, scale: 2 }),
+    num: numeric('num', { precision: 10, scale: 2 }),
+    fl: float('fl'),
+    rl: real('rl'),
+    name: varchar('name', { length: 120 }),
+    nname: nvarchar('nname', { length: 120 }),
+    code: char('code', { length: 4 }),
+    ncode: nchar('ncode', { length: 4 }),
+    body: text('body'),
+    nbody: ntext('nbody'),
+    d: date('d'),
+    dt: datetime('dt'),
+    dt2: datetime2('dt2'),
+    dto: datetimeoffset('dto'),
+    tm: time('tm'),
+    bin: binary('bin', { length: 16 }),
+    vbin: varbinary('vbin', { length: 32 }),
+  });
+`;
+
+/** The same spread for cockroach, including the array and enum forms Postgres shares. */
+const COCKROACH_SOURCE = `
+  import {
+    cockroachTable, bigint, bit, boolean, char, cockroachEnum, date, decimal,
+    doublePrecision, float, geometry, inet, int4, interval, jsonb, numeric, real,
+    smallint, string, text, time, timestamp, uuid, varbit, varchar, vector,
+  } from 'drizzle-orm-v1/cockroach-core';
+  export const mood = cockroachEnum('mood', ['sad', 'ok', 'happy']);
+  export const t = cockroachTable('t', {
+    i: int4('i'),
+    si: smallint('si'),
+    b53: bigint('b53', { mode: 'number' }),
+    b64: bigint('b64', { mode: 'bigint' }),
+    flag: boolean('flag'),
+    dec: decimal('dec', { precision: 10, scale: 2 }),
+    num: numeric('num', { precision: 10, scale: 2 }),
+    rl: real('rl'),
+    fl: float('fl'),
+    dp: doublePrecision('dp'),
+    name: varchar('name', { length: 120 }),
+    code: char('code', { length: 4 }),
+    body: text('body'),
+    str: string('str'),
+    u: uuid('u'),
+    payload: jsonb('payload'),
+    d: date('d'),
+    ts: timestamp('ts'),
+    tm: time('tm'),
+    iv: interval('iv'),
+    ip: inet('ip'),
+    bt: bit('bt', { dimensions: 3 }),
+    vb: varbit('vb', { dimensions: 8 }),
+    g: geometry('g', { type: 'point', mode: 'tuple' }),
+    vec: vector('vec', { dimensions: 3 }),
+    m: mood('m'),
+    tags: text('tags').array(),
+  });
+`;
+
+interface Analyzed {
+  analysis: Analysis;
+  byName: Map<string, Column>;
+  unknowns: string[];
+  /** The emitted zod module, imported and ready to run. */
+  schemas: Record<string, any>;
+}
+
+const cache = new Map<string, Analyzed>();
+
+async function dialect(name: string, source: string): Promise<Analyzed> {
+  const hit = cache.get(name);
+  if (hit) return hit;
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.schema.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  // The real analyzer over the real module, exactly as the CLI runs it.
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  const table = analysis.tables[0];
+  expect(table, `no table analyzed; issues: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+
+  // The real generator over that real analysis, then the module is imported and run. Nothing
+  // here reads the emitted text: a schema that parses is not a schema that validates.
+  const outDir = path.join(dir, `${name}-out`);
+  await new ZodGenerator(analysis).generate({ outDir } as never);
+  const emitted = path.join(outDir, `t-${process.pid}.ts`);
+  await fs.rename(path.join(outDir, 't.zod.ts'), emitted);
+  const schemas = await import(emitted);
+
+  const out: Analyzed = {
+    analysis,
+    byName: new Map(table.columns.map((c) => [c.name, c])),
+    unknowns: table.columns.filter((c) => c.tsType === 'unknown').map((c) => c.name),
+    schemas,
+  };
+  cache.set(name, out);
+  return out;
+}
+
+const mssql = () => dialect('mssql', MSSQL_SOURCE);
+const cockroach = () => dialect('cockroach', COCKROACH_SOURCE);
+
+/** The select-side field for one column of the emitted module. */
+const field = (a: Analyzed, col: string) => a.schemas.SelecttSchema.shape[col];
+const accepts = (schema: any, v: unknown) => schema.safeParse(v).success;
+
+beforeAll(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('the marker that lets these two dialects through', () => {
+  it('does not catch MySql, which is one letter away from MsSql', () => {
+    // `MySqlVarChar` and `MsSqlVarChar` differ by a single letter, and a MySQL column on 0.45.2
+    // presents exactly the shape the marker was added to admit: `dataType: 'string'`, no codec.
+    // Catching it would send every 0.4x MySQL string and boolean down the v1 path and past the
+    // byte caps the class-name path applies.
+    //
+    // The three shapes below were read off real drizzle-orm@0.45.2 columns rather than invented:
+    // `varchar('n',{length:10})` is a MySqlVarChar stating `"string"` with codec undefined,
+    // `boolean('f')` a MySqlBoolean stating `"boolean"`, `text('b')` a MySqlText stating
+    // `"string"`, and the real analyzer answers null for all three.
+    const old = (kind: string, dataType: string) => ({
+      dataType,
+      dimensions: 0,
+      constructor: { [Symbol.for('drizzle:entityKind')]: kind },
+    });
+    expect(describeV1Column(old('MySqlVarChar', 'string'))).toBe(null);
+    expect(describeV1Column(old('MySqlBoolean', 'boolean'))).toBe(null);
+    expect(describeV1Column(old('MySqlText', 'string'))).toBe(null);
+    // And the two it must catch, so this test cannot pass by matching nothing.
+    expect(describeV1Column(old('MsSqlVarChar', 'string'))).toMatchObject({ tsType: 'string' });
+    expect(describeV1Column(old('CockroachBoolean', 'boolean'))).toMatchObject({
+      tsType: 'boolean',
+    });
+  });
+});
+
+describe('mssql, against a real mssqlTable on drizzle v1', () => {
+  it('is identified as mssql and reaches every column', async () => {
+    const a = await mssql();
+    expect(a.analysis.dialect).toBe('mssql');
+    expect(a.analysis.tables[0].columns).toHaveLength(23);
+  });
+
+  it('leaves no column without a type', async () => {
+    // 7 of these 23 were `unknown`: flag, name, nname, code, ncode, body, nbody. The count is
+    // asserted next to the list so that shrinking the fixture cannot quietly shrink the coverage.
+    const a = await mssql();
+    expect(a.unknowns).toEqual([]);
+    expect(a.analysis.issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN')).toEqual([]);
+  });
+
+  it('types the bit column as the boolean SQL Server hands back', async () => {
+    // Measured on SQL Server 2022: a `bit` column inserted with drizzle and read back through
+    // `drizzle-orm/node-mssql` returns JS `true` and `false`, and the server refuses the string
+    // 'yes' outright ("Conversion failed when converting the varchar value 'yes' to data type
+    // bit").
+    const a = await mssql();
+    expect(a.byName.get('flag')).toMatchObject({ tsType: 'boolean', dbType: 'BOOLEAN' });
+    const f = field(a, 'flag');
+    expect(accepts(f, true), 'the true the server returned').toBe(true);
+    expect(accepts(f, false), 'the false the server returned').toBe(true);
+    expect(accepts(f, 'yes'), 'the string the server refused').toBe(false);
+  });
+
+  it('types the whole string family, N-prefixed spellings included', async () => {
+    const a = await mssql();
+    for (const n of ['name', 'nname', 'code', 'ncode', 'body', 'nbody']) {
+      expect(a.byName.get(n)?.tsType, `${n} is a string`).toBe('string');
+    }
+    // `length` was already being read while the type was unknown, so the cap outlived the type
+    // it belonged to. Both survive the fix.
+    expect(a.byName.get('name')?.maxLength).toBe(120);
+    expect(a.byName.get('nname')?.maxLength).toBe(120);
+    expect(a.byName.get('code')?.maxLength).toBe(4);
+    expect(a.byName.get('ncode')?.maxLength).toBe(4);
+    // MySQL's intrinsic TEXT caps are a MySQL fact. SQL Server's `text` holds 2 GB, so borrowing
+    // MySQL's 65535 here would refuse rows this server stores.
+    expect(a.byName.get('body')?.maxBytes).toBeUndefined();
+    expect(a.byName.get('nbody')?.maxBytes).toBeUndefined();
+  });
+
+  it('runs the emitted string schemas against what the server took and refused', async () => {
+    // Measured on SQL Server 2022. `varchar(120)` took 120 'a's and refused 121 with "String or
+    // binary data would be truncated"; `char(4)`/`nchar(4)` returned 'ab  ', space padded to the
+    // declared width; `text`/`ntext` returned the strings they were given.
+    const a = await mssql();
+    const name = field(a, 'name');
+    expect(accepts(name, 'hello'), 'a row the server returned').toBe(true);
+    expect(accepts(name, 'a'.repeat(120)), 'the longest value the server took').toBe(true);
+    expect(accepts(name, 'a'.repeat(121)), 'the value the server refused').toBe(false);
+    expect(accepts(name, 12345), 'a number in a varchar column').toBe(false);
+
+    expect(accepts(field(a, 'code'), 'ab  '), 'the padded char(4) the server returned').toBe(true);
+    expect(accepts(field(a, 'ncode'), 'cd  '), 'the padded nchar(4) the server returned').toBe(true);
+    expect(accepts(field(a, 'code'), 'abcde'), 'past the char(4) width').toBe(false);
+
+    expect(accepts(field(a, 'body'), 'body text')).toBe(true);
+    expect(accepts(field(a, 'nbody'), 'nbody text')).toBe(true);
+    expect(accepts(field(a, 'body'), { a: 1 }), 'an object in a text column').toBe(false);
+  });
+
+  it('keeps a real column at the float32 edge SQL Server stops at', async () => {
+    // Measured on SQL Server 2022: a `real` column stores 3.4028234663852886e38, the largest
+    // finite float32, and refuses 3.4028235677973366e38 with "Arithmetic overflow error for type
+    // real". So MySQL's bound is the right one here, and it is what falling through to it
+    // already produced. Asserted so the cockroach change below cannot move it.
+    const a = await mssql();
+    expect(a.byName.get('rl')).toMatchObject({
+      tsType: 'number',
+      integer: false,
+      min: '-340282346638528859811704183484516925440',
+      max: '340282346638528859811704183484516925440',
+    });
+    const rl = field(a, 'rl');
+    expect(accepts(rl, 3.4028234663852886e38), 'the largest value the server stored').toBe(true);
+    expect(accepts(rl, 3.4028235677973366e38), 'the value the server refused').toBe(false);
+  });
+});
+
+describe('cockroach, against a real cockroachTable on drizzle v1', () => {
+  it('is identified as cockroach and reaches every column', async () => {
+    const a = await cockroach();
+    expect(a.analysis.dialect).toBe('cockroach');
+    expect(a.analysis.tables[0].columns).toHaveLength(27);
+  });
+
+  it('leaves no column without a type', async () => {
+    // 6 of these 27 were `unknown`: flag, name, code, body, str and tags. `tags` is a
+    // `text().array()`, whose element is the same CockroachString that `body` is, so it was the
+    // string hole wearing an array.
+    const a = await cockroach();
+    expect(a.unknowns).toEqual([]);
+    expect(a.analysis.issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN')).toEqual([]);
+  });
+
+  it('types the bool column as the boolean CockroachDB hands back', async () => {
+    // Measured on CockroachDB v24.3: a `bool` column read back through `drizzle-orm/cockroach`
+    // returns JS `true` and `false`, and the server refuses the integer 1 for it ("value type int
+    // doesn't match type bool of column \"flag\"").
+    const a = await cockroach();
+    expect(a.byName.get('flag')).toMatchObject({ tsType: 'boolean', dbType: 'BOOLEAN' });
+    const f = field(a, 'flag');
+    expect(accepts(f, true), 'the true the server returned').toBe(true);
+    expect(accepts(f, false), 'the false the server returned').toBe(true);
+    expect(accepts(f, 1), 'the integer the server refused').toBe(false);
+  });
+
+  it('types varchar, char, string and text alike', async () => {
+    const a = await cockroach();
+    for (const n of ['name', 'code', 'body', 'str']) {
+      expect(a.byName.get(n)?.tsType, `${n} is a string`).toBe('string');
+    }
+    expect(a.byName.get('name')?.maxLength).toBe(120);
+    expect(a.byName.get('code')?.maxLength).toBe(4);
+    expect(a.byName.get('body')?.maxLength).toBeUndefined();
+    expect(a.byName.get('body')?.maxBytes).toBeUndefined();
+  });
+
+  it('runs the emitted string schemas against what the server took and refused', async () => {
+    // Measured on CockroachDB v24.3: `varchar(120)` took 120 'a's and refused 121 with "value too
+    // long for type VARCHAR(120)"; `char(4)` returned 'ab  '; `string` and `string`-as-text
+    // returned what they were given.
+    const a = await cockroach();
+    const name = field(a, 'name');
+    expect(accepts(name, 'hello')).toBe(true);
+    expect(accepts(name, 'a'.repeat(120)), 'the longest value the server took').toBe(true);
+    expect(accepts(name, 'a'.repeat(121)), 'the value the server refused').toBe(false);
+    expect(accepts(name, 12345)).toBe(false);
+    expect(accepts(field(a, 'code'), 'ab  '), 'the padded char(4) the server returned').toBe(true);
+    expect(accepts(field(a, 'body'), 'body text')).toBe(true);
+    expect(accepts(field(a, 'str'), 'str text')).toBe(true);
+    expect(accepts(field(a, 'str'), 12345)).toBe(false);
+  });
+
+  it('reads a string array as an array of strings', async () => {
+    // Measured on CockroachDB v24.3: the column returned ['a','b'] and [], and the server refuses
+    // a bare string for it ("could not parse \"a\" as type string[]"). Before the fix the element
+    // was `unknown`, so the emitted schema was `z.unknown().array()` and took `[1, 2]` as readily
+    // as the real rows.
+    const a = await cockroach();
+    expect(a.byName.get('tags')).toMatchObject({ tsType: 'string', arrayDimensions: 1 });
+    const tags = field(a, 'tags');
+    expect(accepts(tags, ['a', 'b']), 'the array the server returned').toBe(true);
+    expect(accepts(tags, []), 'the empty array the server returned').toBe(true);
+    expect(accepts(tags, 'a'), 'the bare string the server refused').toBe(false);
+    expect(accepts(tags, [1, 2]), 'numbers in a string[] column').toBe(false);
+  });
+
+  it('bounds a real column where Postgres does, not where MySQL does', async () => {
+    // CockroachDB's `real` is a FLOAT4: `information_schema.columns` reports crdb_sql_type FLOAT4
+    // for it, and it speaks the Postgres wire protocol. Measured on v24.3, the same defect the
+    // analyzer already records for Postgres: insert the largest finite float32 and the column
+    // hands back 3.4028235e+38, a double *above* that float32. Bounded at MySQL's edge, which is
+    // that float32 exactly, the select schema refused a row the column had just returned.
+    const a = await cockroach();
+    expect(a.byName.get('rl')).toMatchObject({
+      tsType: 'number',
+      integer: false,
+      min: '-340282356779733661637539395458142568448',
+      max: '340282356779733661637539395458142568448',
+    });
+    const rl = field(a, 'rl');
+    expect(accepts(rl, 3.4028235e38), 'the value the column handed back').toBe(true);
+    // `float`/`doublePrecision` are 8 byte and stay unbounded, so this is a property of the 4
+    // byte column and not of every cockroach float.
+    expect(a.byName.get('fl')?.max).toBeUndefined();
+    expect(a.byName.get('dp')?.max).toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
         specifier: workspace:^
         version: link:../validation-core
     devDependencies:
+      drizzle-orm-v1:
+        specifier: npm:drizzle-orm@1.0.0-rc.4
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.6)(supports-color@7.2.0)(typescript@5.9.3)
@@ -1995,6 +1998,152 @@ packages:
       sql.js:
         optional: true
       sqlite3:
+        optional: true
+
+  drizzle-orm@1.0.0-rc.4:
+    resolution: {integrity: sha512-BT+pf+qoiYHqltoA88Jmf6ilGMXPlpfE0hEJKc2adRtMCAl25Swk/t5gXcWxZNAwdtf3F5gCd2FpeOyP/pT0Hw==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@effect/sql-d1': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-libsql': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-mysql2': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-pg': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-pglite': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-sqlite-bun': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-sqlite-do': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-sqlite-node': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-sqlite-wasm': '>=4.0.0-beta.83 || >=4.0.0'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@sinclair/typebox': '>=0.34.8'
+      '@sqlitecloud/drivers': '>=1.0.653'
+      '@tidbcloud/serverless': '*'
+      '@tursodatabase/database': '>=0.6.0-pre.28 || >=0.6.0'
+      '@tursodatabase/database-common': '>=0.6.0-pre.28 || >=0.6.0'
+      '@tursodatabase/database-wasm': '>=0.6.0-pre.28 || >=0.6.0'
+      '@tursodatabase/serverless': '>=1.1.3'
+      '@tursodatabase/sync': '>=0.6.0-pre.28 || >=0.6.0'
+      '@types/better-sqlite3': '*'
+      '@types/mssql': ^9.1.4
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      arktype: '>=2.0.0'
+      better-sqlite3: '>=9.3.0'
+      bun-types: '*'
+      effect: '>=4.0.0-beta.83 || >=4.0.0'
+      expo-sqlite: '>=14.0.0'
+      mssql: ^11.0.1
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+      typebox: '>=1.0.0'
+      valibot: '>=1.0.0-beta.7'
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@effect/sql-d1':
+        optional: true
+      '@effect/sql-libsql':
+        optional: true
+      '@effect/sql-mysql2':
+        optional: true
+      '@effect/sql-pg':
+        optional: true
+      '@effect/sql-pglite':
+        optional: true
+      '@effect/sql-sqlite-bun':
+        optional: true
+      '@effect/sql-sqlite-do':
+        optional: true
+      '@effect/sql-sqlite-node':
+        optional: true
+      '@effect/sql-sqlite-wasm':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@sinclair/typebox':
+        optional: true
+      '@sqlitecloud/drivers':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@tursodatabase/database':
+        optional: true
+      '@tursodatabase/database-common':
+        optional: true
+      '@tursodatabase/database-wasm':
+        optional: true
+      '@tursodatabase/serverless':
+        optional: true
+      '@tursodatabase/sync':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/mssql':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      arktype:
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      effect:
+        optional: true
+      expo-sqlite:
+        optional: true
+      mssql:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+      typebox:
+        optional: true
+      valibot:
+        optional: true
+      zod:
         optional: true
 
   emoji-regex-xs@1.0.0:
@@ -4485,6 +4634,13 @@ snapshots:
       path-type: 4.0.0
 
   drizzle-orm@0.45.2: {}
+
+  drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3):
+    optionalDependencies:
+      '@sinclair/typebox': 0.34.52
+      arktype: 2.2.3
+      valibot: 1.4.2(typescript@5.9.3)
+      zod: 4.4.3
 
   emoji-regex-xs@1.0.0: {}
 


### PR DESCRIPTION
Four independent Tier A fixes, each measured against a real server before and after. They were
developed in separate worktrees and merged without conflict; each commit stands alone and is
revertable on its own.

## Views generated nothing at all on drizzle-orm 0.x

A view carries no `drizzle:Columns` and no `drizzle:Name` on 0.x. Its columns live only in
`Symbol.for('drizzle:ViewBaseConfig').selectedFields`, and on 1.0.0 a proxy answers both. So the
discovery gate skipped every view on the major `@drzl/analyzer` and `@drzl/cli` both pin at
`^0.45.2`, and said nothing about it: a views-only schema came back `tables: 0, dialect: unknown,
issues: []`.

Verified on `drizzle-orm@0.45.2` after the fix, on a fixture with a table, a plain view, a
materialized view and an `.existing()` view:

```
relations analyzed: 4          (was 1)
  base       readOnly=false   id:number label:string live:boolean
  digest     readOnly=true    id:number live:boolean
  existing   readOnly=false   id:number note:string
  plainview  readOnly=false   id:number label:string
issues : none
dialect: postgres              (was unknown on a views-only file)
```

The `readOnly` rule is kept: the materialized view carries it, the plain views do not.

The salvaged measurement that seeded this work claimed a `getSymbol`-only fix would leave the dialect
loop blind and "drop every column to its coarse default". Reproduced in exactly that state, the
columns were untouched. Two claims in that measurement were false and the implementation says what
is actually true instead.

## mssql and cockroach lost their boolean and string families

Measured on `drizzle-orm@1.0.0-rc.4` through the real analyzer: **7 of 23 mssql columns** and
**6 of 27 cockroach columns** came back `tsType: 'unknown'`, so all five generators emitted a
validator accepting every value for them. Thirteen columns, every one a boolean or a string, each
raising a `DRZL_ANL_UNKNOWN_COLUMN` issue that nothing acted on.

`verify:packed` was run twice to prove no count moved, once with the analyzer reverted to the branch
base, rather than asserting it.

## Seven Gel column types were described wrongly, six worse than unknown

Only `boolean()` came back `unknown`. The other six came back `string`, which is worse: a wrong type
actively rejects every row the database returns, where `unknown` merely accepts everything.

Ground truth is a live Gel 7.1 (`sys::get_version_as_str()` reports `7.1+08db576`), one row written
and read back through `drizzle-orm/gel@0.45.2`. **This repo's own
`packages/analyzer/test/uncovered-dialects.spec.ts` recorded a wrong correct-answer for two of the
six**: `dateDuration()` and `duration()` hand back `RelativeDuration`, not what the spec claimed.
The expectation was fixed alongside the code.

Filed rather than fixed, with its measurement: a real runtime check for those six needs a new
`ColumnShape` variant carrying a class name and an import specifier, an arm in each of five
generators, and a per-mode answer for JSON Schema. That is a public API addition across six
packages.

## The JSON Schema generator ignored `maxBytes`

Four of the five generators applied the MySQL TEXT family byte cap. JSON Schema ignored it, so on
0.4x a `tinytext` column emitted `{"type": "string"}` with no cap of either kind, because its
`maxLength` is empty on that major too. That made DRZL looser than `drizzle-zod@0.8.3` on 0.4x, the
one direction the parity gate exists to forbid.

JSON Schema has no byte-length keyword. The emitted schema carries the byte budget as `maxLength`
plus a description saying plainly that the number is bytes while `maxLength` counts characters,
rather than claiming a guarantee the format cannot make. `docs/generators/json-schema.md` gains a
subsection under "What it cannot say".

## Verification

`pnpm build`, `pnpm -r test`, `pnpm typecheck`, `pnpm lint`, `pnpm verify:packed` and
`pnpm -C docs build` all pass on the merged result, not only on the individual branches.

No lane touched `scripts/verify-packed.sh`; each ran it read-only and reported. That is why four
independent analyzer changes merged with no conflict.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
