### PR TITLE
fix(analyzer): type decimal by its mode, and binary as the string the driver returns

### DIFF
--- a/.changeset/binary-varbinary-byte-string.md
+++ b/.changeset/binary-varbinary-byte-string.md
@@ -1,0 +1,59 @@
+---
+'@drzl/analyzer': minor
+'@drzl/generator-zod': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-arktype': patch
+'@drzl/generator-typebox': patch
+'@drzl/generator-json-schema': patch
+---
+
+A MySQL or SingleStore `binary(n)`/`varbinary(n)` column is a string, and its schemas stop rejecting
+every row.
+
+The same wrong answer took two forms, one per drizzle major. On 0.4x the analyzer read the word
+"Binary" out of the class name and typed all four column builders as `Uint8Array`; on v1 it read the
+`string binary` dataType those columns share with a Postgres `bit(n)` and gave them a bit string, so
+all five generators emitted `^[01]*$` capped at n. Both are wrong about the same thing, and it was
+settled by asking a live MySQL 8.4 through drizzle on both majors rather than by reading any of the
+three layers in between:
+
+```
+raw mysql2          vbin -> Buffer <00 ff 41>
+drizzle 0.45.2      vbin -> string, 3 code points, instanceof Uint8Array false
+drizzle 1.0.0-rc.4  vbin -> string, identical
+```
+
+Measured through the emitted modules against that server, before and after, on both majors: the old
+schemas rejected **every** row the column returned in zod, valibot, arktype and typebox, and the new
+ones accept every one of them. The JSON Schema generator accepted them on 0.4x only by accident,
+because `contentEncoding: 'base64'` is an annotation no validator enforces.
+
+The declared width means two different things depending on direction, and both were measured:
+
+- **out**, the decode is lossy, so n bytes become at most n code points. `<ff ff ff>` stored in a
+  `varbinary(3)` comes back as 3 characters that re-encode to 9 UTF-8 bytes, so a byte cap on a
+  select schema refuses a row the column itself returned.
+- **in**, the server counts the encoded bytes. A `varbinary(8)` takes 8 ascii characters and refuses
+  9, and takes 2 emoji (8 bytes) and refuses 3 (12 bytes), so a character cap on an insert schema
+  promises a write the server refuses.
+
+So the column now carries a `{ kind: 'byteString', length }` shape and each generator picks the
+measurement its mode needs: characters on select, bytes on insert and update. Over a pool of writes
+against the live server, the four typed generators went from 16 disagreements with it to 0 on each
+major.
+
+**What changes for you.** A select schema for one of these columns now accepts the string your
+driver hands you and rejects a `Uint8Array`, which is the opposite of the 0.4x behaviour. An insert
+schema accepts any string inside the byte budget, including the empty string and anything that is
+not a run of `0` and `1`, and rejects one that is too long in bytes. `Column.tsType` for these four
+builders is `'string'` and `Column.dbType` is `'BINARY'` on both majors, where 0.4x used to say
+`Uint8Array`/`BLOB`; the declared width moved off `maxLength` and onto the shape.
+
+**What does not change.** A Postgres `bit(n)` and a Cockroach `bit(n)`/`varbit(n)` keep the bit
+string, which is correct for them. MSSQL `binary`/`varbinary` report `object buffer` and were never
+on this path. Gel `bytes` really does hand back a Buffer and stays a `Uint8Array`. The JSON Schema
+generator states the code-point cap in every mode, since JSON Schema has no keyword that counts
+bytes; that is a necessary condition on insert rather than the whole one.
+
+`drizzle-orm/zod` emits a bare unbounded string for these columns on 0.4x and the same rejects-every-row
+bit string on v1, so this output is deliberately neither.

--- a/.changeset/decimal-number-mode.md
+++ b/.changeset/decimal-number-mode.md
@@ -1,0 +1,41 @@
+---
+'@drzl/analyzer': patch
+---
+
+`decimal` and `numeric` are typed by their mode on drizzle-orm 0.4x, instead of every mode being a
+number.
+
+Drizzle gives each mode its own class, and the class-name path folded all three into one regex,
+`/Decimal|Numeric|Float|Double|Real/i`, which answered `number` for every one of them. Two of the
+three then rejected every row the database hands back, and their insert schemas rejected the value
+the driver wants. Read back through `db.select()` from a real MySQL 8.4.11 over mysql2, on a
+`decimal(10,2)` holding `'1234.56'` and a `decimal(20,0)` holding `'9007199254740993'`:
+
+```
+mode              class                 driver returns     0.4x said   0.4x says
+(default/string)  MySqlDecimal          '1234.56'          number      string
+mode: 'number'    MySqlDecimalNumber    1234.56            number      number
+mode: 'bigint'    MySqlDecimalBigInt    9007199254740993n  number      bigint
+```
+
+The same three modes measured identically on Postgres through PGlite and on SQLite through
+better-sqlite3, and official `drizzle-zod` 0.8.3 accepts exactly those three types on the same three
+columns and refuses the other two on each.
+
+**What changes for you.** On drizzle-orm 0.4x:
+
+- MySQL and SingleStore `decimal()` and `decimal({ mode: 'string' })` emit a string schema, matching
+  `numeric` on Postgres, which has been a string here for exactly this reason.
+- MySQL and SingleStore `decimal({ mode: 'bigint' })` emit a bigint schema.
+- SQLite `numeric({ mode: 'number' })` and `numeric({ mode: 'bigint' })` were `unknown`, so their
+  validators accepted anything; they now emit a number and a bigint schema.
+- Postgres `numeric({ mode: 'bigint' })` was already a bigint but was labelled `dbType: 'BIGINT'`,
+  picked up from the arm meant for `bigint` columns. It is `'NUMERIC'` now. Nothing generated
+  changes: `dbType` is read outside the analyzer only by `isIntegerColumn`, which asks whether it is
+  exactly `'INTEGER'`.
+
+**What does not change.** `decimal({ mode: 'number' })` and `numeric({ mode: 'number' })` stay
+numbers on every dialect; that mode was the one the old answer got right. Nothing on drizzle-orm v1
+moves, since `describeV1Column` already reads the mode off `dataType` and got all three right. The
+`numeric` format check stays attached on v1 only, so a 0.4x string schema is a bare string and still
+takes `'hello'`, as the Postgres one already did.

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -148,15 +148,22 @@ The same rules apply, with each dialect's own widths:
 | MySQL `mediumint()`                     | `z.number().int().gte(-8388608).lte(8388607)`              |
 | MySQL `year()`                          | `z.number().int().gte(1901).lte(2155)`                     |
 | MySQL `serial()`                        | `z.number().int().gte(0)`, since it is unsigned            |
-| MySQL `text()`                          | `z.string().max(65535)`, the width the type itself implies |
-| MySQL `binary(4)`                       | `z.string().regex(/^[01]*$/).max(4)`                       |
+| MySQL `text()`                          | a string capped at 65535 **bytes**, the width the type implies |
+| MySQL `binary(4)`                       | a string, capped at 4 characters on select and 4 bytes on insert |
 | SQLite `blob({ mode: 'json' })`         | `z.json()`                                                 |
 | SQLite `blob({ mode: 'bigint' })`       | `z.bigint()` with the 64 bit range                         |
 | SQLite `integer({ mode: 'timestamp' })` | a date                                                     |
 
-MySQL's text and blob caps are byte counts and this is a character count, which is the same
-approximation `drizzle-orm/zod` makes: without knowing the column's charset it is the only one
-available. Postgres `text` has no cap and does not get one.
+MySQL's text and blob caps are byte counts. Postgres `text` has no cap and does not get one.
+
+A `binary(n)`/`varbinary(n)` is not a bit string, which is what an earlier release of this table
+said and what `drizzle-orm/zod` still emits on drizzle v1. Asked of MySQL 8.4 through drizzle on
+both majors: the column takes any bytes at all and hands them back as a string, so a `^[01]*$`
+pattern rejected every row. The two caps differ because the decode is lossy: `<ff ff ff>` out of a
+`varbinary(3)` is three characters that re-encode to nine bytes, so a byte cap on a select schema
+would refuse a row the column returned, while a `varbinary(8)` refuses three emoji, which is three
+characters and twelve bytes, so a character cap on an insert schema would promise a write the
+server refuses.
 
 ## Which columns appear on insert
 

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1129,6 +1129,14 @@ export class SchemaAnalyzer {
       case 'SQLiteNumeric':
         // Drizzle returns numeric as a string; a JS number cannot hold arbitrary precision.
         return { tsType: 'string', dbType: 'NUMERIC' };
+      // The other two modes of the same column, which matched no arm here and no dialect regex
+      // below either, so both came back UNKNOWN and every generator emitted a schema that
+      // accepted anything at all. Read back through better-sqlite3 3.53.4 on a `numeric` column,
+      // `db.select()` hands back a number in number mode and a bigint in bigint mode.
+      case 'SQLiteNumericNumber':
+        return { tsType: 'number', dbType: 'NUMERIC' };
+      case 'SQLiteNumericBigInt':
+        return { tsType: 'bigint', dbType: 'NUMERIC' };
       case 'SQLiteBoolean':
         return { tsType: 'boolean', dbType: 'INTEGER' };
       // 0.4x gives an enum its own class, which had no arm here at all, so an enum column came
@@ -1177,6 +1185,15 @@ export class SchemaAnalyzer {
         // arbitrary precision. Typing them as numbers made the select validator reject every row
         // the database returned, and the insert validator reject the string the driver wants.
         return { tsType: 'string', dbType: 'NUMERIC' };
+      // The other two modes, each its own class. `PgNumericNumber` reached the coarse
+      // `/Numeric|Float|Double|Real/i` arm and got the right answer there; `PgNumericBigInt` got
+      // its `bigint` from the `/BigInt/i` arm meant for `bigint` columns, and the SQL label that
+      // comes with it, so a `numeric(20,0)` was reported as a BIGINT column. Read back through
+      // PGlite, `db.select()` hands back a number in number mode and a bigint in bigint mode.
+      case 'PgNumericNumber':
+        return { tsType: 'number', dbType: 'NUMERIC' };
+      case 'PgNumericBigInt':
+        return { tsType: 'bigint', dbType: 'NUMERIC' };
       case 'PgDoublePrecision':
         // These really are JS numbers.
         return { tsType: 'number', dbType: 'DOUBLE' };
@@ -1243,8 +1260,30 @@ export class SchemaAnalyzer {
           if (/BigInt53/i.test(ctor)) return { tsType: 'number', dbType: 'BIGINT' };
           if (/\bBigInt\b/i.test(ctor)) return { tsType: 'bigint', dbType: 'BIGINT' };
 
+          // `decimal` is three classes, one per mode, and the arm below matched all three and
+          // called every one a number. Read back through `db.select()` from a real MySQL 8.4.11
+          // over mysql2, on a `decimal(10,2)` holding '1234.56' and a `decimal(20,0)` holding
+          // '9007199254740993':
+          //
+          //   MySqlDecimal        (default, mode:'string')   '1234.56'          string
+          //   MySqlDecimalNumber  (mode:'number')            1234.56            number
+          //   MySqlDecimalBigInt  (mode:'bigint')            9007199254740993n  bigint
+          //
+          // Official drizzle-zod 0.8.3 accepts the same three types on the same three columns,
+          // and refuses the other two on each. So two of the three used to reject every row the
+          // database returns, and the number mode is right and must stay a number: a fix told
+          // only "decimal is a string" would break the one mode that worked.
+          //
+          // The mode is a suffix on the class name, so it is read as one. A `MySqlDecimal` that
+          // is neither is the string mode, which is what `decimal()` with no mode builds.
+          if (/Decimal/i.test(ctor)) {
+            if (/DecimalNumber$/.test(ctor)) return { tsType: 'number', dbType: 'NUMERIC' };
+            if (/DecimalBigInt$/.test(ctor)) return { tsType: 'bigint', dbType: 'NUMERIC' };
+            return { tsType: 'string', dbType: 'NUMERIC' };
+          }
+
           // Numeric/real numbers
-          if (/Decimal|Numeric|Float|Double|Real/i.test(ctor))
+          if (/Numeric|Float|Double|Real/i.test(ctor))
             return { tsType: 'number', dbType: 'NUMERIC' };
 
           // Integer family
@@ -1279,8 +1318,18 @@ export class SchemaAnalyzer {
           if (/BigInt64/i.test(ctor)) return { tsType: 'bigint', dbType: 'BIGINT' };
           if (/BigInt53/i.test(ctor)) return { tsType: 'number', dbType: 'BIGINT' };
 
+          // As MySQL above. SingleStore ships the same three classes, declaring the same three
+          // `data` types and defining the same three `mapFromDriverValue`s, and it is MySQL wire
+          // compatible; there is no in-process SingleStore to read a row back from, so MySQL's
+          // measurement is what stands behind this one.
+          if (/Decimal/i.test(ctor)) {
+            if (/DecimalNumber$/.test(ctor)) return { tsType: 'number', dbType: 'NUMERIC' };
+            if (/DecimalBigInt$/.test(ctor)) return { tsType: 'bigint', dbType: 'NUMERIC' };
+            return { tsType: 'string', dbType: 'NUMERIC' };
+          }
+
           // Numeric/real numbers
-          if (/Decimal|Numeric|Float|Double|Real/i.test(ctor))
+          if (/Numeric|Float|Double|Real/i.test(ctor))
             return { tsType: 'number', dbType: 'NUMERIC' };
 
           // Integer family

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -140,13 +140,38 @@ export type ColumnShape =
    */
   | { kind: 'custom'; sqlType?: string }
   /**
-   * A string of `0`/`1`: Postgres `bit(n)`, MySQL `binary(n)`/`varbinary(n)`.
+   * A string of `0`/`1`: Postgres `bit(n)`, Cockroach `bit(n)`/`varbit(n)`.
    *
-   * `exact` separates the two. A Postgres `bit(3)` is always three digits, while a MySQL
-   * `varbinary(16)` is at most sixteen, so treating both as exact rejected the empty string on
-   * every MySQL binary column.
+   * `exact` separates the two. A Postgres `bit(3)` is always three digits, while a Cockroach
+   * `varbit(16)` is at most sixteen, so treating both as exact rejects the empty string on every
+   * varying column.
+   *
+   * MySQL `binary(n)`/`varbinary(n)` used to be listed here and is not a bit string at all; see
+   * `byteString`.
    */
-  | { kind: 'bitstring'; length?: number; exact?: boolean };
+  | { kind: 'bitstring'; length?: number; exact?: boolean }
+  /**
+   * MySQL/SingleStore `binary(n)`/`varbinary(n)`: arbitrary bytes, handed to the caller as a
+   * string.
+   *
+   * Asked of MySQL 8.4 through drizzle on both majors, on the same row of the same table: the
+   * driver hands up a Buffer, drizzle decodes it, and what the caller receives is a string on
+   * 0.45.2 and on 1.0.0-rc.4 alike. `instanceof Uint8Array` is false for all four column builders
+   * on both majors.
+   *
+   * `length` is the declared width and means two different things depending on direction, which
+   * is why it is carried raw here rather than as a `maxLength` or a `maxBytes`:
+   *
+   *   out   the decode is lossy, so n bytes become at most n code points. Measured: `<ff ff ff>`
+   *         in a varbinary(3) comes back as 3 code points that re-encode to 9 UTF-8 bytes, so a
+   *         byte cap applied to a select schema rejects a row the column itself returned.
+   *   in    the server counts the encoded bytes. Measured on varbinary(8): 8 ascii accepted, 9
+   *         refused, 2 emoji (8 bytes) accepted, 3 emoji (12 bytes) refused, so a code-point cap
+   *         applied to an insert schema accepts a write the server refuses.
+   *
+   * The generators pick which by mode.
+   */
+  | { kind: 'byteString'; length?: number };
 
 export interface Key {
   name?: string;
@@ -365,6 +390,24 @@ const TUPLE_CLASS_SHAPES: Record<string, ColumnShape> = {
 };
 
 /**
+ * 0.4x classes whose value is a byte string, and the whole set of them.
+ *
+ * Enumerated from drizzle-orm 0.45.2's own exports rather than written down: `mysql-core` and
+ * `singlestore-core` each export `binary` and `varbinary` and no `blob` at all, so these four are
+ * every column builder on this major whose value is a run of arbitrary bytes handed over as a
+ * string. Gel's `bytes` really does hand back a Buffer and is not one of them.
+ *
+ * A shape rather than a `maxLength`, because the declared width is a byte budget on the way in and
+ * a code-point ceiling on the way out; see `ColumnShape`.
+ */
+const BYTE_STRING_CLASSES = new Set([
+  'MySqlBinary',
+  'MySqlVarBinary',
+  'SingleStoreBinary',
+  'SingleStoreVarBinary',
+]);
+
+/**
  * Everything Drizzle v1 states about a column outright, or `null` on an older Drizzle.
  *
  * v1 stamps each column with a `dataType` of the form `"<js type> <semantic>"` (`"number
@@ -524,21 +567,35 @@ export function describeV1Column(column: any): Partial<Column> | null {
       // `2020-01-01` into a macaddr, and requires cidr host bits to be zero on top of parsing.
       // Each candidate pattern turned away something the database takes.
       break;
-    case 'binary':
-      // Two unrelated families share this semantic and only the codec separates them. Postgres
-      // `bit(n)`, which the class calls `PgBinaryVector`, is a string of '0' and '1'. MySQL
-      // `binary(n)`/`varbinary(n)` hold arbitrary bytes. Treating both as bit strings made every
-      // MySQL binary column reject the empty string and anything not a run of 0s and 1s.
+    case 'binary': {
+      // Two unrelated families share this semantic. Postgres `bit(n)` and Cockroach
+      // `bit(n)`/`varbit(n)` are strings of '0' and '1'; MySQL and SingleStore
+      // `binary(n)`/`varbinary(n)` hold arbitrary bytes and hand the caller whatever the decode
+      // of those bytes produced. Treating the second family as the first made every MySQL and
+      // SingleStore binary column reject every row the database returns.
+      //
+      // Not the codec. Enumerated from drizzle's own exports on 1.0.0-rc.4, everything reaching
+      // this arm is: pg `bit` (codec 'bit'), mysql `binary`/`varbinary` (codecs 'binary' and
+      // 'varbinary'), singlestore `binary`/`varbinary` (no codec at all) and cockroach
+      // `bit`/`varbit` (no codec either). SingleStore and Cockroach are indistinguishable by
+      // codec, so `codec === 'binary' || codec === 'varbinary'` would silently leave both
+      // SingleStore columns on the bit-string path. `drizzle:entityKind` separates them, survives
+      // minification, and is what the rest of this file already discriminates on.
+      const entity = String(column?.constructor?.[Symbol.for('drizzle:entityKind')] ?? '');
+      const bytes = entity.startsWith('MySql') || entity.startsWith('SingleStore');
       out.tsType = 'string';
       out.dbType = codec === 'bit' ? 'BIT' : 'BINARY';
-      out.shape = {
-        kind: 'bitstring',
-        length: declaredLength(column),
-        // A Postgres `bit(3)` holds exactly three digits; a MySQL `binary(4)`/`varbinary(16)`
-        // holds at most that many, which is why `''` is valid there and not here.
-        exact: codec === 'bit',
-      };
+      out.shape = bytes
+        ? { kind: 'byteString', length: declaredLength(column) }
+        : {
+            kind: 'bitstring',
+            length: declaredLength(column),
+            // A Postgres `bit(3)` holds exactly three digits; a Cockroach `varbit(16)` holds at
+            // most that many, which is why `''` is valid there and not here.
+            exact: codec === 'bit',
+          };
       break;
+    }
     case 'point':
     case 'geometry':
       out.tsType = '[number, number]';
@@ -1200,6 +1257,16 @@ export class SchemaAnalyzer {
       case 'PgJson':
       case 'PgJsonb':
         return { tsType: 'any', dbType: ctor === 'PgJsonb' ? 'JSONB' : 'JSON' };
+      // The four builders in `BYTE_STRING_CLASSES`, which the coarse `/Blob|Binary|VarBinary/i`
+      // arms below would otherwise call a `Uint8Array` on the strength of the word "Binary" in
+      // the class name. Asked of MySQL 8.4 through drizzle 0.45.2 instead: the driver hands up a
+      // Buffer, `mapFromDriverValue` decodes it, and the caller receives a string. Every one of
+      // the four declares `dataType: 'string'` and every one of the four defines that method.
+      case 'MySqlBinary':
+      case 'MySqlVarBinary':
+      case 'SingleStoreBinary':
+      case 'SingleStoreVarBinary':
+        return { tsType: 'string', dbType: 'BINARY' };
       default:
         // SQLite timestamp mode fallback
         if (column?.config?.mode === 'timestamp' || column?.mode === 'timestamp') {
@@ -1448,10 +1515,18 @@ export class SchemaAnalyzer {
       // The shape the class-name path can state for itself, which until now was only ever the
       // json one. A `point` on 0.4x has no codec to read and needs a tuple here or the generators
       // emit a scalar for a value that is not one.
+      const ctorName = String((col as any)?.constructor?.name ?? '');
       const fallbackShape: ColumnShape | undefined =
         dbType === 'JSON' || dbType === 'JSONB' || (col as any)?.config?.mode === 'json'
           ? { kind: 'json' }
-          : TUPLE_CLASS_SHAPES[String((col as any)?.constructor?.name ?? '')];
+          : BYTE_STRING_CLASSES.has(ctorName)
+            ? { kind: 'byteString', length: declaredLength(col) }
+            : TUPLE_CLASS_SHAPES[ctorName];
+      // The same reason the v1 branch above drops it, reached from the other path: the declared
+      // `length` of a binary column is not a character limit, and `maxLength` is applied as one in
+      // every mode by every generator. Left in place the column carried the width twice under two
+      // meanings, and the wrong one is the one that renders.
+      if (fallbackShape?.kind === 'byteString') delete constraints.maxLength;
 
       // A column with no type is how two real bugs looked from the outside: `.array()` and
       // `pgEnum` columns on drizzle-orm 0.4x came back `unknown`, every generator emitted a

--- a/packages/analyzer/test/binary-varbinary.spec.ts
+++ b/packages/analyzer/test/binary-varbinary.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * A MySQL/SingleStore `binary(n)`/`varbinary(n)` hands the caller a string.
+ *
+ * Asked of MySQL 8.4 through drizzle itself, on both majors, rather than read off a type
+ * declaration. The same table, the same row, the same three layers:
+ *
+ *   raw mysql2        bin -> Buffer <68656c6c6f00...>   vbin -> Buffer <00ff41>
+ *   drizzle 0.45.2    bin -> string (16 code points)    vbin -> string (3 code points)
+ *   drizzle 1.0.0-rc.4  identical to 0.45.2
+ *
+ * `instanceof Uint8Array` is false for every one of them on both majors, and no value the column
+ * returns is a run of `0` and `1`. So the two answers this file replaces were each wrong in their
+ * own way and wrong about the same thing: 0.4x said `Uint8Array`, which the class-name path
+ * inferred from the word "Binary", and v1 said a `bitstring`, which is what a Postgres `bit(n)` is
+ * and what this shares a `dataType` with.
+ *
+ * The length is a byte budget on the way in and a code-point ceiling on the way out, which is not
+ * a distinction without a difference: measured on varbinary(3), the row `<ff ff ff>` comes back as
+ * 3 code points that re-encode to 9 UTF-8 bytes, so a byte cap applied to a select schema rejects
+ * a row the column itself returned. Both halves are carried by the shape and applied per mode by
+ * the generators, which their own specs run.
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SchemaAnalyzer, describeV1Column } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function columnsOf(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const a = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  return new Map(a.tables.flatMap((t) => t.columns.map((c) => [`${t.name}.${c.name}`, c])));
+}
+
+describe('drizzle 0.4x, against real mysql-core and singlestore-core columns', () => {
+  const SOURCE = `
+    import { mysqlTable, int, binary, varbinary } from 'drizzle-orm/mysql-core';
+    import {
+      singlestoreTable,
+      int as ssInt,
+      binary as ssBinary,
+      varbinary as ssVarbinary,
+    } from 'drizzle-orm/singlestore-core';
+
+    export const my = mysqlTable('my', {
+      id: int('id').primaryKey(),
+      bin: binary('bin', { length: 16 }),
+      binNoLen: binary('bin_no_len'),
+      vbin: varbinary('vbin', { length: 32 }),
+    });
+
+    export const ss = singlestoreTable('ss', {
+      id: ssInt('id').primaryKey(),
+      bin: ssBinary('bin', { length: 16 }),
+      vbin: ssVarbinary('vbin', { length: 32 }),
+    });
+  `;
+
+  it('types all four column builders as the string the driver returns', async () => {
+    // Four builders, both dialects, enumerated from drizzle's own exports rather than assumed:
+    // mysql-core and singlestore-core each export `binary` and `varbinary` and no `blob` at all on
+    // 0.45.2, so this is the whole set on this major.
+    const cols = await columnsOf('binary-varbinary-0.4x', SOURCE);
+    for (const key of ['my.bin', 'my.binNoLen', 'my.vbin', 'ss.bin', 'ss.vbin']) {
+      expect(cols.get(key)?.tsType, key).toBe('string');
+      expect(cols.get(key)?.dbType, key).toBe('BINARY');
+    }
+  });
+
+  it('carries the declared width as a byte-string shape', async () => {
+    const cols = await columnsOf('binary-varbinary-0.4x', SOURCE);
+    expect(cols.get('my.bin')?.shape).toEqual({ kind: 'byteString', length: 16 });
+    expect(cols.get('my.vbin')?.shape).toEqual({ kind: 'byteString', length: 32 });
+    expect(cols.get('ss.bin')?.shape).toEqual({ kind: 'byteString', length: 16 });
+    expect(cols.get('ss.vbin')?.shape).toEqual({ kind: 'byteString', length: 32 });
+  });
+
+  it('states the width once, on the shape', async () => {
+    // `maxLength` is what every generator applies as a plain character cap in every mode, and the
+    // whole point of the shape is that this width is not that. Two numbers meaning different
+    // things under the same name is how the wrong one gets picked up.
+    const cols = await columnsOf('binary-varbinary-0.4x', SOURCE);
+    for (const key of ['my.bin', 'my.vbin', 'ss.bin', 'ss.vbin']) {
+      expect(cols.get(key)?.maxLength, key).toBeUndefined();
+    }
+  });
+
+  it('leaves a column with no declared width unbounded rather than inventing one', async () => {
+    // `binary()` with no length is `binary(1)` in the server, but drizzle 0.4x records no length
+    // at all, so there is nothing to carry. v1 does record 1, and says so below.
+    const cols = await columnsOf('binary-varbinary-0.4x', SOURCE);
+    expect(cols.get('my.binNoLen')?.shape).toEqual({ kind: 'byteString', length: undefined });
+  });
+});
+
+/**
+ * v1 column descriptors, taken from a real drizzle-orm 1.0.0-rc.4 by enumerating every export of
+ * every dialect whose `dataType` has the semantic half `binary`. That census is the whole set
+ * reaching this arm, and the trap it exposes is that the codec cannot discriminate:
+ *
+ *   pg          bit        codec 'bit'         PgBinaryVector
+ *   mysql       binary     codec 'binary'      MySqlBinary
+ *   mysql       varbinary  codec 'varbinary'   MySqlVarBinary
+ *   singlestore binary     codec undefined     SingleStoreBinary
+ *   singlestore varbinary  codec undefined     SingleStoreVarBinary
+ *   cockroach   bit        codec undefined     CockroachBit
+ *   cockroach   varbit     codec undefined     CockroachVarbit
+ *
+ * SingleStore and Cockroach both carry no codec, so `codec === 'binary' || codec === 'varbinary'`
+ * would leave both SingleStore columns on the bit-string path while looking like it had moved
+ * them. `drizzle:entityKind` is the discriminator, as it is everywhere else in this file.
+ *
+ * MSSQL `binary`/`varbinary` report `object buffer` and never reach this arm at all.
+ */
+const v1col = (entityKind: string, codec: string | undefined, length?: number) => ({
+  dataType: 'string binary',
+  codec,
+  dimensions: 0,
+  ...(length === undefined ? {} : { length }),
+  constructor: { [Symbol.for('drizzle:entityKind')]: entityKind },
+});
+
+describe('drizzle v1, the four column classes that share a dataType with a Postgres bit', () => {
+  it('gives MySQL binary and varbinary a byte string, not a run of 0 and 1', () => {
+    expect(describeV1Column(v1col('MySqlBinary', 'binary', 16))).toMatchObject({
+      tsType: 'string',
+      dbType: 'BINARY',
+      shape: { kind: 'byteString', length: 16 },
+    });
+    expect(describeV1Column(v1col('MySqlVarBinary', 'varbinary', 32))?.shape).toEqual({
+      kind: 'byteString',
+      length: 32,
+    });
+  });
+
+  it('gives SingleStore the same answer, which carries no codec to discriminate on', () => {
+    expect(describeV1Column(v1col('SingleStoreBinary', undefined, 16))?.shape).toEqual({
+      kind: 'byteString',
+      length: 16,
+    });
+    expect(describeV1Column(v1col('SingleStoreVarBinary', undefined, 32))?.shape).toEqual({
+      kind: 'byteString',
+      length: 32,
+    });
+  });
+
+  it('leaves a Postgres bit exactly where it was', () => {
+    // A `bit(3)` really is three characters of '0' and '1', and that answer is correct and stays.
+    expect(describeV1Column(v1col('PgBinaryVector', 'bit', 3))).toMatchObject({
+      tsType: 'string',
+      dbType: 'BIT',
+      shape: { kind: 'bitstring', length: 3, exact: true },
+    });
+  });
+
+  it('leaves Cockroach bit and varbit where they were', () => {
+    expect(describeV1Column(v1col('CockroachBit', undefined, 8))?.shape).toEqual({
+      kind: 'bitstring',
+      length: 8,
+      exact: false,
+    });
+    expect(describeV1Column(v1col('CockroachVarbit', undefined, 8))?.shape).toEqual({
+      kind: 'bitstring',
+      length: 8,
+      exact: false,
+    });
+  });
+});

--- a/packages/analyzer/test/decimal-modes.spec.ts
+++ b/packages/analyzer/test/decimal-modes.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * `decimal`/`numeric` carries its mode in the class name on drizzle 0.4x, and each mode returns a
+ * different JavaScript type.
+ *
+ * Everything below was measured against a running engine before it was written down. Each column
+ * was created, a row inserted through the raw driver, and the row read back twice: once through the
+ * driver and once through `db.select()`, which is what a DRZL select schema has to accept.
+ *
+ * MySQL 8.4.11 in Docker, mysql2, drizzle-orm 0.45.2, `decimal(10,2)` holding '1234.56'
+ * (`decimal(20,0)` holding '9007199254740993' for the bigint mode, which is the only shape
+ * `BigInt(value)` can take):
+ *
+ *   mode           class                  mysql2 hands back   db.select() hands back
+ *   (default)      MySqlDecimal           "1234.56" string    "1234.56"          string
+ *   mode:'string'  MySqlDecimal           "1234.56" string    "1234.56"          string
+ *   mode:'number'  MySqlDecimalNumber     "1234.56" string    1234.56            number
+ *   mode:'bigint'  MySqlDecimalBigInt     "900..93" string    9007199254740993n  bigint
+ *
+ * Postgres via PGlite, same drizzle, `numeric(10,2)` and `numeric(20,0)`, identical readings for
+ * `PgNumeric`, `PgNumericNumber` and `PgNumericBigInt`. SQLite via better-sqlite3 3.53.4, likewise
+ * for `SQLiteNumeric`, `SQLiteNumericNumber` and `SQLiteNumericBigInt`.
+ *
+ * So the driver returns a string in the default and string modes, a number in number mode and a
+ * bigint in bigint mode, on all three engines. The class-name path used to answer `number` for the
+ * whole MySQL and SingleStore family, which is right for exactly one of the three: the select
+ * schema rejected every row in the other two, and the insert schema rejected the value the driver
+ * wants. A fix told only "decimal is a string" would break the number mode, which is why all three
+ * are pinned here rather than the one that started it.
+ *
+ * The v1 path is not affected and is the reference for the answers: drizzle v1 stamps
+ * `string numeric`, a bare `number`, and `bigint int64` on the three modes, which
+ * `describeV1Column` already reads correctly. `v1-column-types.spec.ts` covers that side.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+/** Every column of the first table, by name, from a real drizzle schema module. */
+async function columnsOf(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  const t = analysis.tables[0];
+  expect(t, `no table was analyzed; issues: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  return { analysis, byName: new Map(t!.columns.map((c) => [c.name, c])) };
+}
+
+const MYSQL_SOURCE = `
+  import { mysqlTable, decimal } from 'drizzle-orm/mysql-core';
+  export const t = mysqlTable('t', {
+    d_def: decimal('d_def', { precision: 10, scale: 2 }),
+    d_str: decimal('d_str', { precision: 10, scale: 2, mode: 'string' }),
+    d_num: decimal('d_num', { precision: 10, scale: 2, mode: 'number' }),
+    d_big: decimal('d_big', { precision: 20, scale: 0, mode: 'bigint' }),
+  });
+`;
+
+const SINGLESTORE_SOURCE = `
+  import { singlestoreTable, decimal } from 'drizzle-orm/singlestore-core';
+  export const t = singlestoreTable('t', {
+    d_def: decimal('d_def', { precision: 10, scale: 2 }),
+    d_str: decimal('d_str', { precision: 10, scale: 2, mode: 'string' }),
+    d_num: decimal('d_num', { precision: 10, scale: 2, mode: 'number' }),
+    d_big: decimal('d_big', { precision: 20, scale: 0, mode: 'bigint' }),
+  });
+`;
+
+const PG_SOURCE = `
+  import { pgTable, numeric } from 'drizzle-orm/pg-core';
+  export const t = pgTable('t', {
+    n_def: numeric('n_def', { precision: 10, scale: 2 }),
+    n_str: numeric('n_str', { precision: 10, scale: 2, mode: 'string' }),
+    n_num: numeric('n_num', { precision: 10, scale: 2, mode: 'number' }),
+    n_big: numeric('n_big', { precision: 20, scale: 0, mode: 'bigint' }),
+  });
+`;
+
+const SQLITE_SOURCE = `
+  import { sqliteTable, numeric } from 'drizzle-orm/sqlite-core';
+  export const t = sqliteTable('t', {
+    s_def: numeric('s_def'),
+    s_num: numeric('s_num', { mode: 'number' }),
+    s_big: numeric('s_big', { mode: 'bigint' }),
+  });
+`;
+
+/** The JS type the driver hands back, per column, measured as described at the top of this file. */
+const DRIVER_TYPES: Record<string, Record<string, string>> = {
+  mysql: { d_def: 'string', d_str: 'string', d_num: 'number', d_big: 'bigint' },
+  singlestore: { d_def: 'string', d_str: 'string', d_num: 'number', d_big: 'bigint' },
+  pg: { n_def: 'string', n_str: 'string', n_num: 'number', n_big: 'bigint' },
+  sqlite: { s_def: 'string', s_num: 'number', s_big: 'bigint' },
+};
+
+const SOURCES: Record<string, string> = {
+  mysql: MYSQL_SOURCE,
+  singlestore: SINGLESTORE_SOURCE,
+  pg: PG_SOURCE,
+  sqlite: SQLITE_SOURCE,
+};
+
+describe.each(Object.keys(SOURCES))('%s decimal/numeric modes on drizzle 0.4x', (dialect) => {
+  it('types every mode as the type its driver returns', async () => {
+    // The whole table at once, keyed by column, so a fix that repairs one mode and leaves
+    // another wrong fails naming the column rather than passing on the one it repaired.
+    const { byName } = await columnsOf(`decimal-modes-${dialect}`, SOURCES[dialect]);
+    const actual = Object.fromEntries(
+      Object.keys(DRIVER_TYPES[dialect]).map((n) => [n, byName.get(n)?.tsType])
+    );
+    expect(actual).toEqual(DRIVER_TYPES[dialect]);
+  });
+
+  it('calls every mode a NUMERIC column, whichever JS type it carries', async () => {
+    // The SQL side does not change with the mode: all three are the same `decimal(10,2)` or
+    // `numeric(10,2)` column. `dbType` is read by `isIntegerColumn` in @drzl/validation-core,
+    // which asks only whether it is exactly 'INTEGER', so none of these may be one.
+    const { byName } = await columnsOf(`decimal-modes-${dialect}`, SOURCES[dialect]);
+    const actual = Object.fromEntries(
+      Object.keys(DRIVER_TYPES[dialect]).map((n) => [n, byName.get(n)?.dbType])
+    );
+    const expected = Object.fromEntries(
+      Object.keys(DRIVER_TYPES[dialect]).map((n) => [n, 'NUMERIC'])
+    );
+    expect(actual).toEqual(expected);
+  });
+
+  it('raises no unknown-column warning for any mode', async () => {
+    // SQLite's number and bigint modes used to reach no arm at all and came back `unknown`, so
+    // the emitted schema accepted anything. The warning is the only thing that said so.
+    const { analysis, byName } = await columnsOf(`decimal-modes-${dialect}`, SOURCES[dialect]);
+    expect([...byName.values()].filter((c) => c.tsType === 'unknown').map((c) => c.name)).toEqual(
+      []
+    );
+    expect(analysis.issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN')).toEqual([]);
+  });
+});
+
+describe('what the modes must not pick up on the way', () => {
+  it('leaves the number mode unbounded and non-integer, as it is today', async () => {
+    // Addendum AK is open on exactly this: a `numeric(10,2)` in number mode admits 2^53 where the
+    // column enforces 10^8. Pinned as it stands so this fix cannot be read as having settled it,
+    // and so a later change to the bound is a deliberate edit here rather than a silent one.
+    //
+    // Postgres is the one dialect that already carries a bound, `PgNumericNumber` in
+    // INEXACT_RANGES; MySQL, SingleStore and SQLite carry none. Both states are recorded.
+    const my = (await columnsOf('decimal-modes-mysql', MYSQL_SOURCE)).byName.get('d_num');
+    expect(my).toMatchObject({ tsType: 'number' });
+    expect(my?.min).toBeUndefined();
+    expect(my?.max).toBeUndefined();
+    expect(my?.integer).toBeUndefined();
+
+    const pg = (await columnsOf('decimal-modes-pg', PG_SOURCE)).byName.get('n_num');
+    expect(pg).toMatchObject({
+      tsType: 'number',
+      integer: false,
+      min: '-9007199254740991',
+      max: '9007199254740991',
+    });
+  });
+
+  it('leaves the string modes without a numeric format, as the 0.4x path does everywhere', async () => {
+    // `format: 'numeric'` is set by the v1 path alone. On 0.4x no column gets one, including the
+    // Postgres `numeric` that has been a string here for far longer, so the emitted schema is a
+    // bare string and accepts 'hello'. That gap is one thing across the whole 0.4x path rather
+    // than something this family introduced, and it is reported rather than fixed here.
+    const my = (await columnsOf('decimal-modes-mysql', MYSQL_SOURCE)).byName.get('d_def');
+    const pg = (await columnsOf('decimal-modes-pg', PG_SOURCE)).byName.get('n_def');
+    expect(my?.format).toBeUndefined();
+    expect(pg?.format).toBeUndefined();
+  });
+});

--- a/packages/analyzer/test/mysql-types.spec.ts
+++ b/packages/analyzer/test/mysql-types.spec.ts
@@ -82,8 +82,13 @@ export { table as users };
     expect(map.get('dbl')).toBe('number');
     expect(map.get('rl')).toBe('number');
     expect(map.get('payload')).toBe('any');
+    // `MySqlBlob` is this fixture's invention: mysql-core exports no `blob` on 0.45.2, enumerated
+    // from the module's own exports. It stays on the coarse `/Blob/` arm, which nothing real
+    // reaches on this major.
     expect(map.get('data')).toBe('Uint8Array');
-    expect(map.get('bin')).toBe('Uint8Array');
-    expect(map.get('vbin')).toBe('Uint8Array');
+    // The two that do exist. Asked of MySQL 8.4 through drizzle on both majors: a
+    // `binary`/`varbinary` column hands the caller a string, so `Uint8Array` rejected every row.
+    expect(map.get('bin')).toBe('string');
+    expect(map.get('vbin')).toBe('string');
   });
 });

--- a/packages/analyzer/test/singlestore-types.spec.ts
+++ b/packages/analyzer/test/singlestore-types.spec.ts
@@ -94,8 +94,13 @@ export { table as things };
     expect(get('timeCol')).toBe('string');
     expect(get('yearCol')).toBe('number');
     expect(get('payload')).toBe('any');
-    expect(get('bin')).toBe('Uint8Array');
-    expect(get('vbin')).toBe('Uint8Array');
+    // The two the driver decodes for you. Asked of a server through drizzle on both majors: a
+    // `binary`/`varbinary` column hands the caller a string, so `Uint8Array` rejected every row.
+    expect(get('bin')).toBe('string');
+    expect(get('vbin')).toBe('string');
+    // `SingleStoreBlob` is this fixture's invention: singlestore-core exports no `blob` on 0.45.2,
+    // enumerated from the module's own exports. It stays on the coarse `/Blob/` arm, which nothing
+    // real reaches.
     expect(get('blob')).toBe('Uint8Array');
     expect(get('vec')).toBe('any');
   });

--- a/packages/analyzer/test/singlestore-types.spec.ts
+++ b/packages/analyzer/test/singlestore-types.spec.ts
@@ -81,7 +81,10 @@ export { table as things };
     expect(get('big53')).toBe('number');
     expect(get('big64')).toBe('bigint');
     expect(get('flag')).toBe('boolean');
-    expect(get('price')).toBe('number');
+    // `decimal()` with no mode builds a `SingleStoreDecimal`, and its driver value is a string.
+    // The other two mode classes are not in this hand-written list at all, which is why
+    // `decimal-modes.spec.ts` builds them from `singlestoreTable` instead.
+    expect(get('price')).toBe('string');
     expect(get('dbl')).toBe('number');
     expect(get('rl')).toBe('number');
     expect(get('name')).toBe('string');

--- a/packages/analyzer/test/uncovered-dialects.spec.ts
+++ b/packages/analyzer/test/uncovered-dialects.spec.ts
@@ -212,29 +212,21 @@ describe('SingleStore, against a real singlestoreTable', () => {
     expect(analysis.issues.some((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN' && /"vec"/.test(i.message))).toBe(true);
   });
 
-  it('DEFECT: types every decimal mode as number, and only one of the three is a number', async () => {
-    // On drizzle 0.4x only. v1 gets all three right and is the reference for what a fix
-    // should produce.
+  it('types the default decimal mode as the string the driver returns', async () => {
+    // Was a DEFECT here: `/Decimal|Numeric|Float|Double|Real/i` matched all three mode classes
+    // and returned 'number' for each, so two of the three rejected every row.
     //
-    // `decimal` has three modes and the class-name arm cannot tell them apart, because
-    // `/Decimal|Numeric|Float|Double|Real/i` matches all three class names and returns
-    // 'number' for each. Measured through `mapFromDriverValue` on 0.4x, and through the real
-    // analyzer on v1:
+    //   mode          class                      driver returns   0.4x said   0.4x says
+    //   (default)     SingleStoreDecimal         '1.25' string    number      string
+    //   mode:'number' SingleStoreDecimalNumber   1.25   number    number      number
+    //   mode:'bigint' SingleStoreDecimalBigInt   125n   bigint    number      bigint
     //
-    //   mode          class                      driver returns   0.4x says   v1 says
-    //   (default)     SingleStoreDecimal         "1.25" string     number      string
-    //   mode:'number' SingleStoreDecimalNumber   1.25   number     number      number
-    //   mode:'bigint' SingleStoreDecimalBigInt   125n   bigint     number      bigint
-    //
-    // So two of the three reject every row. A fix told only "decimal should be a string"
-    // would break the number mode, which is correct today, and would still miss the bigint
-    // mode. MySQL 0.4x has the identical three classes and the identical problem, so this is
-    // shared with a covered dialect rather than specific to SingleStore.
-    //
-    // Only the default mode is in the fixture; the other two are recorded here because the
-    // fix has to cover all three and a one-column test would understate it.
+    // MySQL 0.4x ships the identical three classes and had the identical problem, and it is the
+    // dialect the row-by-row measurement was taken on, since there is no in-process SingleStore.
+    // All three modes on all four dialects that have them are pinned in `decimal-modes.spec.ts`,
+    // against those readings; this fixture carries the default mode alone.
     const { byName } = await columnsOf('real-singlestore', SINGLESTORE_SOURCE);
-    expect(byName.get('price')?.tsType).toBe('number');
+    expect(byName.get('price')?.tsType).toBe('string');
   });
 });
 
@@ -295,14 +287,15 @@ describe('Gel, against a real gelTable', () => {
     expect(ts('i53')).toBe('number');
     expect(ts('name')).toBe('string');
     expect(ts('b')).toBe('Uint8Array'); // bytes.d.ts     data: Uint8Array
-    // Gel's decimal really is a string, and here the analyzer gets it right where
-    // SingleStore's does not.
+    // Gel's decimal really is a string, and it is the one dialect that reached the right answer
+    // from the class name alone: `GelDecimal` has an arm of its own, where SingleStore's three
+    // mode classes shared one arm with the floats until that was split.
     expect(ts('dec')).toBe('string'); // decimal.d.ts   data: string
     expect(ts('tstz')).toBe('Date'); // timestamptz.d.ts data: Date
   });
 
   it('DEFECT: types the whole cal:: and duration family as string, which the driver never returns', async () => {
-    // Six columns, all of the same species as the SingleStore `decimal` defect below: the
+    // Six columns, all of the same species as the SingleStore `binary` defect above: the
     // analyzer states a JS type the driver does not produce, so a select validator rejects
     // every row the database returns.
     //

--- a/packages/analyzer/test/uncovered-dialects.spec.ts
+++ b/packages/analyzer/test/uncovered-dialects.spec.ts
@@ -114,24 +114,23 @@ describe('SingleStore, against a real singlestoreTable', () => {
     expect(byName.get('payload')?.shape).toEqual({ kind: 'json' });
   });
 
-  it('DEFECT: types binary and varbinary as Uint8Array, and the driver returns a string', async () => {
-    // Not this task's to fix, and not specific to SingleStore: `mysql-types.spec.ts` and
-    // `sqlite-types.spec.ts` pin the same answer, and MySQL 0.4x behaves identically. It is
-    // recorded here because measuring the dialect and stating the truth was the task, and
-    // because this is a second reject-every-row case in the same measured spread.
-    //
-    // `SingleStoreBinary` and `SingleStoreVarBinary` both declare `data: string` and both
-    // define a `mapFromDriverValue` that turns the driver's Buffer into a string:
+  it('types binary and varbinary as the string the driver returns', async () => {
+    // This used to assert `Uint8Array` and was labelled DEFECT, which it was: the select schema
+    // accepted a Buffer and rejected the string in zod, valibot, arktype and typebox, so it
+    // rejected every row. `SingleStoreBinary` and `SingleStoreVarBinary` both declare
+    // `dataType: 'string'` and both define a `mapFromDriverValue` that decodes the driver's
+    // Buffer, verified by calling it:
     //
     //   mapFromDriverValue(Buffer.from('hi')) -> "hi"   (a string, not bytes)
     //
-    // Measured through the emitted schemas: the select schema accepts a Buffer and rejects
-    // the string in zod, valibot, arktype and typebox. The JSON Schema generator is the only
-    // one that accepts the real value, and only because it types every byte column as a
-    // string anyway.
+    // And end to end, over the MySQL wire protocol SingleStore speaks, on both drizzle majors:
+    // a row written as `<00 ff 41>` into a varbinary comes back as a 3 code point string with
+    // `instanceof Uint8Array` false.
     const { byName } = await columnsOf('real-singlestore', SINGLESTORE_SOURCE);
-    expect(byName.get('bin')?.tsType).toBe('Uint8Array');
-    expect(byName.get('vbin')?.tsType).toBe('Uint8Array');
+    expect(byName.get('bin')?.tsType).toBe('string');
+    expect(byName.get('vbin')?.tsType).toBe('string');
+    expect(byName.get('bin')?.shape).toEqual({ kind: 'byteString', length: 16 });
+    expect(byName.get('vbin')?.shape).toEqual({ kind: 'byteString', length: 32 });
   });
 
   it('carries the declared varchar and char lengths', async () => {

--- a/packages/analyzer/test/v1-dialect-types.spec.ts
+++ b/packages/analyzer/test/v1-dialect-types.spec.ts
@@ -77,13 +77,15 @@ describe('the two meanings of "string binary"', () => {
     expect(describeV1Column(pgBit)?.shape).toEqual({ kind: 'bitstring', length: 3, exact: true });
   });
 
-  it('treats a MySQL binary as a ceiling, so the empty string is valid', () => {
-    // Sharing the Postgres arm made every MySQL binary column reject `''`, and anything that was
-    // not a run of 0s and 1s of exactly the declared width.
+  it('treats a MySQL binary as arbitrary bytes, which is not a bit string at all', () => {
+    // Sharing the Postgres arm made every MySQL binary column reject `''` and anything that was
+    // not a run of 0s and 1s. Loosening the width to a ceiling fixed the empty string and left
+    // the pattern, which still rejected every row the column returns: asked of MySQL 8.4 through
+    // drizzle 1.0.0-rc.4, a varbinary holding `<00 ff 41>` comes back as three code points that
+    // are not `0` or `1`. `binary-varbinary.spec.ts` carries the full measurement.
     expect(describeV1Column(my('string binary', 'varbinary', { length: 16 }))?.shape).toEqual({
-      kind: 'bitstring',
+      kind: 'byteString',
       length: 16,
-      exact: false,
     });
   });
 });

--- a/packages/cli/test/decimal-modes.e2e.spec.ts
+++ b/packages/cli/test/decimal-modes.e2e.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * A `decimal`/`numeric` column's emitted schema, run against the values a real engine returns.
+ *
+ * The analyzer half of this lives in `packages/analyzer/test/decimal-modes.spec.ts`, which pins the
+ * `tsType` of every mode. This half closes the loop the other side cannot: it takes a real drizzle
+ * schema through the real analyzer and the real zod generator, imports the module that comes out,
+ * and asks it about the exact values measured off a running database. Nothing here is asserted
+ * about the text of the generated file.
+ *
+ * It lives in `@drzl/cli` because this is the only package that has drizzle-orm, `@drzl/analyzer`
+ * and a validator library in the same tree, so a fixture written here resolves `drizzle-orm` and
+ * the emitted module resolves `zod`.
+ *
+ * The values, measured before anything was changed. MySQL 8.4.11 in Docker through mysql2,
+ * drizzle-orm 0.45.2, reading back a `decimal(10,2)` holding '1234.56' and a `decimal(20,0)`
+ * holding '9007199254740993':
+ *
+ *   mode           class                 db.select() hands back
+ *   (default)      MySqlDecimal          '1234.56'          string
+ *   mode:'number'  MySqlDecimalNumber    1234.56            number
+ *   mode:'bigint'  MySqlDecimalBigInt    9007199254740993n  bigint
+ *
+ * Postgres through PGlite and SQLite through better-sqlite3 give the same three answers for
+ * `numeric`, and official drizzle-zod 0.8.3 on the same columns accepts exactly those three types
+ * and refuses the other two, which is the second opinion on which value belongs to which mode.
+ *
+ * Before the fix the class-name path called all three `number`, so the two string-returning modes
+ * and the bigint mode each emitted a schema that rejected every row the database hands back.
+ *
+ * Requires a build, as `commands.e2e.spec.ts` does: the generator and the analyzer are consumed
+ * through their package entry points rather than from source.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ZodGenerator } from '@drzl/generator-zod';
+
+const ROOT = path.join(__dirname, '.decimal-tmp');
+
+const SOURCES: Record<string, string> = {
+  mysql: `
+    import { mysqlTable, decimal } from 'drizzle-orm/mysql-core';
+    export const t = mysqlTable('t', {
+      d_def: decimal('d_def', { precision: 10, scale: 2 }).notNull(),
+      d_num: decimal('d_num', { precision: 10, scale: 2, mode: 'number' }).notNull(),
+      d_big: decimal('d_big', { precision: 20, scale: 0, mode: 'bigint' }).notNull(),
+    });
+  `,
+  singlestore: `
+    import { singlestoreTable, decimal } from 'drizzle-orm/singlestore-core';
+    export const t = singlestoreTable('t', {
+      d_def: decimal('d_def', { precision: 10, scale: 2 }).notNull(),
+      d_num: decimal('d_num', { precision: 10, scale: 2, mode: 'number' }).notNull(),
+      d_big: decimal('d_big', { precision: 20, scale: 0, mode: 'bigint' }).notNull(),
+    });
+  `,
+  pg: `
+    import { pgTable, numeric } from 'drizzle-orm/pg-core';
+    export const t = pgTable('t', {
+      d_def: numeric('d_def', { precision: 10, scale: 2 }).notNull(),
+      d_num: numeric('d_num', { precision: 10, scale: 2, mode: 'number' }).notNull(),
+      d_big: numeric('d_big', { precision: 20, scale: 0, mode: 'bigint' }).notNull(),
+    });
+  `,
+  sqlite: `
+    import { sqliteTable, numeric } from 'drizzle-orm/sqlite-core';
+    export const t = sqliteTable('t', {
+      d_def: numeric('d_def').notNull(),
+      d_num: numeric('d_num', { mode: 'number' }).notNull(),
+      d_big: numeric('d_big', { mode: 'bigint' }).notNull(),
+    });
+  `,
+};
+
+/** The row a driver really hands back, one value per mode, and the four it never does. */
+const RETURNED: Record<string, unknown> = {
+  d_def: '1234.56',
+  d_num: 1234.56,
+  d_big: 9007199254740993n,
+};
+const NEVER_RETURNED: Record<string, unknown[]> = {
+  d_def: [1234.56, 9007199254740993n, true, null],
+  d_num: ['1234.56', 9007199254740993n, true, null],
+  d_big: ['1234.56', 1234.56, true, null],
+};
+
+/** Analyze, generate, and import what came out. */
+const modules: Record<string, Record<string, any>> = {};
+
+beforeAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+  for (const [dialect, source] of Object.entries(SOURCES)) {
+    const dir = path.join(ROOT, dialect);
+    await fs.mkdir(dir, { recursive: true });
+    const schema = path.join(dir, 'schema.mjs');
+    await fs.writeFile(schema, source, 'utf8');
+    const analysis = await new SchemaAnalyzer(schema).analyze({});
+    await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+    modules[dialect] = await import(path.join(dir, 't.zod.ts'));
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe.each(Object.keys(SOURCES))('%s, through the emitted zod module', (dialect) => {
+  it.each(Object.keys(RETURNED))('accepts what the driver returns for %s', (col) => {
+    const field = modules[dialect].SelecttSchema.shape[col];
+    expect(field, `no field emitted for ${col}`).toBeTruthy();
+    const r = field.safeParse(RETURNED[col]);
+    expect(r.success, `select schema rejected ${String(RETURNED[col])}`).toBe(true);
+  });
+
+  it.each(Object.keys(NEVER_RETURNED))('refuses what the driver never returns for %s', (col) => {
+    const field = modules[dialect].SelecttSchema.shape[col];
+    for (const v of NEVER_RETURNED[col]) {
+      expect(field.safeParse(v).success, `select schema accepted ${String(v)}`).toBe(false);
+    }
+  });
+
+  it.each(Object.keys(RETURNED))('takes the same value back on insert for %s', (col) => {
+    // The insert side matters as much as the select side: `mapToDriverValue` is `String` for the
+    // number and bigint modes, so what the caller passes in is the JS type the mode names, not
+    // the string the wire carries.
+    const field = modules[dialect].InserttSchema.shape[col];
+    expect(field.safeParse(RETURNED[col]).success).toBe(true);
+  });
+});

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -120,9 +120,15 @@ function atShapeType(c: Column): string | undefined {
     case 'numberVector':
       return s.length ? `number[] == ${s.length}` : 'number[]';
     case 'bitstring':
-      // `== n` for a Postgres `bit(n)`, `<= n` for a MySQL `binary(n)`.
+      // `== n` for a Postgres `bit(n)`, `<= n` for a Cockroach `varbit(n)`.
       if (!s.length) return '/^[01]*$/';
       return `/^[01]*$/ & string ${s.exact ? '==' : '<='} ${s.length}`;
+    case 'byteString':
+      // See the zod generator: a MySQL/SingleStore binary column takes any bytes at all and hands
+      // them back as a string, so no pattern belongs here. The declared width is a code-point
+      // ceiling out and a byte budget in, and `string <= n` is a third measurement that agrees
+      // with neither, so the cap goes to `atCapNarrows` where an exact count can be written.
+      return 'string';
   }
 }
 
@@ -279,7 +285,7 @@ function renderObjectShape(
       // `.default(null)` does work and does keep the narrow. That is a change to the whole
       // applyDefaults path, which has two further defects of its own, and is tracked separately.
       const defaulted = mode === 'insert' && applyDefaults && c.defaultValue !== undefined;
-      const caps = atCapNarrows(c) + (defaulted ? '' : atBigintNarrow(c, checks));
+      const caps = atCapNarrows(c, mode) + (defaulted ? '' : atBigintNarrow(c, checks));
       if (!caps) return `  ${JSON.stringify(c.name)}: ${JSON.stringify(dsl)},`;
       // A Type instance rather than a DSL string, because neither cap is expressible in the DSL:
       // `string <= n` counts UTF-16 code units, which agrees with neither database. ArkType marks
@@ -428,7 +434,19 @@ function atBigintNarrow(c: Column, checks: ColumnCheck[]): string {
  * third measurement, agreeing with neither. Both databases count `varchar(n)` in characters and
  * MySQL counts `tinytext` in bytes, so both are written out here rather than approximated.
  */
-function atCapNarrows(c: Column): string {
+function atCapNarrows(c: Column, mode: Mode): string {
+  // A byte-string column is the one shaped column that carries a cap. It reaches this function
+  // rather than stating the cap in its own DSL because neither of its two measurements is
+  // expressible there, and because which one applies depends on the mode: n code points is what
+  // the column can return, n bytes is what the server accepts. Both were measured against MySQL
+  // 8.4; see the analyzer's `ColumnShape`.
+  if (c.shape?.kind === 'byteString') {
+    const n = c.shape.length;
+    if (!n) return '';
+    return mode === 'select'
+      ? atNarrow(c, (v) => `[...${v}].length <= ${n}`, `at most ${n} characters`)
+      : atNarrow(c, (v) => `new TextEncoder().encode(${v}).length <= ${n}`, `at most ${n} bytes`);
+  }
   if (c.tsType !== 'string' || c.shape) return '';
   const out: string[] = [];
   if (c.maxLength) {

--- a/packages/generator-arktype/test/byte-string.spec.ts
+++ b/packages/generator-arktype/test/byte-string.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * MySQL/SingleStore `binary(n)`/`varbinary(n)` in ArkType, by running the emitted schemas.
+ *
+ * The measurements these assert are in `packages/generator-zod/test/byte-string.spec.ts` and were
+ * taken from MySQL 8.4 through drizzle on both majors. Neither cap is expressible in ArkType's
+ * string DSL: `string <= n` counts UTF-16 code units, which agrees with neither the code points a
+ * select can return nor the bytes an insert is measured in, so both go to a narrow.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArkTypeGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { type } from 'arktype';
+
+const col = (length?: number): Column =>
+  ({
+    name: 'vbin',
+    tsType: 'string',
+    dbType: 'BINARY',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    shape: { kind: 'byteString', length },
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(c: Column) {
+  const analysis: Analysis = {
+    dialect: 'mysql',
+    tables: [{ name: 't', tsName: 't', columns: [c], unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-bytestring');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.arktype.ts'), file);
+  return await import(file);
+}
+
+const ok = (schema: any, x: unknown) => !(schema({ vbin: x }) instanceof type.errors);
+const SELECTED_FF = Buffer.from([0xff, 0xff, 0xff]).toString();
+const EMOJI = '\u{1F600}';
+
+describe('arktype, a byte-string column', () => {
+  it('accepts on select the row a varbinary(3) returns, 3 code points and 9 bytes', async () => {
+    const m = await schemasFor(col(3));
+    expect(ok(m.SelecttSchema, SELECTED_FF)).toBe(true);
+    expect(ok(m.SelecttSchema, 'zzz'), 'not a run of 0 and 1').toBe(true);
+    expect(ok(m.SelecttSchema, ''), 'an empty varbinary').toBe(true);
+    expect(ok(m.SelecttSchema, 'ABCD'), 'four code points out of a varbinary(3)').toBe(false);
+  });
+
+  it('rejects the bytes, which drizzle decoded before the caller saw them', async () => {
+    const m = await schemasFor(col(3));
+    expect(ok(m.SelecttSchema, new Uint8Array([1, 2, 3]))).toBe(false);
+  });
+
+  it('counts bytes on insert and update, which is what the server counts', async () => {
+    const m = await schemasFor(col(8));
+    expect(ok(m.InserttSchema, 'abcdefgh'), '8 bytes').toBe(true);
+    expect(ok(m.InserttSchema, 'abcdefghi'), '9 bytes').toBe(false);
+    expect(ok(m.InserttSchema, EMOJI.repeat(2)), '2 code points, 8 bytes').toBe(true);
+    expect(ok(m.InserttSchema, EMOJI.repeat(3)), '3 code points, 12 bytes').toBe(false);
+    expect(ok(m.UpdatetSchema, EMOJI.repeat(3))).toBe(false);
+  });
+
+  it('is a plain string when the column declares no width', async () => {
+    const m = await schemasFor(col(undefined));
+    expect(ok(m.SelecttSchema, 'anything at all')).toBe(true);
+    expect(ok(m.InserttSchema, 42)).toBe(false);
+  });
+});

--- a/packages/generator-json-schema/src/index.ts
+++ b/packages/generator-json-schema/src/index.ts
@@ -114,6 +114,18 @@ function baseSchema(
           pattern: '^[01]*$',
           ...(s.length ? (s.exact ? { minLength: s.length, maxLength: s.length } : { maxLength: s.length }) : {}),
         };
+      case 'byteString':
+        // A MySQL/SingleStore `binary(n)`/`varbinary(n)`: any bytes at all, handed back as a
+        // string, so no pattern. `maxLength` counts code points, which is exactly what the column
+        // can return: a lossy decode of n bytes yields at most n of them, measured.
+        //
+        // The insert side is a byte budget and JSON Schema has no keyword that counts bytes, so
+        // the same code-point cap is emitted in every mode. It is a necessary condition there
+        // rather than the whole one, since every value the server accepts is at most n bytes and
+        // therefore at most n code points; it turns away no valid write, and lets through a value
+        // like three emoji that a varbinary(8) refuses. That incompleteness is the same one this
+        // generator already carries for MySQL's TEXT byte budget, which it cannot state at all.
+        return { type: 'string', ...(s.length ? { maxLength: s.length } : {}) };
     }
   }
 

--- a/packages/generator-json-schema/test/byte-string.spec.ts
+++ b/packages/generator-json-schema/test/byte-string.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * MySQL/SingleStore `binary(n)`/`varbinary(n)` as JSON Schema, compiled and run by ajv.
+ *
+ * The measurements these assert are in `packages/generator-zod/test/byte-string.spec.ts` and were
+ * taken from MySQL 8.4 through drizzle on both majors.
+ *
+ * JSON Schema has no way to count bytes, so this generator states the one cap it can: `maxLength`,
+ * which the specification defines in code points. That is exactly the select-side truth, and on
+ * the insert side it is a necessary condition rather than the whole one, since every value the
+ * server accepts is at most n bytes and therefore at most n code points. The generator already
+ * carries the same incompleteness for MySQL's TEXT byte budget, where it emits nothing at all.
+ *
+ * The four columns used to come out `{ type: 'string', pattern: '^[01]*$' }` on v1, which rejects
+ * every row, and `{ type: 'string', contentEncoding: 'base64' }` on 0.4x, which accepted the row
+ * only because that keyword is an annotation ajv does not enforce.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import type { Column, Table } from '@drzl/analyzer';
+import { tableSchemas } from '../src/index';
+
+const col = (length?: number): Column =>
+  ({
+    name: 'vbin',
+    tsType: 'string',
+    dbType: 'BINARY',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    shape: { kind: 'byteString', length },
+  }) as Column;
+
+const table = (c: Column): Table =>
+  ({ name: 't', tsName: 't', columns: [c], unique: [], indexes: [], checks: [] }) as never;
+
+function compile(schema: unknown) {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  addFormats(ajv as never);
+  return ajv.compile(schema as never);
+}
+
+const SELECTED_FF = Buffer.from([0xff, 0xff, 0xff]).toString();
+
+describe('json schema, a byte-string column', () => {
+  it('accepts the row a varbinary(3) returns rather than demanding 0 and 1', () => {
+    const validate = compile(tableSchemas(table(col(3))).select);
+    expect(validate({ vbin: SELECTED_FF })).toBe(true);
+    expect(validate({ vbin: 'zzz' }), 'not a run of 0 and 1').toBe(true);
+    expect(validate({ vbin: '' }), 'an empty varbinary').toBe(true);
+  });
+
+  it('is a string, so the bytes themselves are not it', () => {
+    const validate = compile(tableSchemas(table(col(3))).select);
+    expect(validate({ vbin: [255, 255, 255] })).toBe(false);
+  });
+
+  it('states the width in the one unit JSON Schema counts', () => {
+    // Code points, per RFC 8259. A row out of a varbinary(3) has at most 3 of them, so this never
+    // turns one away, and a fourth cannot have come from that column.
+    const validate = compile(tableSchemas(table(col(3))).select);
+    expect(validate({ vbin: 'ABC' })).toBe(true);
+    expect(validate({ vbin: 'ABCD' })).toBe(false);
+    for (const mode of ['insert', 'update'] as const) {
+      const v = compile(tableSchemas(table(col(8)))[mode]);
+      expect(v({ vbin: 'abcdefgh' }), mode).toBe(true);
+      expect(v({ vbin: 'abcdefghi' }), mode).toBe(false);
+    }
+  });
+
+  it('is a plain string when the column declares no width', () => {
+    const validate = compile(tableSchemas(table(col(undefined))).select);
+    expect(validate({ vbin: 'anything at all' })).toBe(true);
+    expect(validate({ vbin: 42 })).toBe(false);
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -138,7 +138,7 @@ const JSON_PREAMBLE = `const ${JSON_CONST} = Type.Recursive((This) =>
  * These used to land on `Type.Unknown()`, or for the tuple types on `Type.String()`, which
  * rejected every row: a `point` really arrives as `[number, number]`.
  */
-function tbShapeExpr(c: Column, typedJsonRef?: string): string | undefined {
+function tbShapeExpr(c: Column, mode: Mode, typedJsonRef?: string): string | undefined {
   const s = c.shape;
   if (!s) return undefined;
   switch (s.kind) {
@@ -159,11 +159,17 @@ function tbShapeExpr(c: Column, typedJsonRef?: string): string | undefined {
     case 'bitstring':
       // `pattern` rather than `format`, which TypeBox ignores unless the consuming project has
       // registered it on `FormatRegistry` first.
-      // Both bounds for a Postgres `bit(n)`, only the ceiling for a MySQL `binary(n)`.
+      // Both bounds for a Postgres `bit(n)`, only the ceiling for a Cockroach `varbit(n)`.
       if (!s.length) return `Type.String({ pattern: '^[01]*$' })`;
       return s.exact
         ? `Type.String({ pattern: '^[01]*$', minLength: ${s.length}, maxLength: ${s.length} })`
         : `Type.String({ pattern: '^[01]*$', maxLength: ${s.length} })`;
+    case 'byteString':
+      // See the zod generator: a MySQL/SingleStore binary column takes any bytes at all and hands
+      // them back as a string, so no pattern belongs here. `maxLength` counts UTF-16 units, which
+      // is neither the code points a select returns nor the bytes an insert is measured in, so
+      // the cap goes to the registered kind through `tbCapExpr`.
+      return tbCapExpr(c, 'Type.String()', mode);
   }
 }
 
@@ -200,7 +206,7 @@ function tbExprForColumn(
   typedJsonRef?: string,
   sets: ColumnSet[] = []
 ): string {
-  const shaped = tbShapeExpr(c, typedJsonRef);
+  const shaped = tbShapeExpr(c, mode, typedJsonRef);
   if (shaped) return shaped;
   // `CHECK (status IN ('a', 'b'))` is a union of literals. `Type.Literal` is the only form
   // TypeBox enforces: a `const` option parses and then accepts anything.
@@ -246,7 +252,7 @@ function tbExprForColumn(
       const base: Array<[string, string]> = formatPattern
         ? [['pattern', JSON.stringify(formatPattern)]]
         : [];
-      return tbCapExpr(c, `Type.String(${renderOptions(merged(base))})`);
+      return tbCapExpr(c, `Type.String(${renderOptions(merged(base))})`, mode);
     }
     case 'number': {
       const o = renderOptions(merged(tbBounds(c)));
@@ -529,12 +535,15 @@ const ROW_PREAMBLE = `TypeRegistry.Set('DrzlRowCheck', (schema: any, value: any)
  * not import it, so the module threw the moment anything loaded it.
  */
 function tbNeedsCapKind(c: Column): boolean {
+  // A byte-string column is the one shaped column that carries a cap, and it needs the kind for
+  // the same reason: its width is code points out and bytes in, and no keyword counts either.
+  if (c.shape?.kind === 'byteString') return !!c.shape.length;
   // Not excluded for an array column: the cap describes the *element*, and the array wraps it
   // after, so `varchar(50).array()` caps each entry.
   return c.tsType === 'string' && !c.shape && !!(c.maxLength || c.maxBytes);
 }
 
-function tbCapExpr(c: Column, base: string): string {
+function tbCapExpr(c: Column, base: string, mode: Mode): string {
   if (!tbNeedsCapKind(c)) return base;
   const branch = (desc: string, expr: string) => `Type.Unsafe<unknown>({
     [Kind]: 'DrzlRowCheck',
@@ -542,6 +551,15 @@ function tbCapExpr(c: Column, base: string): string {
     assert: (v: any) => v == null || ${expr},
   })`;
   const out: string[] = [];
+  if (c.shape?.kind === 'byteString') {
+    const n = c.shape.length!;
+    out.push(
+      mode === 'select'
+        ? branch(`at most ${n} characters`, `[...v].length <= ${n}`)
+        : branch(`at most ${n} bytes`, `new TextEncoder().encode(v).length <= ${n}`)
+    );
+    return `Type.Intersect([${base}, ${out.join(', ')}])`;
+  }
   if (c.maxLength) out.push(branch(`at most ${c.maxLength} characters`, `[...v].length <= ${c.maxLength}`));
   if (c.maxBytes) {
     out.push(branch(`at most ${c.maxBytes} bytes`, `new TextEncoder().encode(v).length <= ${c.maxBytes}`));

--- a/packages/generator-typebox/test/byte-string.spec.ts
+++ b/packages/generator-typebox/test/byte-string.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * MySQL/SingleStore `binary(n)`/`varbinary(n)` in TypeBox, by running the emitted schemas.
+ *
+ * The measurements these assert are in `packages/generator-zod/test/byte-string.spec.ts` and were
+ * taken from MySQL 8.4 through drizzle on both majors. `maxLength` counts UTF-16 code units, which
+ * is neither the code points a select can return nor the bytes an insert is measured in, so both
+ * caps go to the registered kind where an exact count can be written.
+ */
+import { describe, it, expect } from 'vitest';
+import { TypeBoxGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Value } from '@sinclair/typebox/value';
+
+const col = (length?: number): Column =>
+  ({
+    name: 'vbin',
+    tsType: 'string',
+    dbType: 'BINARY',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    shape: { kind: 'byteString', length },
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(c: Column) {
+  const analysis: Analysis = {
+    dialect: 'mysql',
+    tables: [{ name: 't', tsName: 't', columns: [c], unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-bytestring');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), file);
+  return await import(file);
+}
+
+const ok = (schema: any, x: unknown) => Value.Check(schema, { vbin: x });
+const SELECTED_FF = Buffer.from([0xff, 0xff, 0xff]).toString();
+const EMOJI = '\u{1F600}';
+
+describe('typebox, a byte-string column', () => {
+  it('accepts on select the row a varbinary(3) returns, 3 code points and 9 bytes', async () => {
+    const m = await schemasFor(col(3));
+    expect(ok(m.SelecttSchema, SELECTED_FF)).toBe(true);
+    expect(ok(m.SelecttSchema, 'zzz'), 'not a run of 0 and 1').toBe(true);
+    expect(ok(m.SelecttSchema, ''), 'an empty varbinary').toBe(true);
+    expect(ok(m.SelecttSchema, 'ABCD'), 'four code points out of a varbinary(3)').toBe(false);
+  });
+
+  it('rejects the bytes, which drizzle decoded before the caller saw them', async () => {
+    const m = await schemasFor(col(3));
+    expect(ok(m.SelecttSchema, new Uint8Array([1, 2, 3]))).toBe(false);
+  });
+
+  it('counts bytes on insert and update, which is what the server counts', async () => {
+    const m = await schemasFor(col(8));
+    expect(ok(m.InserttSchema, 'abcdefgh'), '8 bytes').toBe(true);
+    expect(ok(m.InserttSchema, 'abcdefghi'), '9 bytes').toBe(false);
+    expect(ok(m.InserttSchema, EMOJI.repeat(2)), '2 code points, 8 bytes').toBe(true);
+    expect(ok(m.InserttSchema, EMOJI.repeat(3)), '3 code points, 12 bytes').toBe(false);
+    expect(ok(m.UpdatetSchema, EMOJI.repeat(3))).toBe(false);
+  });
+
+  it('is a plain string when the column declares no width', async () => {
+    const m = await schemasFor(col(undefined));
+    expect(ok(m.SelecttSchema, 'anything at all')).toBe(true);
+    expect(ok(m.InserttSchema, 42)).toBe(false);
+  });
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -165,7 +165,7 @@ const ${JSON_CONST}: v.GenericSchema<${JSON_CONST}Type> = v.lazy(() =>
  * These used to fall through to `v.any()`/`v.unknown()`, or for the tuple types to `v.string()`,
  * which rejected every row since a `point` really arrives as `[number, number]`.
  */
-function vShapeExpr(c: Column): string | undefined {
+function vShapeExpr(c: Column, mode: Mode): string | undefined {
   const s = c.shape;
   if (!s) return undefined;
   switch (s.kind) {
@@ -187,11 +187,22 @@ function vShapeExpr(c: Column): string | undefined {
         ? `v.pipe(v.array(v.number()), v.length(${s.length}))`
         : 'v.array(v.number())';
     case 'bitstring': {
-      // `v.length` for a Postgres `bit(n)`, `v.maxLength` for a MySQL `binary(n)`.
+      // `v.length` for a Postgres `bit(n)`, `v.maxLength` for a Cockroach `varbit(n)`.
       const len = s.length
         ? `, ${s.exact ? `v.length(${s.length})` : `v.maxLength(${s.length})`}`
         : '';
       return `v.pipe(v.string(), v.regex(/^[01]*$/)${len})`;
+    }
+    case 'byteString': {
+      // See the zod generator: a MySQL/SingleStore binary column takes any bytes at all and hands
+      // them back as a string, and the declared width is code points out and bytes in. Not
+      // `v.maxLength`, which counts UTF-16 units and so is neither.
+      if (!s.length) return 'v.string()';
+      const check =
+        mode === 'select'
+          ? `v.check((val) => [...val].length <= ${s.length}, 'at most ${s.length} characters')`
+          : `v.check((val) => new TextEncoder().encode(val).length <= ${s.length}, 'at most ${s.length} bytes')`;
+      return `v.pipe(v.string(), ${check})`;
     }
   }
 }
@@ -255,7 +266,7 @@ function vExprForColumn(
   sets: ColumnSet[] = [],
   lengths: LengthCheck[] = []
 ): string {
-  const shaped = vShapeExpr(c);
+  const shaped = vShapeExpr(c, mode);
   if (shaped) return shaped;
   // `CHECK (status IN ('a', 'b'))` constrains the column to a set, which is what a picklist is.
   const set = sets.find((x) => x.column === c.name);

--- a/packages/generator-valibot/test/byte-string.spec.ts
+++ b/packages/generator-valibot/test/byte-string.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * MySQL/SingleStore `binary(n)`/`varbinary(n)` in valibot, by running the emitted schemas.
+ *
+ * The measurements these assert are in `packages/generator-zod/test/byte-string.spec.ts` and were
+ * taken from MySQL 8.4 through drizzle on both majors. In short: the column hands back a string of
+ * arbitrary bytes, a select cap can only be code points, and an insert cap can only be bytes.
+ */
+import { describe, it, expect } from 'vitest';
+import { ValibotGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import * as v from 'valibot';
+
+const col = (length?: number): Column =>
+  ({
+    name: 'vbin',
+    tsType: 'string',
+    dbType: 'BINARY',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    shape: { kind: 'byteString', length },
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(c: Column) {
+  const analysis: Analysis = {
+    dialect: 'mysql',
+    tables: [{ name: 't', tsName: 't', columns: [c], unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-bytestring');
+  await fs.mkdir(dir, { recursive: true });
+  await new ValibotGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.valibot.ts'), file);
+  return await import(file);
+}
+
+const ok = (schema: any, x: unknown) => v.safeParse(schema, { vbin: x }).success;
+const SELECTED_FF = Buffer.from([0xff, 0xff, 0xff]).toString();
+const EMOJI = '\u{1F600}';
+
+describe('valibot, a byte-string column', () => {
+  it('accepts on select the row a varbinary(3) returns, 3 code points and 9 bytes', async () => {
+    const m = await schemasFor(col(3));
+    expect(ok(m.SelecttSchema, SELECTED_FF)).toBe(true);
+    expect(ok(m.SelecttSchema, 'zzz'), 'not a run of 0 and 1').toBe(true);
+    expect(ok(m.SelecttSchema, ''), 'an empty varbinary').toBe(true);
+    expect(ok(m.SelecttSchema, 'ABCD'), 'four code points out of a varbinary(3)').toBe(false);
+  });
+
+  it('rejects the bytes, which drizzle decoded before the caller saw them', async () => {
+    const m = await schemasFor(col(3));
+    expect(ok(m.SelecttSchema, new Uint8Array([1, 2, 3]))).toBe(false);
+  });
+
+  it('counts bytes on insert and update, which is what the server counts', async () => {
+    const m = await schemasFor(col(8));
+    expect(ok(m.InserttSchema, 'abcdefgh'), '8 bytes').toBe(true);
+    expect(ok(m.InserttSchema, 'abcdefghi'), '9 bytes').toBe(false);
+    expect(ok(m.InserttSchema, EMOJI.repeat(2)), '2 code points, 8 bytes').toBe(true);
+    expect(ok(m.InserttSchema, EMOJI.repeat(3)), '3 code points, 12 bytes').toBe(false);
+    expect(ok(m.UpdatetSchema, EMOJI.repeat(3))).toBe(false);
+  });
+
+  it('is a plain string when the column declares no width', async () => {
+    const m = await schemasFor(col(undefined));
+    expect(ok(m.SelecttSchema, 'anything at all')).toBe(true);
+    expect(ok(m.InserttSchema, 42)).toBe(false);
+  });
+});

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -185,7 +185,7 @@ function checkRefinements(c: Column, checks: ColumnCheck[]): string {
  * The string cases were the worst of the three: a `point` arrives as `[number, number]`, so the
  * emitted select schema rejected every row the database returned.
  */
-function shapeExpr(c: Column, typedJsonRef?: string): string | undefined {
+function shapeExpr(c: Column, mode: Mode, typedJsonRef?: string): string | undefined {
   const s = c.shape;
   if (!s) return undefined;
   switch (s.kind) {
@@ -223,12 +223,25 @@ function shapeExpr(c: Column, typedJsonRef?: string): string | undefined {
     case 'numberVector':
       return `z.array(z.number())${s.length ? `.length(${s.length})` : ''}`;
     case 'bitstring':
-      // `.length` for a Postgres `bit(n)`, `.max` for a MySQL `binary(n)`: the first is a fixed
-      // width, the second a ceiling, and `''` is valid only under the second.
+      // `.length` for a Postgres `bit(n)`, `.max` for a Cockroach `varbit(n)`: the first is a
+      // fixed width, the second a ceiling, and `''` is valid only under the second.
       return (
         'z.string().regex(/^[01]*$/)' +
         (s.length ? (s.exact ? `.length(${s.length})` : `.max(${s.length})`) : '')
       );
+    case 'byteString':
+      // A MySQL/SingleStore `binary(n)`/`varbinary(n)`, which holds bytes and returns a string.
+      // No pattern: the column takes any bytes at all, so `^[01]*$` rejected every row.
+      //
+      // The cap is the direction-dependent half. Measured against MySQL 8.4: a varbinary(3)
+      // holding `<ff ff ff>` returns 3 code points that re-encode to 9 UTF-8 bytes, so a byte cap
+      // on select refuses a row the column returned; and a varbinary(8) refuses 3 emoji, which is
+      // 3 code points and 12 bytes, so a character cap on insert accepts a write the server does
+      // not. Neither `.length` nor `.max` is either measurement: both count UTF-16 units.
+      if (!s.length) return 'z.string()';
+      return mode === 'select'
+        ? `z.string().refine((v) => [...v].length <= ${s.length}, { message: 'at most ${s.length} characters' })`
+        : `z.string().refine((v) => new TextEncoder().encode(v).length <= ${s.length}, { message: 'at most ${s.length} bytes' })`;
   }
 }
 
@@ -240,7 +253,7 @@ function zodExprForColumn(
   sets: ColumnSet[] = [],
   checks: ColumnCheck[] = []
 ): string {
-  const shaped = shapeExpr(c, typedJsonRef);
+  const shaped = shapeExpr(c, mode, typedJsonRef);
   if (shaped) return shaped;
   // `CHECK (status IN ('a', 'b'))` constrains the column to a set, which is what an enum is. It
   // takes the same shape here as a declared enum rather than becoming a predicate, so the static

--- a/packages/generator-zod/test/byte-string.spec.ts
+++ b/packages/generator-zod/test/byte-string.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * MySQL/SingleStore `binary(n)`/`varbinary(n)`, by running the emitted schemas.
+ *
+ * Everything asserted here was asked of MySQL 8.4 through drizzle on both majors first, and the
+ * two measurements pull the cap in opposite directions:
+ *
+ *   select   `<ff ff ff>` stored in a varbinary(3) comes back as 3 code points that re-encode to
+ *            9 UTF-8 bytes, so a byte cap on a select schema rejects a row the column returned.
+ *   insert   a varbinary(8) takes 8 ascii characters and refuses 9, and takes 2 emoji (8 bytes)
+ *            and refuses 3 (12 bytes), so a character cap on an insert schema accepts a write the
+ *            server refuses.
+ *
+ * Neither cap is right in both directions, which is why the column carries a shape rather than a
+ * `maxLength`, and why this file runs each mode separately.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (length?: number): Column =>
+  ({
+    name: 'vbin',
+    tsType: 'string',
+    dbType: 'BINARY',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    shape: { kind: 'byteString', length },
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(c: Column) {
+  const analysis: Analysis = {
+    dialect: 'mysql',
+    tables: [{ name: 't', tsName: 't', columns: [c], unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-bytestring');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return await import(file);
+}
+
+const ok = (schema: any, v: unknown) => schema.safeParse({ vbin: v }).success;
+
+/** Exactly what drizzle handed back for a varbinary(3) holding those three bytes. */
+const SELECTED_FF = Buffer.from([0xff, 0xff, 0xff]).toString();
+const EMOJI = '\u{1F600}';
+
+describe('a byte-string select schema', () => {
+  it('accepts the string the column returns, whatever bytes were stored', async () => {
+    const m = await schemasFor(col(3));
+    expect([...SELECTED_FF].length, '3 code points').toBe(3);
+    expect(new TextEncoder().encode(SELECTED_FF).length, 'and 9 UTF-8 bytes').toBe(9);
+    expect(ok(m.SelecttSchema, SELECTED_FF), 'a real row out of varbinary(3)').toBe(true);
+    expect(ok(m.SelecttSchema, 'ABC'), 'ascii out of the same column').toBe(true);
+    expect(ok(m.SelecttSchema, ''), 'an empty varbinary').toBe(true);
+    // Not a bit string. The server takes any bytes at all and the driver decodes them as they
+    // came, so `^[01]*$` refused every row that was not a run of 0 and 1.
+    expect(ok(m.SelecttSchema, 'zzz'), 'three bytes that are not 0 or 1').toBe(true);
+  });
+
+  it('rejects the bytes themselves, which is not what the caller receives', async () => {
+    // drizzle maps the driver's Buffer to a string before the caller sees it, measured on both
+    // majors: `instanceof Uint8Array` is false for every one of these columns.
+    const m = await schemasFor(col(3));
+    expect(ok(m.SelecttSchema, Buffer.from([1, 2, 3]))).toBe(false);
+    expect(ok(m.SelecttSchema, new Uint8Array([1, 2, 3]))).toBe(false);
+  });
+
+  it('holds the row to the code points the column can return', async () => {
+    // A lossy decode of n bytes yields at most n code points, so this never turns away a row and
+    // still states the width.
+    const m = await schemasFor(col(3));
+    expect(ok(m.SelecttSchema, 'ABCD'), 'four code points out of a varbinary(3)').toBe(false);
+  });
+});
+
+describe('a byte-string insert schema', () => {
+  it('counts the bytes the server counts', async () => {
+    const m = await schemasFor(col(8));
+    expect(ok(m.InserttSchema, 'abcdefgh'), '8 bytes').toBe(true);
+    expect(ok(m.InserttSchema, 'abcdefghi'), '9 bytes, ER_DATA_TOO_LONG').toBe(false);
+  });
+
+  it('refuses a write the server refuses even though it is short enough in characters', async () => {
+    // The measurement that decides this: 3 emoji is 3 code points and 12 bytes, and a varbinary(8)
+    // refuses it. A character cap accepts it, which is the over-acceptance a byte cap closes.
+    const m = await schemasFor(col(8));
+    expect(ok(m.InserttSchema, EMOJI.repeat(2)), '2 code points, 8 bytes').toBe(true);
+    expect(ok(m.InserttSchema, EMOJI.repeat(3)), '3 code points, 12 bytes').toBe(false);
+  });
+
+  it('applies the same byte budget on update', async () => {
+    const m = await schemasFor(col(8));
+    expect(ok(m.UpdatetSchema, EMOJI.repeat(2))).toBe(true);
+    expect(ok(m.UpdatetSchema, EMOJI.repeat(3))).toBe(false);
+  });
+
+  it('takes any bytes at all inside the budget', async () => {
+    const m = await schemasFor(col(8));
+    expect(ok(m.InserttSchema, ''), 'the empty string, which the server stores').toBe(true);
+    expect(ok(m.InserttSchema, 'zzz'), 'not a run of 0 and 1').toBe(true);
+  });
+});
+
+describe('a byte-string column with no declared width', () => {
+  it('is a plain string in every mode rather than an unbounded regex', async () => {
+    const m = await schemasFor(col(undefined));
+    for (const s of [m.SelecttSchema, m.InserttSchema, m.UpdatetSchema]) {
+      expect(ok(s, 'anything at all')).toBe(true);
+      expect(ok(s, 42)).toBe(false);
+    }
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -2109,13 +2109,52 @@ const ALLOWED: Record<string, Waiver> = {
   'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; MySQL REAL is a synonym for DOUBLE', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; SQLite REAL is an 8 byte IEEE float', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
-  // Official emits `Type.RegExp`, whose check runs `RegExp.prototype.test` against the raw value,
-  // and `test` stringifies what it is given: `[]` becomes '' and matches `^[01]*$`. So official
-  // accepts an empty array for a binary column. This generator emits a `string` carrying a
-  // `pattern`, which refuses a non-string before the pattern is consulted. Postgres masks the
-  // same hole on `c_bit` only because that column has a `minLength` an array cannot satisfy.
-  'mysql/typebox/m_binary': { libs: ['typebox'], modes: MODE_NAMES, why: 'official Type.RegExp accepts a non-string whose string form matches', divergence: { '*/*': `L:  | T: []` } },
-  'mysql/typebox/m_varbinary': { libs: ['typebox'], modes: MODE_NAMES, why: 'as mysql/typebox/m_binary', divergence: { '*/*': `L:  | T: []` } },
+  // ---- binary and varbinary, where official refuses rows the server returns --------------------
+  // Official emits `^[01]*$` capped at n for these columns on v1, which is a bit-string pattern on
+  // a column holding arbitrary bytes, so it rejects every ordinary string MySQL hands back. Asked
+  // of a live MySQL 8.4 through both majors: mysql2 hands up a Buffer and drizzle hands the
+  // CONSUMER a string, value for value identical, with `instanceof Uint8Array` false on all four
+  // builders. So DRZL emitting a plain string is the database's answer and official's pattern is
+  // the divergence.
+  //
+  // `T:` stays empty and `L:` carries the load. DRZL is looser here and right, which is the
+  // direction this ledger exists to record rather than forbid.
+  //
+  // Insert and update drop one value each against select, and that is the declared width doing its
+  // job rather than noise: '3 emoji' is 12 bytes over a `binary(4)` and '5 emoji' is 20 over a
+  // `varbinary(16)`, so DRZL refuses them on the way in and both sides agree.
+  //
+  // These were two typebox-only entries, because the `L:` half did not exist while DRZL emitted a
+  // Uint8Array and refused everything. Widening them to every library is what this change forces.
+  //
+  // The typebox-only reason SURVIVES, on the `T:` half, and a first draft of this comment claimed
+  // it had gone. The stage refuted that in one run: `L:` matched on all twelve pairings and typebox
+  // still measured `T: []`. Official emits `Type.RegExp`, whose check runs `RegExp.prototype.test`
+  // on the raw value, and `test` stringifies what it is given, so `[]` becomes '' and matches
+  // `^[01]*$`. DRZL emits a `string` carrying a `pattern` and refuses a non-string before the
+  // pattern is consulted. So typebox carries both halves and the other three carry only `L:`.
+  'mysql/m_binary': {
+    libs: LIB_NAMES,
+    modes: MODE_NAMES,
+    why: 'official emits a bit-string pattern for a byte column and refuses the strings MySQL returns',
+    divergence: {
+      'select/typebox': `L: 3 emoji, 'zzz', 'a', 'x', '12.5' | T: []`,
+      'select/zod,valibot,arktype': `L: 3 emoji, 'zzz', 'a', 'x', '12.5' | T: `,
+      'insert,update/typebox': `L: 'zzz', 'a', 'x', '12.5' | T: []`,
+      'insert,update/zod,valibot,arktype': `L: 'zzz', 'a', 'x', '12.5' | T: `,
+    },
+  },
+  'mysql/m_varbinary': {
+    libs: LIB_NAMES,
+    modes: MODE_NAMES,
+    why: 'as mysql/m_binary',
+    divergence: {
+      'select/typebox': `L: 'hello', 5-char, 3 emoji, 5 emoji, 'not-a-uuid', 'zzz', 'a', 'happy', 'x', '2020-01-01', '12:00:00', '25:99:99', '999.999.999.999', '10.0.0.1', '12.5' | T: []`,
+      'select/zod,valibot,arktype': `L: 'hello', 5-char, 3 emoji, 5 emoji, 'not-a-uuid', 'zzz', 'a', 'happy', 'x', '2020-01-01', '12:00:00', '25:99:99', '999.999.999.999', '10.0.0.1', '12.5' | T: `,
+      'insert,update/typebox': `L: 'hello', 5-char, 3 emoji, 'not-a-uuid', 'zzz', 'a', 'happy', 'x', '2020-01-01', '12:00:00', '25:99:99', '999.999.999.999', '10.0.0.1', '12.5' | T: []`,
+      'insert,update/zod,valibot,arktype': `L: 'hello', 5-char, 3 emoji, 'not-a-uuid', 'zzz', 'a', 'happy', 'x', '2020-01-01', '12:00:00', '25:99:99', '999.999.999.999', '10.0.0.1', '12.5' | T: `,
+    },
+  },
   // ---- the nullable table ---------------------------------------------------------------------
   // Every divergence below is the one its `notNull` twin in `matrix` already carries, measured
   // again through the wrapper each generator puts round a nullable column. That is the point: the
@@ -6536,6 +6575,21 @@ const ALLOWED: Record<string, Entry> = {
   'sqlite/s_n_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
   'sqlite/s_n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   'sqlite/s_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, 17, 101` }, drzl: 'as pg/n_check', official: 'as pg/n_check', filed: 'as pg/n_check' },
+  // ---- binary and varbinary, where only DRZL enforces the declared width ----------------------
+  // These two were DEFECTS here until the analyzer stopped calling a byte string a Uint8Array. They
+  // are waivers now because DRZL is the stricter side and the server agrees with it.
+  //
+  // `L:` is empty in all twelve pairings, where it used to carry Buffer and Uint8Array: DRZL is no
+  // longer looser than official anywhere on this major. Official 0.4x emits a bare string with no
+  // cap at all, so every value in `T:` is one over the declared byte width that official takes and
+  // both DRZL and MySQL refuse.
+  //
+  // '3 emoji' on m_binary and '5 emoji' on m_varbinary sit in insert and update and not in select,
+  // which is the cap being direction-dependent rather than noise: 12 bytes does not fit a
+  // binary(4) and 20 does not fit a varbinary(16), while a value already in the column came from a
+  // server that had room for it.
+  'mysql/m_binary': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { 'select/*': `L:  | T: 'hello', 300-char, 70k-char, 5-char, 5 emoji, 'not-a-uuid', uuid, 'happy', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1'`, 'insert,update/*': `L:  | T: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'happy', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1'` }, drzl: 'a string capped at the declared byte width', official: 'an uncapped string', filed: 'not a defect: DRZL is stricter here and the server agrees' },
+  'mysql/m_varbinary': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { 'select/*': `L:  | T: 300-char, 70k-char, uuid, '2020-01-01T00:00:00Z', 100 emoji, 22000 cjk`, 'insert,update/*': `L:  | T: 300-char, 70k-char, 5 emoji, uuid, '2020-01-01T00:00:00Z', 100 emoji, 22000 cjk` }, drzl: 'as mysql/m_binary', official: 'as mysql/m_binary', filed: 'as mysql/m_binary' },
 };
 
 /**
@@ -6701,35 +6755,6 @@ const DEFECTS: Record<string, Entry> = {
   // stage by design.
   // The two official majors do not agree about this column, so `official: a string` is only half
   // the picture and a reader needs the rest before acting on it. Measured on the column object and
-  // on both modules:
-  //
-  //                        0.4x                       v1
-  //   drizzle-orm          dataType 'string'          dataType 'string binary'
-  //   official validator   any string                 ^[01]*$ capped at the declared length
-  //   DRZL                 z.instanceof(Uint8Array)   the same capped string official v1 emits
-  //
-  // That settles which side is wrong without appealing to self-consistency: DRZL's 0.4x answer
-  // contradicts drizzle-orm's own declared `dataType` on the major it is measured on. Both
-  // wrong-direction repairs are already gated, so neither can be taken by accident: emitting
-  // `Uint8Array` on v1 breaks the v1 pass, and emitting `^[01]*$` on 0.4x breaks this one, since
-  // official 0.4x accepts 'zzz'.
-  'mysql/m_binary': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: { '*/*': `L: Buffer, Uint8Array | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'` },
-    drzl: 'a Uint8Array',
-    official: "a bare string on 0.4x, where official v1 emits ^[01]*$ capped at 4",
-    filed: "new: drizzle-orm declares dataType 'string' on both majors",
-  },
-  'mysql/m_varbinary': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: { '*/*': `L: Buffer, Uint8Array | T: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010'` },
-    drzl: 'a Uint8Array',
-    official: "a bare string on 0.4x, where official v1 emits ^[01]*$ capped at 16",
-    filed: 'new: as mysql/m_binary',
-  },
-
   // ---- an integer range is missing or wrong on 0.4x ------------------------------------------
   // `sqlite/s_int` is three libraries rather than four, and the missing one is not an omission:
   // zod's `.int()` refuses a number outside the safe-integer range on its own, so zod reaches


### PR DESCRIPTION
Two fixes that move ledger entries in `scripts/verify-packed.sh`, which is why they are separate
from the four in #107. Each was developed in its own worktree with that file read-only; the ledger
edits here are mine, made from the signatures the gate itself printed rather than transcribed.

## `decimal` was typed `number` while the driver returns a string

Measured against a live MySQL 8.4 through `mysql2`, drizzle-orm 0.45.2, `db.select()` on a
`decimal(10,2)` holding `'1234.56'` and a `decimal(20,0)` holding `'9007199254740993'`:

```
MySqlDecimal         (default and mode:'string')  ->  '1234.56'  string
MySqlDecimalNumber   (mode:'number')              ->  1234.56    number
MySqlDecimalBigInt   (mode:'bigint')              ->  900719925… bigint
```

The class-name path matched `/Decimal|Numeric|Float|Double|Real/i` and answered `number` for all
three, so the default and string modes emitted a validator that rejected every row, and the bigint
mode emitted one that rejected every row for a different reason. Postgres has typed `numeric` as a
string for exactly this reason since long before, with the comment on its arm explaining why, so the
precedent was already in the file.

Taken in the same family and by the same method: SQLite `numeric` in number and bigint modes, which
were `unknown` and therefore accepted anything, and the Postgres `numeric({mode:'bigint'})` dbType
label.

`DEFECTS['mysql/m_decimal']` was deleted rather than re-signed: a ledger entry that suppresses
nothing fails this stage by design. The v1 `ALLOWED['mysql/m_decimal']` is untouched, because
nothing on that path changed.

## `binary` and `varbinary` rejected every row on both majors

One wrong answer in two different wrong shapes. On 0.4x the analyzer said `Uint8Array`; on v1 it
said `string` but attached a `bitstring` shape, so all five generators emitted `^[01]*$` capped at n.
Both reject every row a server returns.

Asked of a live MySQL 8.4 through both majors, on the same table and the same rows: `mysql2` hands
up a `Buffer` and drizzle hands the **consumer** a string, value for value identical, with
`instanceof Uint8Array` false on all four builders.

### The ledger moved in both passes, in opposite directions

**v1.** The two waivers said `L: | T: []`, which named a difference without describing it. They now
carry the real divergence, widened from typebox-only to every library: official emits a bit-string
pattern for a byte column and refuses ordinary strings the server returns, so DRZL is looser here
and right.

The typebox-specific half survives and a first draft of that comment said it had gone. The stage
refuted it in one run, `L:` matching on all twelve pairings while typebox still measured `T: []`.
Official's `Type.RegExp` runs `RegExp.prototype.test` on the raw value and `test` stringifies what
it is given, so `[]` becomes `''` and matches `^[01]*$`, while DRZL's string-with-pattern refuses a
non-string first. The entry is per-library now and the comment records that it was wrong once.

**0.4x.** Both entries moved from `DEFECTS` to `ALLOWED`. `L:` is empty in all twelve pairings where
it used to carry `Buffer, Uint8Array`, so DRZL is no longer looser than official anywhere on that
major. Official 0.4x emits a bare uncapped string, so every value in `T:` is over the declared byte
width and both DRZL and MySQL refuse it.

`'3 emoji'` on `m_binary` and `'5 emoji'` on `m_varbinary` sit in insert and update and not in
select. That is the cap being direction-dependent rather than noise: 12 bytes does not fit a
`binary(4)` and 20 does not fit a `varbinary(16)`, while a value already in the column came from a
server that had room for it.

## Verification

`pnpm build`, `pnpm -r test`, `pnpm typecheck`, `pnpm lint`, `pnpm verify:packed` and
`pnpm -C docs build` all pass on the merged result.

Two merge conflicts, both resolved by hand and both benign: `fix/decimal-number-mode` branched
before the Gel fix in #107 and still carried the pre-fix test title, and `fix/binary-varbinary`
collided with the mssql/cockroach change because both added a new constant at the same point in the
analyzer. Neither replaced the other.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
