### PR TITLE
fix(analyzer): describe a MySQL or SingleStore enum as the string it is

### DIFF
--- a/.changeset/enum-columns-on-0-4x.md
+++ b/.changeset/enum-columns-on-0-4x.md
@@ -1,0 +1,26 @@
+---
+'@drzl/analyzer': patch
+---
+
+A MySQL or SingleStore enum column is described as the string it is, on drizzle-orm 0.4x.
+
+Those two dialects give an enum its own column class and state no `codec`, so the class-name map is
+the only path, and it had an arm for `PgEnumColumn` and none for the other two. The column came back
+`tsType: 'unknown'` while carrying a full `enumValues` array.
+
+**The emitted validator was never wrong.** Every generator reads `enumValues` before it reads
+`tsType`, so a MySQL enum column has always produced a real enum of exactly its members. What was
+wrong was the description, and the description reached you anyway, through the untyped-column
+warning:
+
+```
+Column "m_enum" on table "t" has no known type (SQL type enum('a','b','c')),
+so its validator will accept any value.
+```
+
+The emitted schema accepted exactly three values. A warning that is wrong about the one column it
+names teaches you to skip the true ones, which is the cost this fix is really paying off.
+
+Nothing about the generated output changes. `drizzle-orm@1.0.0-rc.4` already answered `string` for
+the same column, so the two majors now agree, and the cross-major diff that carried the
+disagreement has one fewer filed defect.

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1277,7 +1277,20 @@ export class SchemaAnalyzer {
       // 0.4x gives an enum its own class, which had no arm here at all, so an enum column came
       // back `unknown` and every generator emitted a schema that accepted anything. The values
       // were on the column the whole time, in `enumValues`, waiting for a type to attach to.
+      //
+      // The MySQL and SingleStore classes were added later than the Postgres one, and their
+      // absence showed up somewhere unexpected: the emitted validator was already right, because
+      // every generator reads `enumValues` before it reads `tsType`, so the only thing wrong was
+      // the description. That description reached the user anyway, through the untyped-column
+      // warning, which said an enum column "will accept any value" while the emitted schema
+      // accepted exactly three. A warning that is wrong about the one thing it names is worse
+      // than no warning, because it teaches the reader to skip the true ones.
+      //
+      // v1 already answered `string` here, so this is also the two majors agreeing again rather
+      // than a new opinion; the cross-major diff carried the disagreement as a filed defect.
       case 'PgEnumColumn':
+      case 'MySqlEnumColumn':
+      case 'SingleStoreEnumColumn':
         return { tsType: 'string', dbType: 'TEXT' };
       case 'PgInteger':
       case 'PgSmallInt':

--- a/packages/analyzer/test/enum-columns-0.4x.spec.ts
+++ b/packages/analyzer/test/enum-columns-0.4x.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * An enum column's type on drizzle-orm 0.4x, where the class name is all there is to go on.
+ *
+ * 0.4x gives an enum its own column class and states no `codec`, so the class-name map is the only
+ * path. It had an arm for `PgEnumColumn` and none for the MySQL or SingleStore classes, so those
+ * columns came back `tsType: 'unknown'` while carrying a full `enumValues` array.
+ *
+ * The emitted validator was never wrong. Every generator reads `enumValues` before it reads
+ * `tsType`, so a MySQL enum column has always produced a real three-member enum. What was wrong was
+ * the description, and the description reached the user anyway through the untyped-column warning:
+ *
+ *   Column "m_enum" on table "t" has no known type (SQL type enum('a','b','c')),
+ *   so its validator will accept any value.
+ *
+ * Measured on the emitted schema, it accepted exactly three. A warning that is wrong about the one
+ * column it names teaches the reader to skip the true ones, which is the whole cost of this defect.
+ *
+ * `string` rather than a union of the values, because that is what v1 answers for the same column
+ * and the narrowing lives in `enumValues` on both majors. Checked rather than assumed: on
+ * 1.0.0-rc.4 the same table gives `tsType: 'string'`, `enumValues: ['a','b','c']` and no issues.
+ */
+import { describe, it, expect } from 'vitest';
+import { SchemaAnalyzer } from '../src/index';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+async function analyzed(source: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-enum-'));
+  const file = path.join(dir, 'schema.mjs');
+  await fs.writeFile(file, source, 'utf8');
+  return new SchemaAnalyzer(file).analyze();
+}
+
+const MYSQL = `
+import { mysqlTable, mysqlEnum, varchar, int } from 'drizzle-orm/mysql-core';
+export const t = mysqlTable('t', {
+  id: int('id').primaryKey(),
+  m_enum: mysqlEnum('m_enum', ['a', 'b', 'c']).notNull(),
+  name: varchar('name', { length: 10 }).notNull(),
+});
+`;
+
+const SINGLESTORE = `
+import { singlestoreTable, singlestoreEnum, int } from 'drizzle-orm/singlestore-core';
+export const t = singlestoreTable('t', {
+  id: int('id').primaryKey(),
+  s_enum: singlestoreEnum('s_enum', ['x', 'y']).notNull(),
+});
+`;
+
+describe('an enum column on drizzle-orm 0.4x', () => {
+  it('is a string carrying its values, on MySQL', async () => {
+    const res = await analyzed(MYSQL);
+    const col = res.tables[0].columns.find((c) => c.name === 'm_enum');
+    expect(col?.tsType).toBe('string');
+    expect(col?.enumValues).toEqual(['a', 'b', 'c']);
+  });
+
+  it('is a string carrying its values, on SingleStore', async () => {
+    const res = await analyzed(SINGLESTORE);
+    const col = res.tables[0].columns.find((c) => c.name === 's_enum');
+    expect(col?.tsType).toBe('string');
+    expect(col?.enumValues).toEqual(['x', 'y']);
+  });
+
+  it('raises no untyped-column warning, because the validator does not accept any value', async () => {
+    const res = await analyzed(MYSQL);
+    const warned = res.issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN');
+    expect(warned.map((i) => i.message)).toEqual([]);
+  });
+
+  // The control. The warning still has to fire where it is true, or this fix has traded a false
+  // positive for a false negative, which is the worse of the two: nothing then reports a column
+  // whose validator really does take anything.
+  it('still warns for a column it genuinely cannot name', async () => {
+    const res = await analyzed(`
+      import { customType, mysqlTable, int } from 'drizzle-orm/mysql-core';
+      const opaque = customType({ dataType: () => 'geometry' });
+      export const t = mysqlTable('t', {
+        id: int('id').primaryKey(),
+        blob: opaque('blob').notNull(),
+      });
+    `);
+    const warned = res.issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN');
+    expect(warned.length).toBe(1);
+    expect(warned[0].message).toContain('"blob"');
+  });
+});

--- a/packages/analyzer/test/uncovered-dialects.spec.ts
+++ b/packages/analyzer/test/uncovered-dialects.spec.ts
@@ -87,13 +87,18 @@ describe('SingleStore, against a real singlestoreTable', () => {
     expect(analysis.dialect).toBe('singlestore');
   });
 
-  it('types every column it is given except the enum', async () => {
-    // 28 columns tried, 1 `unknown`. The count is asserted alongside the name so that a
-    // regression shows up even if it widens a column this file does not name individually,
-    // and so that deleting a column from the fixture cannot quietly shrink the coverage.
+  it('types every column it is given', async () => {
+    // 28 columns tried, none `unknown`. The count is asserted alongside the emptiness so that a
+    // regression shows up even if it widens a column this file does not name individually, and so
+    // that deleting a column from the fixture cannot quietly shrink the coverage.
+    //
+    // This asserted `['m']` when it was written, and that measurement is what produced the fix:
+    // the enum was the one column left, and its `unknown` was a wrong description rather than a
+    // hole, because the generators had been reading `enumValues` all along. See the enum test
+    // below.
     const { analysis, unknowns } = await columnsOf('real-singlestore', SINGLESTORE_SOURCE);
     expect(analysis.tables[0].columns).toHaveLength(28);
-    expect(unknowns).toEqual(['m']);
+    expect(unknowns).toEqual([]);
   });
 
   it('describes the scalar families correctly', async () => {
@@ -149,20 +154,37 @@ describe('SingleStore, against a real singlestoreTable', () => {
     expect(byName.get('si')).toMatchObject({ integer: true, min: '-32768', max: '32767' });
   });
 
-  it('keeps the enum members even though the column type is unknown', async () => {
-    // The column itself is `unknown`, but `enumValues` survives, and every generator keys on
-    // `enumValues` before it looks at `tsType`. Measured end to end against zod, valibot,
-    // arktype, typebox and the JSON Schema generator: the emitted select schema accepts 'sad'
-    // and refuses 'definitely-not-a-member', so this one is not a hole in practice.
+  it('describes the enum as the string it is, and keeps its members', async () => {
+    // This asserted `tsType: 'unknown'` when it was written, and said so with a note that the
+    // emitted schema was fine anyway: `enumValues` survives, every generator keys on it before it
+    // looks at `tsType`, and the select schema accepts 'sad' and refuses
+    // 'definitely-not-a-member' in all five generators.
     //
-    // It does mean the DRZL_ANL_UNKNOWN_COLUMN warning raised for `m` is a false positive: it
-    // says the validator "will accept any value" and the validator does no such thing. MySQL's
-    // `mysqlEnum` behaves identically, so this is shared with a covered dialect rather than
-    // specific to SingleStore.
+    // The note went further, and that is what got fixed. It observed that
+    // DRZL_ANL_UNKNOWN_COLUMN was therefore a false positive for `m`: it says the validator "will
+    // accept any value" while the validator accepts exactly three. A warning wrong about the one
+    // column it names teaches the reader to skip the true ones.
+    //
+    // The class-name map now has arms for `MySqlEnumColumn` and `SingleStoreEnumColumn` beside the
+    // `PgEnumColumn` one it already had, so the description matches the schema and the warning is
+    // silent here. `string` rather than a union of the members, because that is what v1 answers for
+    // the same column and the narrowing lives in `enumValues` on both majors.
     const { byName, analysis } = await columnsOf('real-singlestore', SINGLESTORE_SOURCE);
-    expect(byName.get('m')?.tsType).toBe('unknown');
+    expect(byName.get('m')?.tsType).toBe('string');
     expect(byName.get('m')?.enumValues).toEqual(['sad', 'ok', 'happy']);
     expect(analysis.enums.map((e) => e.values)).toContainEqual(['sad', 'ok', 'happy']);
+
+    // Named columns only. A first version of this asserted the whole issue list was empty and
+    // failed, which is the assertion earning its place: `vec` is a `vector(3, F32)` and comes back
+    // `any` with no shape, so it warns and the warning is true there. Postgres `vector` has a
+    // `numberVector` shape; the SingleStore class has no arm at all. That is filed under the
+    // uncovered-dialect work rather than fixed here, and the point of this line is that fixing the
+    // false positive did not silence the true one.
+    const warned = analysis.issues
+      .filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN')
+      .map((i) => i.message.match(/"(\w+)"/)?.[1]);
+    expect(warned).not.toContain('m');
+    expect(warned).toContain('vec');
   });
 
   it('DEFECT: leaves tinyint and mediumint unbounded, where MySQL bounds them', async () => {

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -6930,9 +6930,8 @@ const DEFECTS: Record<string, Entry> = {
  *   the same object with the key present                                 accepted
  *
  * So it is the nullable form and not the unknown that opens it, and that is why no column of
- * `matrix` is here. Seven of them are unnamed on this major: `c_geometry`, `c_bit`, `c_vector`,
- * `s_blob`, `s_blob_buf`, `s_int_ts_ms` and `m_enum`, the last of which does not emit an unknown at
- * all because every generator recovers its members from `enumValues`. The other six are `notNull`,
+ * `matrix` is here. The ones unnamed on this major are `c_geometry`, `c_bit`, `c_vector`,
+ * `s_blob`, `s_blob_buf` and `s_int_ts_ms`. They are `notNull`,
  * so they emit a bare `Type.Unknown()` and their keys stay required, which this run measures: an
  * entry for any of them would fail as dead. The three Postgres ones are read on update alone,
  * because `PRESENCE_BARREN` below makes select and insert unreadable on that pairing, and update is
@@ -7145,8 +7144,11 @@ const THREW: Record<string, Crash> = {
  * Columns the analyzer cannot name at all on 0.4x, in the two fixtures nothing else checks.
  *
  * The comparison above is differential and can only see DRZL and official disagreeing. This is
- * absolute, and it is what still fires when they agree about something wrong, which is the state
- * `m_enum` is in below. `check-old.ts` in the stage above does the same job for the Postgres and
+ * absolute, and it is what still fires when they agree about something wrong. `m_enum` used to be
+ * the worked example: DRZL called it `unknown` while every generator recovered its members from
+ * `enumValues`, so the emitted schema was right, the description was not, and nothing differential
+ * could see it. It is named now and its entries are gone.
+ * `check-old.ts` in the stage above does the same job for the Postgres and
  * MySQL-text fixtures; it cannot cover these two, because it runs before this stage writes them.
  * One home per fixture, so a fix has exactly one entry to remove.
  *
@@ -7165,11 +7167,9 @@ const UNNAMED: Record<string, string> = {
   // regardless of `tsType`, and the 0.4x zod output for this column is `z.enum(['a','b','c'])`.
   // So the emitted validator is right, the comparison above reports parity, and nothing but this
   // line records that the analyzer still cannot describe the column. Filed as addendum Z.
-  'mysql/matrix.m_enum': 'no MySqlEnumColumn arm; the generators recover the values from enumValues',
   // The nullable table's share of the same two gaps. Both are the same class as their `matrix`
   // twin, so listing them is the check that the gap is about the column class rather than about
   // `notNull`, which is the only thing that differs between the two.
-  'mysql/nullable.m_n_enum': 'as mysql/matrix.m_enum',
   'sqlite/nullable.s_n_blob': 'as sqlite/matrix.s_blob_buf',
   'sqlite/nullable.s_n_ts_ms': 'as sqlite/matrix.s_int_ts_ms',
   // Unnamed on both majors rather than on this one, and correctly so: a customType's JavaScript


### PR DESCRIPTION
## A warning that was wrong about the one column it named

The analyzer told you this, on drizzle-orm 0.4x:

```
Column "m_enum" on table "t" has no known type (SQL type enum('a','b','c')),
so its validator will accept any value.
```

The emitted validator accepted exactly three values. It always had.

MySQL and SingleStore give an enum its own column class and state no `codec`, so the class-name map
is the only path, and it had an arm for `PgEnumColumn` and none for the other two. The column came
back `tsType: 'unknown'` while carrying a full `enumValues` array.

Every generator reads `enumValues` before it reads `tsType`, so the schema was right the whole time.
What was wrong was the description, and the description reached users anyway through that warning.
A warning wrong about the one column it names teaches the reader to skip the true ones, which is the
cost this pays off.

## The measurement chose the fix

The filed defect was "the warning fires falsely on enums", which points at the warning's predicate.
Measuring pointed one level down:

```
0.4x   m_enum   tsType=unknown   enumValues=["a","b","c"]   ->  warns
v1     m_enum   tsType=string    enumValues=["a","b","c"]   ->  silent
```

The two majors disagreed about the same column and v1 was right. So this adds the two missing arms
rather than special-casing the warning: it corrects the description instead of suppressing the
symptom, and the cross-major diff that carried the disagreement now has one fewer filed defect.

`string` rather than a union of the members, because that is what v1 answers and the narrowing lives
in `enumValues` on both majors.

## Nothing about the generated output changes

That is worth stating plainly, since this is an analyzer type change. `verify:packed` regenerates
every dialect through every generator and compares against the official modules; it passes with no
count and no waiver moved.

## The tests that found this are the tests that changed

`uncovered-dialects.spec.ts` measured the defect when the uncovered dialects were first surveyed. It
asserted `tsType: 'unknown'` and carried a note going further than it asserted: that the warning was
therefore a false positive. That note sat in a test comment and became the filed defect.

Both assertions now hold the fixed state and say what they used to say, so the record of why the fix
happened survives it.

One assertion was added rather than flipped, and it caught me over-reaching. A first version
asserted the whole issue list was empty and failed: `vec`, a SingleStore `vector(3, F32)`, comes
back `any` with no shape and warns, and that warning is true. Postgres `vector` has a `numberVector`
shape; the SingleStore class has no arm at all, which is filed under the uncovered-dialect work.

So the test now asserts both halves: `m_enum` is not warned about, and `vec` still is. Without the
second half this would have traded a false positive for a false negative, which is the worse trade,
since nothing would then report a column whose validator really does take anything.

## Verification

`pnpm build`, `pnpm -r test`, `pnpm typecheck`, `pnpm lint`, `pnpm verify:packed` and
`pnpm -C docs build` all pass.

Control: reverting the two arms fails 3 of the 4 new cases. The fourth, that a genuine `customType`
still warns, passes in both states, which is the point of it.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
