### PR TITLE
fix: make format.engine 'biome' actually format, and report the real generator error

### DIFF
--- a/.changeset/biome-engine-runs-the-binary.md
+++ b/.changeset/biome-engine-runs-the-binary.md
@@ -1,0 +1,19 @@
+---
+'@drzl/validation-core': patch
+---
+
+`format.engine: 'biome'` formats. It never has before.
+
+`@biomejs/biome` publishes a `bin` and no module entry point at all, so the engine's
+`import('@biomejs/biome')` rejected with `ERR_MODULE_NOT_FOUND` whether or not the package was
+installed. Every project that configured biome got unformatted output, and after the previous
+release, a warning telling them to run the CLI by hand.
+
+It now spawns the binary the package actually publishes, found by resolving the package's own
+manifest from the directory being generated into. Both `bin` shapes are handled: a string at 1.5.3
+and below, an object from 1.9.4 on.
+
+**What changes for you.** If you configured `engine: 'biome'` and installed `@biomejs/biome`, your
+output is now formatted with it. If you configured it and did not install it, the warning now tells
+you to install the package, which is advice that works, rather than pointing you at the CLI.
+`engine: 'auto'` and `engine: 'prettier'` are unaffected.

--- a/.changeset/cli-reports-the-real-generator-error.md
+++ b/.changeset/cli-reports-the-real-generator-error.md
@@ -1,0 +1,14 @@
+---
+'@drzl/cli': patch
+---
+
+A generator that fails is reported as what went wrong, not as a missing package.
+
+Every generator branch in the CLI except oRPC's wrapped `generate()` in a catch of one shape, so any
+error at all came back as, for example, `Zod generator missing. Install with: npm install
+@drzl/generator-zod`. The real reason was demoted to a trailing detail line, and the headline named a
+package you already had installed. Ten places.
+
+A module that cannot be resolved and a module that threw while running are now told apart, so a
+genuinely absent optional generator still gets the install hint it is for, and a generator that
+failed reports its own error.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,8 +16,32 @@ import {
   loadConfig,
 } from './config.js';
 import { diffSnapshots, restoreSnapshot, snapshotAll } from './drift.js';
+import { GeneratorNotInstalledError, loadGenerator } from './generator-loader.js';
 import { maybeShowSponsorMessage } from './sponsor.js';
 import { CLI_VERSION } from './version.js';
+
+/**
+ * Say what went wrong with a generator, distinguishing the two things that can.
+ *
+ * Every branch below used to print "<name> generator missing. Install with: npm install
+ * @drzl/generator-<name>" for anything at all that threw, with the real reason on a trailing
+ * "Error details" line. A generator that was installed and merely failed therefore sent its user
+ * to reinstall a package they already had, and the sentence that would have told them what
+ * actually happened was the one written as a footnote.
+ *
+ * `loadGenerator` marks the one case that is an install problem, so the package name comes off the
+ * error rather than being repeated here beside the `import()` that already spells it.
+ */
+function reportGeneratorFailure(kind: string, e: unknown): void {
+  if (e instanceof GeneratorNotInstalledError) {
+    console.error(
+      chalk.red(`The ${kind} generator is not installed.`),
+      chalk.yellow(`\nInstall with: npm install ${e.specifier}`)
+    );
+    return;
+  }
+  console.error(chalk.red(`The ${kind} generator failed:`), (e as any)?.message ?? e);
+}
 
 const program = new Command();
 program.name('drzl').description('DRZL - Drizzle Developer Toolkit').version(CLI_VERSION);
@@ -138,7 +162,10 @@ program
           files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
         } else if (g.kind === 'service') {
           try {
-            const { ServiceGenerator } = await import('@drzl/generator-service');
+            const { ServiceGenerator } = await loadGenerator(
+              '@drzl/generator-service',
+              () => import('@drzl/generator-service')
+            );
             const gen = new ServiceGenerator(analysis);
             const target = g.path ?? 'src/services';
             const files = await gen.generate({
@@ -155,16 +182,15 @@ program
             files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
           } catch (e: any) {
             progress.stop();
-            console.error(
-              chalk.red('Service generator missing.'),
-              chalk.yellow('\nInstall with: npm install @drzl/generator-service')
-            );
-            console.error(chalk.gray('Error details:'), e?.message ?? e);
+            reportGeneratorFailure(g.kind, e);
             process.exit(1);
           }
         } else if (g.kind === 'zod') {
           try {
-            const { ZodGenerator } = await import('@drzl/generator-zod');
+            const { ZodGenerator } = await loadGenerator(
+              '@drzl/generator-zod',
+              () => import('@drzl/generator-zod')
+            );
             const gen = new ZodGenerator(analysis);
             const target = g.path ?? 'src/validators/zod';
             const files = await gen.generate(
@@ -175,16 +201,15 @@ program
             files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
           } catch (e: any) {
             progress.stop();
-            console.error(
-              chalk.red('Zod generator missing.'),
-              chalk.yellow('\nInstall with: npm install @drzl/generator-zod')
-            );
-            console.error(chalk.gray('Error details:'), e?.message ?? e);
+            reportGeneratorFailure(g.kind, e);
             process.exit(1);
           }
         } else if (g.kind === 'valibot') {
           try {
-            const { ValibotGenerator } = await import('@drzl/generator-valibot');
+            const { ValibotGenerator } = await loadGenerator(
+              '@drzl/generator-valibot',
+              () => import('@drzl/generator-valibot')
+            );
             const gen = new ValibotGenerator(analysis);
             const target = g.path ?? 'src/validators/valibot';
             const files = await gen.generate(
@@ -195,16 +220,15 @@ program
             files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
           } catch (e: any) {
             progress.stop();
-            console.error(
-              chalk.red('Valibot generator missing.'),
-              chalk.yellow('\nInstall with: npm install @drzl/generator-valibot')
-            );
-            console.error(chalk.gray('Error details:'), e?.message ?? e);
+            reportGeneratorFailure(g.kind, e);
             process.exit(1);
           }
         } else if (g.kind === 'arktype') {
           try {
-            const { ArkTypeGenerator } = await import('@drzl/generator-arktype');
+            const { ArkTypeGenerator } = await loadGenerator(
+              '@drzl/generator-arktype',
+              () => import('@drzl/generator-arktype')
+            );
             const gen = new ArkTypeGenerator(analysis);
             const target = g.path ?? 'src/validators/arktype';
             const files = await gen.generate(
@@ -215,16 +239,19 @@ program
             files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
           } catch (e: any) {
             progress.stop();
-            console.error(
-              chalk.red('ArkType generator missing.'),
-              chalk.yellow('\nInstall with: npm install @drzl/generator-arktype')
-            );
-            console.error(chalk.gray('Error details:'), e?.message ?? e);
+            reportGeneratorFailure(g.kind, e);
             process.exit(1);
           }
         } else if (g.kind === 'json-schema') {
           try {
-            const { JsonSchemaGenerator } = await import('@drzl/generator-json-schema');
+            // An optional dependency, unlike the other generators, until its npm trusted publisher
+            // exists. A missing optional dependency is skipped rather than failing the install,
+            // which is what keeps `npm i @drzl/cli` working meanwhile, and is why this one really
+            // can be absent on a normal install.
+            const { JsonSchemaGenerator } = await loadGenerator(
+              '@drzl/generator-json-schema',
+              () => import('@drzl/generator-json-schema')
+            );
             const gen = new JsonSchemaGenerator(analysis);
             const target = g.path ?? 'src/validators/json-schema';
             const files = await gen.generate({
@@ -238,20 +265,15 @@ program
             files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
           } catch (e: any) {
             progress.stop();
-            console.error(
-              chalk.red('JSON Schema generator missing.'),
-              chalk.yellow('\nInstall with: npm install @drzl/generator-json-schema'),
-              // An optional dependency, unlike the other generators, until its npm trusted
-              // publisher exists. A missing optional dependency is skipped rather than failing
-              // the install, which is what keeps `npm i @drzl/cli` working meanwhile.
-              ''
-            );
-            console.error(chalk.gray('Error details:'), e?.message ?? e);
+            reportGeneratorFailure(g.kind, e);
             process.exit(1);
           }
         } else if (g.kind === 'typebox') {
           try {
-            const { TypeBoxGenerator } = await import('@drzl/generator-typebox');
+            const { TypeBoxGenerator } = await loadGenerator(
+              '@drzl/generator-typebox',
+              () => import('@drzl/generator-typebox')
+            );
             const gen = new TypeBoxGenerator(analysis);
             const target = g.path ?? 'src/validators/typebox';
             const files = await gen.generate(
@@ -262,11 +284,7 @@ program
             files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
           } catch (e: any) {
             progress.stop();
-            console.error(
-              chalk.red('TypeBox generator missing.'),
-              chalk.yellow('\nInstall with: npm install @drzl/generator-typebox')
-            );
-            console.error(chalk.gray('Error details:'), e?.message ?? e);
+            reportGeneratorFailure(g.kind, e);
             process.exit(1);
           }
         }
@@ -501,7 +519,10 @@ program
             newFiles.push(...files);
           } else if (g.kind === 'service') {
             try {
-              const { ServiceGenerator } = await import('@drzl/generator-service');
+              const { ServiceGenerator } = await loadGenerator(
+                '@drzl/generator-service',
+                () => import('@drzl/generator-service')
+              );
               const gen = new ServiceGenerator(analysis);
               const target = g.path ?? 'src/services';
               const files = await gen.generate({
@@ -521,16 +542,15 @@ program
                   );
               newFiles.push(...files);
             } catch (e: any) {
-              console.error(
-                chalk.red('Service generator missing.'),
-                chalk.yellow('\nInstall with: npm install @drzl/generator-service')
-              );
-              console.error(chalk.gray('Error details:'), e?.message ?? e);
+              reportGeneratorFailure(g.kind, e);
               return;
             }
           } else if (g.kind === 'zod') {
             try {
-              const { ZodGenerator } = await import('@drzl/generator-zod');
+              const { ZodGenerator } = await loadGenerator(
+                '@drzl/generator-zod',
+                () => import('@drzl/generator-zod')
+              );
               const gen = new ZodGenerator(analysis);
               const target = g.path ?? 'src/validators/zod';
               const files = await gen.generate({
@@ -550,16 +570,15 @@ program
                   );
               newFiles.push(...files);
             } catch (e: any) {
-              console.error(
-                chalk.red('Zod generator missing.'),
-                chalk.yellow('\nInstall with: npm install @drzl/generator-zod')
-              );
-              console.error(chalk.gray('Error details:'), e?.message ?? e);
+              reportGeneratorFailure(g.kind, e);
               return;
             }
           } else if (g.kind === 'valibot') {
             try {
-              const { ValibotGenerator } = await import('@drzl/generator-valibot');
+              const { ValibotGenerator } = await loadGenerator(
+                '@drzl/generator-valibot',
+                () => import('@drzl/generator-valibot')
+              );
               const gen = new ValibotGenerator(analysis);
               const target = g.path ?? 'src/validators/valibot';
               const files = await gen.generate({
@@ -579,16 +598,15 @@ program
                   );
               newFiles.push(...files);
             } catch (e: any) {
-              console.error(
-                chalk.red('Valibot generator missing.'),
-                chalk.yellow('\nInstall with: npm install @drzl/generator-valibot')
-              );
-              console.error(chalk.gray('Error details:'), e?.message ?? e);
+              reportGeneratorFailure(g.kind, e);
               return;
             }
           } else if (g.kind === 'arktype') {
             try {
-              const { ArkTypeGenerator } = await import('@drzl/generator-arktype');
+              const { ArkTypeGenerator } = await loadGenerator(
+                '@drzl/generator-arktype',
+                () => import('@drzl/generator-arktype')
+              );
               const gen = new ArkTypeGenerator(analysis);
               const target = g.path ?? 'src/validators/arktype';
               const files = await gen.generate({
@@ -608,11 +626,7 @@ program
                   );
               newFiles.push(...files);
             } catch (e: any) {
-              console.error(
-                chalk.red('ArkType generator missing.'),
-                chalk.yellow('\nInstall with: npm install @drzl/generator-arktype')
-              );
-              console.error(chalk.gray('Error details:'), e?.message ?? e);
+              reportGeneratorFailure(g.kind, e);
               return;
             }
           }

--- a/packages/cli/src/generator-loader.ts
+++ b/packages/cli/src/generator-loader.ts
@@ -1,0 +1,62 @@
+/**
+ * Loading an optional generator package, and telling absence apart from failure.
+ *
+ * Every validation generator is loaded on demand, because a project that only wants zod should not
+ * have to install five. That makes "the package is not installed" a real, expected outcome worth a
+ * helpful message. It does not make it the only outcome: a generator that is installed and running
+ * can throw for any reason a program can throw, and the CLI reported all of those as a missing npm
+ * package too, with the true reason printed underneath as a detail.
+ *
+ * Node reports an unresolvable import as `ERR_MODULE_NOT_FOUND`, and reports the same code when
+ * the module resolved and something *it* imported did not. The code alone therefore does not
+ * separate the two; the message does, because it names the specifier that failed to resolve.
+ */
+
+/** A generator package that is not installed. Everything else is somebody's real error. */
+export class GeneratorNotInstalledError extends Error {
+  constructor(
+    readonly specifier: string,
+    /** What Node threw, kept so nothing is discarded on the way to the message. */
+    readonly reason: unknown
+  ) {
+    super(`${specifier} is not installed`);
+    this.name = 'GeneratorNotInstalledError';
+  }
+}
+
+/**
+ * Whether `err` is Node refusing to resolve `specifier` itself.
+ *
+ * Measured on Node 22, from an ESM entry and from a CJS one, since the CLI ships both builds and
+ * the bundler leaves `import()` as `import()` in each:
+ *
+ *   absent package            ERR_MODULE_NOT_FOUND, `Cannot find package '<specifier>' imported…`
+ *   present, inner dep absent ERR_MODULE_NOT_FOUND, naming the *inner* specifier instead
+ *   present, main file gone   ERR_MODULE_NOT_FOUND, naming the resolved file path
+ *   throws while evaluating   no `code` at all, and whatever message the generator threw
+ *
+ * Only the first is an install problem, and only the first quotes the specifier that was asked
+ * for, which is what this matches on.
+ */
+export function isPackageMissing(err: unknown, specifier: string): boolean {
+  const code = (err as { code?: unknown } | null | undefined)?.code;
+  if (code !== 'ERR_MODULE_NOT_FOUND') return false;
+  const message = (err as { message?: unknown } | null | undefined)?.message;
+  return typeof message === 'string' && message.includes(`'${specifier}'`);
+}
+
+/**
+ * Run `load` and re-throw a missing package as `GeneratorNotInstalledError`.
+ *
+ * `load` is a thunk rather than a specifier so the caller keeps a literal `import('@drzl/…')` in
+ * its own source, which is what lets the bundler see the dependency. Anything it throws that is
+ * not this package's own absence comes out unchanged.
+ */
+export async function loadGenerator<T>(specifier: string, load: () => Promise<T>): Promise<T> {
+  try {
+    return await load();
+  } catch (e) {
+    if (isPackageMissing(e, specifier)) throw new GeneratorNotInstalledError(specifier, e);
+    throw e;
+  }
+}

--- a/packages/cli/test/generator-failures.e2e.spec.ts
+++ b/packages/cli/test/generator-failures.e2e.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * What the CLI says when a generator does not work, spawned as a real process.
+ *
+ * Ten branches answered every failure with "X generator missing. Install with: npm install
+ * @drzl/generator-x", so a user whose generator was installed, resolvable and merely throwing was
+ * sent to reinstall a package they already had. Both halves are proved here by execution: a
+ * generator that is present and throws, and a generator that is genuinely not installed.
+ *
+ * Requires a build. CI builds before testing; locally, run `pnpm build` first.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { promises as fs, existsSync } from 'node:fs';
+import * as os from 'node:os';
+import path from 'node:path';
+
+const run = promisify(execFile);
+const PKG = path.resolve(__dirname, '..');
+const CLI = path.join(PKG, 'dist', 'cli.js');
+const ROOT = path.join(__dirname, '.genfail-tmp');
+
+const SCHEMA = `
+import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+`;
+
+/** Run the CLI and hand back its streams and exit code, whether it succeeded or not. */
+async function cli(argv: string[], cwd: string, exe = CLI) {
+  try {
+    const { stdout, stderr } = await run(process.execPath, [exe, ...argv], {
+      cwd,
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    return { code: 0, stdout, stderr };
+  } catch (e: any) {
+    return { code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}
+
+async function project(name: string, config: string) {
+  const dir = path.join(ROOT, name);
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(path.join(dir, 'src', 'db'), { recursive: true });
+  await fs.writeFile(path.join(dir, 'src', 'db', 'schema.ts'), SCHEMA, 'utf8');
+  await fs.writeFile(path.join(dir, 'drzl.config.ts'), config, 'utf8');
+  return dir;
+}
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.mkdir(ROOT, { recursive: true });
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+/**
+ * A copy of the built CLI outside this repository, with a node_modules holding every direct
+ * dependency of `@drzl/cli` except `omit`.
+ *
+ * A physical copy rather than a symlink because Node resolves from a file's real path, and outside
+ * the repository because the resolver walks upwards: run from anywhere under `packages/`, the
+ * omitted package is found again one directory up and stops being absent. Everything else is
+ * symlinked straight at what pnpm already installed, so the CLI that runs here is the same build,
+ * loading the same generators, with one package genuinely not there.
+ */
+async function cliWithout(omit: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-nogen-'));
+  const dist = path.join(dir, 'dist');
+  await fs.cp(path.join(PKG, 'dist'), dist, { recursive: true });
+  // The CLI reads its version from the manifest beside its build and refuses to start without it.
+  await fs.cp(path.join(PKG, 'package.json'), path.join(dir, 'package.json'));
+
+  const deps = path.join(dir, 'node_modules');
+  await fs.mkdir(path.join(deps, '@drzl'), { recursive: true });
+  const installed = path.join(PKG, 'node_modules');
+  for (const entry of await fs.readdir(installed)) {
+    if (entry.startsWith('.')) continue;
+    if (entry !== '@drzl') {
+      await fs.symlink(path.join(installed, entry), path.join(deps, entry), 'dir');
+      continue;
+    }
+    for (const scoped of await fs.readdir(path.join(installed, '@drzl'))) {
+      if (`@drzl/${scoped}` === omit) continue;
+      await fs.symlink(
+        path.join(installed, '@drzl', scoped),
+        path.join(deps, '@drzl', scoped),
+        'dir'
+      );
+    }
+  }
+  return { dir, cli: path.join(dist, 'cli.js') };
+}
+
+describe('a generator that is installed and throws', () => {
+  it('reports its own error rather than sending the user to reinstall it', async () => {
+    // `out` is a file, so the generator's `mkdir(out/zod)` fails with ENOTDIR. A real failure
+    // from inside a generator that imported perfectly well, which is the case the old catch
+    // could not distinguish.
+    const dir = await project(
+      'zod-throws',
+      `export default {
+         schema: './src/db/schema.ts',
+         outDir: './api',
+         generators: [{ kind: 'zod', path: './out/zod' }],
+       };`
+    );
+    await fs.writeFile(path.join(dir, 'out'), 'not a directory', 'utf8');
+
+    const { code, stderr } = await cli(['generate'], dir);
+    expect(code).not.toBe(0);
+    expect(stderr).toContain('ENOTDIR');
+    expect(stderr).not.toContain('npm install @drzl/generator-zod');
+    expect(stderr).not.toMatch(/generator missing|is not installed/i);
+  }, 120_000);
+
+  it('names the generator that failed, so a multi-generator config says which one', async () => {
+    const dir = await project(
+      'typebox-throws',
+      `export default {
+         schema: './src/db/schema.ts',
+         outDir: './api',
+         generators: [{ kind: 'typebox', path: './out/typebox' }],
+       };`
+    );
+    await fs.writeFile(path.join(dir, 'out'), 'not a directory', 'utf8');
+
+    const { code, stderr } = await cli(['generate'], dir);
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/typebox/i);
+    expect(stderr).toContain('ENOTDIR');
+    expect(stderr).not.toContain('npm install @drzl/generator-typebox');
+  }, 120_000);
+});
+
+describe('a generator that is genuinely not installed', () => {
+  it('still says which package to install', async () => {
+    const { dir: home, cli: exe } = await cliWithout('@drzl/generator-typebox');
+    try {
+      const dir = await project(
+        'typebox-absent',
+        `export default {
+           schema: './src/db/schema.ts',
+           outDir: './api',
+           generators: [{ kind: 'typebox', path: './out/typebox' }],
+         };`
+      );
+      const { code, stderr } = await cli(['generate'], dir, exe);
+      expect(code).not.toBe(0);
+      expect(stderr).toContain('npm install @drzl/generator-typebox');
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  it('is a real absence: the same copy runs a generator it does have', async () => {
+    // Without this the test above proves nothing about the copy being usable at all, and would
+    // pass just as happily against a CLI that failed at startup for an unrelated reason.
+    const { dir: home, cli: exe } = await cliWithout('@drzl/generator-typebox');
+    try {
+      const dir = await project(
+        'zod-present',
+        `export default {
+           schema: './src/db/schema.ts',
+           outDir: './api',
+           generators: [{ kind: 'zod', path: './out/zod' }],
+         };`
+      );
+      const { code } = await cli(['generate'], dir, exe);
+      expect(code).toBe(0);
+      expect(existsSync(path.join(dir, 'out', 'zod', 'users.zod.ts'))).toBe(true);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }, 120_000);
+});

--- a/packages/cli/test/generator-loader.spec.ts
+++ b/packages/cli/test/generator-loader.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Telling "this generator is not installed" apart from "this generator threw".
+ *
+ * Every generator branch in the CLI used to answer both with the same sentence, so a bug inside a
+ * generator that was present and working was reported as a missing npm package and the real reason
+ * was demoted to a trailing detail line. The two are distinguishable, and this proves the
+ * distinguisher on real module loads rather than on hand-built error objects: an absent package, a
+ * present package whose own dependency is absent, and a module that throws while evaluating all
+ * arrive here as they arrive in production.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { GeneratorNotInstalledError, loadGenerator } from '../src/generator-loader';
+
+/**
+ * Outside the repository on purpose. A fixture written under `packages/` would resolve its
+ * "absent" dependency against this workspace's node_modules and stop being absent.
+ */
+let ROOT = '';
+const url = (p: string) => pathToFileURL(p).href;
+
+beforeAll(async () => {
+  ROOT = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-loader-'));
+  await fs.mkdir(path.join(ROOT, 'node_modules', 'present-pkg'), { recursive: true });
+  await fs.writeFile(
+    path.join(ROOT, 'node_modules', 'present-pkg', 'package.json'),
+    JSON.stringify({ name: 'present-pkg', version: '1.0.0', type: 'module', main: 'index.js' }),
+    'utf8'
+  );
+  await fs.writeFile(
+    path.join(ROOT, 'node_modules', 'present-pkg', 'index.js'),
+    `import 'a-dependency-nobody-installed';\nexport const ok = true;\n`,
+    'utf8'
+  );
+  await fs.writeFile(
+    path.join(ROOT, 'throws-on-load.mjs'),
+    `throw new Error('the generator blew up while loading');\n`,
+    'utf8'
+  );
+  await fs.writeFile(path.join(ROOT, 'loads-fine.mjs'), `export const value = 41 + 1;\n`, 'utf8');
+});
+
+afterAll(async () => {
+  if (ROOT) await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe('loadGenerator', () => {
+  it('returns the module when the package loads', async () => {
+    const spec = url(path.join(ROOT, 'loads-fine.mjs'));
+    const mod = await loadGenerator<{ value: number }>(spec, () => import(/* @vite-ignore */ spec));
+    expect(mod.value).toBe(42);
+  });
+
+  it('reports a package that is genuinely not installed as not installed', async () => {
+    const spec = '@drzl/generator-nobody-published';
+    await expect(
+      loadGenerator(spec, () => import(/* @vite-ignore */ spec))
+    ).rejects.toBeInstanceOf(GeneratorNotInstalledError);
+  });
+
+  it('keeps the specifier on the not-installed error, so the install line names it', async () => {
+    const spec = '@drzl/generator-nobody-published';
+    const err = await loadGenerator(spec, () => import(/* @vite-ignore */ spec)).catch((e) => e);
+    expect(err).toBeInstanceOf(GeneratorNotInstalledError);
+    expect((err as GeneratorNotInstalledError).specifier).toBe(spec);
+  });
+
+  it('does not call a present package absent when one of its own imports is', async () => {
+    // The hardest case, and the one a bare `ERR_MODULE_NOT_FOUND` check gets wrong: the package
+    // asked for resolved perfectly well, and something it imported did not. Node reports both
+    // with the same code, and only the message says which specifier failed.
+    const spec = 'present-pkg';
+    const from = url(path.join(ROOT, 'consumer.mjs'));
+    const err = await loadGenerator(spec, () =>
+      import(/* @vite-ignore */ new URL('./node_modules/present-pkg/index.js', from).href)
+    ).catch((e) => e);
+    expect(err).not.toBeInstanceOf(GeneratorNotInstalledError);
+    expect((err as Error).message).toContain('a-dependency-nobody-installed');
+  });
+
+  it('lets an error thrown while the module evaluates through untouched', async () => {
+    const spec = url(path.join(ROOT, 'throws-on-load.mjs'));
+    const err = await loadGenerator(spec, () => import(/* @vite-ignore */ spec)).catch((e) => e);
+    expect(err).not.toBeInstanceOf(GeneratorNotInstalledError);
+    expect((err as Error).message).toBe('the generator blew up while loading');
+  });
+
+  it('lets an error thrown after the module loaded through untouched', async () => {
+    // The load succeeded, so nothing about this is a packaging problem. This is the shape of the
+    // real bug: the CLI wrapped `generate()` in the same try as the import.
+    const spec = url(path.join(ROOT, 'loads-fine.mjs'));
+    const err = await loadGenerator(spec, async () => {
+      await import(/* @vite-ignore */ spec);
+      throw new Error('EACCES: permission denied, mkdir');
+    }).catch((e) => e);
+    expect(err).not.toBeInstanceOf(GeneratorNotInstalledError);
+    expect((err as Error).message).toContain('EACCES');
+  });
+});

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -1,3 +1,8 @@
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { Analysis, Column } from '@drzl/analyzer';
 import type { ImportExtension } from './files.js';
 import type { AffixOptions } from './naming.js';
@@ -254,12 +259,10 @@ const ENGINE_PACKAGE = { prettier: 'prettier', biome: '@biomejs/biome' } as cons
  * and "installed and then threw" reach this from the same branch and nothing else distinguishes
  * them.
  *
- * The advice differs because the remedy does. Installing prettier fixes the prettier case; it is
- * an optional peer of this package and that is the whole of it. Installing `@biomejs/biome` does
- * not fix the biome case: at 2.5.7 that package declares `bin` and no `main`, `module` or
- * `exports`, so importing it as a module rejects with ERR_MODULE_NOT_FOUND whether or not it is
- * installed. Measured, against a real install of it. So the biome message points at the CLI and at
- * the other engines rather than telling anyone to install something that would not help.
+ * Installing the named package is the remedy in both cases, which was not true of biome until the
+ * engine started running the Biome binary rather than importing the package: `@biomejs/biome`
+ * publishes `bin` and no module entry point, so the old advice had to send people to the CLI by
+ * hand. See `formatBiome` below for what was measured.
  */
 function reportUnusableFormatter(engine: 'prettier' | 'biome', cause: unknown): void {
   if (reportedEngines.has(engine)) return;
@@ -269,13 +272,142 @@ function reportUnusableFormatter(engine: 'prettier' | 'biome', cause: unknown): 
     engine === 'prettier'
       ? 'Install prettier, which is an optional peer of @drzl/validation-core, or set ' +
         'format.engine to "auto" to accept whatever formatter is present.'
-      : 'drzl formats with Biome by importing @biomejs/biome as a module; run the Biome CLI ' +
-        'over the output instead, or set format.engine to "auto" or "prettier".';
+      : 'Install @biomejs/biome in the project being generated into, or set format.engine to ' +
+        '"auto" or "prettier".';
   const reason = cause instanceof Error ? cause.message : String(cause);
   console.warn(
     `[drzl] format.engine is "${engine}" but ${pkg} could not be used, so the generated files ` +
       `were left unformatted. ${remedy} Reason: ${reason}`
   );
+}
+
+/**
+ * The nearest directory at or above `from` that exists.
+ *
+ * A child process cannot be spawned into a directory that is not there: `spawn` fails with ENOENT
+ * before the command runs. Every generator calls `fs.mkdir(out, { recursive: true })` before its
+ * first `formatCode`, so in a real run the output directory exists, but `formatCode` is exported
+ * and its own tests pass paths under a temp directory that was never created. Walking up is what
+ * makes that a formatted file rather than a spawn failure. `path.dirname` is its own fixed point at
+ * the filesystem root, which is what terminates this.
+ */
+function nearestExistingDir(from: string): string {
+  let dir = path.dirname(path.resolve(from));
+  for (;;) {
+    try {
+      if (statSync(dir).isDirectory()) return dir;
+    } catch {
+      // Not there, or not readable. Either way the parent is the next thing to try.
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return dir;
+    dir = parent;
+  }
+}
+
+/**
+ * Locate the Biome executable belonging to the project being generated into.
+ *
+ * `@biomejs/biome` cannot be imported. Its manifest declares `bin` and carries no `main`, no
+ * `module`, no `exports` and no `types`, and the tarball has no `index.js` for Node's legacy main
+ * resolution to fall back to, so `import('@biomejs/biome')` rejects with ERR_MODULE_NOT_FOUND on a
+ * complete and correct install. That is not a recent regression: it holds at 1.0.0, 1.5.3, 1.9.4,
+ * 2.0.6, 2.4.16 and 2.5.7, measured by installing each one and importing it, so the engine had
+ * never formatted anything for anybody. `bin` is what the package publishes, so `bin` is what this
+ * uses.
+ *
+ * The manifest is reachable as a subpath *because* there is no `exports` field to gate it, which is
+ * the same fact from the other side: `require.resolve('@biomejs/biome')` throws MODULE_NOT_FOUND
+ * against an install where `require.resolve('@biomejs/biome/package.json')` succeeds.
+ *
+ * Resolution starts from the consumer's project rather than from this package, which is why
+ * `@biomejs/biome` is not declared as a peer here the way prettier is. Prettier is imported, so it
+ * has to resolve from validation-core's own location and pnpm links it there only because the peer
+ * entry exists. Biome is spawned, and the install that matters is the one in the project the files
+ * are being written into.
+ */
+function biomeBinary(startDir: string): string {
+  const require_ = createRequire(pathToFileURL(path.join(startDir, 'noop.js')));
+  // `paths` covers the case where the output directory sits outside the project, as it does for an
+  // absolute `outDir`; the process working directory is then the better anchor.
+  const manifestPath = require_.resolve('@biomejs/biome/package.json', {
+    paths: [startDir, process.cwd()],
+  });
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  // A string at 1.5.3 and below, an object from 1.9.4 on. Both shapes are still installable.
+  const relative = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.biome;
+  if (typeof relative !== 'string') {
+    throw new Error(`@biomejs/biome at ${manifestPath} declares no biome binary`);
+  }
+  const binary = path.resolve(path.dirname(manifestPath), relative);
+  if (!existsSync(binary)) {
+    throw new Error(`@biomejs/biome declares a binary at ${relative}, and there is nothing there`);
+  }
+  return binary;
+}
+
+/**
+ * Format one file's worth of code by piping it through `biome format --stdin-file-path`.
+ *
+ * Supported as far back as 1.5.3, checked by running it there and at 2.5.7.
+ *
+ * Three things about the child are load-bearing, each measured against the real 2.5.7 binary rather
+ * than assumed:
+ *
+ * 1. Only the exit status may be believed. Biome exits 1 and *echoes the input back on stdout* when
+ *    the formatter is disabled in the consumer's biome.json, and again for a file extension it does
+ *    not format. Code that returned stdout whenever stdout was non-empty would hand back unformatted
+ *    text as though it had been formatted, and nothing downstream inspects whitespace.
+ * 2. stdout is collected by hand rather than through `execFile`, whose default 1 MB `maxBuffer`
+ *    truncated a 2.9 MB result to exactly 1048576 bytes and failed with
+ *    ERR_CHILD_PROCESS_STDIO_MAXBUFFER. Generated barrels reach that size.
+ * 3. The child runs in the directory the file is being written to. Biome finds biome.json by
+ *    walking up from its working directory and not from `--stdin-file-path`, so the working
+ *    directory is the whole of whose configuration applies; running the same command from an
+ *    unrelated directory picked up a different biome.json and exited non-zero. That also makes the
+ *    consumer's config apply without passing `--config-path`, whose argument means a directory at
+ *    1.x and either a directory or a file at 2.x, and so cannot be passed compatibly.
+ *
+ * `process.execPath` rather than the file's shebang: `bin/biome` is a Node launcher at every
+ * published version, and a shebang means nothing on Windows.
+ */
+function formatBiome(code: string, filePath: string, configAnchor: string): Promise<string> {
+  const cwd = nearestExistingDir(configAnchor);
+  const binary = biomeBinary(nearestExistingDir(filePath));
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [binary, 'format', `--stdin-file-path=${path.basename(filePath)}`],
+      { cwd, stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+    let out = '';
+    let err = '';
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => (out += chunk));
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => (err += chunk));
+    child.on('error', reject);
+    // Biome can exit before reading all of stdin, and an unhandled EPIPE on a child's stdin is an
+    // uncaught exception rather than a rejected promise. The exit status is what decides the
+    // outcome, so the write failing is not separately interesting.
+    child.stdin.on('error', () => {});
+    child.on('close', (status) => {
+      if (status !== 0) {
+        const detail = err.trim().split('\n')[0] || out.trim().split('\n')[0] || 'no output';
+        reject(new Error(`biome format exited with ${status}: ${detail}`));
+        return;
+      }
+      // Empty stdout is the right answer for empty input, measured, and never for anything else.
+      // This return value is written straight to disk, so a formatter that swallowed the file would
+      // truncate it to nothing, which is a worse outcome than any formatting failure.
+      if (out === '' && code !== '') {
+        reject(new Error('biome format exited 0 but returned nothing'));
+        return;
+      }
+      resolve(out);
+    });
+    child.stdin.end(code);
+  });
 }
 
 /**
@@ -322,23 +454,10 @@ export async function formatCode(code: string, filePath: string, fmt?: FormatOpt
   }
   if (engine === 'biome' || engine === 'auto') {
     try {
-      const dynamicImport: any = Function('s', 'return import(s)');
-      const biome: any = await dynamicImport('@biomejs/biome');
-      if (biome?.formatContent) {
-        const res = await biome.formatContent(code, { filePath });
-        const out = res && (res.content || res.formatted);
-        if (typeof out === 'string') return out;
-        throw new Error('@biomejs/biome formatContent returned no formatted content');
-      }
-      // Biome has shipped this entry point under both names. The second was only ever tried by
-      // the oRPC generator's private copy of this function, and is kept here so that folding the
-      // copies together takes nothing away from it.
-      if (biome?.format) {
-        const res = await biome.format(code, { filePath });
-        if (typeof res === 'string') return res;
-        throw new Error('@biomejs/biome format returned no formatted content');
-      }
-      throw new Error('@biomejs/biome exposes neither formatContent nor format');
+      // `filePath` names the file, which is where the extension comes from; the second argument is
+      // only ever used to decide which directory to run Biome in, and so honours `configPath` the
+      // same way the prettier branch above hands it to `resolveConfig`.
+      return await formatBiome(code, filePath, fmt?.configPath ?? filePath);
     } catch (err) {
       if (engine === 'biome') reportUnusableFormatter('biome', err);
     }

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -297,11 +297,11 @@ function reportUnusableFormatter(engine: 'prettier' | 'biome', cause: unknown): 
  * request, and an unmet request that produces neither formatted output nor a message reads as
  * "this is fine" when it is not: the consumer configured something, it did not happen, and nothing
  * in the run says which. So a named engine that cannot be loaded warns on stderr and still returns
- * the code, rather than throwing. Throwing would lose a whole generation over whitespace, and the
- * consumer would not even be told what for: every generator branch in the CLI except the oRPC one
- * wraps its `generate()` in a catch that prints "<name> generator missing. Install with: npm
- * install @drzl/generator-<name>", so the headline would name a package they already have and the
- * real reason would arrive as a trailing detail line. Measured, with a throw wired in on purpose.
+ * the code, rather than throwing. Throwing would lose a whole generation over whitespace, which is
+ * a bad trade even now that the CLI reports the reason faithfully: it used to answer any throw at
+ * all with "<name> generator missing. Install with: npm install @drzl/generator-<name>", naming a
+ * package the consumer already had, and it now separates an unresolvable package from a generator
+ * that ran and failed.
  */
 export async function formatCode(code: string, filePath: string, fmt?: FormatOptions) {
   if (fmt && fmt.enabled === false) return code;

--- a/packages/validation-core/test/format-biome-auto.spec.ts
+++ b/packages/validation-core/test/format-biome-auto.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * `engine: 'auto'` reaching Biome, which is the half of "tries Prettier, then Biome" that has never
+ * happened.
+ *
+ * Both README and docs describe `auto` as trying Prettier and then Biome. The second step ran, and
+ * could not succeed: it reached for `import('@biomejs/biome')`, and that package publishes `bin`
+ * and no module entry point at any version, so the import always rejected. A consumer with Biome
+ * installed and no Prettier therefore got unformatted files while `auto` was silently doing what it
+ * said it would.
+ *
+ * Prettier is removed here rather than uninstalled, so this is its own file. Its pair,
+ * format-biome.spec.ts, holds prettier in place and shows that it still wins; between them the
+ * ordering is pinned in both directions.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { formatCode } from '../src';
+
+vi.mock('prettier', () => {
+  throw new Error("Cannot find package 'prettier' imported from drzl");
+});
+
+const mangled = "export  const  a={x:1,y:'two'}\nexport  function  f(  n:number  ){return n+1}\n";
+
+/** Biome 2.5.7's real output for the input above, tabs and double quotes. See format-biome.spec.ts. */
+const BIOME_OUTPUT =
+  'export const a = { x: 1, y: "two" };\nexport function f(n: number) {\n\treturn n + 1;\n}\n';
+
+async function projectWithBiome() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-biome-auto-'));
+  const pkgDir = path.join(dir, 'node_modules', '@biomejs', 'biome');
+  await fs.mkdir(path.join(pkgDir, 'bin'), { recursive: true });
+  await fs.writeFile(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: '@biomejs/biome', version: '2.5.7', bin: { biome: 'bin/biome' } })
+  );
+  await fs.writeFile(
+    path.join(pkgDir, 'bin', 'biome'),
+    [
+      '#!/usr/bin/env node',
+      'let input = "";',
+      'process.stdin.setEncoding("utf8");',
+      'process.stdin.on("data", (c) => (input += c));',
+      'process.stdin.on("end", () => {',
+      '  process.stdout.write(' + JSON.stringify(BIOME_OUTPUT) + ');',
+      '  process.exit(0);',
+      '});',
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+  const outDir = path.join(dir, 'src', 'generated');
+  await fs.mkdir(outDir, { recursive: true });
+  return path.join(outDir, 'users.ts');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('formatCode with engine: auto and no prettier', () => {
+  it('really cannot resolve prettier here', async () => {
+    // Without this the test below passes for the wrong reason the day the mock stops applying.
+    await expect(import('prettier')).rejects.toThrow();
+  });
+
+  it('falls through to biome and returns biome output', async () => {
+    const filePath = await projectWithBiome();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await formatCode(mangled, filePath, { engine: 'auto' })).toBe(BIOME_OUTPUT);
+    // `auto` asked for whatever was there and got an answer, so there is nothing to report.
+    expect(warn.mock.calls).toEqual([]);
+  });
+
+  it('stays silent when neither formatter is available', async () => {
+    // Unchanged behaviour, asserted here because the biome branch is no longer a guaranteed
+    // failure and could start warning under `auto` by accident.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-biome-auto-none-'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await formatCode(mangled, path.join(dir, 'users.ts'), { engine: 'auto' })).toBe(mangled);
+    expect(warn.mock.calls).toEqual([]);
+  });
+});

--- a/packages/validation-core/test/format-biome.spec.ts
+++ b/packages/validation-core/test/format-biome.spec.ts
@@ -1,0 +1,274 @@
+/**
+ * `formatCode` with `engine: 'biome'`, against a binary rather than an import.
+ *
+ * The engine had never formatted anything for anyone. `formatCode` reached Biome through
+ * `import('@biomejs/biome')`, and that package has no importable entry point: its manifest declares
+ * `bin` and nothing else, so there is no `main`, no `module`, no `exports` and no `index.js` for
+ * Node's legacy fallback to find. `import()` rejects with ERR_MODULE_NOT_FOUND on a complete,
+ * correct install. Measured against real `npm install`s of 1.0.0, 1.5.3, 1.9.4, 2.0.6, 2.4.16 and
+ * 2.5.7, which is every shape the package has had; the two module entry points the old code probed
+ * for, `formatContent` and `format`, were unreachable at all six.
+ *
+ * `bin` is what the package publishes, so `bin` is what this uses: `biome format --stdin-file-path`,
+ * which is a supported mode as far back as 1.5.3.
+ *
+ * The behaviours asserted below are not invented. Each was measured by running the real 2.5.7
+ * binary and recording what it did, and the stand-in binary these tests install reproduces them:
+ *
+ *   input mangled, no config       -> exit 0, formatted on stdout (tabs, double quotes)
+ *   nearby biome.json              -> exit 0, formatted to that config
+ *   `formatter.enabled: false`     -> exit 1, and *the input echoed back on stdout*
+ *   unsupported extension          -> exit 1, and *the input echoed back on stdout*
+ *   unparseable input              -> exit 1, empty stdout, diagnostics on stderr
+ *   empty input                    -> exit 0, empty stdout
+ *
+ * The two echo-on-failure cases are why exit status is the only thing that may be believed. A
+ * check that took stdout whenever stdout was non-empty would return unformatted code as though it
+ * had been formatted, and nothing downstream would ever notice.
+ *
+ * A stand-in rather than the real 64 MB platform binary, because these tests are about the seam and
+ * not about Biome's formatter: what runs here is a real child process, over a real pipe, resolved
+ * through Node's real resolver out of a real `node_modules/@biomejs/biome` laid out exactly as npm
+ * lays out the real one. Nothing is mocked. The recorded bytes in EXPECTED_2_5_7 came out of the
+ * real binary.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+/**
+ * A `formatCode` with its own record of what it has already warned about.
+ *
+ * The unusable-engine warning fires once per engine per module instance, deliberately: a generate
+ * run reaches `formatCode` once per table per generator and the condition belongs to the
+ * environment rather than to any one file. Vitest gives a whole file one module instance, so
+ * without this the first test to warn would silence every test after it, and their `toHaveBeenCalledTimes(1)`
+ * would pass by warning zero times. Found the hard way: that is exactly how the first run of this
+ * file failed.
+ */
+async function freshFormatCode() {
+  vi.resetModules();
+  return (await import('../src')).formatCode;
+}
+
+const mangled = "export  const  a={x:1,y:'two'}\nexport  function  f(  n:number  ){return n+1}\n";
+
+/**
+ * What `@biomejs/biome@2.5.7` really printed for `mangled`, with no config in scope.
+ *
+ *   printf '<mangled>' | node node_modules/@biomejs/biome/bin/biome format --stdin-file-path=s.ts
+ *
+ * Tabs and double quotes are Biome's defaults, and are what make this distinguishable from both the
+ * input and from prettier's output, which uses two spaces.
+ */
+const EXPECTED_2_5_7 =
+  'export const a = { x: 1, y: "two" };\nexport function f(n: number) {\n\treturn n + 1;\n}\n';
+
+/** The behaviours the stand-in can be asked for, each one recorded from the real binary. */
+type Mode = 'format' | 'disabled' | 'parse-error' | 'empty-on-content' | 'crash' | 'huge';
+
+/**
+ * Build a project directory containing a `node_modules/@biomejs/biome` with the same shape as a
+ * real install: a manifest carrying `bin` and nothing else, and a Node script behind it.
+ *
+ * The manifest deliberately has no `main`, `module`, `exports` or `types`, because the real one has
+ * none either. That is what makes this fixture able to fail the way the real package fails.
+ */
+async function project(mode: Mode, opts: { indent?: string } = {}) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-biome-'));
+  const pkgDir = path.join(dir, 'node_modules', '@biomejs', 'biome');
+  await fs.mkdir(path.join(pkgDir, 'bin'), { recursive: true });
+  await fs.writeFile(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: '@biomejs/biome', version: '2.5.7', bin: { biome: 'bin/biome' } })
+  );
+  // A Node script with a shebang, which is what bin/biome is at every published version; the real
+  // one resolves @biomejs/cli-<platform> and execs the native binary behind it.
+  //
+  // `process.exitCode` throughout, never `process.exit()`. A Node process that calls `process.exit`
+  // straight after a large `process.stdout.write` throws away whatever is still buffered in the
+  // pipe: the HUGE case below arrived as 146176 of its 2400000 bytes, and the first reading of that
+  // was that the reader under test was truncating. It was not. The same bytes written by a child
+  // that sets `exitCode` and returns arrive whole, which is how the two were told apart.
+  await fs.writeFile(
+    path.join(pkgDir, 'bin', 'biome'),
+    [
+      '#!/usr/bin/env node',
+      'const mode = ' + JSON.stringify(mode) + ';',
+      'const indent = ' + JSON.stringify(opts.indent ?? '\t') + ';',
+      'let input = "";',
+      'process.stdin.setEncoding("utf8");',
+      'process.stdin.on("data", (c) => (input += c));',
+      'process.stdin.on("end", () => {',
+      '  const args = process.argv.slice(2);',
+      '  if (args[0] !== "format") { process.stderr.write("unknown command\\n"); process.exitCode = 2; return; }',
+      '  if (!args.some((a) => a.startsWith("--stdin-file-path="))) {',
+      '    process.stderr.write("no --stdin-file-path\\n"); process.exitCode = 2; return;',
+      '  }',
+      '  if (mode === "disabled") {',
+      // Recorded from the real binary: exit 1 with the *input* echoed back, which is the trap.
+      '    process.stdout.write(input);',
+      '    process.stderr.write("The content was not formatted because the formatter is currently disabled.\\n");',
+      '    process.exitCode = 1; return;',
+      '  }',
+      '  if (mode === "parse-error") {',
+      '    process.stderr.write("x.ts:1:19 parse: Expected a property\\n");',
+      '    process.exitCode = 1; return;',
+      '  }',
+      '  if (mode === "crash") { process.stderr.write("boom\\n"); process.exitCode = 70; return; }',
+      '  if (mode === "empty-on-content") { return; }',
+      '  if (mode === "huge") { process.stdout.write("/*x*/\\n".repeat(400000)); return; }',
+      '  if (input === "") { return; }',
+      // The recorded 2.5.7 output for the one input these tests feed in, with the indent swapped
+      // when a config is meant to be in play.
+      '  const out = ' +
+        JSON.stringify(EXPECTED_2_5_7) +
+        '.replace("\\treturn", indent + "return");',
+      '  process.stdout.write(out);',
+      '});',
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+  const outDir = path.join(dir, 'src', 'generated');
+  await fs.mkdir(outDir, { recursive: true });
+  return { dir, filePath: path.join(outDir, 'users.ts') };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('formatCode with engine: biome', () => {
+  it('formats through the binary, and says nothing', async () => {
+    const fmt = await freshFormatCode();
+    const { filePath } = await project('format');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Not the input, and not prettier's output either: prettier is installed in this workspace and
+    // indents with two spaces, so a fallback into the prettier branch would fail this line.
+    expect(await fmt(mangled, filePath, { engine: 'biome' })).toBe(EXPECTED_2_5_7);
+    expect(warn.mock.calls).toEqual([]);
+  });
+
+  it('finds the binary from the output directory, with no help from this package', async () => {
+    const fmt = await freshFormatCode();
+    // The binary is resolved from where the file is being written, not from validation-core's own
+    // location, so a consumer's install is reachable without @biomejs/biome being declared as a
+    // peer of anything. This temp directory has no relationship to this workspace at all, which is
+    // what makes that a demonstration rather than an assertion.
+    const { dir, filePath } = await project('format');
+    expect(dir.startsWith(os.tmpdir())).toBe(true);
+    const deeper = path.join(dir, 'src', 'generated', 'nested', 'deep', 'users.ts');
+    await fs.mkdir(path.dirname(deeper), { recursive: true });
+    expect(await fmt(mangled, deeper, { engine: 'biome' })).toBe(EXPECTED_2_5_7);
+  });
+
+  it('runs the binary where the file will be written, so a nearby biome.json is honoured', async () => {
+    const fmt = await freshFormatCode();
+    // Biome discovers biome.json by walking up from its working directory, not from
+    // --stdin-file-path, so the child's cwd is what decides whose config applies. Measured: the
+    // same command run from an unrelated directory picked up a different configuration and exited
+    // non-zero. The stand-in reports the indent it was told to use, standing in for that config.
+    const { dir, filePath } = await project('format', { indent: '    ' });
+    await fs.writeFile(
+      path.join(dir, 'biome.json'),
+      JSON.stringify({ formatter: { indentStyle: 'space', indentWidth: 4 } })
+    );
+    expect(await fmt(mangled, filePath, { engine: 'biome' })).toContain('\n    return n + 1;');
+  });
+
+  it('does not return stdout when the binary exits non-zero, even though stdout holds content', async () => {
+    const fmt = await freshFormatCode();
+    // The defect this exists to prevent. `formatter.enabled: false` in a consumer's biome.json makes
+    // the real binary exit 1 *and* echo the input back on stdout. Believing stdout would write
+    // unformatted code to disk while reporting success, and nothing downstream inspects whitespace.
+    const { filePath } = await project('disabled');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await fmt(mangled, filePath, { engine: 'biome' })).toBe(mangled);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]?.[0]);
+    // The binary's own words, carried rather than paraphrased, as on the prettier side.
+    expect(message).toContain('formatter is currently disabled');
+  });
+
+  it('treats a parse error as an error rather than as empty output', async () => {
+    const fmt = await freshFormatCode();
+    const { filePath } = await project('parse-error');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await fmt(mangled, filePath, { engine: 'biome' })).toBe(mangled);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('Expected a property');
+  });
+
+  it('refuses output that is empty when the input was not', async () => {
+    const fmt = await freshFormatCode();
+    // formatCode's return value is written straight to disk. A formatter that exits 0 with nothing
+    // on stdout would truncate a generated file to zero bytes, which is worse than any formatting
+    // failure, so it is rejected rather than returned.
+    const { filePath } = await project('empty-on-content');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await fmt(mangled, filePath, { engine: 'biome' })).toBe(mangled);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts empty output when the input was empty', async () => {
+    const fmt = await freshFormatCode();
+    // Measured: the real binary exits 0 with empty stdout for empty stdin. That is a correct
+    // answer, and the guard above must not turn it into a failure.
+    const { filePath } = await project('format');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await fmt('', filePath, { engine: 'biome' })).toBe('');
+    expect(warn.mock.calls).toEqual([]);
+  });
+
+  it('reads output past the 1 MB that execFile would have truncated at', async () => {
+    const fmt = await freshFormatCode();
+    // Measured: execFile's default maxBuffer is 1 MB and a 2.9 MB file came back cut to exactly
+    // 1048576 bytes with ERR_CHILD_PROCESS_STDIO_MAXBUFFER. Generated barrels and JSON Schema
+    // component files reach that size, so stdout is collected by hand instead.
+    const { filePath } = await project('huge');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const out = await fmt(mangled, filePath, { engine: 'biome' });
+    expect(out.length).toBe(6 * 400000);
+    expect(warn.mock.calls).toEqual([]);
+  });
+
+  it('warns once, and returns the code, when @biomejs/biome is not installed', async () => {
+    const fmt = await freshFormatCode();
+    // The experience a consumer with `engine: 'biome'` has had all along, which must not get worse:
+    // unformatted files and one message saying so. What changes is that installing the package now
+    // fixes it, so the message says to install it.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-biome-none-'));
+    const filePath = path.join(dir, 'users.ts');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await fmt(mangled, filePath, { engine: 'biome' })).toBe(mangled);
+    expect(await fmt(mangled, filePath, { engine: 'biome' })).toBe(mangled);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toContain('[drzl]');
+    expect(message).toContain('format.engine');
+    expect(message).toContain('@biomejs/biome');
+  });
+
+  it('does not run the binary when formatting is switched off', async () => {
+    const fmt = await freshFormatCode();
+    const { filePath } = await project('crash');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(await fmt(mangled, filePath, { engine: 'biome', enabled: false })).toBe(mangled);
+    expect(warn.mock.calls).toEqual([]);
+  });
+
+  it('leaves biome alone under auto while prettier answers', async () => {
+    const fmt = await freshFormatCode();
+    // `auto` is documented as "tries Prettier, then Biome", and prettier is installed in this
+    // workspace, so prettier must win even with a usable biome sitting next to the output file.
+    // Its pair, format-biome-auto.spec.ts, takes prettier away and shows biome then answering;
+    // without that pair this test would be satisfied by an `auto` that had lost the biome branch
+    // altogether. Two spaces is prettier's indent, a tab is Biome's.
+    const { filePath } = await project('format');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const out = await fmt(mangled, filePath, { engine: 'auto' });
+    expect(out).not.toBe(EXPECTED_2_5_7);
+    expect(out).toContain('\n  return n + 1;');
+    expect(warn.mock.calls).toEqual([]);
+  });
+});

--- a/packages/validation-core/test/format.spec.ts
+++ b/packages/validation-core/test/format.spec.ts
@@ -14,6 +14,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import path from 'node:path';
 import os from 'node:os';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 import { formatCode } from '../src';
 
 // Outside the workspace on purpose. `resolveConfig` walks up from this path, so a path inside
@@ -59,21 +61,24 @@ describe('formatCode with prettier resolvable', () => {
     expect(warn.mock.calls).toEqual([]);
   });
 
-  it('warns, once, when the chosen engine is biome and biome cannot be loaded', async () => {
-    // The biome branch is reached through a `Function`-built import precisely so no bundler can
-    // see it. Selecting it with biome unreachable must degrade rather than throw, and must not
-    // fall back to the prettier that is installed right here: the config named an engine.
+  it('warns, once, when the chosen engine is biome and biome is not installed', async () => {
+    // Selecting biome where it is absent must degrade rather than throw, and must not fall back to
+    // the prettier that is installed right here: the config named an engine.
     //
-    // Why the expected reason is taken from a run rather than written down: under vitest that
-    // import fails as ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING, and under plain node as
-    // ERR_MODULE_NOT_FOUND. Hardcoding either would assert the harness instead of the message,
-    // and would go stale the moment the harness changed. no-bundled-formatter.spec.ts runs the
-    // node one for real.
+    // The expected reason is taken from a run rather than written down, and what that run does had
+    // to change with the engine. This used to attempt `import('@biomejs/biome')`, because that is
+    // how the engine reached it, and the import failed under every harness: the package publishes
+    // `bin` and no module entry point at all, so the engine had never formatted anything for
+    // anyone. It spawns the published binary now, and finds it by resolving the package's own
+    // manifest, so absence surfaces as a failed resolve rather than a failed import.
     let cause = '';
     try {
-      await Function('s', 'return import(s)')('@biomejs/biome');
+      createRequire(pathToFileURL(path.join(os.tmpdir(), 'noop.js'))).resolve(
+        '@biomejs/biome/package.json',
+        { paths: [os.tmpdir(), process.cwd()] }
+      );
     } catch (e: any) {
-      cause = String(e?.message ?? e);
+      cause = String(e?.message ?? e).split('\n')[0];
     }
     expect(cause, 'biome resolved here, so this test proved nothing').not.toBe('');
 

--- a/packages/validation-core/test/no-bundled-formatter.spec.ts
+++ b/packages/validation-core/test/no-bundled-formatter.spec.ts
@@ -215,8 +215,14 @@ describe('the built validation-core entry', () => {
     // The resolver's own words for a package that is not installed, which is what separates this
     // from a mocked import and from a formatter that loaded and then misbehaved. Asserted for both,
     // since the prose of the message names both packages on its own and would match either way.
+    //
+    // The two engines reach their package differently and their resolvers say different things, so
+    // these are not the same string with a name swapped. Prettier is imported, and an ESM import
+    // that cannot resolve says "Cannot find package". Biome is spawned as the binary it publishes,
+    // which is found by resolving its manifest with `createRequire`, and that says "Cannot find
+    // module" naming the manifest path. Both are quoted from a run rather than composed here.
     expect(run.stderr).toContain("Cannot find package 'prettier'");
-    expect(run.stderr).toContain("Cannot find package '@biomejs/biome'");
+    expect(run.stderr).toContain("Cannot find module '@biomejs/biome/package.json'");
   });
 });
 


### PR DESCRIPTION
Two fixes, both in the same area: what happens when something the config named cannot be reached.

## `format.engine: 'biome'` formats. It never has before.

`@biomejs/biome` publishes a `bin` and no module entry point at all: no `main`, no `module`, no
`exports`. The engine reached for it with `import('@biomejs/biome')`, which rejects with
`ERR_MODULE_NOT_FOUND` **whether or not the package is installed**. Measured against a real install
of 2.5.7.

So every project that configured biome got unformatted output. Until the previous release that was
silent; since then it has been a warning telling the user to run the Biome CLI by hand, which was
the honest advice available while the engine could not work.

It now spawns the binary the package actually publishes. The binary is found by resolving the
package's own manifest from the directory being generated into, because the install that matters is
the consumer's rather than this package's. Both `bin` shapes are handled, a string at 1.5.3 and
below and an object from 1.9.4 on, and both are still installable.

**What changes for you.** Configured `engine: 'biome'` with the package installed: your output is
formatted with Biome, for the first time. Configured it without the package: the warning now says to
install `@biomejs/biome`, which is advice that works. `engine: 'auto'` and `engine: 'prettier'` are
unaffected, and prettier remains an unbundled optional peer.

One trap worth recording, found by running it rather than reading it: `spawn` fails with `ENOENT`
when its `cwd` does not exist, and `formatCode` is exported with its own tests passing paths under a
temp directory that was never created. The engine walks up to the nearest existing directory, which
is what makes that a formatted file rather than a spawn failure.

## A failing generator is reported as what went wrong

Every generator branch in the CLI except oRPC's wrapped `generate()` in a catch of one shape:

```
Zod generator missing. Install with: npm install @drzl/generator-zod
```

Any error at all came back that way, with the real reason demoted to a trailing detail line and the
headline naming a package the user already had installed. Ten places.

That catch exists for a real case, a genuinely absent optional generator, so it is not simply gone.
A module that cannot be **resolved** and a module that **threw while running** are now told apart,
so an absent generator still gets the install hint it is for and a generator that failed reports its
own error.

## Two tests changed because this made them false

Both asserted that biome could not be loaded, which was true when they were written and is the thing
this fixes. They were well built and broke cleanly:

- one derived its expected failure from a real import attempt rather than hardcoding a message, and
  carried the guard `expect(cause, 'biome resolved here, so this test proved nothing')`. Its
  mechanism moved from `import()` to `createRequire().resolve()`; its intent is unchanged.
- the other asserted the resolver's own words. Those differ by mechanism and are not one string with
  a name swapped: an ESM import that cannot resolve says `Cannot find package 'prettier'`, while
  `createRequire` resolving a manifest says `Cannot find module '@biomejs/biome/package.json'`. The
  comment now says so, because the next reader will otherwise "fix" the inconsistency.

## Provenance, stated plainly

Both fixes were written by agents that were killed by a session limit before committing, running any
verification, or writing a changeset. The work was recovered from their worktrees.

Two further lanes from the same batch are **not** in this PR. They produced 1,186 lines that nothing
references, plus a dependency added for a harness that never runs, because both died before writing
their runner. They would have passed every gate for exactly that reason. They are preserved on
`salvage/*` branches rather than shipped.

## Verification

`pnpm build`, `pnpm -r test`, `pnpm typecheck`, `pnpm lint`, `pnpm verify:packed` and
`pnpm -C docs build` all pass. No ledger in `scripts/verify-packed.sh` moved.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
