### PR TITLE
fix(generators): accept the non-finite numbers Postgres stores

### DIFF
--- a/.changeset/non-finite-numbers.md
+++ b/.changeset/non-finite-numbers.md
@@ -1,0 +1,39 @@
+---
+'@drzl/analyzer': patch
+'@drzl/validation-core': patch
+'@drzl/generator-zod': patch
+'@drzl/generator-typebox': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-arktype': patch
+---
+
+Postgres float columns accept `NaN` and the infinities they actually store.
+
+`real` and `double precision` hold `NaN`, `Infinity` and `-Infinity`, and Postgres hands all three
+back on SELECT. Every emitted schema refused them, so reading a row holding one failed validation on
+a column behaving exactly as documented. That is the read path, which no application can avoid.
+
+No range could have fixed it. A `>=`/`<=` pair refuses `Infinity` whatever the numbers are and `NaN`
+compares false against both ends, so the fact is now carried on the column as `allowsNaN` and
+`allowsInfinity` and each generator renders it as a union beside the range. The range is unchanged
+and still describes the column's finite values, so a `real` still refuses `1e300`.
+
+Measured against PostgreSQL 18.3, on the bound-parameter path a validator guards:
+
+```
+real, double precision   NaN, Infinity and -Infinity all stored and returned unchanged
+numeric (no typmod)      the same three, faithfully
+numeric(10,2)            NaN faithful; either infinity refused, 22003 numeric field overflow
+integer, bigint          all three refused
+```
+
+**What changes for you.** On Postgres, a `real` or `double precision` column's schema now accepts
+`NaN`, `Infinity` and `-Infinity`. A `numeric({ mode: 'number' })` column accepts `NaN` and keeps
+refusing both infinities: nothing in the analysis reads a column's precision or scale, so an
+unconstrained `numeric` and a `numeric(10,2)` are indistinguishable, and admitting the infinities
+would promise what the server refuses for the commoner of the two. Integer columns are untouched,
+because Postgres refuses all three there. MySQL and SQLite are untouched; SQLite returns both
+infinities and silently turns `NaN` into NULL, which is a separate answer that has to arrive whole.
+
+The JSON Schema generator does not change. JSON has no `NaN` and no `Infinity`, so there is nothing
+for it to admit.

--- a/docs/generators/arktype.md
+++ b/docs/generators/arktype.md
@@ -89,6 +89,41 @@ out rather than evaluated against `undefined`.
 Only unambiguous comparisons are translated; see
 [Zod → CHECK constraints](/generators/zod#check-constraints) for what is skipped and why.
 
+## `NaN` and the infinities
+
+Postgres stores `NaN`, `Infinity` and `-Infinity` in a `real` and in a `double precision` and hands
+all three back on SELECT. ArkType's bare `number` already takes both infinities and refuses `NaN`,
+and a range refuses an infinity whatever the numbers are, so those columns state the extra members
+as union branches:
+
+```ts
+c_double: "number | number.NaN",                                  // doublePrecision()
+c_num:    "-9007199254740991 <= number <= 9007199254740991 | number.NaN",  // numeric({mode:'number'})
+```
+
+A bounded column that admits all three cannot be written that way. Measured on ArkType itself,
+`(-5 <= number <= 5) | number.NaN` accepts `NaN` and adding a third branch makes the same type
+reject it, while `.json` still lists the branch: the union's discriminator cannot match `NaN`. So a
+`real`, which would need four branches, moves its range to a narrow instead:
+
+```ts
+c_real: type("number | number.NaN").narrow(
+  (v, ctx) => v == null || !Number.isFinite(v) || (v >= -3402... && v <= 3402...)
+    || ctx.mustBe("NaN, an infinity, or between ...")
+),
+```
+
+The unbounded `double precision` is unaffected by that limit, because ArkType folds a unit branch
+into the domain it already belongs to: `number | number.NaN | number.Infinity` reduces to two
+branches on its own.
+
+A `numeric` in number mode takes `NaN` and keeps refusing both infinities, because Postgres refuses
+an infinity in any `numeric` carrying a precision and nothing in the analysis reads one. Integer
+columns are unchanged, and so are MySQL and SQLite. A declared default is still restricted to a
+finite number: the literal is written through `JSON.stringify`, which renders all three as `null`.
+See
+[Zod → `NaN` and the infinities](/generators/zod#nan-and-the-infinities-are-values-not-out-of-range-numbers).
+
 ## Arrays and structured columns
 
 A column declared with `.array()` becomes an array of the element type. The element is

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -37,8 +37,8 @@ export type SelectpeopleOutput = Static<typeof SelectpeopleSchema>;
 | `varchar(255)`      | `Type.Intersect([Type.String(), <code-point cap>])`, see below          |
 | `uuid()`            | `Type.String({ pattern: '...' })`                                      |
 | `smallint()`        | `Type.Integer({ minimum: -32768, maximum: 32767 })`                    |
-| `real()`            | `Type.Number({ minimum: -3.4028235677973366e38, maximum: 3.4028235677973366e38 })`, written out in full |
-| `doublePrecision()` | `Type.Number()`, with no magnitude bound                               |
+| `real()`            | `Type.Number({ minimum: -3.4028235677973366e38, maximum: 3.4028235677973366e38 })`, written out in full, inside a union |
+| `doublePrecision()` | `Type.Number()`, with no magnitude bound, inside a union               |
 
 The two float rows are the database's answer rather than `drizzle-orm/typebox`'s. Postgres accepts
 every double up to `3.4028235677973366e38` in a `real` and answers `out of range for type real` to
@@ -46,6 +46,33 @@ the next one, and it stored `Number.MAX_VALUE` in a `double precision` and hande
 On MySQL a `float()` is bounded lower, at `3.4028234663852886e38`, because a real MySQL 8.4 refuses
 the next double after that one. See
 [Zod → What the column declares](/generators/zod#what-the-column-declares-is-what-the-schema-enforces).
+
+### `NaN` and the infinities
+
+Postgres stores `NaN` and both infinities in either float width and returns them on SELECT, and
+`Type.Number()` refuses all three: TypeBox's number check is `Number.isFinite`, and
+`minimum`/`maximum` refuse an infinity whatever the numbers are. Those columns emit a union whose
+second branch is a registered kind, the same `DrzlRowCheck` the character caps use, because TypeBox
+has no `.refine` and `Type.Literal(NaN)` cannot work: it compares with `===` and `NaN === NaN` is
+false.
+
+```ts
+c_real: Type.Union([
+  Type.Number({ minimum: -3.4028235677973366e38, maximum: 3.4028235677973366e38 }),
+  Type.Unsafe<number>({
+    [Kind]: 'DrzlRowCheck',
+    type: 'number',
+    description: 'NaN, Infinity or -Infinity, which this column stores',
+    assert: (v: any) => typeof v === 'number' && !Number.isFinite(v),
+  }),
+]),
+```
+
+Both `Value.Check` and `TypeCompiler` honour the registered kind. The cost is in serialisation: JSON
+Schema has no `NaN` and no `Infinity`, so the branch carries a bare `type: 'number'` and a
+`JSON.stringify` of the schema describes a number that may sit outside the stated range. A
+`numeric({ mode: 'number' })` column emits the same shape with a `Number.isNaN` predicate, since
+Postgres refuses an infinity in any `numeric` carrying a precision.
 
 ### Why uuid is a pattern and not a format
 

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -97,6 +97,26 @@ each follows the column. Asked of a real Postgres, drizzle reads `.x` and `.y` o
 given, so `{ x: 1, y: 2, z: 3 }` inserts and stores `(1,2)` while a tuple or a string is rendered
 `(undefined,undefined)` and refused.
 
+### `NaN` and the infinities
+
+Postgres stores `NaN`, `Infinity` and `-Infinity` in a `real` and in a `double precision` and hands
+all three back on SELECT. A bare `v.number()` already takes both infinities and refuses `NaN`, and
+`v.maxValue(n)` refuses an infinity whatever `n` is, so what each column needs depends on whether it
+carries a range:
+
+```ts
+c_real:   v.union([v.pipe(v.number(), v.minValue(-3402...), v.maxValue(3402...)),
+                   v.nan(), v.literal(Infinity), v.literal(-Infinity)]),  // real()
+c_double: v.union([v.number(), v.nan()]),                                 // doublePrecision()
+c_num:    v.union([v.pipe(v.number(), v.minValue(-9007199254740991),
+                          v.maxValue(9007199254740991)), v.nan()]),       // numeric({mode:'number'})
+```
+
+A `numeric` in number mode takes `NaN` and keeps refusing both infinities, because Postgres refuses
+an infinity in any `numeric` carrying a precision and nothing in the analysis reads one. Integer
+columns are unchanged, and so are MySQL and SQLite. See
+[Zod → `NaN` and the infinities](/generators/zod#nan-and-the-infinities-are-values-not-out-of-range-numbers).
+
 Valibot has no `json()` built-in, so a json column emits a recursive declaration at the top of the
 file. It is stricter than the official one in two ways, both of which reject values that cannot
 survive the round trip: `Infinity` is refused rather than written out as `null`, and a class

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -58,6 +58,33 @@ Postgres: a real MySQL 8.4 refuses the very next double above the largest float3
 and under the stock `sql_mode` alike. Its `double` and `real` carry no bound, like Postgres's
 `double precision`.
 
+### `NaN` and the infinities are values, not out-of-range numbers
+
+Postgres stores `NaN`, `Infinity` and `-Infinity` in a `real` and in a `double precision`, and hands
+all three back on SELECT. No range can admit them: `.gte()/.lte()` refuses an infinity whatever the
+numbers are, and `NaN` compares false against both ends. `z.number()` refuses all three on its own,
+with no bound at all.
+
+So those columns emit a union, and the range keeps describing the finite values:
+
+```ts
+c_real:   z.union([z.number().gte(-3402...).lte(3402...), z.nan(),
+                   z.literal(Infinity), z.literal(-Infinity)]),   // real()
+c_double: z.union([z.number(), z.nan(),
+                   z.literal(Infinity), z.literal(-Infinity)]),   // doublePrecision()
+c_num:    z.union([z.number().gte(-9007199254740991)
+                            .lte(9007199254740991), z.nan()]),    // numeric({ mode: 'number' })
+```
+
+A `numeric` in number mode takes `NaN` and keeps refusing both infinities. Postgres accepts an
+infinity in an unconstrained `numeric` and answers `22003 numeric field overflow` for a
+`numeric(10,2)`, and nothing in the analysis reads a column's precision or scale, so the two cannot
+be told apart; admitting them would promise what the server refuses for the commoner declaration.
+
+Integer columns are unchanged, because Postgres refuses all three there too, and so are MySQL and
+SQLite. `drizzle-orm/zod` refuses all three on every one of these columns, so this is a deliberate
+divergence with the measurement attached.
+
 Those bounds are the database's rather than `drizzle-orm/zod`'s, which bounds the same two columns
 at `-8388608 .. 8388607` and `-140737488355328 .. 140737488355327`. Both refuse values the column
 hands back, `9000000` in a `real` and `1.75e15` in a `double precision`, so DRZL is deliberately

--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -88,11 +88,11 @@ PGlite, SQLite via `node:sqlite`, and MySQL as a CI service container.
 
 ```
     1440 probes against a real Postgres (40 columns)
-    agree with the database: DRZL 1056, drizzle-orm 1013
-    DRZL closer than drizzle-orm on 49, further on 0
+    agree with the database: DRZL 1061, drizzle-orm 1013
+    DRZL closer than drizzle-orm on 54, further on 0
 
     393 rows read back through the driver (40 columns)
-    rejected by DRZL: 71, of which drizzle-orm also rejects: 71
+    rejected by DRZL: 66, of which drizzle-orm also rejects: 66
 
     53 CHECK probes against a real Postgres (13 constrained columns)
     rows Postgres rejects and the validator accepts: DRZL 0, drizzle-orm 22

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -67,6 +67,35 @@ export interface Column {
   integer?: boolean;
 
   /**
+   * Whether the column stores and returns `NaN`, and whether it does the same for an infinity.
+   *
+   * A range cannot say this. `>=`/`<=` refuses `Infinity` whatever the two numbers are, and `NaN`
+   * compares false against both ends, so a bounded float column described by its range alone
+   * refused three values Postgres stores in it and hands back on SELECT. That is a read-path
+   * defect: every read of such a row fails validation on a column behaving exactly as documented.
+   * The generators render these as a union beside the range rather than as a wider range.
+   *
+   * Measured against PostgreSQL 18.3 through PGlite, on the bound-parameter path a validator
+   * guards. `real` and `double precision` return all three unchanged. An unconstrained `numeric`
+   * does too, but a `numeric(10,2)` refuses either infinity with `22003 numeric field overflow`
+   * while still taking `NaN`, and `integer`/`bigint` refuse all three.
+   *
+   * So `numeric` in `{ mode: 'number' }` states `allowsInfinity: false` deliberately, and it is a
+   * narrowing rather than an oversight: nothing here reads a column's precision or scale, so the
+   * two `numeric` declarations are indistinguishable, and admitting the infinities would make the
+   * schema promise what the server refuses for the commoner of the two.
+   *
+   * Postgres only, today. MySQL refuses all three on a `float`/`double` and silently stores `0.00`
+   * for a `decimal`. SQLite returns both infinities and silently turns `NaN` into NULL, which is
+   * real and is filed on its own: a column needs both halves of that answer or none.
+   *
+   * Absent on every other column, including the string mode of `numeric`, which already carries the
+   * same fact as a pattern; see `COLUMN_FORMATS.numeric` in `@drzl/validation-core`.
+   */
+  allowsNaN?: boolean;
+  allowsInfinity?: boolean;
+
+  /**
    * A string column whose contents have a shape the database enforces.
    *
    * Only formats checked against Postgres itself appear here, and the list is short because most
@@ -363,8 +392,9 @@ const MYSQL_TEXT_CAPS: Record<string, number> = {
  * What no range can express either way is `Infinity` and `NaN`. Postgres stores and returns both
  * in `real` and in `double precision`; a `>=`/`<=` pair refuses them whatever the numbers are, and
  * `z.number()` and `Type.Number()` refuse them with no bound at all. Describing that column
- * honestly needs a union rather than a range, in every generator, which is filed rather than done
- * here.
+ * honestly needs a union rather than a range, in every generator, so the fact is carried beside the
+ * range as `allowsNaN`/`allowsInfinity` and the generators emit that union. The range below is
+ * unchanged by it and still describes the column's finite values.
  */
 /** The largest finite float32, which is exactly where MySQL's `FLOAT` stops. */
 const FLOAT32_MAX = '340282346638528859811704183484516925440';
@@ -606,6 +636,20 @@ export function describeV1Column(column: any): Partial<Column> | null {
       out.integer = false;
       out.tsType = 'number';
       out.dbType = semantic === 'float' ? 'REAL' : 'DOUBLE';
+      // Postgres stores `NaN` and both infinities in either width and returns them on SELECT, so
+      // the range above describes the *finite* values and these say the rest. See `allowsNaN`.
+      //
+      // The codec, for the reason the bound above uses it: `float4` and `float8` are Postgres's
+      // spellings and no other dialect states them. MySQL says `float`, `double` and `real`, and
+      // SQLite, SingleStore, Cockroach and MSSQL state no codec at all on 1.0.0-rc.4, all swept off
+      // real columns. Cockroach is deliberately outside this, unlike the bound: it speaks the
+      // Postgres wire protocol but its float behaviour here was not measured, and Postgres's answer
+      // is not free to assume when the same file already records it saturating magnitudes to
+      // infinity where Postgres refuses them.
+      if (codec === 'float4' || codec === 'float8') {
+        out.allowsNaN = true;
+        out.allowsInfinity = true;
+      }
       break;
     }
     case 'uuid':
@@ -749,6 +793,18 @@ export function describeV1Column(column: any): Partial<Column> | null {
         out.dbType = 'NUMERIC';
         out.integer = false;
         [out.min, out.max] = JS_SAFE_INTEGER_BOUNDS;
+        // Postgres stores `NaN` in a `numeric` of any width and returns it, so the bounds above
+        // describe the finite values and this says the rest. Not the infinities: an unconstrained
+        // `numeric` takes them and a `numeric(10,2)` answers `22003 numeric field overflow`, and
+        // nothing here reads precision or scale, so the two cannot be told apart. Admitting them
+        // would promise what the server refuses for the commoner declaration.
+        //
+        // `numeric:number` is Postgres's codec for the number mode. MySQL and SingleStore say
+        // `decimal:number` and store `0.00` for all three, and SQLite says nothing at all.
+        if (codec === 'numeric:number') {
+          out.allowsNaN = true;
+          out.allowsInfinity = false;
+        }
       } else if (js === 'string') {
         out.tsType = 'string';
         out.dbType = codec === 'varchar' ? 'VARCHAR' : codec === 'char' ? 'CHAR' : 'TEXT';
@@ -1278,6 +1334,29 @@ export class SchemaAnalyzer {
   };
 
   /**
+   * The Postgres number columns that hold a non-finite double, and which of the three each holds.
+   *
+   * The class-name half of what `describeV1Column` reads off the codec, and the two must agree: a
+   * fact stated on one path and not the other is a schema that changes when the user upgrades
+   * drizzle, which the cross-major diff in `verify-packed.sh` fails on. These three class names are
+   * the same on both majors, read off real `pgTable` columns on 0.45.2 and on 1.0.0-rc.4, so this
+   * table also answers for a v1 column and the two answers are identical rather than merely
+   * compatible. non-finite-numbers.spec.ts asserts that agreement through the real analyzer.
+   *
+   * Postgres only. No MySQL, SingleStore or SQLite class belongs here: MySQL refuses all three on a
+   * `float`/`double` and stores `0.00` for a `decimal`, and SQLite returns both infinities while
+   * silently turning `NaN` into NULL, which is a different answer that has to arrive whole.
+   *
+   * `PgNumeric` is absent because its value is a string, and its pattern already accepts `NaN` and
+   * `Infinity`. `PgNumericNumber` states `infinity: false` on purpose; see `Column.allowsNaN`.
+   */
+  private static readonly PG_NON_FINITE: Record<string, { nan: boolean; infinity: boolean }> = {
+    PgReal: { nan: true, infinity: true },
+    PgDoublePrecision: { nan: true, infinity: true },
+    PgNumericNumber: { nan: true, infinity: false },
+  };
+
+  /**
    * Constraints the column definition already carries, which the analysis used to throw away.
    *
    * Everything here is read off Drizzle's own column instance, so it states what the schema
@@ -1285,9 +1364,15 @@ export class SchemaAnalyzer {
    */
   private columnConstraints(
     column: any
-  ): Pick<Column, 'maxLength' | 'min' | 'max' | 'format' | 'integer'> {
+  ): Pick<
+    Column,
+    'maxLength' | 'min' | 'max' | 'format' | 'integer' | 'allowsNaN' | 'allowsInfinity'
+  > {
     const ctor = column?.constructor?.name ?? '';
-    const out: Pick<Column, 'maxLength' | 'min' | 'max' | 'format' | 'integer'> = {};
+    const out: Pick<
+      Column,
+      'maxLength' | 'min' | 'max' | 'format' | 'integer' | 'allowsNaN' | 'allowsInfinity'
+    > = {};
 
     // `length` is set by varchar/char across every dialect, and by SQLite's `text({length})`.
     const length = column?.length ?? column?.config?.length;
@@ -1315,6 +1400,15 @@ export class SchemaAnalyzer {
       const inexact = SchemaAnalyzer.INEXACT_RANGES[ctor];
       if (inexact) [out.min, out.max] = inexact;
       out.integer = false;
+    }
+
+    // Beside the range rather than inside it, because no range can hold either fact: `>=`/`<=`
+    // refuses `Infinity` whatever the bounds are and `NaN` compares false against both ends. The
+    // range describes the finite values of the column and these two describe the rest.
+    const nonFinite = SchemaAnalyzer.PG_NON_FINITE[ctor];
+    if (nonFinite) {
+      out.allowsNaN = nonFinite.nan;
+      out.allowsInfinity = nonFinite.infinity;
     }
 
     if (/^(Pg)?UUID$/i.test(ctor) || /Uuid$/i.test(ctor)) out.format = 'uuid';

--- a/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
+++ b/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
@@ -404,16 +404,15 @@ describe('an inexact numeric column on 0.4x', () => {
     expect(max, 'and is nowhere near +/-8388607').toBeGreaterThan(1e9);
   });
 
-  it('leaves Infinity and NaN outside every range, which the database does not', async () => {
-    // Filed, not fixed, and pinned here so it is measured rather than remembered. PGlite stores
-    // Infinity and NaN in both `real` and `double precision` and returns them unchanged. A
-    // `>=`/`<=` pair cannot admit either, whatever the numbers are, and `z.number()` and
-    // `Type.Number()` refuse both with no bound at all. Describing those columns honestly needs a
-    // union in every generator rather than a wider range.
+  it('leaves Infinity and NaN outside every range, and states them beside it', async () => {
+    // PGlite stores Infinity and NaN in both `real` and `double precision` and returns them
+    // unchanged. A `>=`/`<=` pair cannot admit either, whatever the numbers are, so the range is
+    // *not* what carries them and this asserts that it still is not: the bound on a `real` stays a
+    // finite number, and the 8 byte column stays unbounded.
     //
-    // This asserts what the analyzer states, which is the input to that: a bounded float column
-    // has a finite range and no way to say "or Infinity", and an unbounded one says nothing about
-    // it either way.
+    // The fact itself is carried beside the range, as `allowsNaN`/`allowsInfinity`, which the
+    // generators render as a union. non-finite-numbers.spec.ts is where that is measured on both
+    // majors; this pins the half that must not have changed.
     const cols = await columnsOf(
       'pg-float-inf-0.4x',
       `
@@ -423,5 +422,7 @@ describe('an inexact numeric column on 0.4x', () => {
     );
     expect(Number.isFinite(Number(cols.r.max))).toBe(true);
     expect(cols.d.max, 'nothing on the 8 byte column to admit or refuse it').toBeUndefined();
+    expect(cols.r).toMatchObject({ allowsNaN: true, allowsInfinity: true });
+    expect(cols.d).toMatchObject({ allowsNaN: true, allowsInfinity: true });
   });
 });

--- a/packages/analyzer/test/non-finite-numbers.spec.ts
+++ b/packages/analyzer/test/non-finite-numbers.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * `NaN` and the two infinities on a Postgres number column, which the analysis used to say nothing
+ * about.
+ *
+ * Postgres stores all three in `real` and `double precision` and hands them back on SELECT, so a
+ * schema that refuses them refuses rows the column itself returns. That is a read-path defect and
+ * no application can avoid the read path. A range cannot express it in either direction: a
+ * `>=`/`<=` pair refuses `Infinity` whatever the numbers are, and `NaN` compares false against
+ * both ends. So the fact is stated on the column and the generators render it as a union.
+ *
+ * Measured against PostgreSQL 18.3 through PGlite, on the bound-parameter path a validator guards:
+ *
+ *   real, double precision      NaN, Infinity and -Infinity all stored and returned unchanged
+ *   numeric, no typmod          the same three, faithfully
+ *   numeric(10,2)               NaN faithful; either infinity refused, 22003 numeric field overflow
+ *   integer, bigint             all three refused
+ *
+ * The `numeric` split is why this file asserts `allowsInfinity: false` on the number mode rather
+ * than leaving it open: the analyzer does not read precision or scale at all, so it cannot tell an
+ * unconstrained `numeric` from a `numeric(10,2)`. Admitting the infinities would make the schema
+ * promise what the server refuses for the commoner declaration, which is the worse of the two
+ * errors.
+ *
+ * SQLite and MySQL are deliberately untouched here and are asserted to be untouched. SQLite stores
+ * both infinities faithfully and silently turns `NaN` into NULL, which is a different fact needing
+ * a different fix; MySQL refuses every one of the three on a `float`/`double` and silently stores
+ * `0.00` in a `decimal`.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer, describeV1Column } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+/** A column as drizzle v1 presents one, which is what the codec path reads. */
+const v1col = (dataType: string, codec?: string) => ({ dataType, codec, dimensions: 0 });
+
+async function columnsOf(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  const t = analysis.tables[0];
+  expect(t, `no table was analyzed; issues: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  return Object.fromEntries(t!.columns.map((c) => [c.name, c]));
+}
+
+/** The same Postgres table, written against each major. */
+const PG_SOURCE = (pkg: string) => `
+  import { pgTable, real, doublePrecision, numeric, integer, bigint } from '${pkg}/pg-core';
+  export const t = pgTable('t', {
+    r: real(),
+    d: doublePrecision(),
+    n: numeric({ precision: 10, scale: 2, mode: 'number' }),
+    ns: numeric({ precision: 10, scale: 2 }),
+    i: integer(),
+    b: bigint({ mode: 'number' }),
+  });
+`;
+
+describe('the codec path, which drizzle v1 takes', () => {
+  it('admits all three on a postgres real and double precision', () => {
+    // `float4` and `float8` are Postgres's codec spellings and no other dialect states them, which
+    // is the same discriminator this arm already uses to pick the 4 byte magnitude bound.
+    expect(describeV1Column(v1col('number float', 'float4'))).toMatchObject({
+      dbType: 'REAL',
+      allowsNaN: true,
+      allowsInfinity: true,
+    });
+    expect(describeV1Column(v1col('number double', 'float8'))).toMatchObject({
+      dbType: 'DOUBLE',
+      allowsNaN: true,
+      allowsInfinity: true,
+    });
+  });
+
+  it('admits NaN alone on a postgres numeric in number mode', () => {
+    expect(describeV1Column(v1col('number', 'numeric:number'))).toMatchObject({
+      dbType: 'NUMERIC',
+      allowsNaN: true,
+      allowsInfinity: false,
+    });
+  });
+
+  it('says nothing about a mysql float, double or decimal', () => {
+    // MySQL refuses NaN and both infinities on a `float`/`double`, and silently stores 0.00 in a
+    // `decimal`, so none of the three is a value the column hands back.
+    for (const c of [
+      v1col('number float', 'float'),
+      v1col('number double', 'double'),
+      v1col('number double', 'real'),
+      v1col('number', 'decimal:number'),
+    ]) {
+      const out = describeV1Column(c)!;
+      expect(out.allowsNaN, JSON.stringify(c)).toBeUndefined();
+      expect(out.allowsInfinity, JSON.stringify(c)).toBeUndefined();
+    }
+  });
+
+  it('says nothing about sqlite, singlestore, cockroach or mssql, which state no codec', () => {
+    // Every one of these reaches the float/double arm with no codec at all on 1.0.0-rc.4. SQLite is
+    // the one that really does store an infinity, and it turns NaN into NULL, so it needs its own
+    // answer rather than Postgres's.
+    for (const c of [v1col('number float'), v1col('number double')]) {
+      const out = describeV1Column(c)!;
+      expect(out.allowsNaN, JSON.stringify(c)).toBeUndefined();
+      expect(out.allowsInfinity, JSON.stringify(c)).toBeUndefined();
+    }
+    // A bare `number` with no codec is what a 0.4x column looks like, so this path declines it
+    // outright and the class-name table answers instead. SQLite's `numeric({ mode: 'number' })` is
+    // exactly that on v1, which is why the SQLite half of this is asserted through the real
+    // analyzer below rather than only here.
+    expect(describeV1Column(v1col('number'))).toBeNull();
+  });
+
+  it('leaves every integer width alone, on postgres too', () => {
+    // Postgres refuses all three for `integer` and `bigint`, so an integer column changes in no way.
+    for (const c of [
+      v1col('number int32', 'int'),
+      v1col('number int53', 'bigint:number'),
+      v1col('bigint int64', 'bigint'),
+    ]) {
+      const out = describeV1Column(c)!;
+      expect(out.allowsNaN, JSON.stringify(c)).toBeUndefined();
+      expect(out.allowsInfinity, JSON.stringify(c)).toBeUndefined();
+    }
+  });
+
+  it('leaves the string mode of numeric alone, which already states the fact as a pattern', () => {
+    // `COLUMN_FORMATS.numeric` accepts `NaN` and `Infinity` as text and agrees with Postgres on 43
+    // probes. That column is a string and carries no number flags.
+    const out = describeV1Column(v1col('string numeric', 'numeric'))!;
+    expect(out.tsType).toBe('string');
+    expect(out.allowsNaN).toBeUndefined();
+    expect(out.allowsInfinity).toBeUndefined();
+  });
+});
+
+describe('the class-name path, which drizzle 0.4x takes', () => {
+  it('admits all three on a real and a double precision, NaN alone on a numeric', async () => {
+    const cols = await columnsOf('pg-non-finite-0.4x', PG_SOURCE('drizzle-orm'));
+    expect(cols.r).toMatchObject({ dbType: 'REAL', allowsNaN: true, allowsInfinity: true });
+    expect(cols.d).toMatchObject({ dbType: 'DOUBLE', allowsNaN: true, allowsInfinity: true });
+    expect(cols.n).toMatchObject({ allowsNaN: true, allowsInfinity: false });
+  });
+
+  it('leaves the integers and the string mode of numeric alone', async () => {
+    const cols = await columnsOf('pg-non-finite-ints-0.4x', PG_SOURCE('drizzle-orm'));
+    for (const name of ['i', 'b', 'ns']) {
+      expect(cols[name].allowsNaN, name).toBeUndefined();
+      expect(cols[name].allowsInfinity, name).toBeUndefined();
+    }
+  });
+
+  it('leaves mysql and sqlite alone', async () => {
+    const my = await columnsOf(
+      'mysql-non-finite-0.4x',
+      `
+      import { mysqlTable, float, double, real, decimal } from 'drizzle-orm/mysql-core';
+      export const t = mysqlTable('t', {
+        f: float(), d: double(), r: real(),
+        n: decimal({ precision: 10, scale: 2, mode: 'number' }),
+      });
+      `
+    );
+    for (const name of ['f', 'd', 'r', 'n']) {
+      expect(my[name].allowsNaN, name).toBeUndefined();
+      expect(my[name].allowsInfinity, name).toBeUndefined();
+    }
+    const sq = await columnsOf(
+      'sqlite-non-finite-0.4x',
+      `
+      import { sqliteTable, real, numeric } from 'drizzle-orm/sqlite-core';
+      export const t = sqliteTable('t', { r: real(), n: numeric({ mode: 'number' }) });
+      `
+    );
+    // SQLite really does return both infinities and really does turn NaN into NULL. Both are filed
+    // separately; nothing here may state either of them, because a half-right answer on this column
+    // is what the round-trip gate would then pin as correct.
+    for (const name of ['r', 'n']) {
+      expect(sq[name].allowsNaN, name).toBeUndefined();
+      expect(sq[name].allowsInfinity, name).toBeUndefined();
+    }
+  });
+});
+
+describe('the two majors', () => {
+  it('give the same answer for the same postgres table', async () => {
+    // The classic failure in this file is a fact stated on one path and not the other, which shows
+    // up as a schema that changes when the user upgrades drizzle. The cross-major diff in
+    // verify-packed.sh catches it there; this catches it here.
+    const old = await columnsOf('pg-non-finite-cross-0.4x', PG_SOURCE('drizzle-orm'));
+    const next = await columnsOf('pg-non-finite-cross-v1', PG_SOURCE('drizzle-orm-v1'));
+    const flags = (cols: Record<string, { allowsNaN?: boolean; allowsInfinity?: boolean }>) =>
+      Object.fromEntries(
+        Object.entries(cols).map(([k, c]) => [k, [c.allowsNaN, c.allowsInfinity]])
+      );
+    // A verification that can succeed by matching nothing is not one: both sides have to have
+    // reached the columns before agreeing about them means anything.
+    expect(Object.keys(next), 'the v1 fixture analysed').toEqual(Object.keys(old));
+    expect(flags(next).r, 'v1 reached the real column').toEqual([true, true]);
+    expect(flags(next)).toEqual(flags(old));
+  });
+});

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -13,6 +13,7 @@ import {
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
+  nonFiniteAccepted,
   parseCheck,
   renderDuplicateFinder,
   updateColumns,
@@ -90,6 +91,54 @@ function atRange(num: string, lower?: Bound, upper?: Bound): string {
   if (lower && upper) return `${lower.value} ${MIRROR[lower.op]} ${num} ${upper.op} ${upper.value}`;
   const only = lower ?? upper;
   return only ? `${num} ${only.op} ${only.value}` : num;
+}
+
+/**
+ * How a number column that stores a non-finite double is spelled, decided in one place.
+ *
+ * Both the type expression and the narrow ask this, because they are two halves of one answer and
+ * they are exactly the pair this file has already had drift apart: a DSL that dropped its range
+ * while the narrow declined to state one is a column with no bound at all, and nothing would say
+ * so.
+ *
+ * ArkType needs less repairing than zod and TypeBox and it is not none. Measured on the installed
+ * version, and asserted in this package's non-finite spec rather than remembered:
+ *
+ *   `number` alone                    takes both infinities, refuses NaN
+ *   `(range) | number.NaN`            takes NaN                              two branches, correct
+ *   `(range) | number.NaN | ...`      REFUSES NaN                            three or more, broken
+ *   `number | number.NaN | number.Infinity | number.NegativeInfinity`        folds to two, correct
+ *
+ * The third line is an ArkType defect rather than a rule: `.json` on that type still lists the NaN
+ * branch, so the type reports a member it then rejects, and the union's discriminator is what drops
+ * it. Nothing that reads the emitted text or the parsed type can see this, only running it.
+ *
+ * So a bounded column that admits NaN *and* the infinities needs four branches and cannot have
+ * them: it emits `number | number.NaN` and its range moves to a `.narrow`, the same escape hatch
+ * the character caps and the bigint range already use. Everything else stays declarative, including
+ * the unbounded `double precision`, where ArkType folds the two infinity units back into `number`
+ * on its own and the union is two branches again.
+ */
+function atNumberPlan(
+  c: Column,
+  checks: ColumnCheck[]
+): { kind: 'plain' } | { kind: 'union'; branches: string[] } | { kind: 'narrowed' } {
+  const { nan, infinity } = nonFiniteAccepted(c);
+  if (!nan && !infinity) return { kind: 'plain' };
+  const { lower, upper, equals } = atNarrowRange(c, checks);
+  // An equality pins the column to one value and supersedes every other constraint, this included.
+  if (equals !== undefined) return { kind: 'plain' };
+  const bounded = !!(lower || upper);
+  const branches = [
+    ...(nan ? ['number.NaN'] : []),
+    // Only where a bound would otherwise exclude them. Unbounded, `number` already takes both and
+    // naming them changes nothing.
+    ...(infinity && bounded ? ['number.Infinity', 'number.NegativeInfinity'] : []),
+  ];
+  if (!branches.length) return { kind: 'plain' };
+  // Two branches is always safe, and so is any number of them with no NaN among them: the defect
+  // above is the discriminator failing to match `NaN`, which nothing else triggers.
+  return branches.length === 1 || !nan ? { kind: 'union', branches } : { kind: 'narrowed' };
 }
 
 /**
@@ -188,7 +237,13 @@ function atTypeForColumn(
       // ArkType does accept both at once: `-2147483648 <= number.integer <= 2147483647` parses
       // and rejects 1.5. Preferring the bound alone, on the theory that a range implied
       // integrality, meant every `integer()` column accepted a fraction.
-      return atRange(isIntegerColumn(c) ? 'number.integer' : 'number', lower, upper);
+      const base = isIntegerColumn(c) ? 'number.integer' : 'number';
+      const plan = atNumberPlan(c, checks);
+      // The range has gone to a narrow, so the DSL has to admit every number and let the narrow
+      // decide. See `atNumberPlan` for why a four-branch union cannot do this.
+      if (plan.kind === 'narrowed') return `${base} | number.NaN`;
+      const ranged = atRange(base, lower, upper);
+      return plan.kind === 'union' ? `${ranged} | ${plan.branches.join(' | ')}` : ranged;
     }
     case 'bigint':
       // Bare here on purpose. The string DSL cannot carry this bound at all:
@@ -367,6 +422,12 @@ function atDefaultFits(c: Column, v: unknown, dims: number): boolean {
     case 'string':
       return typeof v === 'string';
     case 'number':
+      // Still finite, and deliberately so now that a `real` column's *type* takes `NaN` and both
+      // infinities. This question is not "does the type hold it" but "can this generator write it
+      // down", and it cannot: the literal is emitted through `JSON.stringify`, which renders all
+      // three as `null`, so a `.default(NaN)` would silently become a default of `null` and be
+      // refused at import on a NOT NULL column. Declining leaves the key merely optional, which is
+      // what a default this generator cannot reproduce already gets.
       return typeof v === 'number' && Number.isFinite(v);
     case 'boolean':
       return typeof v === 'boolean';
@@ -480,7 +541,8 @@ function renderObjectShape(
       // select and update were bounded, and said closing it meant moving the default off the DSL
       // and onto the Type. `atDefault` and `onBuilder` below are that move, so the narrow and the
       // default now coexist and the skip is gone.
-      const caps = atCapNarrows(c, mode) + atBigintNarrow(c, checks);
+      const caps =
+        atCapNarrows(c, mode) + atBigintNarrow(c, checks) + atNonFiniteNarrow(c, checks);
       // A defaultable definition is only valid as an object *property*: `type("bigint = 7")`
       // throws "Defaultable definitions like 'number = 0' are only valid as properties in an
       // object or tuple" at import. A field carrying a narrow is exactly that, a `type(...)` call
@@ -641,6 +703,34 @@ function atBigintNarrow(c: Column, checks: ColumnCheck[]): string {
     equals !== undefined
       ? `exactly ${equals}`
       : `between ${lower?.value ?? 'any'} and ${upper?.value ?? 'any'}`
+  );
+}
+
+/**
+ * The range of a float column that also stores `NaN` and the infinities, as a narrow.
+ *
+ * Reached only where `atNumberPlan` says the DSL had to give the range up, which is a bounded
+ * column admitting all three. The type there is `number | number.NaN`, so this is the only thing
+ * left holding the magnitude: without it a `real` would accept 1e300, which Postgres refuses.
+ *
+ * `!Number.isFinite(v)` is the whole of the non-finite half, and it is exact here rather than
+ * approximate: this narrow is only ever built for a column that admits `NaN` and both infinities,
+ * so every value that predicate lets through is one the column stores. A column admitting `NaN`
+ * alone keeps its range in the DSL and never reaches this.
+ */
+function atNonFiniteNarrow(c: Column, checks: ColumnCheck[]): string {
+  if (c.tsType !== 'number' || c.shape) return '';
+  if (atNumberPlan(c, checks).kind !== 'narrowed') return '';
+  const { lower, upper } = atNarrowRange(c, checks);
+  const parts: ((v: string) => string)[] = [];
+  for (const b of [lower, upper]) {
+    if (b) parts.push((v) => `${v} ${b.op} ${b.value}`);
+  }
+  if (!parts.length) return '';
+  return atNarrow(
+    c,
+    (v) => `(!Number.isFinite(${v}) || (${parts.map((p) => p(v)).join(' && ')}))`,
+    `NaN, an infinity, or between ${lower?.value ?? 'any'} and ${upper?.value ?? 'any'}`
   );
 }
 

--- a/packages/generator-arktype/test/non-finite-numbers.spec.ts
+++ b/packages/generator-arktype/test/non-finite-numbers.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * `NaN` and the two infinities on a Postgres float column, in ArkType output.
+ *
+ * ArkType, like valibot, already takes both infinities on a bare `number` and refuses only `NaN`.
+ * `number.NaN`, `number.Infinity` and `number.NegativeInfinity` are keywords, so the obvious repair
+ * is a union of the range with them.
+ *
+ * It does not work past two branches. Measured on the installed ArkType, and asserted at the top of
+ * this file rather than remembered: `(-5 <= number <= 5) | number.NaN` accepts `NaN`, and adding a
+ * third branch makes the same type reject it while still *reporting* the NaN branch in `.json`. A
+ * bounded `real` needs four branches, so it cannot be spelled that way, and its range moves to a
+ * `.narrow` instead. The `numeric` and the unbounded `double precision` stay at two branches and
+ * stay in the DSL.
+ *
+ * Everything here runs the emitted module, which for this generator is the only test worth writing:
+ * ArkType parses at import, so an expression it cannot resolve throws and takes down whatever
+ * imported the schema.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArkTypeGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { type } from 'arktype';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const PG_FLOAT4_MAX = '340282356779733661637539395458142568448';
+const JS_MAX = '9007199254740991';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'number',
+    dbType: 'DOUBLE',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    integer: false,
+    ...over,
+  }) as Column;
+
+const REAL = col('c_real', {
+  dbType: 'REAL',
+  min: `-${PG_FLOAT4_MAX}`,
+  max: PG_FLOAT4_MAX,
+  allowsNaN: true,
+  allowsInfinity: true,
+});
+const DOUBLE = col('c_double', { dbType: 'DOUBLE', allowsNaN: true, allowsInfinity: true });
+const NUMERIC = col('c_numeric_n', {
+  dbType: 'NUMERIC',
+  min: `-${JS_MAX}`,
+  max: JS_MAX,
+  allowsNaN: true,
+  allowsInfinity: false,
+});
+
+async function emit(columns: Column[], label: string) {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-non-finite');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.arktype.ts'), file);
+  const source = (await fs.readFile(file, 'utf8')).replace(/\s+/g, ' ');
+  return { source, module: await import(file) };
+}
+
+const accepts = (schema: any, key: string, x: unknown) =>
+  !(schema.get(key)(x) instanceof type.errors);
+
+describe('what ArkType does on its own', () => {
+  it('takes the infinities on a bare number and refuses NaN', () => {
+    const bare = type('number');
+    expect(bare(NaN) instanceof type.errors, 'bare number, NaN').toBe(true);
+    expect(bare(Infinity) instanceof type.errors, 'bare number, Infinity').toBe(false);
+    expect(bare(-Infinity) instanceof type.errors, 'bare number, -Infinity').toBe(false);
+  });
+
+  it('drops the NaN branch of a union once a third branch joins it', () => {
+    // The measurement the generator is written against. Two branches hold; three do not, and the
+    // type still lists the NaN branch in its own json, so this is invisible to anything reading
+    // the emitted text or the parsed type instead of running it.
+    const two = type('(-5 <= number <= 5) | number.NaN');
+    expect(two(NaN) instanceof type.errors, 'two branches').toBe(false);
+    const three = type('(-5 <= number <= 5) | number.NaN | number.Infinity');
+    expect(three(NaN) instanceof type.errors, 'three branches').toBe(true);
+    expect(JSON.stringify(three.json), 'while still claiming the branch').toContain('NaN');
+    // The unbounded case is not affected, because ArkType folds a unit branch into the domain it
+    // already belongs to: this reduces to two branches on its own.
+    const folded = type('number | number.NaN | number.Infinity | number.NegativeInfinity');
+    expect(folded(NaN) instanceof type.errors, 'folded to number | NaN').toBe(false);
+    expect(folded.json, 'and says so').toEqual(['number', { unit: 'NaN' }]);
+  });
+});
+
+describe('a postgres real and double precision column', () => {
+  it('accepts NaN and both infinities, and still refuses a string and a null', async () => {
+    const { module: m, source } = await emit([REAL, DOUBLE], 'floats');
+    for (const name of ['c_real', 'c_double']) {
+      expect(accepts(m.SelecttSchema, name, NaN), `${name} NaN`).toBe(true);
+      expect(accepts(m.SelecttSchema, name, Infinity), `${name} Infinity`).toBe(true);
+      expect(accepts(m.SelecttSchema, name, -Infinity), `${name} -Infinity`).toBe(true);
+      expect(accepts(m.SelecttSchema, name, 1.5), `${name} an ordinary number`).toBe(true);
+      expect(accepts(m.SelecttSchema, name, 'x'), `${name} a string`).toBe(false);
+      expect(accepts(m.SelecttSchema, name, null), `${name} null`).toBe(false);
+    }
+    // The bounded column carries its range as a narrow; the unbounded one needs nothing but the
+    // two-branch union.
+    expect(source).toContain("type('number | number.NaN').narrow(");
+    expect(source).toContain(`v >= -${PG_FLOAT4_MAX} && v <= ${PG_FLOAT4_MAX}`);
+    expect(source).toContain("c_double: 'number | number.NaN'");
+    // The insert and update schemas take the same values, since the narrow rides on the Type and
+    // the optional marker rides on the key.
+    for (const schema of [m.InserttSchema, m.UpdatetSchema]) {
+      expect(accepts(schema, 'c_real', NaN)).toBe(true);
+      expect(accepts(schema, 'c_real', 1e300)).toBe(false);
+      expect(accepts(schema, 'c_double', NaN)).toBe(true);
+    }
+  });
+
+  it('keeps the magnitude bound the 4 byte column really has', async () => {
+    const { module: m } = await emit([REAL, DOUBLE], 'magnitude');
+    expect(accepts(m.SelecttSchema, 'c_real', 1e300), 'real at 1e300').toBe(false);
+    expect(accepts(m.SelecttSchema, 'c_double', 1e300), 'double at 1e300').toBe(true);
+    expect(accepts(m.SelecttSchema, 'c_real', 3.4028235e38)).toBe(true);
+  });
+
+  it('survives the array and nullable wrappers', async () => {
+    const { module: m } = await emit(
+      [
+        col('a_real', { ...REAL, name: 'a_real', arrayDimensions: 1 }),
+        col('n_real', { ...REAL, name: 'n_real', nullable: true }),
+      ],
+      'wrappers'
+    );
+    expect(accepts(m.SelecttSchema, 'a_real', [NaN, Infinity, 1.5])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'a_real', [1e300]), 'an out-of-range element').toBe(false);
+    expect(accepts(m.SelecttSchema, 'a_real', NaN), 'a bare element').toBe(false);
+    expect(accepts(m.SelecttSchema, 'n_real', null)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'n_real', NaN)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'n_real', 1e300), 'the narrow still holds').toBe(false);
+  });
+});
+
+describe('a postgres numeric in number mode', () => {
+  it('accepts NaN and keeps refusing both infinities', async () => {
+    const { module: m, source } = await emit([NUMERIC], 'numeric');
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', NaN)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', Infinity)).toBe(false);
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', -Infinity)).toBe(false);
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', 1.5)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', 'x')).toBe(false);
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', null)).toBe(false);
+    // Two branches, so it stays in the DSL and the range stays declarative.
+    expect(source).toContain(`-${JS_MAX} <= number <= ${JS_MAX} | number.NaN`);
+    expect(source, 'no narrow needed').not.toContain('.narrow(');
+  });
+});
+
+describe('every other number column', () => {
+  it('is emitted exactly as before', async () => {
+    const { module: m, source } = await emit(
+      [
+        col('c_int', { dbType: 'INTEGER', integer: true, min: '-2147483648', max: '2147483647' }),
+        col('m_float', {
+          dbType: 'REAL',
+          min: '-340282346638528859811704183484516925440',
+          max: '340282346638528859811704183484516925440',
+        }),
+      ],
+      'untouched'
+    );
+    expect(source).toContain('-2147483648 <= number.integer <= 2147483647');
+    expect(source, 'no NaN branch anywhere').not.toContain('number.NaN');
+    for (const name of ['c_int', 'm_float']) {
+      expect(accepts(m.SelecttSchema, name, NaN), `${name} NaN`).toBe(false);
+      expect(accepts(m.SelecttSchema, name, Infinity), `${name} Infinity`).toBe(false);
+      expect(accepts(m.SelecttSchema, name, -Infinity), `${name} -Infinity`).toBe(false);
+    }
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -16,6 +16,7 @@ import {
   isIntegerColumn,
   moduleFileName,
   moduleSpecifier,
+  nonFiniteAccepted,
   parseCheck,
   renderDuplicateFinder,
   resolveAffix,
@@ -262,7 +263,8 @@ function tbExprForColumn(
     }
     case 'number': {
       const o = renderOptions(merged(tbBounds(c)));
-      return isIntegerColumn(c) ? `Type.Integer(${o})` : `Type.Number(${o})`;
+      const base = isIntegerColumn(c) ? `Type.Integer(${o})` : `Type.Number(${o})`;
+      return tbNonFiniteUnion(c, base);
     }
     case 'bigint':
       // `minimum`/`maximum` do take bigint values here, verified by running the emitted schema:
@@ -462,7 +464,9 @@ function renderTableSchemas(
   const needsRows =
     rows.some((r) => rowCols.some((s) => s.has(r.left) && s.has(r.right))) ||
     lengths.some((k) => rowCols.some((s) => s.has(k.column))) ||
-    [insertCols, updateCols, selectCols].some((cs) => cs.some(tbNeedsCapKind));
+    [insertCols, updateCols, selectCols].some((cs) =>
+      cs.some((c) => tbNeedsCapKind(c) || tbNeedsNonFiniteKind(c))
+    );
   const rowImport = needsRows ? `, Kind, TypeRegistry` : '';
 
     // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
@@ -547,6 +551,56 @@ function tbNeedsCapKind(c: Column): boolean {
   // Not excluded for an array column: the cap describes the *element*, and the array wraps it
   // after, so `varchar(50).array()` caps each entry.
   return c.tsType === 'string' && !c.shape && !!(c.maxLength || c.maxBytes);
+}
+
+/**
+ * Whether this column needs the registered kind for the non-finite doubles it stores.
+ *
+ * Shared with the preamble check for the same reason `tbNeedsCapKind` is: the two used to be two
+ * copies of one condition and drifted, emitting `[Kind]` into a file that did not import it, which
+ * throws the moment anything loads the module.
+ */
+function tbNeedsNonFiniteKind(c: Column): boolean {
+  const { nan, infinity } = nonFiniteAccepted(c);
+  return nan || infinity;
+}
+
+/**
+ * The column widened by the non-finite doubles it really stores, or left exactly as it was.
+ *
+ * A union rather than a wider range, because no range can hold either value: `minimum`/`maximum`
+ * refuse `Infinity` whatever the numbers are, and `NaN` compares false against both ends.
+ *
+ * The added branch is a registered kind rather than a literal, because TypeBox has neither a
+ * `.refine` nor a literal that can hold `NaN`: `Type.Literal(NaN)` is checked with `===` and
+ * `NaN === NaN` is false. This generator already registers `DrzlRowCheck` for the character caps,
+ * whose entry calls the `assert` carried on the schema, so the branch reuses it rather than adding
+ * a second kind that means the same thing.
+ *
+ * `type: 'number'` on the branch is what it costs least to serialise as. A branch carrying no JSON
+ * Schema keywords renders as `{}`, which inside an `anyOf` means "anything" and would turn the
+ * serialised document into one that accepts a string; JSON has no `NaN` and no `Infinity`, so
+ * "a number" is as close as a JSON Schema gets to the truth here. The predicate is what runs, and
+ * the keyword is not consulted: TypeBox dispatches on `[Kind]`.
+ *
+ * Both infinity branches whenever the column admits them, because `Type.Number()` refuses a
+ * non-finite number with no options at all, so there is no unbounded case here where the base
+ * already takes them.
+ */
+function tbNonFiniteUnion(c: Column, base: string): string {
+  const { nan, infinity } = nonFiniteAccepted(c);
+  if (!nan && !infinity) return base;
+  // One branch, not two: a single predicate covers whichever of the three the column admits, and
+  // `NaN` is the only one of them a column can admit alone.
+  const [desc, expr] = infinity
+    ? ['NaN, Infinity or -Infinity, which this column stores', '!Number.isFinite(v)']
+    : ['NaN, which this column stores', 'Number.isNaN(v)'];
+  return `Type.Union([${base}, Type.Unsafe<number>({
+    [Kind]: 'DrzlRowCheck',
+    type: 'number',
+    description: ${JSON.stringify(desc)},
+    assert: (v: any) => typeof v === 'number' && ${expr},
+  })])`;
 }
 
 function tbCapExpr(c: Column, base: string, mode: Mode): string {

--- a/packages/generator-typebox/test/non-finite-numbers.spec.ts
+++ b/packages/generator-typebox/test/non-finite-numbers.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * `NaN` and the two infinities on a Postgres float column, in TypeBox output.
+ *
+ * `Type.Number()` refuses all three with no options at all, because TypeBox's number check is
+ * `Number.isFinite`, and `minimum`/`maximum` refuse the infinities whatever the numbers are. So a
+ * select schema refused three values Postgres stores in the column and returns on SELECT.
+ *
+ * TypeBox has no `.refine` and no literal that can hold `NaN`: `Type.Literal(NaN)` compares with
+ * `===` and `NaN === NaN` is false. What it has is the type registry, which this generator already
+ * uses for the character caps, so the branch is a registered kind carrying its own predicate.
+ * Both `Value.Check` and `TypeCompiler` honour it, and both are executed here: a registered kind
+ * the compiler does not know about is a schema that validates one way interpreted and another way
+ * compiled.
+ */
+import { describe, it, expect } from 'vitest';
+import { TypeBoxGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const PG_FLOAT4_MAX = '340282356779733661637539395458142568448';
+const JS_MAX = '9007199254740991';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'number',
+    dbType: 'DOUBLE',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    integer: false,
+    ...over,
+  }) as Column;
+
+const REAL = col('c_real', {
+  dbType: 'REAL',
+  min: `-${PG_FLOAT4_MAX}`,
+  max: PG_FLOAT4_MAX,
+  allowsNaN: true,
+  allowsInfinity: true,
+});
+const DOUBLE = col('c_double', { dbType: 'DOUBLE', allowsNaN: true, allowsInfinity: true });
+const NUMERIC = col('c_numeric_n', {
+  dbType: 'NUMERIC',
+  min: `-${JS_MAX}`,
+  max: JS_MAX,
+  allowsNaN: true,
+  allowsInfinity: false,
+});
+
+async function emit(columns: Column[], label: string) {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-non-finite');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), file);
+  const source = (await fs.readFile(file, 'utf8')).replace(/\s+/g, ' ');
+  return { source, module: await import(file) };
+}
+
+const accepts = (schema: any, key: string, x: unknown) => Value.Check(schema.properties[key], x);
+/** The same question through the compiler, which is a separate implementation of the same check. */
+const compiled = (schema: any, key: string, x: unknown) =>
+  TypeCompiler.Compile(schema.properties[key]).Check(x);
+
+describe('a postgres real and double precision column', () => {
+  it('accepts NaN and both infinities, interpreted and compiled alike', async () => {
+    const { module: m, source } = await emit([REAL, DOUBLE], 'floats');
+    for (const name of ['c_real', 'c_double']) {
+      for (const check of [accepts, compiled]) {
+        expect(check(m.SelecttSchema, name, NaN), `${name} NaN`).toBe(true);
+        expect(check(m.SelecttSchema, name, Infinity), `${name} Infinity`).toBe(true);
+        expect(check(m.SelecttSchema, name, -Infinity), `${name} -Infinity`).toBe(true);
+        expect(check(m.SelecttSchema, name, 1.5), `${name} an ordinary number`).toBe(true);
+        expect(check(m.SelecttSchema, name, 'x'), `${name} a string`).toBe(false);
+        expect(check(m.SelecttSchema, name, null), `${name} null on a NOT NULL column`).toBe(false);
+      }
+    }
+    // The registered kind has to be imported and set up, or the module throws on import. That is
+    // the failure mode the shared `tbNeedsCapKind` predicate exists to prevent.
+    expect(source).toContain("import { Type, Kind, TypeRegistry } from '@sinclair/typebox'");
+    expect(source).toContain("TypeRegistry.Set('DrzlRowCheck'");
+    expect(source).toContain("[Kind]: 'DrzlRowCheck'");
+    expect(source).toContain('!Number.isFinite(v)');
+  });
+
+  it('keeps the magnitude bound the 4 byte column really has', async () => {
+    const { module: m } = await emit([REAL, DOUBLE], 'magnitude');
+    expect(accepts(m.SelecttSchema, 'c_real', 1e300), 'real at 1e300').toBe(false);
+    expect(compiled(m.SelecttSchema, 'c_real', 1e300), 'real at 1e300, compiled').toBe(false);
+    expect(accepts(m.SelecttSchema, 'c_double', 1e300), 'double at 1e300').toBe(true);
+    expect(accepts(m.SelecttSchema, 'c_real', 3.4028235e38)).toBe(true);
+  });
+
+  it('survives the array and nullable wrappers', async () => {
+    const { module: m } = await emit(
+      [
+        col('a_real', { ...REAL, name: 'a_real', arrayDimensions: 1 }),
+        col('n_real', { ...REAL, name: 'n_real', nullable: true }),
+      ],
+      'wrappers'
+    );
+    expect(accepts(m.SelecttSchema, 'a_real', [NaN, Infinity, 1.5])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'a_real', [1e300]), 'an out-of-range element').toBe(false);
+    expect(accepts(m.SelecttSchema, 'a_real', NaN), 'a bare element').toBe(false);
+    expect(accepts(m.SelecttSchema, 'n_real', null)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'n_real', NaN)).toBe(true);
+  });
+});
+
+describe('a postgres numeric in number mode', () => {
+  it('accepts NaN and keeps refusing both infinities', async () => {
+    const { module: m, source } = await emit([NUMERIC], 'numeric');
+    for (const check of [accepts, compiled]) {
+      expect(check(m.SelecttSchema, 'c_numeric_n', NaN)).toBe(true);
+      expect(check(m.SelecttSchema, 'c_numeric_n', Infinity)).toBe(false);
+      expect(check(m.SelecttSchema, 'c_numeric_n', -Infinity)).toBe(false);
+      expect(check(m.SelecttSchema, 'c_numeric_n', 1.5)).toBe(true);
+      expect(check(m.SelecttSchema, 'c_numeric_n', 'x')).toBe(false);
+      expect(check(m.SelecttSchema, 'c_numeric_n', null)).toBe(false);
+    }
+    expect(source).toContain('Number.isNaN(v)');
+    expect(source, 'no infinity branch').not.toContain('!Number.isFinite(v)');
+  });
+});
+
+describe('every other number column', () => {
+  it('is emitted exactly as before, with no registry entry at all', async () => {
+    const { module: m, source } = await emit(
+      [
+        col('c_int', { dbType: 'INTEGER', integer: true, min: '-2147483648', max: '2147483647' }),
+        col('m_float', {
+          dbType: 'REAL',
+          min: '-340282346638528859811704183484516925440',
+          max: '340282346638528859811704183484516925440',
+        }),
+      ],
+      'untouched'
+    );
+    expect(source).toContain('Type.Integer({ minimum: -2147483648, maximum: 2147483647 })');
+    expect(source, 'no registered kind').not.toContain('TypeRegistry');
+    for (const name of ['c_int', 'm_float']) {
+      expect(accepts(m.SelecttSchema, name, NaN), `${name} NaN`).toBe(false);
+      expect(accepts(m.SelecttSchema, name, Infinity), `${name} Infinity`).toBe(false);
+      expect(accepts(m.SelecttSchema, name, -Infinity), `${name} -Infinity`).toBe(false);
+    }
+  });
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -10,6 +10,7 @@ import {
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
+  nonFiniteAccepted,
   parseCheck,
   renderDuplicateFinder,
   resolveConfiguredImport,
@@ -72,6 +73,30 @@ function vBounds(
   }
 
   return [lo, hi].filter(Boolean).map((x) => `v.${x!.action}(${literal(x!.value)})`);
+}
+
+/**
+ * The union branches for the non-finite doubles this column really stores, or none.
+ *
+ * A union rather than a wider range, because no range can hold either value: `v.maxValue(n)`
+ * refuses `Infinity` whatever `n` is, and `NaN` compares false against both ends.
+ *
+ * `bounded` is why this is not the same list zod and TypeBox emit. Measured on the installed
+ * valibot: a bare `v.number()` already accepts `Infinity` and `-Infinity` and refuses only `NaN`,
+ * so an unbounded `double precision` needs one branch where a bounded `real` needs three. Emitting
+ * the redundant pair anyway would put two branches in the generated file that change nothing, and
+ * the measurement is asserted in this package's non-finite spec rather than trusted.
+ *
+ * Both infinity branches together once any bound is present, rather than one per side. For the
+ * three Postgres columns this reaches, the type's own bounds always come as a pair; a lone bound
+ * can only arrive from a CHECK, and the branch that is then redundant admits nothing new.
+ */
+function vNonFiniteBranches(c: Column, bounded: boolean): string[] {
+  const { nan, infinity } = nonFiniteAccepted(c);
+  return [
+    ...(nan ? ['v.nan()'] : []),
+    ...(infinity && bounded ? ['v.literal(Infinity)', 'v.literal(-Infinity)'] : []),
+  ];
 }
 
 /** Which checks `vBounds` has already stated, so they are not also emitted as actions. */
@@ -326,10 +351,14 @@ function vExprForColumn(
           : []
       );
     case 'number': {
-      return piped('v.number()', [
-        ...(isIntegerColumn(c) ? ['v.integer()'] : []),
-        ...vBounds(c, (v) => v, checks),
-      ]);
+      const bounds = vBounds(c, (v) => v, checks);
+      const actions = [...(isIntegerColumn(c) ? ['v.integer()'] : []), ...bounds];
+      const branches = vNonFiniteBranches(c, bounds.length > 0);
+      if (!branches.length) return piped('v.number()', actions);
+      // The bounds stay on the number branch and the union is what `extra` then applies to, so a
+      // CHECK that could not be folded into a bound still sees every value the column admits.
+      const finite = actions.length ? `v.pipe(v.number(), ${actions.join(', ')})` : 'v.number()';
+      return piped(`v.union([${finite}, ${branches.join(', ')}])`, []);
     }
     case 'bigint': {
       // Bounds must be bigint literals: a 64 bit bound written as a number rounds.

--- a/packages/generator-valibot/test/non-finite-numbers.spec.ts
+++ b/packages/generator-valibot/test/non-finite-numbers.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * `NaN` and the two infinities on a Postgres float column, in valibot output.
+ *
+ * Valibot needs less repairing than zod and TypeBox and it is not none. Measured on the installed
+ * version: a bare `v.number()` accepts `Infinity` and `-Infinity` and refuses `NaN`, so the NaN
+ * branch is needed on every column here. The infinity branches are needed only where the column
+ * carries a range, because `v.maxValue(n)` refuses `Infinity` whatever `n` is, which is exactly
+ * the `real` and the `numeric` and not the `double precision`.
+ *
+ * That asymmetry is the reason this is four separate patches rather than one shared renderer.
+ */
+import { describe, it, expect } from 'vitest';
+import { ValibotGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import * as v from 'valibot';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const PG_FLOAT4_MAX = '340282356779733661637539395458142568448';
+const JS_MAX = '9007199254740991';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'number',
+    dbType: 'DOUBLE',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    integer: false,
+    ...over,
+  }) as Column;
+
+const REAL = col('c_real', {
+  dbType: 'REAL',
+  min: `-${PG_FLOAT4_MAX}`,
+  max: PG_FLOAT4_MAX,
+  allowsNaN: true,
+  allowsInfinity: true,
+});
+const DOUBLE = col('c_double', { dbType: 'DOUBLE', allowsNaN: true, allowsInfinity: true });
+const NUMERIC = col('c_numeric_n', {
+  dbType: 'NUMERIC',
+  min: `-${JS_MAX}`,
+  max: JS_MAX,
+  allowsNaN: true,
+  allowsInfinity: false,
+});
+
+async function emit(columns: Column[], label: string) {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-non-finite');
+  await fs.mkdir(dir, { recursive: true });
+  await new ValibotGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.valibot.ts'), file);
+  const source = (await fs.readFile(file, 'utf8')).replace(/\s+/g, ' ');
+  return { source, module: await import(file) };
+}
+
+const accepts = (schema: any, key: string, x: unknown) =>
+  v.safeParse(schema.entries[key], x).success;
+
+describe('what valibot does on its own', () => {
+  it('refuses NaN and takes both infinities, which is why the repair is uneven', () => {
+    // The measurement the generator is written against, run rather than remembered. If a future
+    // valibot changes either answer, this fails first and says so.
+    expect(v.safeParse(v.number(), NaN).success, 'bare number, NaN').toBe(false);
+    expect(v.safeParse(v.number(), Infinity).success, 'bare number, Infinity').toBe(true);
+    expect(v.safeParse(v.number(), -Infinity).success, 'bare number, -Infinity').toBe(true);
+    const bounded = v.pipe(v.number(), v.minValue(-5), v.maxValue(5));
+    expect(v.safeParse(bounded, Infinity).success, 'bounded, Infinity').toBe(false);
+    expect(v.safeParse(bounded, -Infinity).success, 'bounded, -Infinity').toBe(false);
+  });
+});
+
+describe('a postgres real and double precision column', () => {
+  it('accepts NaN and both infinities, and still refuses a string and a null', async () => {
+    const { module: m, source } = await emit([REAL, DOUBLE], 'floats');
+    for (const name of ['c_real', 'c_double']) {
+      expect(accepts(m.SelecttSchema, name, NaN), `${name} NaN`).toBe(true);
+      expect(accepts(m.SelecttSchema, name, Infinity), `${name} Infinity`).toBe(true);
+      expect(accepts(m.SelecttSchema, name, -Infinity), `${name} -Infinity`).toBe(true);
+      expect(accepts(m.SelecttSchema, name, 1.5), `${name} an ordinary number`).toBe(true);
+      expect(accepts(m.SelecttSchema, name, 'x'), `${name} a string`).toBe(false);
+      expect(accepts(m.SelecttSchema, name, null), `${name} null`).toBe(false);
+    }
+    expect(source, 'the bounded column states the infinities').toContain('v.literal(Infinity)');
+    expect(source, 'the unbounded one does not need to').toContain(
+      'c_double: v.union([v.number(), v.nan()])'
+    );
+  });
+
+  it('keeps the magnitude bound the 4 byte column really has', async () => {
+    const { module: m } = await emit([REAL, DOUBLE], 'magnitude');
+    expect(accepts(m.SelecttSchema, 'c_real', 1e300), 'real at 1e300').toBe(false);
+    expect(accepts(m.SelecttSchema, 'c_double', 1e300), 'double at 1e300').toBe(true);
+    expect(accepts(m.SelecttSchema, 'c_real', 3.4028235e38)).toBe(true);
+  });
+
+  it('survives the array and nullable wrappers', async () => {
+    const { module: m } = await emit(
+      [
+        col('a_real', { ...REAL, name: 'a_real', arrayDimensions: 1 }),
+        col('n_real', { ...REAL, name: 'n_real', nullable: true }),
+      ],
+      'wrappers'
+    );
+    expect(accepts(m.SelecttSchema, 'a_real', [NaN, Infinity, 1.5])).toBe(true);
+    expect(accepts(m.SelecttSchema, 'a_real', [1e300]), 'an out-of-range element').toBe(false);
+    expect(accepts(m.SelecttSchema, 'a_real', NaN), 'a bare element').toBe(false);
+    expect(accepts(m.SelecttSchema, 'n_real', null)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'n_real', NaN)).toBe(true);
+  });
+});
+
+describe('a postgres numeric in number mode', () => {
+  it('accepts NaN and keeps refusing both infinities', async () => {
+    const { module: m, source } = await emit([NUMERIC], 'numeric');
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', NaN)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', Infinity)).toBe(false);
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', -Infinity)).toBe(false);
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', 1.5)).toBe(true);
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', 'x')).toBe(false);
+    expect(accepts(m.SelecttSchema, 'c_numeric_n', null)).toBe(false);
+    expect(source).toContain('v.nan()');
+    expect(source, 'no infinity branch').not.toContain('v.literal(Infinity)');
+  });
+});
+
+describe('every other number column', () => {
+  it('is emitted exactly as before', async () => {
+    const { module: m, source } = await emit(
+      [
+        col('c_int', { dbType: 'INTEGER', integer: true, min: '-2147483648', max: '2147483647' }),
+        col('m_float', {
+          dbType: 'REAL',
+          min: '-340282346638528859811704183484516925440',
+          max: '340282346638528859811704183484516925440',
+        }),
+      ],
+      'untouched'
+    );
+    expect(source).toContain(
+      'v.pipe(v.number(), v.integer(), v.minValue(-2147483648), v.maxValue(2147483647))'
+    );
+    expect(source, 'no union anywhere').not.toContain('v.nan()');
+    for (const name of ['c_int', 'm_float']) {
+      expect(accepts(m.SelecttSchema, name, NaN), `${name} NaN`).toBe(false);
+      expect(accepts(m.SelecttSchema, name, Infinity), `${name} Infinity`).toBe(false);
+      expect(accepts(m.SelecttSchema, name, -Infinity), `${name} -Infinity`).toBe(false);
+    }
+  });
+});

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -21,6 +21,7 @@ import {
   isIntegerColumn,
   moduleFileName,
   moduleSpecifier,
+  nonFiniteAccepted,
   resolveAffix,
   schemaName,
   selectColumns,
@@ -67,6 +68,27 @@ function numericBounds(
   }
 
   return [lo, hi].filter(Boolean).map((x) => `.${x!.op}(${literal(x!.value)})`).join('');
+}
+
+/**
+ * The column widened by the non-finite doubles it really stores, or left exactly as it was.
+ *
+ * A union rather than a wider range, because no range can hold either value: `.gte()/.lte()`
+ * refuses `Infinity` whatever the numbers are, and `NaN` compares false against both ends. The
+ * range keeps describing the finite values of the column and each branch adds one more.
+ *
+ * Both infinity branches whenever the column admits them, unlike valibot and ArkType, because
+ * zod 4 refuses a non-finite number with no bound at all: `z.number()` is `Number.isFinite`, so
+ * there is no unbounded case here where the base already takes them. Measured on the installed
+ * zod, which answers no to `NaN`, `Infinity` and `-Infinity` alike.
+ */
+function withNonFinite(c: Column, base: string): string {
+  const { nan, infinity } = nonFiniteAccepted(c);
+  const branches = [
+    ...(nan ? ['z.nan()'] : []),
+    ...(infinity ? ['z.literal(Infinity)', 'z.literal(-Infinity)'] : []),
+  ];
+  return branches.length ? `z.union([${base}, ${branches.join(', ')}])` : base;
 }
 
 /** Which checks `numericBounds` has already stated, so they are not also emitted as predicates. */
@@ -304,7 +326,7 @@ function zodExprForColumn(
       return str;
     case 'number': {
       const base = isIntegerColumn(c) ? 'z.number().int()' : 'z.number()';
-      return base + numericBounds(c, (v) => v, checks);
+      return withNonFinite(c, base + numericBounds(c, (v) => v, checks));
     }
     case 'bigint':
       // Bounds have to be bigint literals. A 64 bit bound written as a plain number rounds, so

--- a/packages/generator-zod/test/non-finite-numbers.spec.ts
+++ b/packages/generator-zod/test/non-finite-numbers.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * `NaN` and the two infinities on a Postgres float column, in zod output.
+ *
+ * Postgres stores all three in `real` and `double precision` and hands them back on SELECT, and
+ * stores `NaN` in a `numeric`. `z.number()` refuses all three with no bound at all, and a
+ * `.gte()/.lte()` pair refuses the infinities whatever the numbers are, so every read of such a
+ * row failed validation on a column behaving exactly as documented.
+ *
+ * Every assertion runs the emitted module. The emitted text is asserted too, because the union is
+ * the point of the change and a reader of the generated file should see it, but a string that
+ * looks right and does not parse is the recurring failure in this repository, so the text is never
+ * the only check.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const PG_FLOAT4_MAX = '340282356779733661637539395458142568448';
+const JS_MAX = '9007199254740991';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'number',
+    dbType: 'DOUBLE',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    integer: false,
+    ...over,
+  }) as Column;
+
+/** The three Postgres columns this change is about, exactly as the analyzer states them. */
+const REAL = col('c_real', {
+  dbType: 'REAL',
+  min: `-${PG_FLOAT4_MAX}`,
+  max: PG_FLOAT4_MAX,
+  allowsNaN: true,
+  allowsInfinity: true,
+});
+const DOUBLE = col('c_double', { dbType: 'DOUBLE', allowsNaN: true, allowsInfinity: true });
+const NUMERIC = col('c_numeric_n', {
+  dbType: 'NUMERIC',
+  min: `-${JS_MAX}`,
+  max: JS_MAX,
+  allowsNaN: true,
+  allowsInfinity: false,
+});
+
+async function emit(columns: Column[], label: string) {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-non-finite');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  // Whitespace collapsed, because the emitted file is run through prettier and a union this long
+  // is wrapped over six lines. The assertions are about which branches were emitted, not about
+  // where the formatter chose to break them.
+  const source = (await fs.readFile(file, 'utf8')).replace(/\s+/g, ' ');
+  return { source, module: await import(file) };
+}
+
+const accepts = (schema: any, v: unknown) => schema.safeParse(v).success;
+
+describe('a postgres real and double precision column', () => {
+  it('accepts NaN and both infinities, and still refuses a string and a null', async () => {
+    const { module: m, source } = await emit([REAL, DOUBLE], 'floats');
+    for (const name of ['c_real', 'c_double']) {
+      const f = m.SelecttSchema.shape[name];
+      expect(accepts(f, NaN), `${name} NaN`).toBe(true);
+      expect(accepts(f, Infinity), `${name} Infinity`).toBe(true);
+      expect(accepts(f, -Infinity), `${name} -Infinity`).toBe(true);
+      expect(accepts(f, 1.5), `${name} an ordinary number`).toBe(true);
+      expect(accepts(f, 'x'), `${name} a string`).toBe(false);
+      expect(accepts(f, null), `${name} null on a NOT NULL column`).toBe(false);
+    }
+    expect(source).toContain(
+      `z.union([ z .number() .gte(-${PG_FLOAT4_MAX}) .lte(${PG_FLOAT4_MAX}), z.nan(), z.literal(Infinity), z.literal(-Infinity), ])`
+    );
+    expect(source).toContain(
+      'z.union([z.number(), z.nan(), z.literal(Infinity), z.literal(-Infinity)])'
+    );
+  });
+
+  it('keeps the magnitude bound the 4 byte column really has', async () => {
+    // The union widens the column by exactly three values. A `real` still refuses 1e300, which
+    // Postgres refuses too, and a `double precision` still takes it.
+    const { module: m } = await emit([REAL, DOUBLE], 'magnitude');
+    expect(accepts(m.SelecttSchema.shape.c_real, 1e300), 'real at 1e300').toBe(false);
+    expect(accepts(m.SelecttSchema.shape.c_double, 1e300), 'double at 1e300').toBe(true);
+    // A full-magnitude float4 as the text protocol returns it, which is the value the bound exists
+    // to keep accepting.
+    expect(accepts(m.SelecttSchema.shape.c_real, 3.4028235e38)).toBe(true);
+  });
+
+  it('survives the array and nullable wrappers', async () => {
+    const { module: m } = await emit(
+      [
+        col('a_real', { ...REAL, name: 'a_real', arrayDimensions: 1 }),
+        col('n_real', { ...REAL, name: 'n_real', nullable: true }),
+      ],
+      'wrappers'
+    );
+    expect(accepts(m.SelecttSchema.shape.a_real, [NaN, Infinity, 1.5])).toBe(true);
+    expect(accepts(m.SelecttSchema.shape.a_real, [1e300]), 'an out-of-range element').toBe(false);
+    expect(accepts(m.SelecttSchema.shape.a_real, NaN), 'a bare element').toBe(false);
+    expect(accepts(m.SelecttSchema.shape.n_real, null)).toBe(true);
+    expect(accepts(m.SelecttSchema.shape.n_real, NaN)).toBe(true);
+  });
+});
+
+describe('a postgres numeric in number mode', () => {
+  it('accepts NaN and keeps refusing both infinities', async () => {
+    // Deliberate and documented: Postgres takes an infinity in an unconstrained `numeric` and
+    // answers 22003 numeric field overflow for a `numeric(10,2)`, and the analyzer reads no
+    // precision at all, so it cannot tell the two apart.
+    const { module: m, source } = await emit([NUMERIC], 'numeric');
+    const f = m.SelecttSchema.shape.c_numeric_n;
+    expect(accepts(f, NaN)).toBe(true);
+    expect(accepts(f, Infinity)).toBe(false);
+    expect(accepts(f, -Infinity)).toBe(false);
+    expect(accepts(f, 1.5)).toBe(true);
+    expect(accepts(f, 'x')).toBe(false);
+    expect(accepts(f, null)).toBe(false);
+    expect(source).toContain(
+      `z.union([z.number().gte(-${JS_MAX}).lte(${JS_MAX}), z.nan()])`
+    );
+    expect(source, 'no infinity branch').not.toContain('z.literal(Infinity)');
+  });
+});
+
+describe('every other number column', () => {
+  it('is emitted exactly as before', async () => {
+    // Postgres refuses all three on an `integer`, and MySQL refuses them on a `float`, so neither
+    // column may change. A column with no flags at all is what a MySQL or SQLite analysis produces.
+    const { module: m, source } = await emit(
+      [
+        col('c_int', { dbType: 'INTEGER', integer: true, min: '-2147483648', max: '2147483647' }),
+        col('m_float', {
+          dbType: 'REAL',
+          min: '-340282346638528859811704183484516925440',
+          max: '340282346638528859811704183484516925440',
+        }),
+      ],
+      'untouched'
+    );
+    expect(source).toContain('z.number().int().gte(-2147483648).lte(2147483647)');
+    expect(source, 'no union anywhere').not.toContain('z.nan()');
+    for (const name of ['c_int', 'm_float']) {
+      const f = m.SelecttSchema.shape[name];
+      expect(accepts(f, NaN), `${name} NaN`).toBe(false);
+      expect(accepts(f, Infinity), `${name} Infinity`).toBe(false);
+      expect(accepts(f, -Infinity), `${name} -Infinity`).toBe(false);
+    }
+  });
+});

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -213,6 +213,31 @@ export function isIntegerColumn(c: Column): boolean {
   return c.dbType === 'INTEGER' || (c.min !== undefined && c.max !== undefined);
 }
 
+/**
+ * The non-finite doubles the emitted schema must admit beside the column's range, as the analyzer
+ * stated them.
+ *
+ * One reading of two flags, shared so that four generators cannot drift on what they mean, and not
+ * a shared *rendering*: the four libraries do not need the same repair. `z.number()` and
+ * `Type.Number()` refuse `NaN` and both infinities outright, `v.number()` and ArkType's `number`
+ * refuse only `NaN`, and any bound at all makes all four refuse the infinities, so what each has to
+ * add depends on the library and on whether the column carries a range.
+ *
+ * Guarded on `tsType` so an enum, a shape or a string can never pick these up from a stale
+ * analysis. `@drzl/generator-json-schema` deliberately does not call this at all: JSON has no `NaN`
+ * and no `Infinity`, so there is nothing for a JSON Schema to admit.
+ *
+ * A numeric CHECK folded into one end of the column's range does not take a branch away, in any of
+ * the four. That is a decision rather than an oversight, and it is deliberately the loose one: what
+ * Postgres does with `CHECK (c >= 0)` and a `NaN` was not measured for this change, and dropping
+ * the branch on a column that carries a CHECK would put back, for that column, exactly the
+ * read-path failure this exists to remove.
+ */
+export function nonFiniteAccepted(c: Column): { nan: boolean; infinity: boolean } {
+  if (c.tsType !== 'number' || c.shape) return { nan: false, infinity: false };
+  return { nan: c.allowsNaN === true, infinity: c.allowsInfinity === true };
+}
+
 export function insertColumns(table: Table): Column[] {
   return table.columns.filter((c) => !isGeneratedColumn(c));
 }

--- a/packages/validation-core/test/non-finite-accepted.spec.ts
+++ b/packages/validation-core/test/non-finite-accepted.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * `nonFiniteAccepted`, against the real function rather than a copy of it.
+ *
+ * Four generators read it and each renders a different repair, so what has to hold in one place is
+ * the *reading*: which columns answer yes, and which can never answer yes however the analysis
+ * drifts. The guard is the part worth a test. Deleting `c.tsType !== 'number' || c.shape` from
+ * `src/index.ts` fails the last case below and only that one, run rather than counted, which is the
+ * whole point of it: a stale or hand-written analysis carrying the flags on a string or a shaped
+ * column would otherwise put a `z.nan()` branch beside a `z.string()`.
+ */
+import { describe, it, expect } from 'vitest';
+import { nonFiniteAccepted } from '../src/index';
+import type { Column } from '@drzl/analyzer';
+
+const col = (over: Partial<Column>): Column =>
+  ({
+    name: 'c',
+    tsType: 'number',
+    dbType: 'DOUBLE',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+describe('nonFiniteAccepted', () => {
+  it('reads what the analyzer stated for a postgres float', () => {
+    expect(nonFiniteAccepted(col({ allowsNaN: true, allowsInfinity: true }))).toEqual({
+      nan: true,
+      infinity: true,
+    });
+  });
+
+  it('separates the numeric answer from the float one', () => {
+    // `numeric({ mode: 'number' })` takes NaN and no infinity, because Postgres refuses an infinity
+    // in any `numeric` carrying a precision and nothing reads a column's precision.
+    expect(
+      nonFiniteAccepted(col({ dbType: 'NUMERIC', allowsNaN: true, allowsInfinity: false }))
+    ).toEqual({ nan: true, infinity: false });
+  });
+
+  it('answers no for a column that states nothing, which is every other dialect', () => {
+    expect(nonFiniteAccepted(col({ dbType: 'REAL' }))).toEqual({ nan: false, infinity: false });
+    expect(nonFiniteAccepted(col({ dbType: 'INTEGER', integer: true }))).toEqual({
+      nan: false,
+      infinity: false,
+    });
+  });
+
+  it('refuses to answer yes for anything that is not a plain number', () => {
+    // Both guards, with the flags set, so a passing case here cannot be the flags being absent.
+    expect(
+      nonFiniteAccepted(col({ tsType: 'string', allowsNaN: true, allowsInfinity: true }))
+    ).toEqual({ nan: false, infinity: false });
+    expect(
+      nonFiniteAccepted(
+        col({ shape: { kind: 'numberVector', length: 3 }, allowsNaN: true, allowsInfinity: true })
+      )
+    ).toEqual({ nan: false, infinity: false });
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1890,6 +1890,19 @@ type Waiver = {
   why: string;
   /** The exact divergence, keyed `<modes>/<libraries>`. */
   divergence: Record<string, string>;
+  /**
+   * Pairings inside `libs` x `modes` that genuinely do not diverge, named one at a time.
+   *
+   * The product is asserted exactly, which is what stops a waiver covering four pairings while
+   * claiming twelve. A real divergence that misses one cell of the product therefore has nowhere
+   * to go, and the alternatives are both worse: widening `libs` or `modes` until the product fits
+   * understates which pairings are waived, and splitting the column across two keys is not
+   * possible since the key is the column.
+   *
+   * Asserted in the fail-closed direction. A pairing named here that *does* diverge fails the run,
+   * so this can only ever shrink what the waiver claims, never quietly absorb a new difference.
+   */
+  except?: string[];
 };
 
 const LIB_NAMES = ['zod', 'valibot', 'arktype', 'typebox'];
@@ -2104,9 +2117,25 @@ const ALLOWED: Record<string, Waiver> = {
   //                      only valibot and arktype do, because `z.number()` and `Type.Number()`
   //                      refuse it with no bound at all. Filed: describing that column honestly
   //                      needs a union in every generator rather than a range.
-  'pg/c_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'bounded where Postgres stops accepting rather than at drizzle-zod +/-8388607, which refuses rows the column returns', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38 | T: ` } },
+  // The arktype update arm gains `Infinity` alone rather than `NaN, Infinity`. Not a gap in the
+  // fix: official `drizzle-orm/arktype` already accepts NaN in its union-shaped arms, so NaN was
+  // never a divergence there and still is not. Measured directly: `{x:'number'}` rejects NaN,
+  // `{x:'(bound | null)'}` accepts it.
+  'pg/c_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'bounded where Postgres stops accepting rather than at drizzle-zod +/-8388607, which refuses rows the column returns. Non-finite values were added on top: Postgres stores NaN and both infinities in a float column and returns them, and a Select schema refusing what the database hands back fails on real rows (AW).', divergence: { 'select,insert/*': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/arktype': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_real, but at MySQL edge: a real MySQL 8.4 refuses 3.4028235e38 where Postgres takes it', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` } },
-  'pg/c_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'no finite bound is true of an 8 byte float, which holds every finite JS number', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
+  // All four libraries now carry the same signature, where zod and typebox used to differ from
+  // valibot and arktype on the infinities. That convergence is the fix: the two that refused a
+  // non-finite number no longer do.
+  // NaN and not the infinities, and the asymmetry is the point. Postgres takes NaN into a numeric
+  // whether or not it carries a precision, and takes an infinity only when it does not: a
+  // `numeric(10,2)` answers `22003 numeric field overflow`. The analyzer does not read precision
+  // or scale at all, so it cannot tell the two declarations apart, and accepting would make the
+  // schema admit what the server refuses for the commoner one. Narrower on purpose (AW).
+  //
+  // arktype on update is excepted because official already accepts NaN there, so there is nothing
+  // to waive. It is the one cell of the twelve that reports parity.
+  'pg/c_numeric_n': { libs: LIB_NAMES, modes: MODE_NAMES, except: ['update/arktype'], why: 'Postgres stores NaN in a numeric column and returns it; official refuses the value the database hands back', divergence: { '*/*': `L: NaN | T: ` } },
+  'pg/c_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'no finite bound is true of an 8 byte float, which holds every finite JS number. Non-finite values were added on top: Postgres stores NaN and both infinities in a float column and returns them, and a Select schema refusing what the database hands back fails on real rows (AW).', divergence: { 'select,insert/*': `L: 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/zod,valibot,typebox': `L: 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; MySQL REAL is a synonym for DOUBLE', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; SQLite REAL is an 8 byte IEEE float', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
@@ -2162,7 +2191,10 @@ const ALLOWED: Record<string, Waiver> = {
   // wrapping is where a constraint gets lost, and a signature identical to the twin's is the
   // evidence that nothing was lost. Three have no twin and they are the three CHECK columns,
   // because no column of `matrix` carries a CHECK.
-  'pg/n_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_real, through the nullable wrapper', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38 | T: ` } },
+  // Every arktype arm gains `Infinity` alone here, where `c_real` above diverges only on update:
+  // the nullable wrapper makes all three modes union shaped, and official accepts NaN in all of
+  // them. Same reason, wider reach.
+  'pg/n_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_real, through the nullable wrapper', divergence: { '*/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, '*/arktype': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   'pg/c_bytea_null': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_bytea, through the nullable wrapper', divergence: { '*/*': `L: Uint8Array | T: ` } },
   'pg/valibot/n_json': { libs: ['valibot'], modes: MODE_NAMES, why: 'as pg/valibot/c_json', divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` } },
   'pg/valibot/n_point': { libs: ['valibot'], modes: MODE_NAMES, why: 'as pg/valibot/c_point', divergence: { '*/*': `L:  | T: [1,2,3]` } },
@@ -2381,7 +2413,6 @@ const CROSS_ALLOWED: Record<string, { why: string; divergence: string }> = {
   //
   // No `real` entry: the float4 bound refuses Infinity in all four, so they agree there for a
   // reason that has nothing to do with the libraries.
-  'pg/c_double': { why: 'z.number() and Type.Number() refuse a non-finite number with no bound; v.number() and arktype number accept one, as Postgres does', divergence: `Infinity: valibot/arktype accept, zod/typebox reject` },
   'mysql/m_real': { why: 'as pg/c_double', divergence: `Infinity: valibot/arktype accept, zod/typebox reject` },
   'mysql/m_double': { why: 'as pg/c_double', divergence: `Infinity: valibot/arktype accept, zod/typebox reject` },
   'sqlite/s_real': { why: 'as pg/c_double', divergence: `Infinity: valibot/arktype accept, zod/typebox reject` },
@@ -2412,7 +2443,6 @@ const CROSS_ALLOWED: Record<string, { why: string; divergence: string }> = {
    * strict ones, exactly as with `Infinity` on the 8 byte floats above, and the honest description
    * of a Postgres float column still needs a union in every generator rather than a range.
    */
-  'pg/n_real': { why: "arktype's number refuses NaN and its (number | null) accepts one, as Postgres does", divergence: `NaN: arktype accept, zod/valibot/typebox reject` },
   'mysql/m_n_float': { why: 'as pg/n_real', divergence: `NaN: arktype accept, zod/valibot/typebox reject` },
   'sqlite/s_n_real': { why: 'as pg/n_real on NaN, and as pg/c_double on Infinity, which no bound holds back here', divergence: `NaN: arktype accept, zod/valibot/typebox reject; Infinity: valibot/arktype accept, zod/typebox reject` },
   // No bigint entry either, for the reason given in ALLOWED: arktype now bounds a bigint with a
@@ -3153,7 +3183,15 @@ for (const [key, seen] of seenAll) {
   const wantModes = [...entry.modes].sort().join(',');
   if (gotLibs !== wantLibs) waiverProblems.push(`${name}[${key}] declares libs ${wantLibs}, measured ${gotLibs}`);
   if (gotModes !== wantModes) waiverProblems.push(`${name}[${key}] declares modes ${wantModes}, measured ${gotModes}`);
-  const wantPairings = entry.libs.length * entry.modes.length;
+  const excepted = entry.except ?? [];
+  const wrongly = excepted.filter((x) => seen.has(x));
+  if (wrongly.length) {
+    waiverProblems.push(
+      `${name}[${key}] excepts ${wrongly.join(', ')}, which diverged on this run. ` +
+        `Remove the exception or the waiver is understating what it covers.`
+    );
+  }
+  const wantPairings = entry.libs.length * entry.modes.length - excepted.length;
   if (seen.size !== wantPairings) {
     waiverProblems.push(
       `${name}[${key}] declares ${wantPairings} pairings, measured ${seen.size}: ` +
@@ -4734,41 +4772,17 @@ if (crashed.length) {
  * still fails below.
  */
 /**
- * Rejections that are DRZL's own defect, filed and pinned rather than fixed in this change.
+ * Rejections that are DRZL's own defect, filed and pinned rather than fixed.
  *
- * Postgres float and numeric columns store `NaN`, `Infinity` and `-Infinity`, and the driver hands
- * them back as those JavaScript values. The emitted number schema refuses all three, so reading a
- * row that holds one fails validation on a column that is behaving exactly as documented. That is
- * the failure this whole stage exists to detect, and the first thing it detected.
+ * Empty, and that is a result rather than a default. It held five pins when this stage was written:
+ * `c_real` and `c_double` on NaN and on Infinity, and `c_numeric_n` on NaN, all cases where Postgres
+ * stores a value, returns it, and the emitted schema refused it. Fixing that (AW) made every one of
+ * them stop firing, and a pin that stops firing fails the run, which is how the fix reported itself
+ * here rather than needing to be checked for by hand.
  *
- * Not waived, and kept apart from the two ledgers above for that reason: those say the schema is
- * right, this says it is wrong. Fixing it changes emitted output for every float column and moves
- * DRZL away from `drizzle-orm`, which rejects these too, so it goes in its own change with its own
- * cascade through the parity ledgers. Addendum AW.
- *
- * Pinned exactly, in both directions: an unpinned rejection here still fails, and a pin that stops
- * firing fails too, which is what will report the fix when it lands.
+ * Kept rather than deleted so the next one has somewhere to go that is asserted in both directions.
  */
-const DEFECTS: Record<string, { why: string; cases: { label: string; returned: string }[] }> = {
-  c_real: {
-    why: 'real() refuses NaN and Infinity, which Postgres stores and returns',
-    cases: [
-      { label: 'NaN', returned: 'NaN' },
-      { label: 'Infinity', returned: 'Infinity' },
-    ],
-  },
-  c_double: {
-    why: 'doublePrecision() refuses NaN and Infinity, which Postgres stores and returns',
-    cases: [
-      { label: 'NaN', returned: 'NaN' },
-      { label: 'Infinity', returned: 'Infinity' },
-    ],
-  },
-  c_numeric_n: {
-    why: 'numeric({ mode: number }) refuses NaN, which Postgres stores and returns',
-    cases: [{ label: 'NaN', returned: 'NaN' }],
-  },
-};
+const DEFECTS: Record<string, { why: string; cases: { label: string; returned: string }[] }> = {};
 
 const excusedNarrow = new Set<string>();
 const excusedLossy = new Set<string>();
@@ -7144,22 +7158,37 @@ const ALLOWED: Record<string, Entry> = {
   // `pg/c_numeric_n` is deliberately not among them. Its bound is the safe-integer range, which is
   // about what a JS number can carry rather than about the column, official emits the same one,
   // and Postgres is stricter than both: it refuses 2147483648 into a `numeric(10,2)`.
+  // The arktype update arm gains `Infinity` alone. Official arktype already accepts NaN in its
+  // union-shaped arms, so NaN was never a divergence there. Same split as the v1 pass.
   'pg/c_real': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38 | T: ` },
-    drzl: 'a number within the magnitude Postgres accepts into a real',
+    divergence: {
+      'select,insert/*': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, NaN, Infinity | T: `,
+      'update/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, NaN, Infinity | T: `,
+      'update/arktype': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, Infinity | T: `,
+    },
+    drzl: 'a number within the magnitude Postgres accepts into a real, plus the non-finite values it stores',
     official: 'a number within +/-8388607, which refuses rows the column returns',
     filed: 'not a defect: the database is the arbiter, see the same key in the v1 pass',
   },
+  // NaN and not the infinities, because Postgres takes an infinity into a numeric only when the
+  // column carries no precision and the analyzer does not read precision at all. arktype on update
+  // is excepted: official already accepts NaN there, so there is nothing to waive. See the v1 copy
+  // of this entry for the full reasoning.
+  'pg/c_numeric_n': { libs: LIB_NAMES, modes: MODE_NAMES, except: ['update/arktype'], divergence: { '*/*': `L: NaN | T: ` }, drzl: 'a number, plus the NaN Postgres stores in a numeric column', official: 'a number, refusing the NaN the database hands back', filed: 'not a defect: as pg/c_real' },
   // Not `as pg/c_real` in the signature, which it was until MySQL was measured: the two 4 byte
   // floats have different edges, and `3.4028235e38` is the probe that says so.
   'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` }, drzl: 'as pg/c_real, at the narrower MySQL edge', official: 'as pg/c_real', filed: 'as pg/c_real' },
   'pg/c_double': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
-    divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` },
-    drzl: 'an unbounded number, because no finite bound is true of an 8 byte float',
+    divergence: {
+      'select,insert/*': `L: 9007199254740993, 3.4028235e38, NaN, Infinity | T: `,
+      'update/zod,valibot,typebox': `L: 9007199254740993, 3.4028235e38, NaN, Infinity | T: `,
+      'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: `,
+    },
+    drzl: 'an unbounded number, because no finite bound is true of an 8 byte float, plus the non-finite values it stores',
     official: 'a number within +/-140737488355327, which refuses an ordinary microsecond epoch',
     filed: 'not a defect: as pg/c_real',
   },
@@ -7173,7 +7202,7 @@ const ALLOWED: Record<string, Entry> = {
   // twin's is the evidence that the wrapping loses nothing. Three have no twin and they are the
   // three CHECK columns: no column of `matrix` carries a CHECK, and no first-party module reads
   // one at all.
-  'pg/n_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38 | T: ` }, drzl: 'as pg/c_real', official: 'as pg/c_real', filed: 'as pg/c_real' },
+  'pg/n_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, '*/arktype': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_real', official: 'as pg/c_real', filed: 'as pg/c_real' },
   'pg/n_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
   'pg/n_point': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: [1,2,3]` }, drzl: 'as pg/c_point', official: 'as pg/c_point', filed: 'as pg/c_point' },
   'pg/n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
@@ -8159,7 +8188,7 @@ async function main() {
       if (gotModes !== wantModes) {
         ledgerProblems.push(`${name}[${key}] declares modes ${wantModes}, measured ${gotModes}`);
       }
-      const wantPairings = entry.libs.length * entry.modes.length;
+      const wantPairings = entry.libs.length * entry.modes.length - (entry.except?.length ?? 0);
       if (seen.pairings !== wantPairings) {
         ledgerProblems.push(
           `${name}[${key}] declares ${wantPairings} pairings, measured ${seen.pairings}: ` +


### PR DESCRIPTION
Addendum AW, Tier A. Found by the round-trip stage on its first working run, and fixed here.

Postgres `real` and `double precision` hold `NaN`, `Infinity` and `-Infinity`, and `SELECT` hands all three back. Every emitted schema refused them, so **reading a row that holds one fails validation on a column behaving exactly as documented**. That is the read path, which no application can avoid.

`drizzle-orm` refuses them too, so no parity stage could see this. Only the database could arbitrate.

## No range could have fixed it

A `>=`/`<=` pair refuses `Infinity` whatever the numbers are, and `NaN` compares false against both ends. So the fact is carried on the column as `allowsNaN`/`allowsInfinity`, set on **both** analyzer paths (the v1 codec path and the 0.4x class-name path), and each generator renders it beside the range. The range is unchanged and still describes the column's finite values, so a `real` still refuses `1e300`.

## Scope, measured rather than assumed

PostgreSQL 18.3, SQLite 3.50.4, MySQL 8.4.11, on the bound-parameter path a validator actually guards:

| | NaN | Infinity | -Infinity |
|---|---|---|---|
| pg `real`, `double precision` | faithful | faithful | faithful |
| pg `numeric` (no typmod) | faithful | faithful | faithful |
| pg `numeric(10,2)` | faithful | **22003 overflow** | **22003 overflow** |
| pg `integer`, `bigint` | rejects | rejects | rejects |
| sqlite `real`/`integer`/`numeric` | **stored as NULL** | faithful | faithful |
| mysql `float`, `double` | rejects | rejects | rejects |
| mysql `decimal(10,2)` | silently `0.00` | silently `0.00` | silently `0.00` |

My planned scope before measuring was "Postgres float columns". That misses `numeric`, gets `numeric(10,2)` backwards, and leaves SQLite wrong in a fourth way.

**`numeric` in number mode takes `NaN` and still refuses the infinities.** Postgres accepts an infinity there only when the column carries no precision, the analyzer does not read precision or scale at all, and promising what the server refuses for the commoner declaration is the worse of the two errors. Deliberate and documented, not an oversight.

SQLite and MySQL are untouched here and are filed as **AY** and **AZ**.

## Per generator, because the libraries disagree with each other

|  | NaN | Infinity | -Infinity |
|---|---|---|---|
| zod 4.4.3 `z.number()` | NO | NO | NO |
| typebox `Type.Number()` | NO | NO | NO |
| valibot `v.number()` | NO | ok | ok |
| arktype `type('number')` | NO | ok | ok |

One patch applied four times would have been wrong in two of them.

**TypeBox could not use `Type.Literal(NaN)`**, since literal comparison is `===` and `NaN !== NaN`. It needed a registered kind with a real predicate.

**ArkType has a defect that hides in the emitted text.** A two-branch `(range) | number.NaN` accepts `NaN`, but at three or more branches the union's discriminator drops it while `.json` still lists the branch. `real` needs four branches, so it uses a narrow instead. Nothing reading the generated text or the parsed type would catch that; only evaluating the schema does, which is why every new test runs the emitted module rather than diffing its text.

## How the gate reported the fix

The five `DEFECTS` pins written when AW was filed all went stale, which fails the build by design:

```
FAIL: these pinned cases did not happen on this run:
  DEFECTS c_real on NaN        DEFECTS c_real on Infinity
  DEFECTS c_double on NaN      DEFECTS c_double on Infinity
  DEFECTS c_numeric_n on NaN
```

Two `CROSS_ALLOWED` entries also went stale because they described disagreements *between* the four generators, and all four now agree. Meanwhile `mysql/m_real`, `mysql/m_double`, `sqlite/s_real` and two more survived untouched, which is the check confirming the change did not leak past its dialect.

Numbers moved as expected: agreement with Postgres 1056 to 1061, closer-than-drizzle-orm 49 to 54, round-trip rejections 71 to 66, which is exactly the five pinned cases.

## One new mechanism in the gate, worth review

The `c_numeric_n` divergence covers 11 of 12 pairings: official arktype already accepts `NaN` on update, so there is nothing to waive in that cell. The waiver type asserts the `libs` x `modes` product exactly, and both alternatives were worse: widening the product understates which pairings are waived, and splitting across two keys is impossible since the key is the column.

`Waiver.except` names the cell. It is asserted fail-closed: a pairing named there that **does** diverge fails the run, so it can only shrink what a waiver claims, never absorb a new difference. Applied to both the v1 and 0.4x passes, since the file already records that holding one ledger to a weaker rule than its neighbour is a mistake it made once.

Also worth a second look: `pg/c_double`'s previous split grouped `zod,typebox` against `valibot,arktype` because those pairs genuinely disagreed on the infinities. That grouping is no longer true and I replaced it with a split by mode.

## Tests

New spec per generator plus the analyzer and validation-core, all running the emitted schema rather than diffing its text: the three values accepted or refused as specified, `'x'` and `null` still refused on a NOT NULL column, `1e300` still refused by `real`, array and nullable wrappers preserving all of it, TypeBox checked through both `Value.Check` and `TypeCompiler`. Each spec also pins the library behaviour it is written against, so a library change fails there first.

`pnpm verify:packed`, `build`, `-r test`, `typecheck`, `lint`, `docs build` all green.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4