### PR TITLE
fix(generators): stop coercing a bare number into a date

### DIFF
--- a/.changeset/date-coercion-accepts-non-dates.md
+++ b/.changeset/date-coercion-accepts-non-dates.md
@@ -1,0 +1,45 @@
+---
+'@drzl/validation-core': patch
+'@drzl/generator-zod': patch
+'@drzl/generator-typebox': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-arktype': patch
+---
+
+`date({ mode: 'date' })` and `timestamp({ mode: 'date' })` stop accepting a string that is only a
+number.
+
+`coerceDates` lets a client send a date as a string, and every generator took any string at all in
+that position. `new Date` reads a bare number as a year, or as `month.day`, so `'12.5'`, `'0101'`
+and `'010'` were all real dates and Postgres refuses all three: validation passed and the INSERT
+then failed at the server, which is the one outcome an Insert schema exists to prevent.
+
+A coerced string now has to look like a date notation. The obvious justification for the rule, that
+Postgres refuses a bare number, turned out to be false and the real one is stronger. Postgres reads
+a six or eight digit run as a compact `YYMMDD` / `YYYYMMDD` date and takes it happily, but where
+both parsers accept such a string they never agree on which date it is. Measured against a real
+Postgres over every all-digit string in the probe set that both accept, ten of them, the two answers
+differed every single time:
+
+```
+'250101'    Postgres 2025-01-01    V8 the year 250101
+'241231'    Postgres 2024-12-31    V8 the year 241231
+'121212'    Postgres 2012-12-12    V8 the year 121212
+'000101'    Postgres 2000-01-01    V8 0100-12-31
+'20200101'  Postgres 2020-01-01    V8 refuses it outright
+```
+
+So coercing a bare number either sends the server a value it rejects or silently writes a different
+date than the database would have stored. A leading `+` or `-` goes the same way: `'+2020-01-01'`
+and `'-2020-01-01'` are valid dates in V8 and Postgres refuses both.
+
+**What changes for you.** On a `mode: 'date'` column, a string that is entirely a number, or that
+starts with a sign, is no longer coerced and no longer validates. Everything that reads as a date to
+both parsers is untouched: `'2020-01-01'`, `'2020-01-01T00:00:00Z'`, `'1999-01-08 04:05:06'`,
+`'01/02/2020'`, `'January 8, 1999'`, `'2020-1-5'` and `'  2020-01-01  '` all still pass, as does a
+real `Date`. `coerceDates` itself is unchanged and its `all` / `none` / `input` behaviour is the
+same; this narrows what a coerced string may be, it does not remove coercion. Numbers are untouched
+too, so an epoch millisecond still coerces.
+
+The JSON Schema generator does not change. Dates arrive as strings once serialised, whatever
+`coerceDates` does in TypeScript, and it already describes them as such.

--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -88,7 +88,7 @@ PGlite, SQLite via `node:sqlite`, and MySQL as a CI service container.
 
 ```
     1440 probes against a real Postgres (40 columns)
-    agree with the database: DRZL 1061, drizzle-orm 1013
+    agree with the database: DRZL 1067, drizzle-orm 1013
     DRZL closer than drizzle-orm on 54, further on 0
 
     393 rows read back through the driver (40 columns)

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -10,6 +10,7 @@ import type {
   ValidationGenerateOptions,
 } from '@drzl/validation-core';
 import {
+  COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
@@ -40,9 +41,14 @@ function atDateType(
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>
 ): string {
   if (coerceDates === 'none') return 'Date';
-  if (coerceDates === 'all') return 'Date | string';
+  // Not a bare `string`. `new Date` reads a bare number as a year or as month.day, so `'12.5'`,
+  // `'0101'` and `'010'` all passed here and Postgres refuses all three. ArkType states the
+  // narrowing as a regex literal in its DSL, the same way a column format is stated; see
+  // `COERCIBLE_DATE_STRING` for what was measured and why.
+  const coercible = `Date | /${COERCIBLE_DATE_STRING}/`;
+  if (coerceDates === 'all') return coercible;
   // 'input'
-  return mode === 'select' ? 'Date' : 'Date | string';
+  return mode === 'select' ? 'Date' : coercible;
 }
 
 /**

--- a/packages/generator-arktype/test/date-coercion.spec.ts
+++ b/packages/generator-arktype/test/date-coercion.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * What a `mode: 'date'` column accepts on write, in ArkType output.
+ *
+ * `coerceDates` defaults to accepting a string beside the `Date` on insert and update, which is
+ * what lets a client send an ISO string. That branch used to be a bare `string`, so `'12.5'`,
+ * `'0101'` and `'010'` all passed and Postgres refuses all three: the schema passed and the INSERT
+ * then failed at the server, which is the one outcome an Insert schema exists to prevent.
+ *
+ * Everything here runs the emitted module, which for this generator is the only test worth
+ * writing: ArkType parses at import, so a regex literal it cannot resolve throws and takes down
+ * whatever imported the schema. The pattern carries lookaheads and no alternation for exactly that
+ * reason, since `|` inside a regex literal shares a character with ArkType's own union operator.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArkTypeGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { type } from 'arktype';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'Date',
+    dbType: 'TIMESTAMP',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+async function schemasFor(
+  coerceDates: 'input' | 'all' | 'none',
+  label: string
+): Promise<Record<string, never>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [
+      { name: 't', tsName: 't', columns: [col('at')], unique: [], indexes: [], checks: [] },
+    ] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-dates');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir, coerceDates } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.arktype.ts'), file);
+  return await import(file);
+}
+
+const accepts = (schema: any, x: unknown) => !(schema.get('at')(x) instanceof type.errors);
+
+describe('the default, which accepts a string on write only', () => {
+  it('takes a Date and every notation Postgres and V8 read as the same date', async () => {
+    const m = await schemasFor('input', 'input');
+    expect(accepts(m.InserttSchema, new Date()), 'a Date').toBe(true);
+    for (const s of [
+      '2020-01-01',
+      '2020-01-01T00:00:00Z',
+      '1999-01-08 04:05:06',
+      '01/02/2020',
+      'January 8, 1999',
+      '2020-1-5',
+      '  2020-01-01  ',
+    ]) {
+      expect(accepts(m.InserttSchema, s), s).toBe(true);
+    }
+  });
+
+  it('refuses a string that is only a number, which Postgres does not read as a date', async () => {
+    const m = await schemasFor('input', 'input');
+    for (const s of ['12.5', '0101', '010']) {
+      expect(accepts(m.InserttSchema, s), s).toBe(false);
+      expect(Number.isNaN(new Date(s).getTime()), `${s} is a valid Date in V8`).toBe(false);
+    }
+    for (const s of ['2020', '99', '1', '0', '.5', '+2020-01-01', '-2020-01-01', ' 2020 ', '']) {
+      expect(accepts(m.InserttSchema, s), s).toBe(false);
+    }
+  });
+
+  it('still refuses the values a bare coercion would have taken', async () => {
+    const m = await schemasFor('input', 'input');
+    expect(accepts(m.InserttSchema, null), 'null on a NOT NULL column').toBe(false);
+    expect(accepts(m.InserttSchema, true), 'a boolean').toBe(false);
+    expect(accepts(m.InserttSchema, [1, 2]), 'an array').toBe(false);
+  });
+
+  it('leaves select strict, since a row out of the database is already a Date', async () => {
+    const m = await schemasFor('input', 'input');
+    expect(accepts(m.SelecttSchema, new Date())).toBe(true);
+    expect(accepts(m.SelecttSchema, '2020-01-01'), 'a string on select').toBe(false);
+  });
+});
+
+describe('the explicit settings', () => {
+  it("accepts a string on select too under 'all', and narrows there as well", async () => {
+    const m = await schemasFor('all', 'all');
+    expect(accepts(m.SelecttSchema, '2020-01-01')).toBe(true);
+    expect(accepts(m.SelecttSchema, '12.5'), 'still not a bare number').toBe(false);
+    expect(accepts(m.SelecttSchema, null), 'still not null').toBe(false);
+  });
+
+  it("takes a Date only under 'none', which is what matches the official module", async () => {
+    const m = await schemasFor('none', 'none');
+    expect(accepts(m.InserttSchema, new Date())).toBe(true);
+    expect(accepts(m.InserttSchema, '2020-01-01')).toBe(false);
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -11,6 +11,7 @@ import type {
 } from '@drzl/validation-core';
 import {
   formatCode,
+  COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
@@ -60,8 +61,15 @@ function tbDateType(
 ): string {
   // TypeBox has no Date primitive that also accepts an ISO string, so a coercing position is
   // stated as the union the value can actually be.
+  //
+  // Not a bare `Type.String()`. `new Date` reads a bare number as a year or as month.day, so
+  // `'12.5'`, `'0101'` and `'010'` all passed here and Postgres refuses all three. `pattern` is
+  // how TypeBox states it, the same way a column format is stated; see `COERCIBLE_DATE_STRING`
+  // for what was measured and why.
   if (coerceDates === 'none') return 'Type.Date()';
-  const union = 'Type.Union([Type.Date(), Type.String()])';
+  const union =
+    `Type.Union([Type.Date(), Type.String({ pattern: ` +
+    `${JSON.stringify(COERCIBLE_DATE_STRING)} })])`;
   if (coerceDates === 'all') return union;
   return mode === 'select' ? 'Type.Date()' : union;
 }

--- a/packages/generator-typebox/test/date-coercion.spec.ts
+++ b/packages/generator-typebox/test/date-coercion.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * What a `mode: 'date'` column accepts on write, in TypeBox output.
+ *
+ * `coerceDates` defaults to accepting a string beside the `Date` on insert and update, which is
+ * what lets a client send an ISO string. That branch used to be a bare `Type.String()`, so
+ * `'12.5'`, `'0101'` and `'010'` all passed and Postgres refuses all three: the schema passed and
+ * the INSERT then failed at the server, which is the one outcome an Insert schema exists to
+ * prevent.
+ *
+ * Both `Value.Check` and `TypeCompiler` are exercised, because a `pattern` the compiler builds
+ * differently from the interpreter is a schema that validates one way read and another way run.
+ */
+import { describe, it, expect } from 'vitest';
+import { TypeBoxGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'Date',
+    dbType: 'TIMESTAMP',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+async function schemasFor(
+  coerceDates: 'input' | 'all' | 'none',
+  label: string
+): Promise<Record<string, never>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [
+      { name: 't', tsName: 't', columns: [col('at')], unique: [], indexes: [], checks: [] },
+    ] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-dates');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir, coerceDates } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), file);
+  return await import(file);
+}
+
+const accepts = (schema: any, x: unknown) => Value.Check(schema.properties.at, x);
+/** The same question through the compiler, which is a separate implementation of the same check. */
+const compiled = (schema: any, x: unknown) => TypeCompiler.Compile(schema.properties.at).Check(x);
+
+describe('the default, which accepts a string on write only', () => {
+  it('takes a Date and every notation Postgres and V8 read as the same date', async () => {
+    const m = await schemasFor('input', 'input');
+    for (const check of [accepts, compiled]) {
+      expect(check(m.InserttSchema, new Date()), 'a Date').toBe(true);
+      for (const s of [
+        '2020-01-01',
+        '2020-01-01T00:00:00Z',
+        '1999-01-08 04:05:06',
+        '01/02/2020',
+        'January 8, 1999',
+        '2020-1-5',
+        '  2020-01-01  ',
+      ]) {
+        expect(check(m.InserttSchema, s), s).toBe(true);
+      }
+    }
+  });
+
+  it('refuses a string that is only a number, which Postgres does not read as a date', async () => {
+    const m = await schemasFor('input', 'input');
+    for (const check of [accepts, compiled]) {
+      for (const s of ['12.5', '0101', '010']) {
+        expect(check(m.InserttSchema, s), s).toBe(false);
+        expect(Number.isNaN(new Date(s).getTime()), `${s} is a valid Date in V8`).toBe(false);
+      }
+      for (const s of ['2020', '99', '1', '0', '.5', '+2020-01-01', '-2020-01-01', ' 2020 ', '']) {
+        expect(check(m.InserttSchema, s), s).toBe(false);
+      }
+    }
+  });
+
+  it('still refuses the values a bare coercion would have taken', async () => {
+    const m = await schemasFor('input', 'input');
+    for (const check of [accepts, compiled]) {
+      expect(check(m.InserttSchema, null), 'null on a NOT NULL column').toBe(false);
+      expect(check(m.InserttSchema, true), 'a boolean').toBe(false);
+      expect(check(m.InserttSchema, [1, 2]), 'an array').toBe(false);
+    }
+  });
+
+  it('leaves select strict, since a row out of the database is already a Date', async () => {
+    const m = await schemasFor('input', 'input');
+    expect(accepts(m.SelecttSchema, new Date())).toBe(true);
+    expect(accepts(m.SelecttSchema, '2020-01-01'), 'a string on select').toBe(false);
+  });
+});
+
+describe('the explicit settings', () => {
+  it("accepts a string on select too under 'all', and narrows there as well", async () => {
+    const m = await schemasFor('all', 'all');
+    expect(accepts(m.SelecttSchema, '2020-01-01')).toBe(true);
+    expect(accepts(m.SelecttSchema, '12.5'), 'still not a bare number').toBe(false);
+    expect(accepts(m.SelecttSchema, null), 'still not null').toBe(false);
+  });
+
+  it("takes a Date only under 'none', which is what matches the official module", async () => {
+    const m = await schemasFor('none', 'none');
+    expect(accepts(m.InserttSchema, new Date())).toBe(true);
+    expect(accepts(m.InserttSchema, '2020-01-01')).toBe(false);
+  });
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -7,6 +7,7 @@ import type {
 } from '@drzl/validation-core';
 import type { CardinalityCheck, ColumnCheck, ColumnSet, LengthCheck } from '@drzl/validation-core';
 import {
+  COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
@@ -38,7 +39,13 @@ function vDateExpr(
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>
 ): string {
   if (coerceDates === 'none') return 'v.date()';
-  const coercer = `v.pipe(v.string(), v.transform((s) => new Date(s)))`;
+  // Not every string. `new Date` reads a bare number as a year or as month.day, so `'12.5'`,
+  // `'0101'` and `'010'` all became real dates here and Postgres refuses all three. The regex
+  // runs before the transform, so a string that is not a date notation never reaches `new Date`;
+  // see `COERCIBLE_DATE_STRING` for what was measured and why.
+  const coercer =
+    `v.pipe(v.string(), v.regex(new RegExp(${JSON.stringify(COERCIBLE_DATE_STRING)})), ` +
+    `v.transform((s) => new Date(s)))`;
   if (coerceDates === 'all') return `v.union([v.date(), ${coercer}])`;
   // 'input'
   return mode === 'select' ? 'v.date()' : `v.union([v.date(), ${coercer}])`;

--- a/packages/generator-valibot/test/date-coercion.spec.ts
+++ b/packages/generator-valibot/test/date-coercion.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * What a `mode: 'date'` column accepts on write, in valibot output.
+ *
+ * `coerceDates` defaults to coercing on insert and update, which is what lets a client send an ISO
+ * string. The coercing branch is a `v.pipe(v.string(), ...)` beside `v.date()`, and it used to take
+ * any string at all. `new Date` reads a bare number as a year or as `month.day`, so `'12.5'`,
+ * `'0101'` and `'010'` all went through and Postgres refuses all three: the schema passed and the
+ * INSERT then failed at the server, which is the one outcome an Insert schema exists to prevent.
+ *
+ * Everything here runs the emitted module rather than reading its text, because the regex sits
+ * between two pipe steps and only running it says which strings reach `new Date`.
+ */
+import { describe, it, expect } from 'vitest';
+import { ValibotGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import * as v from 'valibot';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'Date',
+    dbType: 'TIMESTAMP',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+async function schemasFor(
+  coerceDates: 'input' | 'all' | 'none',
+  label: string
+): Promise<Record<string, never>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [
+      { name: 't', tsName: 't', columns: [col('at')], unique: [], indexes: [], checks: [] },
+    ] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-dates');
+  await fs.mkdir(dir, { recursive: true });
+  await new ValibotGenerator(analysis).generate({ outDir: dir, coerceDates } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.valibot.ts'), file);
+  return await import(file);
+}
+
+const accepts = (schema: any, x: unknown) => v.safeParse(schema.entries.at, x).success;
+
+describe('the default, which coerces on write only', () => {
+  it('takes a Date and every notation Postgres and V8 read as the same date', async () => {
+    const m = await schemasFor('input', 'input');
+    expect(accepts(m.InserttSchema, new Date()), 'a Date').toBe(true);
+    for (const s of [
+      '2020-01-01',
+      '2020-01-01T00:00:00Z',
+      '1999-01-08 04:05:06',
+      '01/02/2020',
+      'January 8, 1999',
+      '2020-1-5',
+      '  2020-01-01  ',
+    ]) {
+      expect(accepts(m.InserttSchema, s), s).toBe(true);
+    }
+  });
+
+  it('refuses a string that is only a number, which Postgres does not read as a date', async () => {
+    const m = await schemasFor('input', 'input');
+    for (const s of ['12.5', '0101', '010']) {
+      expect(accepts(m.InserttSchema, s), s).toBe(false);
+      expect(Number.isNaN(new Date(s).getTime()), `${s} is a valid Date in V8`).toBe(false);
+    }
+    for (const s of ['2020', '99', '1', '0', '.5', '+2020-01-01', '-2020-01-01', ' 2020 ', '']) {
+      expect(accepts(m.InserttSchema, s), s).toBe(false);
+    }
+  });
+
+  it('still refuses the values a bare coercion would have taken', async () => {
+    const m = await schemasFor('input', 'input');
+    expect(accepts(m.InserttSchema, null), 'null on a NOT NULL column').toBe(false);
+    expect(accepts(m.InserttSchema, true), 'a boolean').toBe(false);
+    expect(accepts(m.InserttSchema, [1, 2]), 'an array').toBe(false);
+  });
+
+  it('leaves select strict, since a row out of the database is already a Date', async () => {
+    const m = await schemasFor('input', 'input');
+    expect(accepts(m.SelecttSchema, new Date())).toBe(true);
+    expect(accepts(m.SelecttSchema, '2020-01-01'), 'a string on select').toBe(false);
+  });
+});
+
+describe('the explicit settings', () => {
+  it("coerces on select too under 'all', and narrows there as well", async () => {
+    const m = await schemasFor('all', 'all');
+    expect(accepts(m.SelecttSchema, '2020-01-01')).toBe(true);
+    expect(accepts(m.SelecttSchema, '12.5'), 'still not a bare number').toBe(false);
+    expect(accepts(m.SelecttSchema, null), 'still not null').toBe(false);
+  });
+
+  it("coerces nowhere under 'none', which is what matches the official module", async () => {
+    const m = await schemasFor('none', 'none');
+    expect(accepts(m.InserttSchema, new Date())).toBe(true);
+    expect(accepts(m.InserttSchema, '2020-01-01')).toBe(false);
+  });
+});

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -16,6 +16,7 @@ import {
   parseCheck,
   renderDuplicateFinder,
   resolveConfiguredImport,
+  COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
@@ -340,8 +341,14 @@ function zodExprForColumn(
       // a string, so a NOT NULL timestamp column accepted `null`, `true` and an array on insert.
       // Coercing only from the two types that carry a date, and validating the result, keeps the
       // intent while rejecting all three.
+      //
+      // Not every string either. `new Date` reads a bare number as a year or as month.day, so
+      // `'12.5'`, `'0101'` and `'010'` were all real dates here and Postgres refuses all three.
+      // A string that does not match `COERCIBLE_DATE_STRING` is passed through untouched and the
+      // `z.date()` behind it turns it away; see that constant for what was measured and why.
       const coerced =
-        "z.preprocess((v) => (typeof v === 'string' || typeof v === 'number' ? new Date(v) : v), z.date())";
+        `z.preprocess((v) => (typeof v === 'number' || (typeof v === 'string' && ` +
+        `new RegExp(${JSON.stringify(COERCIBLE_DATE_STRING)}).test(v)) ? new Date(v) : v), z.date())`;
       if (coerceDates === 'all') return coerced;
       if (coerceDates === 'none') return 'z.date()';
       // 'input'

--- a/packages/generator-zod/test/date-coercion.spec.ts
+++ b/packages/generator-zod/test/date-coercion.spec.ts
@@ -6,6 +6,12 @@
  * anything: `new Date(null)` is the epoch, `new Date(true)` is one millisecond past it, and
  * `new Date([1, 2])` parses the array as a string. So a NOT NULL timestamp column accepted
  * `null`, `true` and an array, and every one of them silently became a real date.
+ *
+ * Narrowing to strings and numbers was not enough. `new Date` reads a bare number as a year or as
+ * `month.day`, so `'12.5'`, `'0101'` and `'010'` were real dates too, and Postgres refuses all
+ * three: the schema passed and the INSERT then failed at the server. A string now has to look like
+ * a date notation before it is coerced at all; `COERCIBLE_DATE_STRING` in validation-core carries
+ * the measurement.
  */
 import { describe, it, expect } from 'vitest';
 import { ZodGenerator } from '../src/index';
@@ -63,6 +69,43 @@ describe('the default, which coerces on write only', () => {
     expect(accepts(m.InserttSchema, 'nonsense'), 'an unparseable string').toBe(false);
   });
 
+  it('refuses a string that is only a number, which Postgres does not read as a date', async () => {
+    // The three the ground-truth gate caught. `new Date('12.5')` is a real date in V8, and so are
+    // `'0101'` and `'010'`, so the insert passed validation and then failed at the server.
+    const m = await schemasFor('input', 'input');
+    for (const s of ['12.5', '0101', '010']) {
+      expect(accepts(m.InserttSchema, s), s).toBe(false);
+      expect(Number.isNaN(new Date(s).getTime()), `${s} is a valid Date in V8`).toBe(false);
+    }
+    for (const s of ['2020', '99', '1', '0', '.5', '+2020-01-01', '-2020-01-01', ' 2020 ']) {
+      expect(accepts(m.InserttSchema, s), s).toBe(false);
+    }
+  });
+
+  it('still takes every notation Postgres and V8 read as the same date', async () => {
+    const m = await schemasFor('input', 'input');
+    for (const s of [
+      '2020-01-01',
+      '2020-01-01T00:00:00Z',
+      '1999-01-08 04:05:06',
+      '01/02/2020',
+      'January 8, 1999',
+      '2020-1-5',
+      '  2020-01-01  ',
+    ]) {
+      expect(accepts(m.InserttSchema, s), s).toBe(true);
+    }
+  });
+
+  it('leaves the number path alone, so an epoch millisecond still coerces', async () => {
+    // The narrowing is about strings. A number carries no notation to be wrong about, and
+    // `1700000000000` as a string is refused while the same value as a number is taken.
+    const m = await schemasFor('input', 'input');
+    expect(accepts(m.InserttSchema, 1700000000000), 'a number').toBe(true);
+    expect(accepts(m.InserttSchema, 0), 'the epoch').toBe(true);
+    expect(accepts(m.InserttSchema, '1700000000000'), 'the same value as a string').toBe(false);
+  });
+
   it('leaves select strict, since a row out of the database is already a Date', async () => {
     const m = await schemasFor('input', 'input');
     expect(accepts(m.SelecttSchema, new Date())).toBe(true);
@@ -75,6 +118,7 @@ describe('the explicit settings', () => {
     const m = await schemasFor('all', 'all');
     expect(accepts(m.SelecttSchema, '2020-01-01')).toBe(true);
     expect(accepts(m.SelecttSchema, null), 'still not null').toBe(false);
+    expect(accepts(m.SelecttSchema, '12.5'), 'and still not a bare number').toBe(false);
   });
 
   it("coerces nowhere under 'none', which is what matches the official module", async () => {

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -179,6 +179,51 @@ export const COLUMN_FORMATS: Record<string, string> = {
 };
 
 /**
+ * Which strings a `mode: 'date'` column may coerce, for `coerceDates`.
+ *
+ * A string matching this may be handed to `new Date`; one that does not is left alone and fails
+ * the `Date` check that follows it. This narrows coercion, it does not remove it: `coerceDates`
+ * still decides *where* a string is coerced at all.
+ *
+ * Two things are refused, both measured against a real Postgres through PGlite.
+ *
+ * **A string that is only a number.** V8's legacy date parser reads a bare digit run as a year,
+ * or as `month.day`, so `new Date('12.5')`, `new Date('0101')` and `new Date('010')` are all real
+ * dates. Postgres refuses those three, so the insert passed validation and then failed at the
+ * server, which is the outcome an Insert schema exists to prevent.
+ *
+ * The obvious justification for the rule, that Postgres refuses a bare number, is false. Postgres
+ * reads a six or eight digit run as a compact `YYMMDD` / `YYYYMMDD` date and takes it happily. The
+ * real justification is stronger: where both parsers accept such a string they never agree on
+ * which date it is. Measured over every all-digit string in the probe set that both accept, ten of
+ * them, the two answers differed every single time and none of the ten agreed:
+ *
+ *   '250101'    Postgres 2025-01-01    V8 the year 250101
+ *   '241231'    Postgres 2024-12-31    V8 the year 241231
+ *   '121212'    Postgres 2012-12-12    V8 the year 121212
+ *   '000101'    Postgres 2000-01-01    V8 0100-12-31
+ *
+ * So coercing a bare number is not merely permissive. Either the value reaches the server and is
+ * rejected, or it is silently written as a different date than the one the database would have
+ * stored. Refusing to coerce it is the only answer that is never wrong.
+ *
+ * **A string starting with a sign.** `new Date('+2020-01-01')` and `new Date('-2020-01-01')` are
+ * valid dates in V8 and Postgres refuses both. It also costs nothing: the sign-prefixed strings
+ * Postgres does take are `infinity`, `+infinity` and `-infinity`, and no JS `Date` represents
+ * those, so a `mode: 'date'` column could never carry one whatever this pattern said.
+ *
+ * Not to be confused with the rejected `date` entry in `COLUMN_FORMATS` above. That would have
+ * constrained a string-typed date column, whose value goes to the server verbatim, so refusing
+ * `20200101` or `infinity` there would turn away a working insert. Here the string is on its way
+ * into a JS `Date`, and neither of those survives the trip.
+ *
+ * Verified still coercing, both parsers agreeing on the date: `2020-01-01`,
+ * `2020-01-01T00:00:00Z`, `1999-01-08 04:05:06`, `01/02/2020`, `January 8, 1999`, `2020-1-5` and
+ * `  2020-01-01  `.
+ */
+export const COERCIBLE_DATE_STRING = '^(?!\\s*[+-])(?!\\s*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?\\s*$)';
+
+/**
  * Why a character limit is not `.max(n)`.
  *
  * Postgres and MySQL count `varchar(n)` in **characters**; every JavaScript validator counts

--- a/packages/validation-core/test/coercible-date-string.spec.ts
+++ b/packages/validation-core/test/coercible-date-string.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * The pattern that decides which strings a `mode: 'date'` column may coerce.
+ *
+ * Every expectation here is a measurement against a real Postgres through PGlite, not a reading of
+ * the regex. The columns are `date` and `timestamp`; the two answers per string are "does Postgres
+ * take it" and "does `new Date(s)` produce a valid Date", and the pattern's job is to keep the
+ * cases where those two disagree out of the coercion.
+ */
+import { describe, it, expect } from 'vitest';
+import { COERCIBLE_DATE_STRING } from '../src/index';
+
+const re = () => new RegExp(COERCIBLE_DATE_STRING);
+const coercible = (s: string) => re().test(s);
+
+describe('strings the pattern refuses to coerce', () => {
+  it('refuses the three the ground-truth gate caught, which Postgres rejects', () => {
+    // `new Date` reads each of these as a year or as month.day. Postgres refuses all three, so
+    // the insert passed validation and then failed at the server.
+    for (const s of ['0101', '010', '12.5']) {
+      expect(coercible(s), s).toBe(false);
+    }
+  });
+
+  it('refuses every other bare number Postgres rejects', () => {
+    for (const s of ['2020', '99', '1', '0', '1700000000000', '.5', '5.', '1e3', ' 2020 ']) {
+      expect(coercible(s), s).toBe(false);
+    }
+  });
+
+  it('refuses the bare numbers Postgres accepts, because the two read them differently', () => {
+    // Postgres takes a six or eight digit run as a compact YYMMDD / YYYYMMDD date, so the simple
+    // justification "Postgres refuses a bare number" is false. What holds instead is that the two
+    // parsers never agree on which date it is: over every all-digit string in the probe set that
+    // both accept the two answers differed every single time. Each row below is what a real
+    // Postgres stored for that string through PGlite, beside what `new Date` makes of it.
+    const BOTH_ACCEPT: Array<[string, string]> = [
+      ['200101', '2020-01-01'],
+      ['250101', '2025-01-01'],
+      ['241231', '2024-12-31'],
+      ['121212', '2012-12-12'],
+      ['010101', '2001-01-01'],
+      ['000101', '2000-01-01'],
+      ['111111', '2011-11-11'],
+    ];
+    for (const [s, postgres] of BOTH_ACCEPT) {
+      expect(coercible(s), s).toBe(false);
+      const d = new Date(s);
+      expect(Number.isNaN(d.getTime()), `${s} is a valid Date in V8`).toBe(false);
+      expect(d.toISOString().slice(0, 10), `${s} in V8 vs Postgres`).not.toBe(postgres);
+    }
+    // Eight digits: Postgres accepts, V8 refuses outright since the year exceeds its 275760 cap.
+    for (const s of ['20200101', '19990108']) {
+      expect(coercible(s), s).toBe(false);
+      expect(Number.isNaN(new Date(s).getTime()), `${s} in V8`).toBe(true);
+    }
+  });
+
+  it('refuses a leading sign, which V8 accepts and Postgres does not', () => {
+    for (const s of ['+2020-01-01', '-2020-01-01', '+1', '-1']) {
+      expect(coercible(s), s).toBe(false);
+    }
+    // The sign-prefixed strings Postgres does take, and no JS Date represents any of them, so a
+    // `mode: 'date'` column could never carry one whatever this pattern said.
+    for (const s of ['+infinity', '-infinity']) {
+      expect(coercible(s), s).toBe(false);
+      expect(Number.isNaN(new Date(s).getTime()), `${s} in V8`).toBe(true);
+    }
+  });
+
+  it('refuses an empty or blank string', () => {
+    for (const s of ['', '  ', '\t\n']) {
+      expect(coercible(s), JSON.stringify(s)).toBe(false);
+    }
+  });
+});
+
+describe('strings the pattern still coerces', () => {
+  it('takes every notation Postgres and V8 both read as the same date', () => {
+    for (const s of [
+      '2020-01-01',
+      '2020-01-01T00:00:00Z',
+      '2020-01-01 00:00:00',
+      '1999-01-08 04:05:06',
+      '01/02/2020',
+      'January 8, 1999',
+      '2020-1-5',
+      '  2020-01-01  ',
+    ]) {
+      expect(coercible(s), s).toBe(true);
+      expect(Number.isNaN(new Date(s).getTime()), `${s} in V8`).toBe(false);
+    }
+  });
+
+  it('is anchored, so a date buried inside a refused string stays refused', () => {
+    // The pattern is all lookahead, and `test` is unhooked from any anchor the caller adds, so
+    // this asserts the `^` is doing its work rather than the match sliding along the string.
+    expect(coercible('0101')).toBe(false);
+    expect(coercible('12.5')).toBe(false);
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1961,8 +1961,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'coerceDates accepts a date string or epoch number on write',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   'pg/c_ts_d': {
@@ -1970,8 +1970,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'as pg/c_date_d',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   'mysql/m_date': {
@@ -1979,8 +1979,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'as pg/c_date_d',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   'mysql/m_datetime': {
@@ -1988,8 +1988,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'as pg/c_date_d',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   'mysql/m_ts': {
@@ -1997,8 +1997,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'as pg/c_date_d',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   'sqlite/s_int_ts': {
@@ -2006,8 +2006,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'as pg/c_date_d',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   'sqlite/s_int_ts_ms': {
@@ -2015,8 +2015,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'as pg/c_date_d',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   // Official emits `Type.String({ format: 'uuid' })`, and TypeBox fails a format it has no entry
@@ -2204,8 +2204,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'as pg/c_ts_d',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   // The first divergence in either pass that comes from a CHECK, because `matrix` carries none and
@@ -2231,8 +2231,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'as pg/c_date_d',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   'mysql/m_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/n_check, in MySQL spelling', divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 1900, 2000, 2500, 17, 101` } },
@@ -2244,8 +2244,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'as sqlite/s_int_ts',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   'sqlite/s_n_ts_ms': {
@@ -2253,8 +2253,8 @@ const ALLOWED: Record<string, Waiver> = {
     modes: WRITE,
     why: 'as sqlite/s_int_ts_ms',
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
   },
   'sqlite/s_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, why: "as pg/n_check; the extra label is official's SQLite integer bound being the safe-integer range where its Postgres one is int32", divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, 17, 101` } },
@@ -4269,30 +4269,25 @@ for (const col of cols) {
 }
 
 /**
- * Insert-side over-permissiveness, filed and pinned rather than fixed here.
+ * Insert-side over-permissiveness, filed and pinned rather than fixed.
  *
- * `date({ mode: 'date' })` and `timestamp({ mode: 'date' })` emit a coercing schema, and coercion
- * to a `Date` is far looser than Postgres's date parser: `new Date('12.5')` is a real date in V8,
- * and `'0101'` and `'010'` are dates too. Postgres refuses all three, so validation passes and the
- * INSERT then fails at the server, which is the one outcome an Insert schema exists to prevent.
+ * Empty, and that is a result. It held six pins: `c_date_d` and `c_ts_d` on `'0101'`, `'010'` and
+ * `'12.5'`, all strings `new Date()` turns into a real date and Postgres refuses, so validation
+ * passed and the INSERT then failed at the server. They appeared the moment this stage began
+ * grading the Insert schema rather than the Select one; they had always been there with nothing
+ * asking the question. Narrowing what a coerced string may be (AX) made all six stop firing, and a
+ * pin that stops firing fails the run, which is how the fix reported itself here.
  *
- * These surfaced the moment this stage began grading the Insert schema instead of the Select one.
- * They were always here; nothing was asking the question. Fixing the coercion changes emitted
- * output for every date and timestamp column, so it goes in its own change. Addendum AX.
+ * The rule that replaced them is worth keeping in view, because the obvious one is wrong. Postgres
+ * reads a 6 or 8 digit run as a compact date, so "the server refuses bare numbers" is false: ten
+ * such strings are accepted by both parsers. In every one of those ten the two disagree about
+ * which date it is, `'200101'` being 2020-01-01 to Postgres and the year 200101 to V8. So the test
+ * is not that the server refuses the string, it is that coercing it either fails at the server or
+ * silently writes a different date than the database would have stored.
  *
- * Pinned by column and probe label, asserted in both directions: an unpinned disagreement fails,
- * and a pin that stops firing fails too, which is how the fix will announce itself.
+ * Kept rather than deleted so the next one has somewhere to go that is asserted in both directions.
  */
-const DEFECTS: Record<string, { why: string; labels: string[] }> = {
-  c_date_d: {
-    why: 'mode date coerces; new Date() parses strings Postgres will not',
-    labels: ["'0101'", "'010'", "'12.5'"],
-  },
-  c_ts_d: {
-    why: 'as c_date_d',
-    labels: ["'0101'", "'010'", "'12.5'"],
-  },
-};
+const DEFECTS: Record<string, { why: string; labels: string[] }> = {};
 
 const firedDefects = new Set<string>();
 const pinned = (r: Row): boolean => {
@@ -7082,18 +7077,18 @@ const ALLOWED: Record<string, Entry> = {
     libs: LIB_NAMES,
     modes: WRITE,
     divergence: {
-      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,
+      '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
+      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
     },
     drzl: 'a Date, or a string or number coerced to one',
     official: 'a Date only',
     filed: 'not a defect: coerceDates',
   },
-  'pg/c_ts_d': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'mysql/m_date': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'mysql/m_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'mysql/m_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'sqlite/s_int_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'pg/c_ts_d': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_date': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'sqlite/s_int_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   // TypeBox fails a format it has no entry for rather than ignoring it, so official's schema
   // rejects every valid uuid in any project that has not populated `FormatRegistry` first.
   'pg/c_uuid': {
@@ -7205,7 +7200,7 @@ const ALLOWED: Record<string, Entry> = {
   'pg/n_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, '*/arktype': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_real', official: 'as pg/c_real', filed: 'as pg/c_real' },
   'pg/n_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
   'pg/n_point': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: [1,2,3]` }, drzl: 'as pg/c_point', official: 'as pg/c_point', filed: 'as pg/c_point' },
-  'pg/n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'pg/n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   // The database has already answered this one in this same script: the CHECK ground-truth stage
   // runs 53 probes over the `checked` table against a real Postgres and reports rows Postgres
   // rejects and the validator accepts as DRZL 0, drizzle-orm 22, and `k_between BETWEEN 5 AND 15`
@@ -7216,11 +7211,11 @@ const ALLOWED: Record<string, Entry> = {
   'mysql/m_n_tinytext': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 100 emoji` }, drzl: 'as mysql/m_tinytext', official: 'as mysql/m_tinytext', filed: 'as mysql/m_tinytext' },
   'mysql/m_n_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` }, drzl: 'as mysql/m_float', official: 'as mysql/m_float', filed: 'as pg/c_real' },
   'mysql/m_n_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
-  'mysql/m_n_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_n_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   'mysql/m_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 1900, 2000, 2500, 17, 101` }, drzl: 'as pg/n_check', official: 'as pg/n_check', filed: 'as pg/n_check' },
   'sqlite/s_n_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
   'sqlite/s_n_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
-  'sqlite/s_n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', '12.5', '0101', '010', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: "", 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1', '12.5', '0101', '010' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'sqlite/s_n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   'sqlite/s_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, 17, 101` }, drzl: 'as pg/n_check', official: 'as pg/n_check', filed: 'as pg/n_check' },
   // ---- binary and varbinary, where only DRZL enforces the declared width ----------------------
   // These two were DEFECTS here until the analyzer stopped calling a byte string a Uint8Array. They


### PR DESCRIPTION
Addendum AX. `date({ mode: 'date' })` and `timestamp({ mode: 'date' })` emit a coercing schema, and coercion to a `Date` is looser than Postgres's parser.

```
c_date_d and c_ts_d on '0101', '010', '12.5'
Postgres rejects, DRZL accepted
```

`new Date('12.5')` is a real date in V8. Validation passed and the INSERT then failed at the server, which is the one outcome an Insert schema exists to prevent. Surfaced the moment the ground-truth stage began grading the Insert schema rather than the Select one (#124); it had always been there with nothing asking the question.

## The obvious rule is wrong, and the measurement said so

I proposed: *a string that is only digits is not a date notation, and Postgres refuses these.* The second half is false. Postgres reads a 6 or 8 digit run as a compact `YYMMDD`/`YYYYMMDD` date, so **ten** bare-number strings are accepted by both parsers.

What holds is stronger. In **every one of those ten**, the two parsers disagree about which date it is:

```
'200101'    Postgres 2020-01-01    V8 the year 200101
'000101'    Postgres 2000-01-01    V8 0100-12-31
'241231'    Postgres 2024-12-31    V8 the year 241231
'20200101'  Postgres 2020-01-01    V8 refuses it (year > 275760)
```

Zero agreements out of ten. So the test is not *the server refuses the string*, it is **coercing it either fails at the server or silently writes a different date than the database would have stored**. Refusing is the only answer that is never wrong, and the second failure mode is the worse one: no error anywhere, just a row holding the year 250101.

A leading sign goes for the same reason: `'+2020-01-01'` is valid in V8 and Postgres refuses it. The signed strings Postgres does take, `infinity` and `-infinity`, have no JS `Date` representation and were already refused.

## What changed

`COERCIBLE_DATE_STRING` in `validation-core`, alternation free because a `|` inside an ArkType regex literal shares a character with its union operator:

```
^(?!\s*[+-])(?!\s*\d*\.?\d*(?:[eE][+-]?\d+)?\s*$)
```

All four validator generators coerce and all four changed. `generator-json-schema` does not coerce and is untouched. The `coerceDates` option and its `all`/`none`/`input` behaviour are unchanged: this narrows what a coerced string may be, it does not remove coercion. Numbers are untouched, so `1700000000000` as a number still coerces while the same value as a string does not.

## How the gate reported it

All six `DEFECTS` pins written when AX was filed went stale, which fails the build by design:

```
FAIL: these DEFECTS pins matched nothing on this run:
  c_date_d on '0101'   c_date_d on '010'   c_date_d on '12.5'
  c_ts_d   on '0101'   c_ts_d   on '010'   c_ts_d   on '12.5'
```

Agreement with Postgres went 1061 to 1067, exactly the six. That ledger is now empty, with the corrected rule written into its docstring so nobody re-derives the wrong one.

Ledger cascade: 60 substitutions across 20 entries, both majors together. Each also drops a stale `""`, which the new pattern refuses and Postgres refuses too.

Only the size budgets moved otherwise, all still under, with arktype and typebox at 18 bytes/column headroom.

## Tests

Written first and confirmed red against the unmodified sources. Every spec evaluates the emitted module rather than diffing its text; TypeBox is checked through both `Value.Check` and `TypeCompiler`. Per generator: the three strings refused, `'2020-01-01'` and an ISO timestamp still pass, a real `Date` still passes, and `null`/`true`/`[1,2]` still refused on a NOT NULL column. That last guarantee was previously asserted only for zod and is now asserted in all four.

## Three things I want visible rather than buried

1. **`'20200101'` and `'990108'` are now refused where Postgres accepts them.** A deliberate narrowing against the repo's "never reject what the database accepts" rule: a `mode: 'date'` column cannot carry a value no JS `Date` represents, and the same rule is what stops `'250101'` being written as the year 250101. For zod this is a no-op since V8 already refused them.
2. **valibot, arktype and typebox remain looser in a different way**, outside this addendum: they accept any non-numeric string without checking it parses, so `'hello'` passes on a date column. zod does not, because `z.date()` validates the coerced result. Separate defect, left alone.
3. The 0.4x ledger edit was applied blind, since the run halts at the v1 stage. It is confirmed by this run reaching exit 0.

`pnpm verify:packed`, `build`, `-r test` (1218 tests), `typecheck`, `lint`, `docs build` all green.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4