### PR TITLE
fix(generators): require a date string to parse to a real date

### DIFF
--- a/.changeset/date-string-must-parse.md
+++ b/.changeset/date-string-must-parse.md
@@ -1,0 +1,45 @@
+---
+'@drzl/validation-core': patch
+'@drzl/generator-typebox': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-arktype': patch
+---
+
+`date({ mode: 'date' })` and `timestamp({ mode: 'date' })` stop accepting a string that is not a
+date, in the valibot, ArkType and TypeBox generators.
+
+`coerceDates` lets a client send a date as a string, and a previous fix narrowed *which* strings may
+be coerced: one that is entirely a number, or that starts with a sign, is refused, because V8 and
+Postgres disagree about what such a string means. That was a gate on the shape of the input, and
+these three generators asked nothing at all about the result. So every string that was not a bare
+number went through: `'hello'`, `'zzz'`, `'25:99:99'`, `'not-a-uuid'`, `'10.0.0.1'`, a uuid, a
+300-character run of `x` and a string of emoji all validated, all became an Invalid Date, and
+Postgres refuses every one of them. Validation passed and the INSERT then failed at the server,
+which is the one outcome an Insert schema exists to prevent.
+
+The zod generator was already correct and is what the other three now match. `z.preprocess(coerce,
+z.date())` validates what came *out* of the coercion, and an Invalid Date is a real `Date` instance
+that `z.date()` still turns away, so no bare instance check would have done: the timestamp is the
+only thing that differs and it is `NaN`.
+
+Each library states it in the form it has. valibot adds a `v.check` after the transform, which sees
+the transform's output rather than its input. ArkType adds a `.narrow`, because the constraint is a
+predicate over the result of a call and its string DSL cannot state one. TypeBox has no declarative
+form for it either, so it intersects the registered kind it already uses for character caps onto the
+string branch; the `pattern` beside it still serialises into a JSON Schema, the intersected branch
+does not.
+
+**What changes for you.** On a `mode: 'date'` column, a string that `new Date` cannot parse is no
+longer accepted on the write path. Everything that reads as a date is untouched: `'2020-01-01'`,
+`'2020-01-01T00:00:00Z'`, `'1999-01-08 04:05:06'`, `'01/02/2020'`, `'January 8, 1999'`, `'2020-1-5'`
+and `'  2020-01-01  '` all still pass, as does a real `Date`. `coerceDates` itself is unchanged and
+its `all` / `none` / `input` behaviour is the same, so `'none'` still emits a plain date type and
+`'all'` still narrows the select schema the same way as the write schemas.
+
+`'12:00:00'` is worth naming, because the two parsers could have disagreed about it and do not.
+`new Date('12:00:00')` is an Invalid Date, and Postgres refuses `'12:00:00'` for `date`, `timestamp`
+and `timestamptz` with `invalid input syntax`. The types that do take it are `time`, `timetz` and
+`interval`, none of which is ever a `mode: 'date'` column. So it is refused, and both sides agree it
+should be.
+
+The zod and JSON Schema generators do not change.

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -16,6 +16,7 @@ import {
   isIntegerColumn,
   nonFiniteAccepted,
   parseCheck,
+  parsesToADate,
   renderDuplicateFinder,
   updateColumns,
   selectColumns,
@@ -45,6 +46,10 @@ function atDateType(
   // `'0101'` and `'010'` all passed here and Postgres refuses all three. ArkType states the
   // narrowing as a regex literal in its DSL, the same way a column format is stated; see
   // `COERCIBLE_DATE_STRING` for what was measured and why.
+  //
+  // The regex is only half of it, and the other half cannot be written here: this is the gate on
+  // the *shape* of the string, and what the string turns into is a question about the result of
+  // `new Date`, which no DSL string can ask. That half is `atDateNarrow`.
   const coercible = `Date | /${COERCIBLE_DATE_STRING}/`;
   if (coerceDates === 'all') return coercible;
   // 'input'
@@ -548,7 +553,10 @@ function renderObjectShape(
       // and onto the Type. `atDefault` and `onBuilder` below are that move, so the narrow and the
       // default now coexist and the skip is gone.
       const caps =
-        atCapNarrows(c, mode) + atBigintNarrow(c, checks) + atNonFiniteNarrow(c, checks);
+        atCapNarrows(c, mode) +
+        atBigintNarrow(c, checks) +
+        atNonFiniteNarrow(c, checks) +
+        atDateNarrow(c, mode, coerceDates);
       // A defaultable definition is only valid as an object *property*: `type("bigint = 7")`
       // throws "Defaultable definitions like 'number = 0' are only valid as properties in an
       // object or tuple" at import. A field carrying a narrow is exactly that, a `type(...)` call
@@ -737,6 +745,54 @@ function atNonFiniteNarrow(c: Column, checks: ColumnCheck[]): string {
     c,
     (v) => `(!Number.isFinite(${v}) || (${parts.map((p) => p(v)).join(' && ')}))`,
     `NaN, an infinity, or between ${lower?.value ?? 'any'} and ${upper?.value ?? 'any'}`
+  );
+}
+
+/**
+ * The other half of a coerced date: that the string really is one.
+ *
+ * `atDateType` above puts `COERCIBLE_DATE_STRING` in the DSL, which gates the *shape* of the
+ * string. Nothing gated the result, and the two are not the same question: `'hello'`, `'zzz'`,
+ * `'25:99:99'`, `'not-a-uuid'`, `'10.0.0.1'` and a 300-character run of `x` are none of them bare
+ * numbers, so every one of them matched the pattern and this generator accepted it while Postgres
+ * refuses all of them. See `parsesToADate`.
+ *
+ * A narrow rather than a union branch, because a branch is the wrong direction: a union admits
+ * more and this has to admit less. The constraint is a predicate over the result of a call, which
+ * the string DSL cannot state at all, so it lands where the character caps, the bigint range and
+ * the non-finite range already are.
+ *
+ * The union defect recorded on `atNumberPlan` is *not* the reason, and it does not apply. That one
+ * is the discriminator failing to match `NaN` specifically, which is why the rule there is that
+ * two branches are always safe and so is any number of them with no `NaN` among them. A nullable
+ * date column emits three here, `(Date | /.../ | null)`, and it was run rather than assumed: null,
+ * a `Date` and `'2020-01-01'` are all accepted and `'hello'` is not.
+ *
+ * The narrow sits on the whole value, as every other narrow in this file does, so it has to let a
+ * `Date` through: the union's other branch is a real `Date` and this must not turn it away. That
+ * is what the `typeof` guard is for, and it is why the predicate is a disjunction where the
+ * TypeBox branch carries a conjunction, since there the same check sits on the string alone.
+ *
+ * The guard changes no verdict, and that was measured rather than assumed: an Invalid `Date`
+ * instance is refused by ArkType's own `Date` keyword before a narrow is consulted, on all three
+ * `coerceDates` settings and in all four generators. What reaches this predicate is therefore a
+ * valid `Date` or a string, and `new Date(aValidDate)` has the same timestamp. So the guard buys
+ * clarity and one skipped allocation rather than a different answer.
+ */
+function atDateNarrow(
+  c: Column,
+  mode: Mode,
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>
+): string {
+  if (c.tsType !== 'Date' || c.shape) return '';
+  // The same three-way answer `atDateType` gives, so the narrow is present exactly where the
+  // string branch it narrows is.
+  if (coerceDates === 'none') return '';
+  if (coerceDates === 'input' && mode === 'select') return '';
+  return atNarrow(
+    c,
+    (v) => `(typeof ${v} !== 'string' || ${parsesToADate(`new Date(${v})`)})`,
+    'a date the runtime can parse'
   );
 }
 

--- a/packages/generator-arktype/test/date-coercion.spec.ts
+++ b/packages/generator-arktype/test/date-coercion.spec.ts
@@ -52,6 +52,36 @@ async function schemasFor(
 
 const accepts = (schema: any, x: unknown) => !(schema.get('at')(x) instanceof type.errors);
 
+/**
+ * Strings that are not a bare number, so `COERCIBLE_DATE_STRING` lets them through, and that
+ * `new Date` then turns into an Invalid Date.
+ *
+ * Every one of them is a member of the packed gate's probe pool, and the waiver for the date
+ * columns recorded all of them as accepted here while zod refused them: the pattern gates the
+ * *shape* of the string and nothing looked at what the coercion would produce. An Invalid Date is
+ * still a `Date` instance, so `instanceof` cannot see it and `getTime()` is what has to be asked.
+ */
+const NOT_DATES = [
+  'hello',
+  'zzz',
+  'not-a-uuid',
+  '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  'a',
+  'happy',
+  'x',
+  'xxxxx',
+  '12:00:00',
+  '25:99:99',
+  '999.999.999.999',
+  '10.0.0.1',
+  'x'.repeat(300),
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+  '一'.repeat(300),
+];
+
+/** A probe short enough to name in an assertion message. */
+const label = (s: string) => (s.length > 20 ? `${s.slice(0, 20)}... (${s.length})` : s);
+
 describe('the default, which accepts a string on write only', () => {
   it('takes a Date and every notation Postgres and V8 read as the same date', async () => {
     const m = await schemasFor('input', 'input');
@@ -87,6 +117,15 @@ describe('the default, which accepts a string on write only', () => {
     expect(accepts(m.InserttSchema, [1, 2]), 'an array').toBe(false);
   });
 
+  it('refuses a string that reaches `new Date` and comes back Invalid', async () => {
+    const m = await schemasFor('input', 'input');
+    for (const s of NOT_DATES) {
+      expect(Number.isNaN(new Date(s).getTime()), `${label(s)} is a real date`).toBe(true);
+      expect(accepts(m.InserttSchema, s), label(s)).toBe(false);
+      expect(accepts(m.UpdatetSchema, s), `${label(s)} on update`).toBe(false);
+    }
+  });
+
   it('leaves select strict, since a row out of the database is already a Date', async () => {
     const m = await schemasFor('input', 'input');
     expect(accepts(m.SelecttSchema, new Date())).toBe(true);
@@ -100,6 +139,9 @@ describe('the explicit settings', () => {
     expect(accepts(m.SelecttSchema, '2020-01-01')).toBe(true);
     expect(accepts(m.SelecttSchema, '12.5'), 'still not a bare number').toBe(false);
     expect(accepts(m.SelecttSchema, null), 'still not null').toBe(false);
+    for (const s of NOT_DATES) {
+      expect(accepts(m.SelecttSchema, s), `${label(s)} on select`).toBe(false);
+    }
   });
 
   it("takes a Date only under 'none', which is what matches the official module", async () => {

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -19,6 +19,7 @@ import {
   moduleSpecifier,
   nonFiniteAccepted,
   parseCheck,
+  parsesToADate,
   renderDuplicateFinder,
   resolveAffix,
   resolveConfiguredImport,
@@ -62,16 +63,61 @@ function tbDateType(
   // TypeBox has no Date primitive that also accepts an ISO string, so a coercing position is
   // stated as the union the value can actually be.
   //
-  // Not a bare `Type.String()`. `new Date` reads a bare number as a year or as month.day, so
-  // `'12.5'`, `'0101'` and `'010'` all passed here and Postgres refuses all three. `pattern` is
-  // how TypeBox states it, the same way a column format is stated; see `COERCIBLE_DATE_STRING`
-  // for what was measured and why.
+  // The string branch carries two constraints, because they are two different questions.
+  //
+  // `pattern` is the gate on the string. `new Date` reads a bare number as a year or as month.day,
+  // so `'12.5'`, `'0101'` and `'010'` all passed here and Postgres refuses all three; see
+  // `COERCIBLE_DATE_STRING` for what was measured and why.
+  //
+  // The intersected kind is the gate on the result, and without it any string the pattern let
+  // through was accepted whatever `new Date` made of it: `'hello'`, `'zzz'` and `'25:99:99'` are
+  // not bare numbers, so they matched the pattern and were taken. TypeBox has no declarative form
+  // for this, exactly as it has none for a character cap, so it goes to the same registered kind
+  // the caps use; see `parsesToADate`.
+  //
+  // The `typeof` guard is there because `new Date` throws a TypeError on a bigint and on a symbol,
+  // and a predicate that throws is neither an accept nor a reject. It is not what stops that
+  // happening today: measured on TypeBox 0.34, an intersection stops at its first failing branch
+  // in both `Value.Check` and `TypeCompiler`, so an unguarded assert beside `Type.String` is never
+  // reached with `1n` or with `null` at all. Evaluation order is not something this generator
+  // should be relying on, and the guard costs one comparison.
+  //
+  // The cost is that the extra branch does not survive serialisation to JSON Schema, where the
+  // `pattern` beside it does. Emitting nothing rather than a check JSON Schema cannot state is not
+  // a better trade: JSON has no notion of a string that parses, and the pattern still serialises.
   if (coerceDates === 'none') return 'Type.Date()';
-  const union =
-    `Type.Union([Type.Date(), Type.String({ pattern: ` +
-    `${JSON.stringify(COERCIBLE_DATE_STRING)} })])`;
+  const coercible =
+    `Type.Intersect([Type.String({ pattern: ${JSON.stringify(COERCIBLE_DATE_STRING)} }), ` +
+    `Type.Unsafe<unknown>({
+    [Kind]: 'DrzlRowCheck',
+    description: 'a date the runtime can parse',
+    assert: (v: any) => typeof v === 'string' && ${parsesToADate('new Date(v)')},
+  })])`;
+  const union = `Type.Union([Type.Date(), ${coercible}])`;
   if (coerceDates === 'all') return union;
   return mode === 'select' ? 'Type.Date()' : union;
+}
+
+/**
+ * Whether this column, in this mode, emits the coerced-string branch that carries the kind.
+ *
+ * Shared with the preamble check, for the reason `tbNeedsCapKind` and `tbNeedsNonFiniteKind`
+ * carry: two copies of one condition drift, and what a drifted copy emits is `[Kind]` into a file
+ * that did not import it, which throws the moment anything loads the module.
+ *
+ * `mode` is a parameter because `coerceDates: 'input'` answers differently for select than for
+ * the write modes, and the preamble has to be right in both directions: too little and the module
+ * throws at import, too much and it carries an import nothing uses.
+ */
+function tbNeedsDateKind(
+  c: Column,
+  mode: Mode,
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>
+): boolean {
+  if (c.tsType !== 'Date' || c.shape) return false;
+  if (coerceDates === 'none') return false;
+  if (coerceDates === 'all') return true;
+  return mode !== 'select';
 }
 
 /**
@@ -472,8 +518,17 @@ function renderTableSchemas(
   const needsRows =
     rows.some((r) => rowCols.some((s) => s.has(r.left) && s.has(r.right))) ||
     lengths.some((k) => rowCols.some((s) => s.has(k.column))) ||
-    [insertCols, updateCols, selectCols].some((cs) =>
-      cs.some((c) => tbNeedsCapKind(c) || tbNeedsNonFiniteKind(c))
+    (
+      [
+        [insertCols, 'insert'],
+        [updateCols, 'update'],
+        [selectCols, 'select'],
+      ] as Array<[Column[], Mode]>
+    ).some(([cs, m]) =>
+      cs.some(
+        (c) =>
+          tbNeedsCapKind(c) || tbNeedsNonFiniteKind(c) || tbNeedsDateKind(c, m, coerceDates)
+      )
     );
   const rowImport = needsRows ? `, Kind, TypeRegistry` : '';
 

--- a/packages/generator-typebox/test/date-coercion.spec.ts
+++ b/packages/generator-typebox/test/date-coercion.spec.ts
@@ -54,6 +54,36 @@ const accepts = (schema: any, x: unknown) => Value.Check(schema.properties.at, x
 /** The same question through the compiler, which is a separate implementation of the same check. */
 const compiled = (schema: any, x: unknown) => TypeCompiler.Compile(schema.properties.at).Check(x);
 
+/**
+ * Strings that are not a bare number, so `COERCIBLE_DATE_STRING` lets them through, and that
+ * `new Date` then turns into an Invalid Date.
+ *
+ * Every one of them is a member of the packed gate's probe pool, and the waiver for the date
+ * columns recorded all of them as accepted here while zod refused them: the pattern gates the
+ * *shape* of the string and nothing looked at what the coercion would produce. An Invalid Date is
+ * still a `Date` instance, so `instanceof` cannot see it and `getTime()` is what has to be asked.
+ */
+const NOT_DATES = [
+  'hello',
+  'zzz',
+  'not-a-uuid',
+  '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  'a',
+  'happy',
+  'x',
+  'xxxxx',
+  '12:00:00',
+  '25:99:99',
+  '999.999.999.999',
+  '10.0.0.1',
+  'x'.repeat(300),
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+  '一'.repeat(300),
+];
+
+/** A probe short enough to name in an assertion message. */
+const label = (s: string) => (s.length > 20 ? `${s.slice(0, 20)}... (${s.length})` : s);
+
 describe('the default, which accepts a string on write only', () => {
   it('takes a Date and every notation Postgres and V8 read as the same date', async () => {
     const m = await schemasFor('input', 'input');
@@ -95,6 +125,17 @@ describe('the default, which accepts a string on write only', () => {
     }
   });
 
+  it('refuses a string that reaches `new Date` and comes back Invalid', async () => {
+    const m = await schemasFor('input', 'input');
+    for (const check of [accepts, compiled]) {
+      for (const s of NOT_DATES) {
+        expect(Number.isNaN(new Date(s).getTime()), `${label(s)} is a real date`).toBe(true);
+        expect(check(m.InserttSchema, s), label(s)).toBe(false);
+        expect(check(m.UpdatetSchema, s), `${label(s)} on update`).toBe(false);
+      }
+    }
+  });
+
   it('leaves select strict, since a row out of the database is already a Date', async () => {
     const m = await schemasFor('input', 'input');
     expect(accepts(m.SelecttSchema, new Date())).toBe(true);
@@ -108,6 +149,11 @@ describe('the explicit settings', () => {
     expect(accepts(m.SelecttSchema, '2020-01-01')).toBe(true);
     expect(accepts(m.SelecttSchema, '12.5'), 'still not a bare number').toBe(false);
     expect(accepts(m.SelecttSchema, null), 'still not null').toBe(false);
+    for (const check of [accepts, compiled]) {
+      for (const s of NOT_DATES) {
+        expect(check(m.SelecttSchema, s), `${label(s)} on select`).toBe(false);
+      }
+    }
   });
 
   it("takes a Date only under 'none', which is what matches the official module", async () => {

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -13,6 +13,7 @@ import {
   isIntegerColumn,
   nonFiniteAccepted,
   parseCheck,
+  parsesToADate,
   renderDuplicateFinder,
   resolveConfiguredImport,
   updateColumns,
@@ -39,13 +40,22 @@ function vDateExpr(
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>
 ): string {
   if (coerceDates === 'none') return 'v.date()';
-  // Not every string. `new Date` reads a bare number as a year or as month.day, so `'12.5'`,
-  // `'0101'` and `'010'` all became real dates here and Postgres refuses all three. The regex
-  // runs before the transform, so a string that is not a date notation never reaches `new Date`;
-  // see `COERCIBLE_DATE_STRING` for what was measured and why.
+  // Not every string, and the pipe says so twice, because those are two different questions.
+  //
+  // The regex is the gate on the string. `new Date` reads a bare number as a year or as month.day,
+  // so `'12.5'`, `'0101'` and `'010'` all became real dates here and Postgres refuses all three;
+  // see `COERCIBLE_DATE_STRING` for what was measured and why. It runs before the transform, so
+  // such a string never reaches `new Date` at all.
+  //
+  // The check is the gate on the result, and without it any string the regex let through was
+  // accepted whatever came out: `'hello'`, `'zzz'` and `'25:99:99'` are not bare numbers, so they
+  // passed the pattern, became an Invalid Date and were taken. A valibot action sees the previous
+  // step's *output*, so this one is handed the `Date` rather than the string, and an Invalid Date
+  // is a real `Date` instance whose only tell is `getTime()`; see `parsesToADate`.
   const coercer =
     `v.pipe(v.string(), v.regex(new RegExp(${JSON.stringify(COERCIBLE_DATE_STRING)})), ` +
-    `v.transform((s) => new Date(s)))`;
+    `v.transform((s) => new Date(s)), ` +
+    `v.check((d) => ${parsesToADate('d')}, 'a date the runtime can parse'))`;
   if (coerceDates === 'all') return `v.union([v.date(), ${coercer}])`;
   // 'input'
   return mode === 'select' ? 'v.date()' : `v.union([v.date(), ${coercer}])`;

--- a/packages/generator-valibot/test/date-coercion.spec.ts
+++ b/packages/generator-valibot/test/date-coercion.spec.ts
@@ -51,6 +51,36 @@ async function schemasFor(
 
 const accepts = (schema: any, x: unknown) => v.safeParse(schema.entries.at, x).success;
 
+/**
+ * Strings that are not a bare number, so `COERCIBLE_DATE_STRING` lets them through, and that
+ * `new Date` then turns into an Invalid Date.
+ *
+ * Every one of them is a member of the packed gate's probe pool, and the waiver for the date
+ * columns recorded all of them as accepted here while zod refused them: the pattern gates the
+ * *shape* of the string and nothing looked at what came out of the coercion. An Invalid Date is
+ * still a `Date` instance, so `instanceof` cannot see it and `getTime()` is what has to be asked.
+ */
+const NOT_DATES = [
+  'hello',
+  'zzz',
+  'not-a-uuid',
+  '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  'a',
+  'happy',
+  'x',
+  'xxxxx',
+  '12:00:00',
+  '25:99:99',
+  '999.999.999.999',
+  '10.0.0.1',
+  'x'.repeat(300),
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+  '一'.repeat(300),
+];
+
+/** A probe short enough to name in an assertion message. */
+const label = (s: string) => (s.length > 20 ? `${s.slice(0, 20)}... (${s.length})` : s);
+
 describe('the default, which coerces on write only', () => {
   it('takes a Date and every notation Postgres and V8 read as the same date', async () => {
     const m = await schemasFor('input', 'input');
@@ -86,6 +116,15 @@ describe('the default, which coerces on write only', () => {
     expect(accepts(m.InserttSchema, [1, 2]), 'an array').toBe(false);
   });
 
+  it('refuses a string that reaches `new Date` and comes back Invalid', async () => {
+    const m = await schemasFor('input', 'input');
+    for (const s of NOT_DATES) {
+      expect(Number.isNaN(new Date(s).getTime()), `${label(s)} is a real date`).toBe(true);
+      expect(accepts(m.InserttSchema, s), label(s)).toBe(false);
+      expect(accepts(m.UpdatetSchema, s), `${label(s)} on update`).toBe(false);
+    }
+  });
+
   it('leaves select strict, since a row out of the database is already a Date', async () => {
     const m = await schemasFor('input', 'input');
     expect(accepts(m.SelecttSchema, new Date())).toBe(true);
@@ -99,6 +138,9 @@ describe('the explicit settings', () => {
     expect(accepts(m.SelecttSchema, '2020-01-01')).toBe(true);
     expect(accepts(m.SelecttSchema, '12.5'), 'still not a bare number').toBe(false);
     expect(accepts(m.SelecttSchema, null), 'still not null').toBe(false);
+    for (const s of NOT_DATES) {
+      expect(accepts(m.SelecttSchema, s), `${label(s)} on select`).toBe(false);
+    }
   });
 
   it("coerces nowhere under 'none', which is what matches the official module", async () => {

--- a/packages/generator-zod/test/date-coercion.spec.ts
+++ b/packages/generator-zod/test/date-coercion.spec.ts
@@ -53,6 +53,36 @@ async function schemasFor(
 
 const accepts = (schema: any, x: unknown) => schema.shape.at.safeParse(x).success;
 
+/**
+ * Strings that are not a bare number, so `COERCIBLE_DATE_STRING` lets them through, and that
+ * `new Date` then turns into an Invalid Date.
+ *
+ * This generator already refused every one of them and the other three did not, which is what made
+ * it the reference for the fix: `z.preprocess(coerce, z.date())` validates the *result* of the
+ * coercion, and an Invalid Date is a `Date` instance that `z.date()` still turns away. The list is
+ * the packed gate's probe pool, and the same list is asserted in the other three packages.
+ */
+const NOT_DATES = [
+  'hello',
+  'zzz',
+  'not-a-uuid',
+  '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  'a',
+  'happy',
+  'x',
+  'xxxxx',
+  '12:00:00',
+  '25:99:99',
+  '999.999.999.999',
+  '10.0.0.1',
+  'x'.repeat(300),
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+  '一'.repeat(300),
+];
+
+/** A probe short enough to name in an assertion message. */
+const label = (s: string) => (s.length > 20 ? `${s.slice(0, 20)}... (${s.length})` : s);
+
 describe('the default, which coerces on write only', () => {
   it('takes a Date, an ISO string and an epoch number', async () => {
     const m = await schemasFor('input', 'input');
@@ -67,6 +97,15 @@ describe('the default, which coerces on write only', () => {
     expect(accepts(m.InserttSchema, true), 'a boolean').toBe(false);
     expect(accepts(m.InserttSchema, [1, 2]), 'an array').toBe(false);
     expect(accepts(m.InserttSchema, 'nonsense'), 'an unparseable string').toBe(false);
+  });
+
+  it('refuses a string that reaches `new Date` and comes back Invalid', async () => {
+    const m = await schemasFor('input', 'input');
+    for (const s of NOT_DATES) {
+      expect(Number.isNaN(new Date(s).getTime()), `${label(s)} is a real date`).toBe(true);
+      expect(accepts(m.InserttSchema, s), label(s)).toBe(false);
+      expect(accepts(m.UpdatetSchema, s), `${label(s)} on update`).toBe(false);
+    }
   });
 
   it('refuses a string that is only a number, which Postgres does not read as a date', async () => {

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -224,6 +224,40 @@ export const COLUMN_FORMATS: Record<string, string> = {
 export const COERCIBLE_DATE_STRING = '^(?!\\s*[+-])(?!\\s*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?\\s*$)';
 
 /**
+ * Whether a coercion really produced a date, as an expression over an emitted `Date`.
+ *
+ * `COERCIBLE_DATE_STRING` above is a gate on the *shape* of the input string and this is a gate on
+ * the *result*. They are two different questions and the second one was not being asked at all:
+ * `'hello'`, `'zzz'`, `'25:99:99'`, `'not-a-uuid'`, `'10.0.0.1'`, a 300-character run of `x` and a
+ * string of emoji are none of them bare numbers, so the pattern passed every one of them through,
+ * `new Date` returned an Invalid Date for every one of them, and nothing looked. Postgres refuses
+ * all of them, so validation passed and the INSERT then failed at the server.
+ *
+ * **An Invalid Date is still a `Date`.** `new Date('hello') instanceof Date` is true and
+ * `typeof` says `object`, so no instance check and no type guard can tell the two apart. The
+ * timestamp is the only thing that differs, and it is `NaN`, which is also why the test cannot be
+ * `d.getTime() !== NaN`: nothing is equal to `NaN`, including itself.
+ *
+ * The zod generator has always asked this without needing to say so, because
+ * `z.preprocess(coerce, z.date())` validates what came *out* of the coercion and `z.date()` fails
+ * an Invalid Date. The other three either accept the string or transform it and then stop looking,
+ * so each states this in whatever form its library has: valibot as a `v.check` after the
+ * transform, ArkType as a `.narrow`, TypeBox as the `assert` of a registered kind. One expression,
+ * shared, so the four cannot drift on what "is a date" means.
+ *
+ * `'12:00:00'` is the one probe worth naming, because V8 and Postgres could have disagreed about
+ * it and do not. `new Date('12:00:00')` is an Invalid Date, and measured against Postgres through
+ * PGlite, `'12:00:00'` is refused by `date`, `timestamp` and `timestamptz` alike with
+ * `invalid input syntax`. The three Postgres types that do take it are `time`, `timetz` and
+ * `interval`, and none of those is ever a `mode: 'date'` column. So refusing it is right on both
+ * counts. `'25:99:99'` is refused by both as well, Postgres with `date/time field value out of
+ * range`.
+ */
+export function parsesToADate(expr: string): string {
+  return `!Number.isNaN(${expr}.getTime())`;
+}
+
+/**
  * Why a character limit is not `.max(n)`.
  *
  * Postgres and MySQL count `varchar(n)` in **characters**; every JavaScript validator counts

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -1956,13 +1956,21 @@ const ALLOWED: Record<string, Waiver> = {
   // `coerceDates` defaults to coercing on insert and update, which is a documented DRZL option
   // and is what `coerceDates: 'none'` turns off to match official exactly. Only strings and
   // numbers are coerced: null, booleans and arrays are rejected, which `z.coerce.date()` accepts.
+  //
+  // The two arms differ on more than a value and the reason is worth stating, because this waiver
+  // previously read as one thing while excusing another. zod also takes an epoch number, since it
+  // is the only arm with a number branch at all; the other three never had one. That is a
+  // cross-generator inconsistency rather than a defect against the database, filed and not fixed
+  // here. What both arms now agree on is that a string has to parse to a real date (BA): the
+  // signature used to carry `'hello'`, `'zzz'` and 22000 CJK characters under a `why` that said
+  // "a date string or epoch number", which described neither of them.
   'pg/c_date_d': {
     libs: LIB_NAMES,
     modes: WRITE,
-    why: 'coerceDates accepts a date string or epoch number on write',
+    why: 'coerceDates accepts a parseable date string on write, and an epoch number in the zod arm',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   'pg/c_ts_d': {
@@ -1971,7 +1979,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   'mysql/m_date': {
@@ -1980,7 +1988,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   'mysql/m_datetime': {
@@ -1989,7 +1997,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   'mysql/m_ts': {
@@ -1998,7 +2006,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   'sqlite/s_int_ts': {
@@ -2007,7 +2015,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   'sqlite/s_int_ts_ms': {
@@ -2016,7 +2024,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   // Official emits `Type.String({ format: 'uuid' })`, and TypeBox fails a format it has no entry
@@ -2205,7 +2213,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_ts_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   // The first divergence in either pass that comes from a CHECK, because `matrix` carries none and
@@ -2232,7 +2240,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as pg/c_date_d',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   'mysql/m_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/n_check, in MySQL spelling', divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 1900, 2000, 2500, 17, 101` } },
@@ -2245,7 +2253,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as sqlite/s_int_ts',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   'sqlite/s_n_ts_ms': {
@@ -2254,7 +2262,7 @@ const ALLOWED: Record<string, Waiver> = {
     why: 'as sqlite/s_int_ts_ms',
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
   },
   'sqlite/s_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, why: "as pg/n_check; the extra label is official's SQLite integer bound being the safe-integer range where its Postgres one is int32", divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, 17, 101` } },
@@ -7078,17 +7086,17 @@ const ALLOWED: Record<string, Entry> = {
     modes: WRITE,
     divergence: {
       '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `,
-      '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,
+      '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,
     },
     drzl: 'a Date, or a string or number coerced to one',
     official: 'a Date only',
     filed: 'not a defect: coerceDates',
   },
-  'pg/c_ts_d': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'mysql/m_date': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'mysql/m_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'mysql/m_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
-  'sqlite/s_int_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'pg/c_ts_d': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_date': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'sqlite/s_int_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: `,     }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   // TypeBox fails a format it has no entry for rather than ignoring it, so official's schema
   // rejects every valid uuid in any project that has not populated `FormatRegistry` first.
   'pg/c_uuid': {
@@ -7200,7 +7208,7 @@ const ALLOWED: Record<string, Entry> = {
   'pg/n_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, '*/arktype': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_real', official: 'as pg/c_real', filed: 'as pg/c_real' },
   'pg/n_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
   'pg/n_point': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: [1,2,3]` }, drzl: 'as pg/c_point', official: 'as pg/c_point', filed: 'as pg/c_point' },
-  'pg/n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'pg/n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   // The database has already answered this one in this same script: the CHECK ground-truth stage
   // runs 53 probes over the `checked` table against a real Postgres and reports rows Postgres
   // rejects and the validator accepts as DRZL 0, drizzle-orm 22, and `k_between BETWEEN 5 AND 15`
@@ -7211,11 +7219,11 @@ const ALLOWED: Record<string, Entry> = {
   'mysql/m_n_tinytext': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 100 emoji` }, drzl: 'as mysql/m_tinytext', official: 'as mysql/m_tinytext', filed: 'as mysql/m_tinytext' },
   'mysql/m_n_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` }, drzl: 'as mysql/m_float', official: 'as mysql/m_float', filed: 'as pg/c_real' },
   'mysql/m_n_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
-  'mysql/m_n_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'mysql/m_n_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   'mysql/m_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 1900, 2000, 2500, 17, 101` }, drzl: 'as pg/n_check', official: 'as pg/n_check', filed: 'as pg/n_check' },
   'sqlite/s_n_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
   'sqlite/s_n_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
-  'sqlite/s_n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid, 'zzz', 'a', 'happy', 'x', '2020-01-01', '2020-01-01T00:00:00Z', '12:00:00', '25:99:99', 100 emoji, 22000 cjk, '999.999.999.999', '10.0.0.1' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
+  'sqlite/s_n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/zod': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, '*/valibot,arktype,typebox': `L: '2020-01-01', '2020-01-01T00:00:00Z' | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   'sqlite/s_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, 17, 101` }, drzl: 'as pg/n_check', official: 'as pg/n_check', filed: 'as pg/n_check' },
   // ---- binary and varbinary, where only DRZL enforces the declared width ----------------------
   // These two were DEFECTS here until the analyzer stopped calling a byte string a Uint8Array. They


### PR DESCRIPTION
Addendum BA, Tier A. Found by reading a waiver, not by a gate firing.

`valibot`, `arktype` and `typebox` accepted **any string at all** on the write path of a `date({ mode: 'date' })` or `timestamp({ mode: 'date' })` column. `'hello'`, `'zzz'`, 22000 CJK characters and `'999.999.999.999'` all validated, and Postgres then refused the row.

`zod` did not, and is the reference: `z.preprocess(coerce, z.date())` validates the **coerced result**. The other three coerced the string and never looked at what came out.

## The waiver's own reason is what gave it away

```
why: 'coerceDates accepts a date string or epoch number on write'

'*/valibot,arktype,typebox':
  L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, 5 emoji, 'not-a-uuid', uuid,
     'zzz', 'a', 'happy', 'x', '12:00:00', '25:99:99', 100 emoji, 22000 cjk,
     '999.999.999.999', '10.0.0.1'
```

`'hello'` is not a date string and `'zzz'` is not an epoch number. This is the defect class the repo keeps finding, a claim that holds for a reason unrelated to what it covers, except located in the **waiver** rather than in the check. That is the worse position: a waiver whose sentence reads as intended gets skipped by every reviewer, including me until now.

The reason is corrected in this PR too, not just the code. Leaving it would repeat the thing being fixed.

## Why nothing caught it

The pass that compares DRZL's four generators against each other reads `SelectmatrixSchema` and nothing else, so any disagreement between them on `insert` or `update` is invisible. The file already knew: a comment on the crash ledger states it, and demonstrates it by making the typebox Insert and Update schemas accept `null` on a NOT NULL column and watching the run stay byte-identical to green. The observation was recorded, the consequence never drawn. Filed as **BB**, not fixed here.

The relative gate could not catch it either, because official has the same looseness, so nothing fires.

## Per generator

An Invalid Date is still a `Date` instance, so every arm tests `getTime()` rather than the instance.

| | after |
|---|---|
| valibot | one more pipe step after the transform: `v.check((d) => !Number.isNaN(d.getTime()), ...)` |
| arktype | `.narrow((v, ctx) => ... !Number.isNaN(new Date(v).getTime()) \|\| ctx.mustBe(...))`, through `atNarrow` so arrays get one `.every` per dimension |
| typebox | intersection with the registered `DrzlRowCheck` kind the character caps already use |
| zod | unchanged, already correct |

Rationale lives once in `validation-core` as `parsesToADate`. The `COERCIBLE_DATE_STRING` pattern from #127 stays: that gates the *shape of the input*, this gates the *result of coercion*.

## `'12:00:00'` and `'25:99:99'`, checked rather than assumed

Both are in the probe pool, so I asked for these specifically instead of letting the fix decide them by accident. `new Date('12:00:00')` is an **Invalid Date** in V8, and Postgres refuses it for `date`, `timestamp` and `timestamptz`. The types that accept it are `time`, `timetz` and `interval`, none of which is ever a `mode: 'date'` column. `'25:99:99'` is refused by both. No disagreement; refusing is right on both counts.

## Ledger

66 pairings, 11 keys x 2 write modes x 3 libraries, **one** distinct measured signature. Twenty substitutions across both majors:

```
before  L: 'hello', 300-char, 70k-char, 5-char, 3 emoji, ... '999.999.999.999', '10.0.0.1' | T:
after   L: '2020-01-01', '2020-01-01T00:00:00Z' | T:
```

`'*/zod'` unchanged everywhere. Ground truth is unchanged at DRZL 1067/1440, because that stage grades zod, so `benchmarks.md` needs no edit.

## A second inconsistency, deliberately not fixed

The epoch number `1700000000000` is accepted only by zod; the other three never had a number branch at all. Confirmed pre-existing by stashing the change and re-measuring on master, rather than assumed from the diff. Out of scope for BA, and now named explicitly in the waiver's reason instead of hiding under a vague sentence.

## Watch item

arktype is now **273 bytes/column against a 280 budget**, down from about 56 bytes of headroom to 7. The next date-shaped addition to that generator hits the ceiling.

## Tests

Written first and confirmed red: valibot, arktype and typebox each failed 2 of 7 on the unmodified sources; **zod passed all 9**, which is what establishes it as the reference rather than an assumption. A shared `NOT_DATES` list drawn from the gate's own pool, asserted on insert, update, and on select under `coerceDates: 'all'`. Every spec evaluates the emitted module; TypeBox through both `Value.Check` and `TypeCompiler`. Nullable and `Date[]` columns covered in all four.

`pnpm verify:packed`, `build`, `-r test` (1223 tests), `typecheck`, `lint`, `docs build` all green.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4