### PR TITLE
fix(arktype): refuse NaN through a union arm where the column cannot hold one

### DIFF
--- a/.changeset/arktype-nan-optional-arm.md
+++ b/.changeset/arktype-nan-optional-arm.md
@@ -1,0 +1,47 @@
+---
+'@drzl/generator-arktype': patch
+---
+
+The ArkType generator refuses `NaN` on a column that stores none, through the optional and nullable
+arms where it used to let one through.
+
+`NaN` is a value the schema has to answer for per dialect rather than once. Postgres genuinely
+stores it in a `real`, a `double precision` and a `numeric`, and hands it back on SELECT, so all
+four generators accept it there and that does not change. A real MySQL 8.4 stores it nowhere:
+`float` and `double` refuse it outright, and `decimal(10,2)` silently writes `0.00` with an empty
+`SHOW WARNINGS`. SQLite turns it into NULL. The analyzer already says which is which, with
+`allowsNaN` on the column, and until now the ArkType generator only read that flag in the direction
+that adds `NaN` and never in the direction that keeps it out.
+
+**The mechanism was ArkType's, and it was invisible in the emitted text.** A bounded number stops
+refusing `NaN` the moment it becomes one branch of a union beside a unit branch, while still
+refusing an infinity and everything out of range. Both wrappers this generator emits are that
+union. `(min <= number <= max | null)` for a nullable column is one, and it accepts `NaN` on the
+object itself. The `?` on an optional key is the other: the object still refuses a present `NaN`,
+but `schema.get(key)` hands back `T | undefined`, and that type accepts it. Since `update` is the
+mode where every key is optional, one MySQL `float` column disagreed with the other three
+generators there and agreed with them in `select` and `insert`.
+
+`NaN` alone, because it is the one value that compares false against both ends of a range. Integer
+columns were never affected: `number.integer` states integrality as a predicate, which `NaN` fails
+inside a union exactly as it does outside one.
+
+**What changes.** On a column the analyzer marks as storing no `NaN`, which is every MySQL,
+SingleStore and SQLite float and every `numeric` in number mode outside Postgres, the emitted
+ArkType field now carries a `.narrow` refusing `NaN`, in every mode and through both wrappers. The
+narrow reaches array elements the same way every other narrow in this generator does, and an
+applied default moves onto the Type beside it rather than being dropped.
+
+**Postgres does not move.** A `real`, a `double precision` and a `numeric` in number mode still
+accept `NaN` and, where the width allows, both infinities, in `select`, `insert` and `update`,
+nullable or not. No Postgres column gains the narrow, so the generated Postgres output is unchanged
+byte for byte.
+
+Two things this deliberately does not change. An unbounded MySQL or SQLite `double` still accepts
+both infinities, because ArkType's bare `number` does and that is a separate, already-documented
+divergence from zod and TypeBox rather than this leak: it is present in `select` and `insert` too,
+where nothing is optional. And a `decimal` column is a string in Drizzle's number-free mode and is
+governed by its pattern, not by this.
+
+The zod, valibot, TypeBox and JSON Schema generators do not change. All four already refused `NaN`
+on these columns.

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -568,6 +568,9 @@ function renderObjectShape(
         atCapNarrows(c, mode) +
         atBigintNarrow(c, checks) +
         atNonFiniteNarrow(c, checks) +
+        // Mutually exclusive with the one above it: that one is reached only where the column
+        // admits `NaN` and this one only where it does not.
+        atNanNarrow(c, mode, checks, sets, !!dflt) +
         atDateNarrow(c, mode, coerceDates);
       // A defaultable definition is only valid as an object *property*: `type("bigint = 7")`
       // throws "Defaultable definitions like 'number = 0' are only valid as properties in an
@@ -758,6 +761,77 @@ function atNonFiniteNarrow(c: Column, checks: ColumnCheck[]): string {
     (v) => `(!Number.isFinite(${v}) || (${parts.map((p) => p(v)).join(' && ')}))`,
     `NaN, an infinity, or between ${lower?.value ?? 'any'} and ${upper?.value ?? 'any'}`
   );
+}
+
+/**
+ * Whether the rendered field will be one branch of a union rather than a type standing alone.
+ *
+ * Two things this file writes put a number beside a unit branch. `| null` for a nullable column is
+ * one, and it is visible on the object itself. The `?` for an optional key is the other, and it is
+ * visible through `schema.get(key)`, where the field comes back as `T | undefined`; the object
+ * keeps checking a present key against `T` alone, so a whole row parses correctly and the field
+ * pulled out of the same schema does not.
+ *
+ * Read off `atField` rather than guessed, and it has to stay that way: the `?` is applied there
+ * under exactly this condition, and a default replaces it rather than joining it, which is what
+ * `defaulted` carries. A default does not spare a *nullable* column, whose `| null` is still there.
+ */
+function atUnionArm(c: Column, mode: Mode, defaulted: boolean): boolean {
+  if (c.nullable) return true;
+  if (mode === 'select' || defaulted) return false;
+  return mode === 'update' || c.hasDefault;
+}
+
+/**
+ * `NaN` refused on a column that stores none, in the two places the string DSL stops refusing it.
+ *
+ * The mirror image of `atNonFiniteNarrow`, and the dialect is the whole of the difference. Postgres
+ * really does store `NaN` in a float, so `allowsNaN` is true there and the schema must take it; a
+ * real MySQL 8.4 refuses it on `float` and on `double` and silently writes `0.00` for a
+ * `decimal(10,2)`, so `allowsNaN` is false and the schema must not. One flag, set by the analyzer,
+ * decides which, and nothing here reads the dialect.
+ *
+ * The mechanism is ArkType's, measured on the installed version and asserted in this package's
+ * `nan-union-arm` spec rather than remembered:
+ *
+ *   `min <= number <= max`            refuses NaN
+ *   `(min <= number <= max | null)`   ACCEPTS NaN, and still refuses an infinity and 1e300
+ *   `{ "x?": "min <= number <= max" }`  the object refuses NaN, `.get("x")` ACCEPTS it
+ *   `number`                          refuses NaN
+ *   `(number | null)`                 ACCEPTS NaN
+ *   `(number.integer | null)`         refuses NaN
+ *
+ * It is `NaN` alone, because `NaN` is the one value that compares false against both ends of a
+ * range: an infinity fails a bound inside a union exactly as it does outside one. And it spares the
+ * integers, because integrality is a predicate rather than a comparison and `NaN` fails it, so no
+ * integer column pays for this.
+ *
+ * A narrow rather than a union branch or a keyword, because there is no keyword for it. Every
+ * number keyword ArkType has was tried inside a `| null`: `number.integer` and `number.epoch`
+ * refuse `NaN` and also refuse `1.5`, `number.safe` leaks exactly as a bare range does, and the
+ * three unit keywords intersect with a range to an unsatisfiable type that throws at import.
+ *
+ * The guards below mirror the arms of `atTypeForColumn` that render something other than a bare or
+ * ranged `number`. A set, an enum and an equality all render as literals, which `NaN` is not, so a
+ * narrow beside them would be bytes in the consumer's bundle for a verdict already reached.
+ */
+function atNanNarrow(
+  c: Column,
+  mode: Mode,
+  checks: ColumnCheck[],
+  sets: ColumnSet[],
+  defaulted: boolean
+): string {
+  if (c.tsType !== 'number' || c.shape) return '';
+  // The column stores `NaN` and the schema has to take it. `atNonFiniteNarrow` holds that side.
+  if (nonFiniteAccepted(c).nan) return '';
+  if (!atUnionArm(c, mode, defaulted)) return '';
+  if (c.enumValues && c.enumValues.length) return '';
+  if (sets.some((s) => s.column === c.name)) return '';
+  // The same discard `atTypeForColumn` makes: a scalar check describes an element, never the list.
+  if (atNarrowRange(c, c.arrayDimensions ? [] : checks).equals !== undefined) return '';
+  if (isIntegerColumn(c)) return '';
+  return atNarrow(c, (v) => `!Number.isNaN(${v})`, 'a number, not NaN');
 }
 
 /**

--- a/packages/generator-arktype/test/nan-union-arm.spec.ts
+++ b/packages/generator-arktype/test/nan-union-arm.spec.ts
@@ -1,0 +1,318 @@
+/**
+ * `NaN` through ArkType's optional and nullable arms, on a column that stores no `NaN`.
+ *
+ * A sibling of `non-finite-numbers.spec.ts` and the other half of the same question. That file
+ * asks what a Postgres `real` must *accept*; this one asks what a MySQL `float` must refuse, and
+ * the answer differs only because the arbiter is a different database. Measured against a real
+ * MySQL 8.4: `float` and `double` refuse `NaN` outright and `decimal(10,2)` silently writes
+ * `0.00`, so MySQL stores no `NaN` in any numeric column. The analyzer says exactly this by
+ * leaving `allowsNaN` off, and it is the only thing that separates the two dialects here.
+ *
+ * The mechanism, asserted at the top of this file rather than remembered: a *bounded* ArkType
+ * number stops refusing `NaN` the moment it becomes a branch of a union beside a unit. Both arms
+ * this generator emits are such a union. `| null` for a nullable column is one, visible on the
+ * object itself. The `?` on an optional key is the other, visible through `schema.get(key)`, which
+ * is how the packed gate takes a schema apart into one type per column.
+ *
+ * `number.integer` is not affected, because integrality is a real predicate and `NaN` fails it,
+ * so nothing is spent on the integer columns.
+ *
+ * Everything below runs the emitted module. The union defect already recorded on `atNumberPlan`
+ * is a branch that `.json` still lists and the schema then rejects, so reading the emitted text or
+ * the parsed type proves nothing here.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArkTypeGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { type } from 'arktype';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+/** What the analyzer really emits for each of these, read off a run rather than invented. */
+const MYSQL_FLOAT_MAX = '340282346638528859811704183484516925440';
+const PG_FLOAT4_MAX = '340282356779733661637539395458142568448';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'number',
+    dbType: 'DOUBLE',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    integer: false,
+    ...over,
+  }) as Column;
+
+// MySQL. `float` carries a range and no `allowsNaN`; `double` and `real` carry neither.
+const MYSQL = [
+  col('m_float', { dbType: 'REAL', min: `-${MYSQL_FLOAT_MAX}`, max: MYSQL_FLOAT_MAX }),
+  col('m_n_float', {
+    dbType: 'REAL',
+    min: `-${MYSQL_FLOAT_MAX}`,
+    max: MYSQL_FLOAT_MAX,
+    nullable: true,
+  }),
+  col('m_double', { dbType: 'DOUBLE' }),
+  col('m_n_double', { dbType: 'DOUBLE', nullable: true }),
+  col('m_int', { dbType: 'INTEGER', integer: true, min: '-2147483648', max: '2147483647' }),
+  col('m_n_int', {
+    dbType: 'INTEGER',
+    integer: true,
+    min: '-2147483648',
+    max: '2147483647',
+    nullable: true,
+  }),
+];
+
+// Postgres. Both widths store all three and hand them back, which is what `allowsNaN` says.
+const POSTGRES = [
+  col('c_real', {
+    dbType: 'REAL',
+    min: `-${PG_FLOAT4_MAX}`,
+    max: PG_FLOAT4_MAX,
+    allowsNaN: true,
+    allowsInfinity: true,
+  }),
+  col('n_real', {
+    dbType: 'REAL',
+    min: `-${PG_FLOAT4_MAX}`,
+    max: PG_FLOAT4_MAX,
+    allowsNaN: true,
+    allowsInfinity: true,
+    nullable: true,
+  }),
+  col('c_double', { dbType: 'DOUBLE', allowsNaN: true, allowsInfinity: true }),
+  col('n_double', { dbType: 'DOUBLE', allowsNaN: true, allowsInfinity: true, nullable: true }),
+];
+
+async function emit(dialect: string, columns: Column[], label: string, opts: object = {}) {
+  const analysis: Analysis = {
+    dialect,
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  } as never;
+  const dir = path.join(__dirname, '.tmp-nan-arm');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir, ...opts } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.arktype.ts'), file);
+  const source = (await fs.readFile(file, 'utf8')).replace(/\s+/g, ' ');
+  return { source, module: await import(file) };
+}
+
+/**
+ * One column of one schema, as the packed gate takes it: `schema.get(key)`, which is where an
+ * optional key becomes a union with `undefined` and where this defect is visible at all.
+ */
+const field = (schema: any, key: string, x: unknown) =>
+  !(schema.get(key)(x) instanceof type.errors);
+
+/**
+ * The same column through the whole object, which is where the nullable arm shows the same leak.
+ *
+ * Every other column is filled with a value it accepts, because a select schema demands them all
+ * and a row missing one fails for a reason that has nothing to do with the column under test.
+ */
+const rowOf =
+  (base: Record<string, unknown>) =>
+  (schema: any, key: string, x: unknown): boolean =>
+    !(schema({ ...base, [key]: x }) instanceof type.errors);
+
+const MODES = ['Select', 'Insert', 'Update'] as const;
+
+describe('what ArkType does on its own', () => {
+  it('stops refusing NaN once a bounded number joins a union with a unit', () => {
+    const R = `-${MYSQL_FLOAT_MAX} <= number <= ${MYSQL_FLOAT_MAX}`;
+    const required = type({ m: R });
+    expect(required({ m: NaN }) instanceof type.errors, 'required key, on the object').toBe(true);
+    expect(required.get('m')(NaN) instanceof type.errors, 'required key, on the field').toBe(true);
+
+    // The optional arm. The object still refuses it, so nothing that parses a whole row sees this;
+    // the field pulled out of the schema does not.
+    const optional = type({ 'm?': R });
+    expect(optional({ m: NaN }) instanceof type.errors, 'optional key, on the object').toBe(true);
+    expect(optional.get('m')(NaN) instanceof type.errors, 'optional key, on the field').toBe(false);
+
+    // The nullable arm, which leaks on the object too.
+    const nullable = type({ m: `(${R} | null)` });
+    expect(nullable({ m: NaN }) instanceof type.errors, 'nullable, on the object').toBe(false);
+
+    // It is `NaN` alone. An infinity fails the bound in a union exactly as it does outside one,
+    // because only `NaN` compares false against both ends.
+    expect(nullable({ m: Infinity }) instanceof type.errors, 'nullable, Infinity').toBe(true);
+    expect(nullable({ m: 1e300 }) instanceof type.errors, 'nullable, out of range').toBe(true);
+
+    // And integrality is a predicate rather than a comparison, so an integer column is untouched.
+    const int = type({ m: '(-2147483648 <= number.integer <= 2147483647 | null)' });
+    expect(int({ m: NaN }) instanceof type.errors, 'integer, nullable').toBe(true);
+    expect(type({ 'm?': 'number.integer' }).get('m')(NaN) instanceof type.errors).toBe(true);
+  });
+});
+
+const MYSQL_ROW = {
+  m_float: 1.5,
+  m_n_float: 1.5,
+  m_double: 1.5,
+  m_n_double: 1.5,
+  m_int: 7,
+  m_n_int: 7,
+};
+const PG_ROW = { c_real: 1.5, n_real: 1.5, c_double: 1.5, n_double: 1.5 };
+
+describe('a mysql float and double column', () => {
+  const row = rowOf(MYSQL_ROW);
+
+  // Collected rather than asserted one at a time, because the interesting number is how many of
+  // the twenty four combinations leak, and a bare `expect` stops at the first.
+  it('refuses NaN in every mode, on the field and on the row', async () => {
+    const { module: m } = await emit('mysql', MYSQL, 'mysql-nan');
+    const leaks: string[] = [];
+    for (const mode of MODES) {
+      const s = m[`${mode}tSchema`];
+      expect(row(s, 'm_float', 1.5), `${mode} the baseline row is accepted`).toBe(true);
+      for (const name of ['m_float', 'm_n_float', 'm_double', 'm_n_double']) {
+        if (field(s, name, NaN)) leaks.push(`${mode} ${name} field`);
+        if (row(s, name, NaN)) leaks.push(`${mode} ${name} row`);
+      }
+    }
+    expect(leaks).toEqual([]);
+  });
+
+  it('refuses both infinities wherever a bound can hold them back', async () => {
+    const { module: m } = await emit('mysql', MYSQL, 'mysql-inf');
+    for (const mode of MODES) {
+      const s = m[`${mode}tSchema`];
+      // `float` carries MySQL's own range, so the bound refuses an infinity by itself.
+      for (const name of ['m_float', 'm_n_float']) {
+        expect(field(s, name, Infinity), `${mode} ${name} Infinity`).toBe(false);
+        expect(field(s, name, -Infinity), `${mode} ${name} -Infinity`).toBe(false);
+        expect(field(s, name, 1e300), `${mode} ${name} out of range`).toBe(false);
+      }
+    }
+  });
+
+  it('still takes an ordinary number and still refuses a string and a bare null', async () => {
+    const { module: m } = await emit('mysql', MYSQL, 'mysql-ordinary');
+    for (const mode of MODES) {
+      const s = m[`${mode}tSchema`];
+      for (const name of ['m_float', 'm_n_float', 'm_double', 'm_n_double']) {
+        expect(field(s, name, 1.5), `${mode} ${name} 1.5`).toBe(true);
+        expect(field(s, name, 0), `${mode} ${name} 0`).toBe(true);
+        expect(field(s, name, 'x'), `${mode} ${name} a string`).toBe(false);
+      }
+      for (const name of ['m_float', 'm_double']) {
+        expect(field(s, name, null), `${mode} ${name} null on NOT NULL`).toBe(false);
+        expect(row(s, name, null), `${mode} ${name} null on NOT NULL, row`).toBe(false);
+      }
+      for (const name of ['m_n_float', 'm_n_double']) {
+        expect(field(s, name, null), `${mode} ${name} null on a nullable column`).toBe(true);
+      }
+      // An integer column keeps refusing a fraction and its own out-of-range value.
+      expect(field(s, 'm_int', 1.5), `${mode} m_int 1.5`).toBe(false);
+      expect(field(s, 'm_int', 2147483648), `${mode} m_int out of range`).toBe(false);
+      expect(field(s, 'm_int', 7), `${mode} m_int 7`).toBe(true);
+      expect(field(s, 'm_int', NaN), `${mode} m_int NaN`).toBe(false);
+      expect(field(s, 'm_n_int', NaN), `${mode} m_n_int NaN`).toBe(false);
+    }
+  });
+
+  it('spends nothing on the integer columns, which refuse NaN by themselves', async () => {
+    const { source } = await emit('mysql', MYSQL, 'mysql-cost');
+    // `number.integer` is a predicate and holds inside a union, so no integer column carries the
+    // narrow. Anything else is bytes in the consumer's bundle for a verdict already reached.
+    expect(source, 'm_int stays a plain DSL string').toContain(
+      `m_int: '-2147483648 <= number.integer <= 2147483647'`
+    );
+    expect(source, 'and so does the nullable one').toContain(
+      `m_n_int: '(-2147483648 <= number.integer <= 2147483647 | null)'`
+    );
+    // One narrow per leaking arm and not one per column: a NOT NULL float is a union arm only in
+    // update, where every key is optional, while a nullable one is one in all three modes. Two
+    // NOT NULL floats at one mode each and two nullable ones at three.
+    expect(source.match(/Number\.isNaN/g)?.length ?? 0, 'one narrow per leaking arm').toBe(8);
+  });
+});
+
+describe('the two wrappers the narrow has to survive', () => {
+  // Neither shape occurs on MySQL, which has no array column, but `atNanNarrow` is written against
+  // the column rather than the dialect and both paths change with it: the array walk is a
+  // different predicate and an applied default moves off the DSL and onto the Type the moment the
+  // field carries any narrow at all.
+  const ARRAY = col('a_float', {
+    dbType: 'REAL',
+    min: `-${MYSQL_FLOAT_MAX}`,
+    max: MYSQL_FLOAT_MAX,
+    arrayDimensions: 1,
+    nullable: true,
+  });
+  const DEFAULTED = col('d_float', {
+    dbType: 'REAL',
+    min: `-${MYSQL_FLOAT_MAX}`,
+    max: MYSQL_FLOAT_MAX,
+    nullable: true,
+    hasDefault: true,
+    defaultValue: 1.5,
+  });
+
+  it('reaches into an array and still refuses NaN element by element', async () => {
+    const { module: m } = await emit('mysql', [ARRAY], 'array');
+    for (const mode of MODES) {
+      const s = m[`${mode}tSchema`];
+      expect(field(s, 'a_float', [1.5, 0]), `${mode} ordinary elements`).toBe(true);
+      expect(field(s, 'a_float', []), `${mode} an empty list`).toBe(true);
+      expect(field(s, 'a_float', null), `${mode} the nullable list itself`).toBe(true);
+      expect(field(s, 'a_float', [1.5, NaN]), `${mode} a NaN element`).toBe(false);
+      expect(field(s, 'a_float', [1e300]), `${mode} an out-of-range element`).toBe(false);
+      expect(field(s, 'a_float', NaN), `${mode} a bare element`).toBe(false);
+    }
+  });
+
+  it('keeps an applied default, which the narrow pushes onto the Type', async () => {
+    const { module: m, source } = await emit('mysql', [DEFAULTED], 'defaulted', {
+      applyDefaults: true,
+    });
+    expect(source, 'the default rides on the builder beside the narrow').toContain('.default(1.5)');
+    // The default is what an absent key becomes, and the narrow still holds for a present one.
+    const filled = m.InserttSchema({});
+    expect(filled instanceof type.errors, 'an empty insert').toBe(false);
+    expect(filled.d_float).toBe(1.5);
+    expect(field(m.InserttSchema, 'd_float', NaN), 'insert NaN').toBe(false);
+    expect(field(m.UpdatetSchema, 'd_float', NaN), 'update NaN').toBe(false);
+    expect(field(m.SelecttSchema, 'd_float', NaN), 'select NaN').toBe(false);
+    expect(field(m.InserttSchema, 'd_float', 1.5), 'insert an ordinary number').toBe(true);
+  });
+});
+
+describe('a postgres real and double precision column', () => {
+  const row = rowOf(PG_ROW);
+
+  it('still accepts NaN and both infinities in every mode, nullable or not', async () => {
+    const { module: m } = await emit('postgres', POSTGRES, 'pg-nan');
+    for (const mode of MODES) {
+      const s = m[`${mode}tSchema`];
+      for (const name of ['c_real', 'n_real', 'c_double', 'n_double']) {
+        expect(field(s, name, NaN), `${mode} ${name} NaN`).toBe(true);
+        expect(field(s, name, Infinity), `${mode} ${name} Infinity`).toBe(true);
+        expect(field(s, name, -Infinity), `${mode} ${name} -Infinity`).toBe(true);
+        expect(field(s, name, 1.5), `${mode} ${name} 1.5`).toBe(true);
+        expect(field(s, name, 0), `${mode} ${name} 0`).toBe(true);
+        expect(field(s, name, 'x'), `${mode} ${name} a string`).toBe(false);
+        expect(row(s, name, NaN), `${mode} ${name} NaN, row`).toBe(true);
+      }
+      // The 4 byte column keeps the magnitude bound it really has, and the 8 byte one does not.
+      expect(field(s, 'c_real', 1e300), `${mode} c_real at 1e300`).toBe(false);
+      expect(field(s, 'c_double', 1e300), `${mode} c_double at 1e300`).toBe(true);
+      expect(field(s, 'c_real', null), `${mode} c_real null on NOT NULL`).toBe(false);
+      expect(field(s, 'n_real', null), `${mode} n_real null`).toBe(true);
+    }
+  });
+
+  it('carries no NaN narrow, because the column really does store one', async () => {
+    const { source } = await emit('postgres', POSTGRES, 'pg-cost');
+    expect(source, 'nothing refuses NaN on a postgres float').not.toContain('Number.isNaN');
+    expect(source).toContain(`c_double: 'number | number.NaN'`);
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -2121,7 +2121,7 @@ const ALLOWED: Record<string, Waiver> = {
   // never a divergence there and still is not. Measured directly: `{x:'number'}` rejects NaN,
   // `{x:'(bound | null)'}` accepts it.
   'pg/c_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'bounded where Postgres stops accepting rather than at drizzle-zod +/-8388607, which refuses rows the column returns. Non-finite values were added on top: Postgres stores NaN and both infinities in a float column and returns them, and a Select schema refusing what the database hands back fails on real rows (AW).', divergence: { 'select,insert/*': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/arktype': `L: 9000000, 2147483648, 9007199254740993, 3.4028235e38, Infinity | T: ` } },
-  'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_real, but at MySQL edge: a real MySQL 8.4 refuses 3.4028235e38 where Postgres takes it', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` } },
+  'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_real, but at MySQL edge: a real MySQL 8.4 refuses 3.4028235e38 where Postgres takes it', divergence: { '*/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993 | T: `, 'update/arktype': `L: 9000000, 2147483648, 9007199254740993 | T: NaN`, 'select,insert/arktype': `L: 9000000, 2147483648, 9007199254740993 | T: ` } },
   // All four libraries now carry the same signature, where zod and typebox used to differ from
   // valibot and arktype on the infinities. That convergence is the fix: the two that refused a
   // non-finite number no longer do.
@@ -2135,9 +2135,9 @@ const ALLOWED: Record<string, Waiver> = {
   // to waive. It is the one cell of the twelve that reports parity.
   'pg/c_numeric_n': { libs: LIB_NAMES, modes: MODE_NAMES, except: ['update/arktype'], why: 'Postgres stores NaN in a numeric column and returns it; official refuses the value the database hands back', divergence: { '*/*': `L: NaN | T: ` } },
   'pg/c_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'no finite bound is true of an 8 byte float, which holds every finite JS number. Non-finite values were added on top: Postgres stores NaN and both infinities in a float column and returns them, and a Select schema refusing what the database hands back fails on real rows (AW).', divergence: { 'select,insert/*': `L: 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/zod,valibot,typebox': `L: 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
-  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; MySQL REAL is a synonym for DOUBLE', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
-  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
-  'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; SQLite REAL is an 8 byte IEEE float', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
+  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; MySQL REAL is a synonym for DOUBLE', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
+  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
+  'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; SQLite REAL is an 8 byte IEEE float', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   // ---- binary and varbinary, where official refuses rows the server returns --------------------
   // Official emits `^[01]*$` capped at n for these columns on v1, which is a bit-string pattern on
   // a column holding arbitrary bytes, so it rejects every ordinary string MySQL hands back. Asked
@@ -2222,7 +2222,7 @@ const ALLOWED: Record<string, Waiver> = {
   'pg/n_check': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'DRZL enforces the column CHECK; no first-party module reads one', divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 1900, 2000, 2500, 17, 101` } },
   'mysql/m_n_text': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as mysql/m_text', divergence: { '*/*': `L:  | T: 22000 cjk` } },
   'mysql/m_n_tinytext': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as mysql/m_tinytext', divergence: { '*/*': `L:  | T: 100 emoji` } },
-  'mysql/m_n_float': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as mysql/m_float', divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` } },
+  'mysql/m_n_float': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as mysql/m_float, and arktype is tighter in every mode rather than only on update: the nullable arm leaks on the object, the optional one only through the key', divergence: { '*/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993 | T: `, '*/arktype': `L: 9000000, 2147483648, 9007199254740993 | T: NaN` } },
   'mysql/valibot/m_n_json': { libs: ['valibot'], modes: MODE_NAMES, why: 'as pg/valibot/c_json', divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` } },
   'mysql/m_n_datetime': {
     libs: LIB_NAMES,
@@ -2233,7 +2233,7 @@ const ALLOWED: Record<string, Waiver> = {
     },
   },
   'mysql/m_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/n_check, in MySQL spelling', divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 1900, 2000, 2500, 17, 101` } },
-  'sqlite/s_n_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as sqlite/s_real', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
+  'sqlite/s_n_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as sqlite/s_real', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, '*/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN` } },
   'sqlite/s_n_blob': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as sqlite/s_blob_buf', divergence: { '*/*': `L: Uint8Array | T: ` } },
   'sqlite/valibot/s_n_json': { libs: ['valibot'], modes: MODE_NAMES, why: 'as pg/valibot/c_json', divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` } },
   'sqlite/s_n_ts': {
@@ -2418,9 +2418,9 @@ const CROSS_ALLOWED: Record<string, CrossWaiver> = {
   //
   // No `real` entry: the float4 bound refuses Infinity in all four, so they agree there for a
   // reason that has nothing to do with the libraries.
-  'mysql/m_real': { modes: ['select', 'insert', 'update'], why: 'as pg/c_double', divergence: { 'select': `Infinity: valibot/arktype accept, zod/typebox reject`, 'insert': `Infinity: valibot/arktype accept, zod/typebox reject`, 'update': `NaN: arktype accept, zod/valibot/typebox reject; Infinity: valibot/arktype accept, zod/typebox reject` } },
-  'mysql/m_double': { modes: ['select', 'insert', 'update'], why: 'as pg/c_double', divergence: { 'select': `Infinity: valibot/arktype accept, zod/typebox reject`, 'insert': `Infinity: valibot/arktype accept, zod/typebox reject`, 'update': `NaN: arktype accept, zod/valibot/typebox reject; Infinity: valibot/arktype accept, zod/typebox reject` } },
-  'sqlite/s_real': { modes: ['select', 'insert', 'update'], why: 'as pg/c_double', divergence: { 'select': `Infinity: valibot/arktype accept, zod/typebox reject`, 'insert': `Infinity: valibot/arktype accept, zod/typebox reject`, 'update': `NaN: arktype accept, zod/valibot/typebox reject; Infinity: valibot/arktype accept, zod/typebox reject` } },
+  'mysql/m_real': { modes: ['select', 'insert', 'update'], why: 'as pg/c_double', divergence: { '*': `Infinity: valibot/arktype accept, zod/typebox reject` } },
+  'mysql/m_double': { modes: ['select', 'insert', 'update'], why: 'as pg/c_double', divergence: { '*': `Infinity: valibot/arktype accept, zod/typebox reject` } },
+  'sqlite/s_real': { modes: ['select', 'insert', 'update'], why: 'as pg/c_double', divergence: { '*': `Infinity: valibot/arktype accept, zod/typebox reject` } },
   // The same two splits on the nullable table, which is what says the wrapper each generator puts
   // round a nullable column does not change which library can express what.
   'pg/n_json': { modes: ['select', 'insert', 'update'], why: 'as pg/c_json', divergence: { '*': `NaN: arktype accept, zod/valibot/typebox reject; Infinity: arktype accept, zod/valibot/typebox reject; Date: arktype accept, zod/valibot/typebox reject; Buffer: arktype accept, zod/valibot/typebox reject; Uint8Array: arktype accept, zod/valibot/typebox reject` } },
@@ -2448,8 +2448,11 @@ const CROSS_ALLOWED: Record<string, CrossWaiver> = {
    * strict ones, exactly as with `Infinity` on the 8 byte floats above, and the honest description
    * of a Postgres float column still needs a union in every generator rather than a range.
    */
-  'mysql/m_n_float': { modes: ['select', 'insert', 'update'], why: 'as pg/n_real', divergence: { '*': `NaN: arktype accept, zod/valibot/typebox reject` } },
-  'sqlite/s_n_real': { modes: ['select', 'insert', 'update'], why: 'as pg/n_real on NaN, and as pg/c_double on Infinity, which no bound holds back here', divergence: { '*': `NaN: arktype accept, zod/valibot/typebox reject; Infinity: valibot/arktype accept, zod/typebox reject` } },
+  // The NaN half is gone: arktype no longer lets one through a union arm, and MySQL and SQLite
+  // store no NaN in any numeric column, so refusing it is right here where accepting it is
+  // right on Postgres. What is left is the Infinity half, which is a different mechanism: an
+  // unbounded `number` takes both infinities in valibot and arktype, in every mode.
+  'sqlite/s_n_real': { modes: ['select', 'insert', 'update'], why: 'as pg/c_double on Infinity, which no bound holds back here', divergence: { '*': `Infinity: valibot/arktype accept, zod/typebox reject` } },
   // No bigint entry either, for the reason given in ALLOWED: arktype now bounds a bigint with a
   // narrow, so the four generators agree about `c_bigint_b`, `m_bigint_b` and `s_blob_bigint`.
   // No `c_char` entry. There was one, reading "zod and valibot count code points; TypeBox and
@@ -2478,18 +2481,7 @@ const CROSS_ALLOWED: Record<string, CrossWaiver> = {
  * and confirmed by re-measuring on master rather than deduced from a diff, but nothing in the gate
  * could see it: select mode has no coercion, so all four agreed there. Filed as BC.
  */
-const CROSS_DEFECTS: Record<string, CrossWaiver> = {
-  // Not the same defect as the rest of this ledger, and not a waiver either. ArkType's optional
-  // union arm accepts NaN where its bare `number` refuses one, which is the behaviour the
-  // `pg/n_real` waiver already documents for the nullable arm. There it is waived because Postgres
-  // stores NaN in a float column, so accepting it is right. Here the database is MySQL, which
-  // stores no NaN in any numeric column at all: measured against a real MySQL 8.4, `float` and
-  // `double` reject it outright and `decimal` silently writes 0.00. So arktype alone accepts a
-  // value the server will refuse, on update only, because that is the only mode whose fields are
-  // optional. Filed as BD.
-  'mysql/m_float': { modes: ['update'], why: 'arktype accepts NaN through the optional union arm; MySQL stores no NaN in any numeric column', divergence: { '*': `NaN: arktype accept, zod/valibot/typebox reject` } },
-};
-const usedCrossWaivers = new Set<string>();
+const CROSS_DEFECTS: Record<string, CrossWaiver> = {};const usedCrossWaivers = new Set<string>();
 // What each cross-generator waiver actually discarded, so the declaration can be compared with the
 // run. `crossAllowed` used to return a boolean and the caller threw the rows away unread.
 const crossWaived = new Map<string, string>();
@@ -7272,7 +7264,7 @@ const ALLOWED: Record<string, Entry> = {
   'pg/c_numeric_n': { libs: LIB_NAMES, modes: MODE_NAMES, except: ['update/arktype'], divergence: { '*/*': `L: NaN | T: ` }, drzl: 'a number, plus the NaN Postgres stores in a numeric column', official: 'a number, refusing the NaN the database hands back', filed: 'not a defect: as pg/c_real' },
   // Not `as pg/c_real` in the signature, which it was until MySQL was measured: the two 4 byte
   // floats have different edges, and `3.4028235e38` is the probe that says so.
-  'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` }, drzl: 'as pg/c_real, at the narrower MySQL edge', official: 'as pg/c_real', filed: 'as pg/c_real' },
+  'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993 | T: `, 'update/arktype': `L: 9000000, 2147483648, 9007199254740993 | T: NaN`, 'select,insert/arktype': `L: 9000000, 2147483648, 9007199254740993 | T: ` }, drzl: 'as pg/c_real, at the narrower MySQL edge', official: 'as pg/c_real', filed: 'as pg/c_real' },
   'pg/c_double': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,
@@ -7285,9 +7277,9 @@ const ALLOWED: Record<string, Entry> = {
     official: 'a number within +/-140737488355327, which refuses an ordinary microsecond epoch',
     filed: 'not a defect: as pg/c_real',
   },
-  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
-  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
-  'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
 
   // ---- the nullable table --------------------------------------------------------------------
   // Each of these is the divergence its `notNull` twin in `matrix` already carries, measured again
@@ -7307,11 +7299,11 @@ const ALLOWED: Record<string, Entry> = {
   'pg/n_check': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 1900, 2000, 2500, 17, 101` }, drzl: 'the column CHECK, as a bound', official: 'no CHECK at all: no first-party module reads one', filed: 'not a defect: this is what DRZL is for' },
   'mysql/m_n_text': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 22000 cjk` }, drzl: 'as mysql/m_text', official: 'as mysql/m_text', filed: 'as mysql/m_text' },
   'mysql/m_n_tinytext': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 100 emoji` }, drzl: 'as mysql/m_tinytext', official: 'as mysql/m_tinytext', filed: 'as mysql/m_tinytext' },
-  'mysql/m_n_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: 9000000, 2147483648, 9007199254740993 | T: ` }, drzl: 'as mysql/m_float', official: 'as mysql/m_float', filed: 'as pg/c_real' },
+  'mysql/m_n_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993 | T: `, '*/arktype': `L: 9000000, 2147483648, 9007199254740993 | T: NaN` }, drzl: 'as mysql/m_float', official: 'as mysql/m_float', filed: 'as pg/c_real' },
   'mysql/m_n_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
   'mysql/m_n_datetime': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/*': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   'mysql/m_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 1900, 2000, 2500, 17, 101` }, drzl: 'as pg/n_check', official: 'as pg/n_check', filed: 'as pg/n_check' },
-  'sqlite/s_n_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot,arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  'sqlite/s_n_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, '*/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
   'sqlite/s_n_json': { libs: ['valibot'], modes: MODE_NAMES, divergence: { '*/*': `L:  | T: Infinity, Date, Buffer, Uint8Array` }, drzl: 'as pg/c_json', official: 'as pg/c_json', filed: 'as pg/c_json' },
   'sqlite/s_n_ts': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/*': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: `, }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'as pg/c_date_d' },
   'sqlite/s_n_check': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L:  | T: 0, 1, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, 17, 101` }, drzl: 'as pg/n_check', official: 'as pg/n_check', filed: 'as pg/n_check' },


### PR DESCRIPTION
Addendum BD. The last entry in `CROSS_DEFECTS`, which is now empty.

## The mechanism is not what the filing said

I filed this as "arktype's optional union arm accepts NaN". The measurement says otherwise: **ArkType's bounded `number` stops refusing `NaN` the moment it becomes one branch of a union beside a unit branch**, while still refusing an infinity and everything out of range.

```
min <= number <= max              refuses NaN
(min <= number <= max | null)     ACCEPTS NaN, still refuses Infinity and 1e300
{ "x?": "min <= number <= max" }  object refuses NaN, schema.get("x") ACCEPTS it
number.integer | null             refuses NaN
```

`NaN` alone, because it is the one value that compares false against **both** ends of a range. Integer columns were never affected: `number.integer` states integrality as a predicate, which `NaN` fails inside a union too.

## The gate saw 1 instance; the mechanism was leaking in 14 of 24

Two unions are emitted, and they leak differently:

| arm | leaks on | modes |
|---|---|---|
| `\| null` (nullable column) | the object itself | all three |
| `?` (optional key) | only a field lookup | update only |

`update` is the only mode where every key is optional, which is exactly why the gate reported `update m_float on NaN` and nothing else. The nullable arm was invisible to the pool.

This is worth stating plainly: **a gate probes a fixed pool, so one visible instance of a mechanism is a lower bound and never a measurement.** Asking for more than the gate found is what surfaced the other 13.

## Dialect-aware, not a blanket tightening

The same acceptance is **correct on Postgres**, which stores `NaN` in a float column and returns it (#125). The analyzer already carries the fact as `allowsNaN`.

Postgres output is **byte-identical** before and after, and arktype stays at **275 against its 280 budget**, because no Postgres float gains the narrow. Verified rather than assumed: `NaN` and both infinities are still accepted on `pg` `real` and `double precision`, NOT NULL and nullable, in all three modes.

The DSL cannot express this. `number.integer` and `number.epoch` refuse `NaN` and also refuse `1.5`; `number.safe` leaks exactly as a bare range does; the unit keywords intersect with a range to an unsatisfiable type that throws at import.

## A waiver died rather than shifting

`CROSS_ALLOWED['mysql/m_n_float']` read `as pg/n_real`. That is the wrong arbiter: Postgres stores `NaN`, MySQL stores none in any numeric column. The entry was wrong on its face and only the fix exposed it.

The rest of the cascade splits by nullability, which the signatures do not encode and which I got wrong twice before the gate's exact-match rule stopped me:

```
m_float    NOT NULL   update/arktype gains NaN; select and insert do not
m_n_float  nullable   */arktype gains NaN in every mode
s_n_real   nullable   */arktype gains NaN in every mode
```

`CROSS_DEFECTS` is now empty. It held twelve pins: eleven retired by #132 and this one by this PR, each fix reporting itself by making its pins stop firing.

## Also checked, and reported either way

- **Infinity does not leak through either arm.** An infinity fails a bound inside a union exactly as it does outside one.
- **A separate, pre-existing Infinity divergence remains** on unbounded MySQL and SQLite `double`/`real`: ArkType's bare `number` accepts both infinities in every mode, so it is not this leak. Already waived; fixing it needs a narrow on every unbounded number column in every mode and belongs in its own change.

## Tests

Written first, 3 of 9 failing on unmodified sources, enumerating all 14 leaking combinations and asserting the narrow count. Every spec runs the emitted module through the real analyzer, checking both the field (`.get`) and the whole row, in all three modes, on both dialects.

`pnpm verify:packed`, `build`, `-r test` (1263 tests), `typecheck`, `lint`, `docs build` all green.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
