### PR TITLE
fix(typebox): keep the key required when a nullable column is unknown

### DIFF
--- a/.changeset/nullable-unknown-key-required.md
+++ b/.changeset/nullable-unknown-key-required.md
@@ -1,0 +1,60 @@
+---
+'@drzl/generator-typebox': patch
+'@drzl/analyzer': patch
+---
+
+A TypeBox select schema stops accepting a row that never mentions a column it declares, and two
+SQLite classes the drizzle-orm 0.4x path could not name are named.
+
+**The hole was a kind check, not a missing `required`.** Measured on TypeBox 0.34.52 rather than
+reasoned about: `Value.Check` on an object visits every property named in `required` with
+`value[key]`, which is `undefined` when the key is absent, and `Type.Unknown()` accepts `undefined`
+along with everything else. The only thing that then refuses the row is a guard beside that visit,
+`ExtendsUndefinedCheck(property) || IsAnyOrUnknown(property)`, and `IsAnyOrUnknown` reads the
+property's `Kind`. So a bare `Type.Unknown()` keeps its key and
+`Type.Union([Type.Unknown(), Type.Null()])` does not: its kind is `Union`, the guard never fires,
+and the union's own check passes on `undefined` through the unknown arm. `TypeCompiler` agrees with
+`Value.Check` on every case, so neither entry point caught it.
+
+The `required` array named the key the whole time. Both the emitted source and the serialised JSON
+Schema said the key was required, and one of them was not, which is why this was invisible to
+anything that read the output instead of running it.
+
+**What changes in the generator.** A nullable column whose type nothing can name no longer gets the
+null union. `Type.Unknown()` already accepts `null`, so the union added no value and took the key
+away. This reaches a `customType`, a column the analyzer could not name, an `any` column and a
+typed json one, each alone or inside the `Type.Unsafe<T>` that `typedJson` and `typedColumns` emit,
+since `Type.Unsafe` copies the wrapped schema's kind. Nothing is lost: the runtime check admits the
+same set of values, and the static type does too, because a bare unknown already includes `null` and
+a narrowed one takes its type from drizzle's own `$inferSelect`, which spells a nullable column
+`T | null` on its own.
+
+A nullable **array** of unknowns keeps its union, because `Type.Array(...)` has its own kind and
+never had the hole. `insert` and `update` are unaffected: an absent key there is legitimate and is
+decided by `Type.Optional`, which lets the key go missing over an unknown exactly as it should. The
+emitted field shrinks from `Type.Union([Type.Unknown(), Type.Null()])` to `Type.Unknown()`.
+
+The zod, valibot, ArkType and JSON Schema generators do not change. All four already required the
+key for their own nullable unknown.
+
+**What changes in the analyzer.** Two SQLite classes fell off the end of the 0.4x class-name path
+and came back `unknown`, so every generator emitted a schema that accepts any value at all. Both
+answers are taken from drizzle's own mappers on 0.45.2 and both match what v1 already says about the
+same column:
+
+- `blob({ mode: 'buffer' })` builds a `SQLiteBlobBuffer`, whose `mapFromDriverValue` hands the
+  driver's Buffer straight back, so it is described as a buffer. A bare `blob()` is the same class
+  on this major and is described the same way; on v1 a bare `blob()` builds a `SQLiteBlobJson`
+  instead, and each major is reported as it is.
+- `integer({ mode: 'timestamp' })` and `integer({ mode: 'timestamp_ms' })` are one class,
+  `SQLiteTimestamp`, and one type: both hand back a `Date`, differing only in the scale of the
+  integer on the wire, which `mapFromDriverValue` consumes and no validator ever sees. The arm that
+  used to answer this tested `config.mode === 'timestamp'` and named only the first, so the second
+  was unknown. Keying on the class covers both.
+
+A `SQLiteBlob` class does not exist on either major, which is why a real `blob()` reached neither
+that arm nor anything else.
+
+Naming those two closes the TypeBox key hole for them as a side effect. It does not close it in
+general, which is why the generator changed as well: a nullable `customType` has no runtime shape to
+read on either major and is unnameable by design.

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -517,6 +517,24 @@ const BYTE_STRING_CLASSES = new Set([
 ]);
 
 /**
+ * 0.4x classes that hand back a real byte buffer rather than a string of bytes.
+ *
+ * The distinction from `BYTE_STRING_CLASSES` above is drizzle's own: those four define a
+ * `mapFromDriverValue` that decodes the driver's Buffer into a string, and this one does not.
+ * Asked of drizzle 0.45.2 directly, `blob({ mode: 'buffer' }).mapFromDriverValue(Buffer.from([1]))`
+ * hands the Buffer straight back.
+ *
+ * One class covers both spellings on this major: `blob()` and `blob({ mode: 'buffer' })` are the
+ * same `SQLiteBlobBuffer`, and only `json` and `bigint` mode build something else. On v1 a bare
+ * `blob()` builds a `SQLiteBlobJson` instead, so the two majors genuinely disagree about that one
+ * column and each is reported as it is; the two explicit modes agree.
+ *
+ * A set rather than a `GEOMETRIC_CLASS_SHAPES` entry only for consistency with the three sets
+ * beside it, which each name one family; a buffer shape carries no width.
+ */
+const BUFFER_CLASSES = new Set(['SQLiteBlobBuffer']);
+
+/**
  * Everything Drizzle v1 states about a column outright, or `null` on an older Drizzle.
  *
  * v1 stamps each column with a `dataType` of the form `"<js type> <semantic>"` (`"number
@@ -1424,12 +1442,36 @@ export class SchemaAnalyzer {
           tsType: column?.config?.mode === 'timestamp' ? 'Date' : 'number',
           dbType: 'INTEGER',
         };
+      // Both timestamp modes of `integer()`, which are one class and one type. `timestamp` and
+      // `timestamp_ms` differ in the scale of the number on the wire, seconds against
+      // milliseconds, and `mapFromDriverValue` consumes that difference and hands back a `Date`
+      // either way; nothing downstream of the analyzer ever sees the integer. So an arm keyed on
+      // the class covers both, where the mode check that used to answer this fell through the
+      // switch to a default arm testing `config.mode === 'timestamp'` and named only the first.
+      // The second came back `unknown`, and every generator emitted a schema accepting anything.
+      //
+      // `DATE` rather than the `INTEGER` that mode check returned, so the two majors describe the
+      // column identically. `dbType` is read in exactly one place outside this file,
+      // `isIntegerColumn`, which the generators consult only for a `tsType` of `number`, so the
+      // relabel reaches no output. Measured rather than argued: emitting a `Date` column under
+      // both labels, nullable and not, through all five generators gives ten byte-identical pairs.
+      case 'SQLiteTimestamp':
+        return { tsType: 'Date', dbType: 'DATE' };
       case 'SQLiteText':
         return { tsType: 'string', dbType: 'TEXT' };
       case 'SQLiteReal':
         return { tsType: 'number', dbType: 'REAL' };
+      // No 0.4x column is a `SQLiteBlob`: `sqlite-core` builds a `SQLiteBlobBuffer`, a
+      // `SQLiteBlobJson` or a `SQLiteBigInt`, one per mode, and exports no class of this name at
+      // all. The arm answers the hand-built column in sqlite-types.spec.ts and nothing drizzle
+      // produces, which is why a real `blob()` reached neither it nor anything else.
       case 'SQLiteBlob':
         return { tsType: 'Uint8Array', dbType: 'BLOB' };
+      // The class a real `blob()` and `blob({ mode: 'buffer' })` both build. See `BUFFER_CLASSES`
+      // for the measurement; the answers here are v1's own for the same column, so this is the
+      // two majors agreeing rather than a new opinion.
+      case 'SQLiteBlobBuffer':
+        return { tsType: 'Buffer', dbType: 'BYTEA' };
       // SQLite spells a mode as a distinct class rather than as config, so `text({mode:'json'})`
       // is a `SQLiteTextJson` and matched no arm at all: the column came back UNKNOWN, which is
       // wider than the `any` a json column at least used to get.
@@ -1915,11 +1957,13 @@ export class SchemaAnalyzer {
           ? { kind: 'json' }
           : BYTE_STRING_CLASSES.has(ctorName)
             ? { kind: 'byteString', length: declaredLength(col) }
-            : NUMBER_VECTOR_CLASSES.has(ctorName)
-              ? { kind: 'numberVector', length: declaredLength(col) }
-              : BIT_STRING_CLASSES.has(ctorName)
-                ? { kind: 'bitstring', length: declaredLength(col), exact: true }
-                : GEOMETRIC_CLASS_SHAPES[ctorName];
+            : BUFFER_CLASSES.has(ctorName)
+              ? { kind: 'buffer' }
+              : NUMBER_VECTOR_CLASSES.has(ctorName)
+                ? { kind: 'numberVector', length: declaredLength(col) }
+                : BIT_STRING_CLASSES.has(ctorName)
+                  ? { kind: 'bitstring', length: declaredLength(col), exact: true }
+                  : GEOMETRIC_CLASS_SHAPES[ctorName];
       // The same reason the v1 branch above drops it, reached from the other path: the declared
       // `length` of a binary column is not a character limit, and `maxLength` is applied as one in
       // every mode by every generator. Left in place the column carried the width twice under two

--- a/packages/analyzer/test/sqlite-blob-timestamp-0.4x.spec.ts
+++ b/packages/analyzer/test/sqlite-blob-timestamp-0.4x.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * The two SQLite classes the 0.4x class-name path could not name.
+ *
+ * Both came back `unknown`, so every generator emitted a schema that accepts any value at all,
+ * and on TypeBox a nullable one also let the key go missing from a select row. v1 answers both
+ * correctly from its `dataType`, so these expectations are v1's own answers rather than new
+ * opinions, and the last test here asserts that by analyzing the same source under both majors.
+ *
+ * Measured against drizzle's own mappers on 0.45.2 rather than inferred from the class names:
+ *
+ *   blob({ mode: 'buffer' })       SQLiteBlobBuffer   mapFromDriverValue hands back a Buffer
+ *   blob()                         SQLiteBlobBuffer   the same class, so the same answer
+ *   integer({ mode: 'timestamp' })     SQLiteTimestamp   hands back a Date
+ *   integer({ mode: 'timestamp_ms' })  SQLiteTimestamp   hands back a Date
+ *
+ * The two integer modes are one class and one type. They differ in the scale of the number on
+ * the wire, seconds against milliseconds, which `mapFromDriverValue` consumes and no validator
+ * ever sees, so an arm keyed on the class covers both and an arm keyed on the mode string could
+ * not. The old code was keyed on the mode string and named only `timestamp`.
+ *
+ * A bare `blob()` is `SQLiteBlobBuffer` on 0.45.2 and `SQLiteBlobJson` on 1.0.0-rc.4, so the two
+ * majors genuinely disagree about that one column and DRZL repeats each of them. That is why the
+ * cross-major assertion below names the explicit modes only.
+ */
+import { describe, it, expect } from 'vitest';
+import { SchemaAnalyzer } from '../src/index';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+async function analysed(mod: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-sqlite-blob-'));
+  const file = path.join(dir, 'schema.mjs');
+  await fs.writeFile(
+    file,
+    `
+import { sqliteTable, blob, integer } from '${mod}';
+export const t = sqliteTable('t', {
+  s_blob: blob('s_blob'),
+  s_blob_buf: blob('s_blob_buf', { mode: 'buffer' }),
+  s_blob_json: blob('s_blob_json', { mode: 'json' }),
+  s_blob_bigint: blob('s_blob_bigint', { mode: 'bigint' }),
+  s_int: integer('s_int'),
+  s_int_ts: integer('s_int_ts', { mode: 'timestamp' }),
+  s_int_ts_ms: integer('s_int_ts_ms', { mode: 'timestamp_ms' }),
+  s_int_bool: integer('s_int_bool', { mode: 'boolean' }),
+});
+`,
+    'utf8'
+  );
+  const res = await new SchemaAnalyzer(file).analyze();
+  return {
+    byName: new Map(res.tables[0].columns.map((c) => [c.name, c])),
+    issues: res.issues,
+  };
+}
+
+const OLD = 'drizzle-orm/sqlite-core';
+const NEW = 'drizzle-orm-v1/sqlite-core';
+
+describe('a SQLite buffer blob on drizzle-orm 0.4x', () => {
+  it('describes blob({ mode: buffer }) as the Buffer the driver hands back', async () => {
+    const { byName } = await analysed(OLD);
+    expect(byName.get('s_blob_buf')?.tsType).toBe('Buffer');
+    expect(byName.get('s_blob_buf')?.dbType).toBe('BYTEA');
+    expect(byName.get('s_blob_buf')?.shape).toEqual({ kind: 'buffer' });
+  });
+
+  it('describes a bare blob() the same way, because 0.4x builds the same class', async () => {
+    const { byName } = await analysed(OLD);
+    expect(byName.get('s_blob')?.shape).toEqual({ kind: 'buffer' });
+  });
+
+  it('leaves the other two blob modes alone', async () => {
+    const { byName } = await analysed(OLD);
+    expect(byName.get('s_blob_json')?.shape).toEqual({ kind: 'json' });
+    expect(byName.get('s_blob_bigint')?.tsType).toBe('bigint');
+  });
+});
+
+describe('a SQLite timestamp integer on drizzle-orm 0.4x', () => {
+  it('describes mode timestamp_ms as a Date, which mode timestamp already was', async () => {
+    const { byName } = await analysed(OLD);
+    expect(byName.get('s_int_ts_ms')?.tsType).toBe('Date');
+    expect(byName.get('s_int_ts')?.tsType).toBe('Date');
+  });
+
+  it('gives the two modes the same SQL label, since they are one class', async () => {
+    const { byName } = await analysed(OLD);
+    expect(byName.get('s_int_ts_ms')?.dbType).toBe(byName.get('s_int_ts')?.dbType);
+  });
+
+  it('leaves a plain and a boolean integer alone', async () => {
+    const { byName } = await analysed(OLD);
+    expect(byName.get('s_int')?.tsType).toBe('number');
+    expect(byName.get('s_int_bool')?.tsType).toBe('boolean');
+  });
+});
+
+describe('the untyped-column warning', () => {
+  it('names none of these columns on 0.4x any more', async () => {
+    const { issues } = await analysed(OLD);
+    const warned = issues
+      .filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN')
+      .map((i) => i.message.match(/"(\w+)"/)?.[1]);
+    expect(warned).toEqual([]);
+  });
+});
+
+describe('the two majors', () => {
+  it('describe the two explicit modes identically', async () => {
+    const [oldSide, newSide] = await Promise.all([analysed(OLD), analysed(NEW)]);
+    for (const name of ['s_blob_buf', 's_int_ts', 's_int_ts_ms']) {
+      expect(oldSide.byName.get(name), `${name} on 0.4x`).toEqual(newSide.byName.get(name));
+    }
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -202,6 +202,35 @@ const JSON_PREAMBLE = `const ${JSON_CONST} = Type.Recursive((This) =>
 `;
 
 /**
+ * The one expression a column whose type nothing can name emits, and the test for having emitted
+ * it.
+ *
+ * Both live here because the nullable wrapper further down has to recognise its own input, and
+ * the alternative is a second copy of the four branch conditions that produce this, which would
+ * drift. A `customType`, a column the analyzer could not name, an `any` column and a typed json
+ * one all arrive as this expression, alone or inside a `Type.Unsafe<T>` that narrows only the
+ * static type.
+ *
+ * What makes the test necessary rather than cosmetic, measured on TypeBox 0.34.52: a required
+ * property is checked against `value[key]`, which is `undefined` when the key is absent, and
+ * `Type.Unknown()` accepts `undefined`. The only thing that then refuses the row is a guard
+ * beside that check reading `IsAnyOrUnknown(property)`, which tests `property[Kind]`. So a bare
+ * `Type.Unknown()` keeps its key, and `Type.Union([Type.Unknown(), Type.Null()])` does not: its
+ * kind is `Union`, the guard does not fire, and the union's own check passes on `undefined`
+ * through the unknown arm. The `required` array names the key either way, so the emitted text and
+ * the serialised JSON Schema both claim a key that one of them did not have.
+ *
+ * `Type.Unsafe<T>(...)` copies the wrapped schema's kind, so a narrowed unknown is still one.
+ */
+const UNKNOWN_EXPR = 'Type.Unknown()';
+
+function isUnknownExpr(expr: string): boolean {
+  return (
+    expr === UNKNOWN_EXPR || (expr.startsWith('Type.Unsafe<') && expr.endsWith(`(${UNKNOWN_EXPR})`))
+  );
+}
+
+/**
  * A column whose value is structured rather than scalar.
  *
  * These used to land on `Type.Unknown()`, or for the tuple types on `Type.String()`, which
@@ -213,12 +242,12 @@ function tbShapeExpr(c: Column, mode: Mode, typedJsonRef?: string): string | und
   switch (s.kind) {
     case 'json':
       // `typedJson` still wins, since the inferred type is narrower than "any JSON".
-      if (typedJsonRef) return `Type.Unsafe<${typedJsonRef}>(Type.Unknown())`;
+      if (typedJsonRef) return `Type.Unsafe<${typedJsonRef}>(${UNKNOWN_EXPR})`;
       return JSON_CONST;
     case 'custom':
       // Nothing to check at runtime: see the zod generator for why guessing from `getSQLType()`
       // would be wrong. `Type.Unsafe<T>` is TypeBox's escape hatch for exactly this.
-      return typedJsonRef ? `Type.Unsafe<${typedJsonRef}>(Type.Unknown())` : 'Type.Unknown()';
+      return typedJsonRef ? `Type.Unsafe<${typedJsonRef}>(${UNKNOWN_EXPR})` : UNKNOWN_EXPR;
     case 'buffer':
       return 'Type.Uint8Array()';
     case 'tuple':
@@ -351,10 +380,10 @@ function tbExprForColumn(
     case 'any':
       // `typedJson` swaps the wide type for the one Drizzle inferred. `Type.Unsafe<T>` is
       // TypeBox's own escape hatch for a static type it cannot narrow at runtime.
-      if (typedJsonRef) return `Type.Unsafe<${typedJsonRef}>(Type.Unknown())`;
-      return 'Type.Unknown()';
+      if (typedJsonRef) return `Type.Unsafe<${typedJsonRef}>(${UNKNOWN_EXPR})`;
+      return UNKNOWN_EXPR;
     default:
-      return 'Type.Unknown()';
+      return UNKNOWN_EXPR;
   }
 }
 
@@ -402,7 +431,24 @@ function tbField(
   }
   // Nullability wraps the constrained type, so null skips the constraint. That reproduces SQL,
   // where a CHECK passes when it evaluates to TRUE or NULL.
-  if (c.nullable) expr = `Type.Union([${expr}, Type.Null()])`;
+  //
+  // Except over an unknown, where the union is the whole of a defect rather than a wrapper: it
+  // adds nothing, since `Type.Unknown()` already accepts `null`, and it takes the key away, since
+  // TypeBox keeps a required unknown key only while the property's kind *is* `Unknown`. See
+  // `isUnknownExpr` for the measurement. So a select schema for a nullable `customType` accepted a
+  // row that never mentioned the column, while the same column declared `notNull` refused one.
+  //
+  // Nothing is lost by leaving it off. The runtime check is the same set of values either way, and
+  // the static type is too: a bare unknown already admits `null`, and where `typedJson` or
+  // `typedColumns` has narrowed it the type comes from drizzle's own `$inferSelect`, which spells
+  // a nullable column `T | null` on its own. The union was restating that, not adding it.
+  //
+  // The test is on the expression rather than on the column, because an array of unknowns is not
+  // one: `Type.Array(...)` has its own kind, keeps its key, and still needs the null arm.
+  //
+  // This says nothing about whether the key is optional in a write schema. That is decided below,
+  // by `Type.Optional`, and `Type.Optional(Type.Unknown())` lets the key go missing as it should.
+  if (c.nullable && !isUnknownExpr(expr)) expr = `Type.Union([${expr}, Type.Null()])`;
   // The default goes on the schema itself, before anything wraps it. Applied after the
   // `Type.Unsafe` wrapper instead, it landed on the wrapper, where `withDefault` declines to
   // touch it and the default was silently dropped: the field carried none at all and nothing

--- a/packages/generator-typebox/test/nullable-unknown-key.spec.ts
+++ b/packages/generator-typebox/test/nullable-unknown-key.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * A row that never mentions a column, checked against a select schema that declares it.
+ *
+ * The mechanism, measured on TypeBox 0.34.52 rather than reasoned about. `Value.Check` on an
+ * object visits every property named in `required` with `value[key]`, which is `undefined` when
+ * the key is absent, and `Type.Unknown()` accepts `undefined` like everything else. What stops a
+ * required unknown key going missing is a second guard beside that visit:
+ *
+ *     if ((ExtendsUndefinedCheck(property) || IsAnyOrUnknown(property)) && !(key in value))
+ *
+ * `IsAnyOrUnknown` reads `property[Kind]`, so it fires on `Type.Unknown()` and does not fire on
+ * `Type.Union([Type.Unknown(), Type.Null()])`, whose kind is `Union`. The union's own check then
+ * passes on `undefined` through its unknown arm. So the nullable form of an unnameable column
+ * accepted `{}` while the notNull form refused it, and the `required` array named the key in both.
+ * That is why this file runs the schemas: the emitted text and the serialised JSON Schema both
+ * say the key is required, and one of them was not.
+ *
+ * `Type.Unsafe<T>(...)` copies the wrapped schema's `Kind`, so a narrowed unknown keeps the guard
+ * too, and the static type of a nullable column already carries `| null` through drizzle's own
+ * `$inferSelect`, so nothing is lost by dropping a union that only ever restated it.
+ *
+ * Both entry points, because they are two implementations: `Value.Check` walks the schema and
+ * `TypeCompiler` emits a function. Measured, they agree on every case here.
+ */
+import { describe, it, expect } from 'vitest';
+import { TypeBoxGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'unknown',
+    dbType: 'UNKNOWN',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+async function schemasFor(columns: Column[], label: string): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'sqlite',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks: [] }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-nullable-unknown');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${label}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), file);
+  return await import(file);
+}
+
+/** Both TypeBox entry points, so a disagreement between them is a failure rather than a coin toss. */
+function check(schema: any, value: unknown): boolean {
+  const walked = Value.Check(schema, value);
+  const compiled = TypeCompiler.Compile(schema).Check(value);
+  if (walked !== compiled) {
+    throw new Error(
+      `Value.Check says ${walked} and TypeCompiler says ${compiled} for ${JSON.stringify(value)}`
+    );
+  }
+  return walked;
+}
+
+// The three ways a column reaches `Type.Unknown()`: a customType with no runtime shape, a column
+// whose type the analyzer could not name at all, and a json column with no shape.
+const UNNAMEABLE: Array<[string, Partial<Column>]> = [
+  ['a customType', { shape: { kind: 'custom', sqlType: 'blob' } as never }],
+  ['an unnamed column', {}],
+  ['an any column', { tsType: 'any' }],
+];
+
+describe('a nullable column whose type is unknown, in a select schema', () => {
+  for (const [what, over] of UNNAMEABLE) {
+    it(`refuses a row that never mentions ${what}`, async () => {
+      const m = await schemasFor(
+        [col('id', { tsType: 'number', dbType: 'INTEGER' }), col('c', { ...over, nullable: true })],
+        `sel-${what.replace(/\W+/g, '')}`
+      );
+      expect(check(m.SelecttSchema, { id: 1 }), 'the key omitted').toBe(false);
+      expect(check(m.SelecttSchema, { id: 1, c: null }), 'an explicit null').toBe(true);
+      expect(check(m.SelecttSchema, { id: 1, c: 'anything' }), 'any value at all').toBe(true);
+      expect(check(m.SelecttSchema, { id: 1, c: undefined }), 'an explicit undefined').toBe(true);
+    });
+  }
+
+  it('still refuses a row that omits a notNull unknown column', async () => {
+    const m = await schemasFor([col('c')], 'sel-notnull');
+    expect(check(m.SelecttSchema, {}), 'the key omitted').toBe(false);
+    expect(check(m.SelecttSchema, { c: null }), 'an explicit null').toBe(true);
+    expect(check(m.SelecttSchema, { c: 7 }), 'any value at all').toBe(true);
+  });
+
+  it('leaves a nullable column whose type is known alone', async () => {
+    const m = await schemasFor(
+      [col('c', { tsType: 'string', dbType: 'TEXT', nullable: true })],
+      'sel-known'
+    );
+    expect(check(m.SelecttSchema, {}), 'the key omitted').toBe(false);
+    expect(check(m.SelecttSchema, { c: null }), 'an explicit null').toBe(true);
+    expect(check(m.SelecttSchema, { c: 'x' }), 'a string').toBe(true);
+    expect(check(m.SelecttSchema, { c: 1 }), 'a number').toBe(false);
+  });
+
+  it('leaves a nullable array of unknowns alone, since the array is not the unknown', async () => {
+    const m = await schemasFor([col('c', { nullable: true, arrayDimensions: 1 })], 'sel-array');
+    expect(check(m.SelecttSchema, {}), 'the key omitted').toBe(false);
+    expect(check(m.SelecttSchema, { c: null }), 'an explicit null').toBe(true);
+    expect(check(m.SelecttSchema, { c: [1, 'x'] }), 'an array').toBe(true);
+    expect(check(m.SelecttSchema, { c: 1 }), 'a bare value').toBe(false);
+  });
+});
+
+describe('the write schemas, where an absent key is legitimate', () => {
+  it('lets insert omit a nullable unknown column', async () => {
+    const m = await schemasFor([col('c', { nullable: true })], 'ins');
+    expect(check(m.InserttSchema, {}), 'the key omitted').toBe(true);
+    expect(check(m.InserttSchema, { c: null })).toBe(true);
+    expect(check(m.InserttSchema, { c: 'x' })).toBe(true);
+  });
+
+  it('lets update omit one, and a notNull one too', async () => {
+    const m = await schemasFor([col('c', { nullable: true }), col('d')], 'upd');
+    expect(check(m.UpdatetSchema, {}), 'both keys omitted').toBe(true);
+    expect(check(m.UpdatetSchema, { c: null, d: 1 })).toBe(true);
+  });
+
+  it('still demands a notNull unknown column on insert', async () => {
+    const m = await schemasFor([col('c')], 'ins-notnull');
+    expect(check(m.InserttSchema, {}), 'the key omitted').toBe(false);
+    expect(check(m.InserttSchema, { c: 1 })).toBe(true);
+  });
+
+  it('lets insert omit a notNull unknown column that has a default', async () => {
+    const m = await schemasFor([col('c', { hasDefault: true })], 'ins-default');
+    expect(check(m.InserttSchema, {}), 'the key omitted').toBe(true);
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -2291,7 +2291,25 @@ const allowed = (dialect: string, lib: string, col: string, mode: string, signat
  * asserted exactly like ALLOWED, in both directions, so an entry that suppresses nothing fails and
  * an entry whose pairings have moved fails with the measured reading printed.
  */
-const PRESENCE_ALLOWED: Record<string, Waiver> = {};
+const PRESENCE_ALLOWED: Record<string, Waiver> = {
+  // DRZL is the stricter side here, and that is the whole point of the change that produced it.
+  // A nullable `customType` cannot be named by any analyzer, so its schema is an unknown. TypeBox
+  // used to wrap that in `Type.Union([Type.Unknown(), Type.Null()])`, and a union's own kind is
+  // `Union`, so the guard that refuses an absent key for an `Unknown` property never fired: a row
+  // that never mentioned the column validated clean against a schema declaring it, while the
+  // serialised JSON Schema said `"required": ["s_n_custom"]` either way.
+  //
+  // Official emits the identical union, so both sides agreed and no differential check could see
+  // it. It took an absolute assertion, that a select schema requires every key, to find at all.
+  // Now that DRZL emits a bare unknown, which already admits null and keeps its key, this pairing
+  // is the one place the fix is visible as a divergence (AQ).
+  'sqlite/typebox/s_n_custom': {
+    libs: ['typebox'],
+    modes: ['select'],
+    why: 'a nullable unknown keeps its key in DRZL; official wraps it in a union whose key TypeBox lets go missing',
+    divergence: { 'select/typebox': `official optional, DRZL required` },
+  },
+};
 
 /**
  * Where the presence axis cannot read a side at all, because that side's schema for the column
@@ -2336,7 +2354,6 @@ let presenceUnreadable = 0;
  * would go dead.
  */
 const SELECT_OPTIONAL: Record<string, string> = {
-  'sqlite/typebox/s_n_custom': 'a nullable customType is unknown on both majors, and official emits the same union',
 };
 const usedSelectOptional = new Set<string>();
 const selectOptionalProblems: string[] = [];
@@ -7096,6 +7113,20 @@ const WRITE = ['insert', 'update'];
  * in its own ALLOWED map, except where noted on `c_char`.
  */
 const ALLOWED: Record<string, Entry> = {
+  // ---- five columns that stopped being defects when the class-name path learned their names ----
+  // Each of these was `unknown, which accepts every value in the pool`. `SQLiteBlobBuffer` and the
+  // millisecond timestamp mode now have arms, so what is left is the ordinary divergence the rest
+  // of this ledger already carries: a byte column typed as `Uint8Array` where official demands a
+  // `Buffer`, and a date column that coerces on write where official does not.
+  //
+  // Note the timestamp pair is write modes only. On select the two agree exactly, which is the
+  // shape of a defect fixed rather than moved.
+  'sqlite/s_blob': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: Uint8Array | T: ` }, drzl: 'as pg/c_bytea', official: 'as pg/c_bytea', filed: 'not a defect: as pg/c_bytea' },
+  'sqlite/s_blob_buf': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: Uint8Array | T: ` }, drzl: 'as sqlite/s_blob', official: 'as sqlite/s_blob', filed: 'as sqlite/s_blob' },
+  'sqlite/s_n_blob': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/*': `L: Uint8Array | T: ` }, drzl: 'as sqlite/s_blob', official: 'as sqlite/s_blob', filed: 'as sqlite/s_blob' },
+  'sqlite/s_int_ts_ms': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/*': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: ` }, drzl: 'as pg/c_date_d', official: 'as pg/c_date_d', filed: 'not a defect: as pg/c_date_d' },
+  'sqlite/s_n_ts_ms': { libs: LIB_NAMES, modes: WRITE, divergence: { '*/*': `L: 0, 1, 1.5, -1, 200, 40000, 9000000, 2147483648, 1900, 2000, 2500, '2020-01-01', '2020-01-01T00:00:00Z', 17, 18, 50, 100, 101 | T: ` }, drzl: 'as sqlite/s_int_ts_ms', official: 'as sqlite/s_int_ts_ms', filed: 'as sqlite/s_int_ts_ms' },
+
   // Two independent differences meet on this column, and only the first of them is in the v1 pass.
   //
   //   code points   a character limit counts characters; official counts `.length`, which is
@@ -7408,42 +7439,6 @@ const DEFECTS: Record<string, Entry> = {
   // diverges from official any more. `pg/c_geometry` and `pg/n_geometry` moved to `ALLOWED` above,
   // narrowed from all four libraries and twelve pairings to valibot and three, in the one direction
   // where DRZL is the stricter and correct side.
-  'sqlite/s_blob': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      'select,insert/*': allProbes(62, ['Buffer']),
-      'update/zod,valibot,arktype': allProbes(61, ['undefined', 'Buffer']),
-      'update/typebox': allProbes(62, ['Buffer']),
-    },
-    drzl: 'unknown, which accepts every value in the pool',
-    official: 'a Buffer',
-    filed: 'new: no SQLiteBlobBuffer arm in the class-name path',
-  },
-  'sqlite/s_blob_buf': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      'select,insert/*': allProbes(62, ['Buffer']),
-      'update/zod,valibot,arktype': allProbes(61, ['undefined', 'Buffer']),
-      'update/typebox': allProbes(62, ['Buffer']),
-    },
-    drzl: 'unknown, which accepts every value in the pool',
-    official: 'a Buffer',
-    filed: 'new: as sqlite/s_blob',
-  },
-  'sqlite/s_int_ts_ms': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      'select,insert/*': allProbes(62, ['Date']),
-      'update/zod,valibot,arktype': allProbes(61, ['undefined', 'Date']),
-      'update/typebox': allProbes(62, ['Date']),
-    },
-    drzl: 'unknown, which accepts every value in the pool',
-    official: 'a Date',
-    filed: 'new: integer({ mode: timestamp_ms }) is unnamed on 0.4x',
-  },
 
   // ---- a wrong type on MySQL -----------------------------------------------------------------
   // The class-name path answering with the wrong JavaScript type rather than with nothing.
@@ -7508,30 +7503,6 @@ const DEFECTS: Record<string, Entry> = {
   // `pg/n_geometry` and `pg/n_bit` were here, the nullable twins of the two above, and went
   // the same way for the same reason: the classes are named, so a nullable one is no longer an
   // unknown wrapped in a union.
-  'sqlite/s_n_blob': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      'select/*': allProbes(61, ['null', 'Buffer']),
-      'insert,update/zod,valibot,arktype': allProbes(60, ['null', 'undefined', 'Buffer']),
-      'insert,update/typebox': allProbes(61, ['null', 'Buffer']),
-    },
-    drzl: 'unknown, which accepts every value in the pool',
-    official: 'a Buffer, or null',
-    filed: 'as sqlite/s_blob_buf: no SQLiteBlobBuffer arm in the class-name path',
-  },
-  'sqlite/s_n_ts_ms': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      'select/*': allProbes(61, ['null', 'Date']),
-      'insert,update/zod,valibot,arktype': allProbes(60, ['null', 'undefined', 'Date']),
-      'insert,update/typebox': allProbes(61, ['null', 'Date']),
-    },
-    drzl: 'unknown, which accepts every value in the pool',
-    official: 'a Date, or null',
-    filed: 'as sqlite/s_int_ts_ms: integer({ mode: timestamp_ms }) has no arm on 0.4x',
-  },
   'sqlite/s_n_int': {
     libs: ['valibot', 'arktype', 'typebox'],
     modes: MODE_NAMES,
@@ -7636,33 +7607,28 @@ const SELECT_OPTIONAL: Record<string, string> = {
   // `vector`, `geometry` and `bit` means those columns no longer emit an unknown, so their nullable
   // form is no longer the union whose TypeBox key may go missing, and this check retired each one
   // by name as its arm landed. Only SQLite is left, where two classes are still unnamed.
-  'sqlite/typebox/s_n_blob': 'no SQLiteBlobBuffer arm, so a nullable unknown whose TypeBox key may be missing',
-  'sqlite/typebox/s_n_ts_ms': 'as sqlite/typebox/s_n_blob, with no timestamp_ms arm',
-  'sqlite/typebox/s_n_custom': 'a nullable customType is unknown on both majors, and official emits the same union',
 };
 
 const PRESENCE: Record<string, Entry> = {
   // `pg/n_geometry` sat here for the same reason and left with the rest of them.
-  'sqlite/s_n_blob': {
+  // The two entries that stood here said DRZL was the looser side, its TypeBox key going missing
+  // where official's stayed required. Both columns are named now, so neither is an unknown and
+  // neither key can go missing. What replaces them points the other way (AQ).
+  //
+  // `s_n_custom` cannot be named by anything: a `customType` has no runtime shape to read. So it
+  // is the one column where the fix is visible as a divergence, and the direction is DRZL being
+  // stricter than the first-party module rather than looser.
+  'sqlite/s_n_custom': {
     libs: ['typebox'],
     modes: ['select'],
-    divergence: { '*/*': 'official required, DRZL optional' },
-    drzl: 'as pg/n_vector',
-    official: 'as pg/n_vector',
-    filed: 'as sqlite/s_blob_buf: no SQLiteBlobBuffer arm in the class-name path',
+    divergence: { '*/*': 'official optional, DRZL required' },
+    drzl: 'a bare unknown, which admits null and keeps its key',
+    official: 'Type.Union([Type.Unknown(), Type.Null()]), whose key TypeBox lets go missing',
+    filed: 'not a defect: a row missing a declared column should not validate',
   },
-  'sqlite/s_n_ts_ms': {
-    libs: ['typebox'],
-    modes: ['select'],
-    divergence: { '*/*': 'official required, DRZL optional' },
-    drzl: 'as pg/n_vector',
-    official: 'as pg/n_vector',
-    filed: 'as sqlite/s_int_ts_ms: integer({ mode: timestamp_ms }) has no arm on 0.4x',
-  },
-  // No `pg/n_bit` entry, and its absence is the reason SELECT_OPTIONAL exists next to this map:
+  // No `pg/n_bit` entry, and its absence is the reason SELECT_OPTIONAL existed next to this map:
   // official's TypeBox schema throws on the object with that key omitted rather than reporting it
-  // missing, so this differential comparison has no verdict to differ from. `s_n_custom` is absent
-  // for the opposite reason: official emits the same union DRZL does, so the two agree.
+  // missing, so this differential comparison has no verdict to differ from.
 };
 
 // A field lookup that throws yields nothing, and nothing is not read as agreement anywhere below:
@@ -7793,9 +7759,6 @@ const THREW: Record<string, Crash> = {
 const UNNAMED: Record<string, string> = {
   // No SQLiteBlobBuffer arm in the class-name path, and a bare `blob()` really is a buffer column
   // on 0.45.2. Both also carry a DEFECTS entry above, which is the relative half of the finding.
-  'sqlite/matrix.s_blob': 'no SQLiteBlobBuffer arm in the class-name path',
-  'sqlite/matrix.s_blob_buf': 'as sqlite/matrix.s_blob',
-  'sqlite/matrix.s_int_ts_ms': 'integer({ mode: timestamp_ms }) has no arm; only mode timestamp does',
   // The one the comparison cannot see, and the reason this absolute check earns its place. The
   // analyzer names no type for a 0.4x mysqlEnum and prints "so its validator will accept any
   // value", and that sentence is false: every generator reads `enumValues` off the column
@@ -7805,8 +7768,6 @@ const UNNAMED: Record<string, string> = {
   // The nullable table's share of the same two gaps. Both are the same class as their `matrix`
   // twin, so listing them is the check that the gap is about the column class rather than about
   // `notNull`, which is the only thing that differs between the two.
-  'sqlite/nullable.s_n_blob': 'as sqlite/matrix.s_blob_buf',
-  'sqlite/nullable.s_n_ts_ms': 'as sqlite/matrix.s_int_ts_ms',
   // Unnamed on both majors rather than on this one, and correctly so: a customType's JavaScript
   // type exists at compile time and nowhere else. It is here because this list is the absolute
   // record of what the analyzer cannot name, not of what it names differently per major.


### PR DESCRIPTION
Addendum AQ, Tier A. **A row that never mentions a column passed validation against a select schema that declares it.**

## The mechanism, measured

TypeBox 0.34.52:

```
Type.Object({ x: Type.Unknown() })              {} -> false   required:["x"]
Type.Object({ x: Union([Unknown, Null]) })      {} -> TRUE    required:["x"]
Type.Object({ x: Union([String, Null]) })       {} -> false   required:["x"]
```

TypeBox visits a required property as `value[key]`, which is `undefined` when the key is absent, and `Type.Unknown()` accepts `undefined`. The only thing that then refuses the row is a guard reading `property[Kind]`. That kind is `Unknown` for the bare form and `Union` for the wrapped one, so the guard simply never fired.

**Both forms serialise `"required":["x"]`.** The emitted source and the JSON Schema each claimed a key one of them did not enforce, and `Value.Check` and `TypeCompiler` agreed with each other throughout, so neither entry point nor any text diff could have caught it.

The fix is smaller than the defect: stop wrapping an unknown in a union. `Type.Unknown()` already admits `null`, so the union added nothing and took the key away. Output is 25 bytes smaller per affected column.

## Why only an absolute check could find it

A `customType` has no runtime shape to read, so it is unnameable on **both** majors, and `drizzle-orm/typebox-legacy` emits the identical `{"anyOf":[{},{"type":"null"}]}`. Both sides agreed, so no differential comparison could ever report it.

That is the general point worth keeping: **a gate built entirely on comparing DRZL with the first-party module is blind by construction to every defect the two share.** This one took an absolute assertion, that a select schema requires every key.

The analyzer's own warning was accurate the whole time and is not the defect: `Column "s_n_custom" has no known type, so its validator will accept any value`. Accepting any *value* is the documented consequence. Accepting a *missing key* was not, and nothing said so.

## The other half: two SQLite classes named

Measured against drizzle's own mappers rather than assumed:

| builder | class | mapper returns |
|---|---|---|
| `blob()` **and** `blob({mode:'buffer'})` on 0.45.2 | `SQLiteBlobBuffer` | the Buffer, unchanged |
| `integer({mode:'timestamp'})` **and** `{mode:'timestamp_ms'}` | `SQLiteTimestamp` | a `Date`, both |

`timestamp_ms` does not differ in type from `timestamp`. They differ only in the integer's scale on the wire, which the mapper consumes and no validator sees, so naming one and not the other was arbitrary. Only the 0.4x class-name path changed; the v1 codec path already answered both. A new test asserts the two majors now produce identical column objects.

Two dead arms fell out: no `SQLiteBlob` class exists on either major, and the `SQLiteInteger` arm's `mode === 'timestamp'` test is unreachable.

## The ledger rearranges rather than shrinking

Nine one-line entries retired outright across `SELECT_OPTIONAL`, `UNNAMED` and `PRESENCE`. `SELECT_OPTIONAL` is now empty, and it emptied in three stages: three entries went when `vector`, `geometry` and `bit` gained arms (#122), two when these SQLite classes did, and the last when TypeBox stopped wrapping unknowns.

**Five entries moved from `DEFECTS` to `ALLOWED` rather than being deleted.** They stopped being defects without stopping diverging: what remains is the ordinary `Uint8Array`-not-`Buffer` and coerced-date divergence the rest of the ledger already carries. Deleting them would have asserted an agreement that does not exist.

The timestamp pair is now **write modes only**, agreeing exactly on select. A defect that had merely moved would still differ everywhere.

**Two presence entries flip direction.** They said DRZL's TypeBox key went missing where official's stayed required. Both columns are named now, so what replaces them is `sqlite/s_n_custom` with DRZL as the **stricter** side, which is the one column that can still carry the difference.

## Tests

Written first and confirmed failing: 6 of 8 in the analyzer spec, 3 of 10 in the TypeBox spec. The 7 that already passed there are the guard cases, which is what shows the fix did not overreach.

Every spec runs the emitted module through both `Value.Check` and `TypeCompiler`, raising if they disagree. Select on a nullable unnameable column: `{}` refused, `{c: null}` accepted, `{c: anything}` accepted. Unchanged: notNull unknown, known-type nullable, nullable array of unknowns, and insert/update where an absent key is legitimately fine.

TypeBox size unchanged at 444 of its 460 budget; the budget fixture is Postgres-only and has no nullable unknown left. 0.4x analysis now reports **90 columns, 1 unnamed and filed** — the `customType`, correctly.

`pnpm verify:packed`, `build`, `-r test` (1283 tests), `typecheck`, `lint`, `docs build` all green.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
