### PR TITLE
fix(analyzer): bound a decimal by its declared precision, and by its mode

### DIFF
--- a/.changeset/numeric-precision-and-modes.md
+++ b/.changeset/numeric-precision-and-modes.md
@@ -1,0 +1,82 @@
+---
+'@drzl/analyzer': patch
+---
+
+A `numeric(p, s)` column is bounded by the width it declares rather than by what a JS number can
+carry, its `mode: 'bigint'` spelling stops being described as a 64 bit integer, and Gel's two float
+columns stop refusing every value they store.
+
+**The declaration always carried the numbers and nothing read either of them.** `precision` and
+`scale` sit on the column object on both drizzle majors, so a `numeric(10,2)` and an unconstrained
+`numeric` were the same column to the analysis, and the number mode was bounded at
++/-9007199254740991 for both. That is 2^53 on a column that stops at 10^8.
+
+Measured against PostgreSQL 18.3 through PGlite and MySQL 8.4.11 in Docker, both on the
+bound-parameter path a validator guards, and the two agree value for value:
+
+| column    | value                   | Postgres                      | MySQL                         |
+| --------- | ----------------------- | ----------------------------- | ----------------------------- |
+| `(10,2)`  | `99999999.99`           | accepts                       | accepts                       |
+| `(10,2)`  | `99999999.994`          | accepts, stores `99999999.99` | accepts, stores `99999999.99` |
+| `(10,2)`  | `99999999.995`          | refuses                       | refuses                       |
+| `(10,2)`  | `100000000`             | refuses                       | refuses                       |
+| `(10,2)`  | `2147483648`            | refuses                       | refuses                       |
+| `(10,2)`  | `9007199254740991`      | refuses                       | refuses                       |
+| `(20,0)`  | `99999999999999999999`  | accepts                       | accepts                       |
+| `(20,0)`  | `100000000000000000000` | refuses                       | refuses                       |
+| `numeric` | `1e40`                  | accepts                       | n/a                           |
+
+Postgres answers `22003 numeric field overflow` on every refusal and MySQL
+`ER_WARN_DATA_OUT_OF_RANGE`. So both databases enforce the declared width, and `drizzle-zod` reads
+neither number: **DRZL now disagrees with both official validators on this column, deliberately, and
+the database is why.** The bound is the largest value the column can hold, `(10^p - 1)` shifted
+right by `s` places.
+
+One divergence is left in on purpose and is measured rather than assumed. Both servers round to the
+scale before checking the integer digits, so both accept `99999999.994` and store `99999999.99`. The
+accepted set is open at the top and no inclusive bound describes it; the one chosen is exactly the
+set of values the column can hold and hand back, so a select schema accepts every row the column
+returns and the band an insert schema turns away is the band the server would have rounded away.
+
+**`mode: 'bigint'` was described as an int64 column.** Drizzle v1 stamps `dataType: 'bigint int64'`
+on all four dialects' bigint-mode classes, so a `numeric(20,0)` was bounded at
++/-9223372036854775807 and labelled `BIGINT`. That column accepts `18446744073709551615` and twenty
+nines on both servers, so the emitted schema refused values the column stores and returns on every
+read. It is a `NUMERIC` column bounded by its own precision now, and on drizzle 0.4x, where it
+carried no bound at all, by the same one.
+
+**A bare `decimal` on MySQL and SingleStore is `decimal(10,0)`.** Measured:
+`create table dd (v decimal)` reports `decimal(10,0)` in `information_schema`, and the column accepts
+`9999999999` while refusing `10000000000` and `9007199254740991`. It takes that width rather than the
+safe-integer fallback. Postgres's bare `numeric` really is unconstrained and keeps the fallback.
+SQLite takes no bound at all: `NUMERIC` there is an affinity rather than a type, and measured through
+`node:sqlite` a `numeric` column stores `1e300` and `1e32` as REALs and hands each back, so even the
+safe-integer bound would refuse rows it returns.
+
+**The infinity question reopened and moved.** `numeric` in `{ mode: 'number' }` stated
+`allowsInfinity: false` for every declaration, and the recorded reason was that nothing read
+precision, so an unconstrained `numeric` and a `numeric(10,2)` could not be told apart. They can now:
+measured through PGlite, an unconstrained `numeric` stores and returns `Infinity` and `-Infinity`
+while a `numeric(10,2)` answers `22003` for either, and both take `NaN`. Each declaration says what
+its own server does. A column carrying a precision is unchanged.
+
+**Gel's `real` and `doublePrecision` were typed `number` and described no further.** Both came back
+labelled `NUMERIC` with no range, no `integer` flag and nothing about the non-finite doubles.
+Measured on a live Gel 7.1 through the `gel` client, casting a literal so the server parses it, and
+again through a stored property on a real object type:
+
+- `std::float32` and `std::float64` both store `nan`, `inf` and `-inf` and hand all three back
+  unchanged. Every read of such a row used to fail validation.
+- `std::float32` accepts `3.4028235677973366e38`, stores it as `3.4028234663852886e38`, and refuses
+  `3.402823567797337e38` and `1e300` with "is out of range for type std::float32". That edge is
+  Postgres's exactly, to the double, so `real` takes the constant this package already carries for a
+  Postgres `real`.
+- `std::float64` took `1e300` and `Number.MAX_VALUE` faithfully, so it carries no finite bound, and
+  the two are labelled `REAL` and `DOUBLE` rather than both `NUMERIC`.
+
+**Both analyzer paths move together.** The v1 codec path and the drizzle 0.4x class-name path
+compute the bound with the same function off the same column, so a schema cannot change when a user
+upgrades drizzle. That agreement is asserted per dialect through the real analyzer.
+
+No generator changed. The facts are stated on the `Column` and the existing `min`/`max`/`integer`/
+`allowsNaN`/`allowsInfinity` rendering carries them, in all five.

--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -88,8 +88,8 @@ PGlite, SQLite via `node:sqlite`, and MySQL as a CI service container.
 
 ```
     1440 probes against a real Postgres (40 columns)
-    agree with the database: DRZL 1067, drizzle-orm 1013
-    DRZL closer than drizzle-orm on 54, further on 0
+    agree with the database: DRZL 1069, drizzle-orm 1013
+    DRZL closer than drizzle-orm on 56, further on 0
 
     393 rows read back through the driver (40 columns)
     rejected by DRZL: 66, of which drizzle-orm also rejects: 66

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -50,8 +50,16 @@ export interface Column {
    *
    * Strings rather than numbers because a 64 bit bound is not representable as a JS number:
    * `9223372036854775807` rounds to `9223372036854775808` the moment it becomes one, so a
-   * numeric field here would silently emit a wrong bound. Absent for floats and for `numeric`,
-   * which have no integer range.
+   * numeric field here would silently emit a wrong bound. A 20 digit `numeric(20,0)` bound is
+   * further past that again.
+   *
+   * Not an integer range, despite the name this field used to be described by. An inexact column
+   * carries one too: a `real` is bounded by the magnitude the database refuses past, and a
+   * `numeric(10,2)` by the width its own declaration states. `integer` says which kind it is, and
+   * saying it is what stops a bounded float schema refusing 1.5.
+   *
+   * Absent where nothing declares a bound: an 8 byte float holds every finite JS number, and a
+   * `numeric` with no precision holds arbitrary precision.
    */
   min?: string;
   max?: string;
@@ -80,14 +88,22 @@ export interface Column {
    * does too, but a `numeric(10,2)` refuses either infinity with `22003 numeric field overflow`
    * while still taking `NaN`, and `integer`/`bigint` refuse all three.
    *
-   * So `numeric` in `{ mode: 'number' }` states `allowsInfinity: false` deliberately, and it is a
-   * narrowing rather than an oversight: nothing here reads a column's precision or scale, so the
-   * two `numeric` declarations are indistinguishable, and admitting the infinities would make the
-   * schema promise what the server refuses for the commoner of the two.
+   * So `numeric` in `{ mode: 'number' }` answers each of the two separately: `allowsNaN` at any
+   * width, and `allowsInfinity` only where the declaration carries no precision. That used to be a
+   * flat `false`, and the recorded reason was that nothing here read a column's precision or scale,
+   * so the two declarations were indistinguishable and the narrower answer was the safer one.
+   * `declaredDecimalRange` reads both numbers now, the two are distinguishable, and each says what
+   * its own server does.
    *
-   * Postgres only, today. MySQL refuses all three on a `float`/`double` and silently stores `0.00`
-   * for a `decimal`. SQLite returns both infinities and silently turns `NaN` into NULL, which is
-   * real and is filed on its own: a column needs both halves of that answer or none.
+   * Postgres and Gel. MySQL refuses all three on a `float`/`double`, and on a `decimal` refuses
+   * them outright rather than storing `0.00`: measured on MySQL 8.4.11 in `STRICT_TRANS_TABLES`,
+   * all three answer `Incorrect decimal value`. SQLite returns both infinities and silently turns
+   * `NaN` into NULL, which is real and is filed on its own: a column needs both halves of that
+   * answer or none.
+   *
+   * Gel joined on a measurement of its own rather than on being Postgres-backed: a live Gel 7.1
+   * stored `nan`, `inf` and `-inf` in both `std::float32` and `std::float64` and handed all three
+   * back unchanged, through a cast and through a stored property.
    *
    * Absent on every other column, including the string mode of `numeric`, which already carries the
    * same fact as a pattern; see `COLUMN_FORMATS.numeric` in `@drzl/validation-core`.
@@ -406,12 +422,17 @@ const MYSQL_FLOAT_RANGE: [string, string] = [`-${FLOAT32_MAX}`, FLOAT32_MAX];
 /**
  * The range a JS number holds every integer of.
  *
- * What a `numeric`/`decimal` column in `{ mode: 'number' }` is bounded by, because the value
- * arrives as a JS number and the column's own precision is wider than one can carry. Narrower
- * than the database on that column too: PGlite refuses 2147483648 into a `numeric(10,2)` with
- * `numeric field overflow`, so this admits values that column will not take. It is what both
- * drizzle majors and `drizzle-zod` emit, and reading the declared precision instead would make
- * DRZL disagree with all three.
+ * What a `numeric`/`decimal` column in `{ mode: 'number' }` is bounded by **when its declaration
+ * carries no precision**, which is then the only thing left to bound it by. Where a precision is
+ * declared it is the column's own width instead; see `declaredDecimalRange`.
+ *
+ * This used to apply to every such column, on the reasoning that it is what both drizzle majors and
+ * `drizzle-zod` emit and that reading the declared precision would put DRZL out of step with all
+ * three. The database was asked and it is stricter than all three: PGlite refuses 100000000,
+ * 2147483648 and 9007199254740991 into a `numeric(10,2)` with `22003 numeric field overflow`, and
+ * MySQL 8.4.11 refuses the same three from a `decimal(10,2)`. Being out of step with validators
+ * that read neither number is the right outcome when the server reads both, and the divergence is
+ * carried with that measurement attached in both parity passes.
  */
 const JS_SAFE_INTEGER_BOUNDS: [string, string] = ['-9007199254740991', '9007199254740991'];
 
@@ -585,6 +606,24 @@ export function describeV1Column(column: any): Partial<Column> | null {
     case 'int53':
     case 'uint53':
     case 'int64': {
+      // `numeric({ mode: 'bigint' })` is not an int64 column and v1 says it is: all four
+      // dialects' bigint-mode classes carry `dataType: 'bigint int64'`, so a `numeric(20,0)` took
+      // the range below and was labelled BIGINT with it. It is a NUMERIC column whose width is its
+      // own declared precision, which is wider than a signed 64 bit integer at 20 digits and
+      // narrower at 10. See `DECIMAL_BIGINT_MODE`.
+      if (DECIMAL_BIGINT_MODE.test(entityKind)) {
+        out.tsType = 'bigint';
+        out.dbType = 'NUMERIC';
+        // A bigint holds whole numbers by construction, so this states what the value already is
+        // rather than narrowing anything. It is the number mode that must not say it: measured on
+        // PGlite, a `numeric(1,0)` accepts 9.4 and stores 9, so `integer: true` there would refuse
+        // a value the server takes.
+        out.integer = true;
+        // Absent where nothing states a width, rather than guessed at; see `decimalModeRange`.
+        const range = decimalModeRange(column, entityKind, 'bigint');
+        if (range) [out.min, out.max] = range;
+        break;
+      }
       // Every width Drizzle names. Missing `int8` and `int24` did not leave MySQL's `tinyint` and
       // `mediumint` alone: they fell through to the bare-number arm below, whose safe-integer
       // bounds then *overrode* the correct ones the class-name table had supplied, so a tinyint
@@ -810,18 +849,40 @@ export function describeV1Column(column: any): Partial<Column> | null {
         out.tsType = 'number';
         out.dbType = 'NUMERIC';
         out.integer = false;
-        [out.min, out.max] = JS_SAFE_INTEGER_BOUNDS;
+        // The column's own width where it declares one, and what a JS number can carry where it
+        // does not. The declared width replaces the safe-integer range outright rather than
+        // narrowing it, because it is the truthful answer in both directions: a `numeric(10,2)`
+        // refuses 2147483648, and a `numeric(30,0)` in this mode hands back 1e30 on SELECT, which
+        // the safe-integer bound refuses on a row the column itself returned.
+        //
+        // Ungated, because this arm is the number mode and nothing else. Swept over every column
+        // builder all six v1 cores export, in five argument shapes each: the columns whose
+        // `dataType` is a bare `number` with no semantic half are `PgNumericNumber`,
+        // `MySqlDecimalNumber`, `SQLiteNumericNumber`, `SingleStoreDecimalNumber`,
+        // `MsSqlDecimalNumber`, `MsSqlNumericNumber` and `CockroachDecimalNumber`, and no other
+        // builder on any of the six reaches here at all. So there is no column here whose
+        // `precision` means something other than a decimal width, and gating on the class name
+        // would only have excluded the four dialects that state no codec. The sweep is asserted in
+        // numeric-precision.spec.ts rather than left as this sentence.
+        const range = decimalModeRange(column, entityKind, 'number');
+        if (range) [out.min, out.max] = range;
         // Postgres stores `NaN` in a `numeric` of any width and returns it, so the bounds above
-        // describe the finite values and this says the rest. Not the infinities: an unconstrained
-        // `numeric` takes them and a `numeric(10,2)` answers `22003 numeric field overflow`, and
-        // nothing here reads precision or scale, so the two cannot be told apart. Admitting them
-        // would promise what the server refuses for the commoner declaration.
+        // describe the finite values and this says the rest. The infinities are the half that
+        // depends on the declaration: measured through PGlite, an unconstrained `numeric` stores
+        // and returns both, and a `numeric(10,2)` answers `22003 numeric field overflow` for
+        // either. That used to be stated as a flat `false` because nothing here read precision, so
+        // the two declarations were indistinguishable; they are distinguishable now.
         //
         // `numeric:number` is Postgres's codec for the number mode. MySQL and SingleStore say
-        // `decimal:number` and store `0.00` for all three, and SQLite says nothing at all.
+        // `decimal:number` and refuse all three outright, measured on MySQL 8.4.11 as
+        // `Incorrect decimal value: 'NaN'`, and SQLite says nothing at all.
         if (codec === 'numeric:number') {
           out.allowsNaN = true;
-          out.allowsInfinity = false;
+          // The *declared* precision, not the effective bound: Postgres is the only dialect here
+          // and its bare `numeric` really is unconstrained, so the two agree, but the question this
+          // asks is whether the declaration carries a typmod rather than whether anything bounds
+          // the column.
+          out.allowsInfinity = !declaredDecimalRange(column);
         }
       } else if (js === 'string') {
         out.tsType = 'string';
@@ -887,6 +948,132 @@ function unwrapArrayColumn(column: any): { element: any; dimensions: number } {
 function declaredLength(column: any): number | undefined {
   const n = column?.length ?? column?.config?.length ?? column?.config?.dimensions;
   return typeof n === 'number' && Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
+ * The magnitude a `numeric(p, s)` / `decimal(p, s)` column really holds, or nothing where the
+ * declaration carries no precision.
+ *
+ * Both numbers have always been on the column, on both majors, and nothing read either of them, so
+ * a `numeric(10,2)` and an unconstrained `numeric` were the same column to this file. The number
+ * mode was bounded at the safe-integer range instead, which is 2^53 on a column that stops at 10^8.
+ *
+ * Measured against PostgreSQL 18.3 through PGlite and MySQL 8.4.11 in Docker, both on the
+ * bound-parameter path a validator guards, and the two agree value for value:
+ *
+ *   numeric(10,2)   99999999.99            accepted
+ *   numeric(10,2)   100000000              refused, 22003 / ER_WARN_DATA_OUT_OF_RANGE
+ *   numeric(10,2)   2147483648             refused
+ *   numeric(10,2)   9007199254740991       refused, which is the bound this replaces
+ *   numeric(20,0)   99999999999999999999   accepted
+ *   numeric(20,0)   100000000000000000000  refused
+ *   numeric(5,3)    99.999 / 100           accepted / refused
+ *
+ * So the value is `(10^p - 1)` shifted right by `s` decimal places, spelled out digit by digit
+ * rather than computed, because a 20 digit bound is not representable as a JS number and this file
+ * carries every other bound as a decimal string for that reason.
+ *
+ * Three shapes of declaration, each measured rather than assumed:
+ *
+ *   `{ precision, scale }`   the ordinary case
+ *   `{ precision }`          scale 0. `numeric(10)` is `numeric(10,0)` to Postgres, read back
+ *                            through `format_type`, and it stores 0.1 as 0.
+ *   `{ scale }`              no constraint at all. Drizzle renders a bare `numeric` with no
+ *                            typmod when no precision is given, on both majors, so there is
+ *                            nothing declared to bound by.
+ *
+ * `s >= p` is a real declaration rather than a mistake: Postgres takes `numeric(2,5)`, which holds
+ * two significant digits five places right of the point, and measured on the same server it accepts
+ * 0.00001 and refuses 0.001. That is the third branch below.
+ *
+ * **One measured divergence, and it is deliberate.** Both servers round the value to the scale
+ * *before* they check the integer digits, so both accept 99999999.994 into a `numeric(10,2)` and
+ * store 99999999.99, and both refuse 99999999.995. The accepted set is therefore open at the top
+ * and no inclusive bound describes it exactly. This is the closed set of values the column can hold
+ * and hand back, so a select schema built on it accepts every row the column returns, and the band
+ * an insert schema turns away is the band the server would have rounded away.
+ */
+function declaredDecimalRange(column: any): [string, string] | undefined {
+  const cfg = column?.config ?? {};
+  const precision = column?.precision ?? cfg.precision;
+  const scale = column?.scale ?? cfg.scale ?? 0;
+  if (typeof precision !== 'number' || !Number.isInteger(precision) || precision < 1)
+    return undefined;
+  if (typeof scale !== 'number' || !Number.isInteger(scale) || scale < 0) return undefined;
+  const nines = '9'.repeat(precision);
+  const max =
+    scale === 0
+      ? nines
+      : scale < precision
+        ? `${nines.slice(0, precision - scale)}.${nines.slice(precision - scale)}`
+        : `0.${'0'.repeat(scale - precision)}${nines}`;
+  return [`-${max}`, max];
+}
+
+/**
+ * The two numeric modes of `numeric`/`decimal`, by `drizzle:entityKind` and by constructor name,
+ * which are the same string for every class either one matches.
+ *
+ * Drizzle spells the mode as a distinct class on every dialect: `PgNumericNumber`,
+ * `MySqlDecimalBigInt`, `SingleStoreDecimalNumber`, `SQLiteNumericBigInt`. That suffix is the only
+ * signal both majors share. The codec would do for Postgres and MySQL, which say `numeric:number`
+ * and `decimal:bigint`, and SingleStore and SQLite state no codec at all on 1.0.0-rc.4, so half the
+ * family would be left behind by it; 0.4x states no codec anywhere.
+ *
+ * The bigint half matters most. v1 stamps `dataType: 'bigint int64'` on all four bigint-mode
+ * classes, so a `numeric(20,0)` reached the int64 arm below, came back bounded at
+ * +/-9223372036854775807 and labelled a BIGINT column. Measured on both servers, that column
+ * accepts 18446744073709551615 and 99999999999999999999, so the emitted schema refused values the
+ * column stores and hands back.
+ */
+const DECIMAL_NUMBER_MODE = /(?:Numeric|Decimal)Number$/;
+const DECIMAL_BIGINT_MODE = /(?:Numeric|Decimal)BigInt$/;
+
+/**
+ * A bare `decimal` on MySQL and SingleStore, which is not the unconstrained column it reads as.
+ *
+ * Measured on MySQL 8.4.11: `create table dd (v decimal)` reports `decimal(10,0)` in
+ * `information_schema.columns`, and the column then accepts 9999999999 and refuses both
+ * 10000000000 and 9007199254740991 with `ER_WARN_DATA_OUT_OF_RANGE`. So the declaration carries no
+ * precision and the column has one anyway, and the safe-integer fallback was ninety thousand times
+ * wider than the column.
+ *
+ * SingleStore takes MySQL's, which is where every other answer in this file for that dialect comes
+ * from: it is MySQL wire compatible, ships the same three mode classes, and there is no in-process
+ * SingleStore here to read a row back from.
+ *
+ * Deliberately not extended to MSSQL, whose `DECIMAL` documents a different default width and which
+ * was not measured for this. It keeps the safe-integer fallback, which is what it had.
+ */
+const MYSQL_IMPLICIT_DECIMAL_RANGE: [string, string] = ['-9999999999', '9999999999'];
+
+/**
+ * The bound to state for a `numeric`/`decimal` column in one of its two numeric modes, or nothing.
+ *
+ * Three answers, and which one applies is a property of the dialect rather than of the mode:
+ *
+ *   declared precision   the column's own width, whatever the dialect
+ *   MySQL, SingleStore   `decimal(10,0)` where nothing is declared; see the constant above
+ *   SQLite               nothing, ever. `NUMERIC` there is an affinity rather than a type: it takes
+ *                        no precision argument on either major, and it stores whatever it is given
+ *                        as an INTEGER or a REAL. Measured through `node:sqlite`, a `numeric`
+ *                        column stores 1e300 and 1e32 as REALs and hands each back unchanged, so
+ *                        any of the bounds above would refuse rows the column itself returns.
+ *   everything else      the safe-integer range in the number mode, because the value arrives as a
+ *                        JS number and nothing else bounds it, and nothing in the bigint mode,
+ *                        because an unconstrained Postgres `numeric` really does hold any integer.
+ */
+function decimalModeRange(
+  column: any,
+  kind: string,
+  mode: 'number' | 'bigint'
+): [string, string] | undefined {
+  const declared = declaredDecimalRange(column);
+  if (declared) return declared;
+  if (kind.startsWith('MySql') || kind.startsWith('SingleStore'))
+    return MYSQL_IMPLICIT_DECIMAL_RANGE;
+  if (kind.startsWith('SQLite')) return undefined;
+  return mode === 'number' ? JS_SAFE_INTEGER_BOUNDS : undefined;
 }
 
 /**
@@ -1345,11 +1532,29 @@ export class SchemaAnalyzer {
     SQLiteReal: null,
     SingleStoreDouble: null,
     SingleStoreReal: null,
-    // `numeric({ mode: 'number' })`, which v1 reaches through the bare-number arm of
-    // `describeV1Column`. This one is about what a JS number can carry rather than about the
-    // column, which Postgres caps far lower: it refuses 2147483648 into a `numeric(10,2)`.
-    PgNumericNumber: JS_SAFE_INTEGER_BOUNDS,
+    // Gel, whose `real` is a `std::float32` and whose `doublePrecision` is a `std::float64`. Both
+    // used to be answered by a `/Real|DoublePrecision/i` arm that said NUMERIC and stated nothing
+    // else at all, so a `real` column accepted 1e300 and the server refused it.
+    //
+    // Measured on a live Gel 7.1 (`geldata/gel:7`, sys::get_version_as_str() -> 7.1+08db576)
+    // through the `gel` client, casting each literal so the server parses it, and again through a
+    // stored property on a real object type. The float32 edge is Postgres's exactly, to the double:
+    //
+    //   3.4028234663852886e38   accepted, returned unchanged
+    //   3.4028235677973366e38   accepted, and stored as 3.4028234663852886e38
+    //   3.402823567797337e38    refused, "is out of range for type std::float32"
+    //   1e300                   refused, the same way
+    //
+    // The same value accepted, the same next double up refused, and the same rounding down of the
+    // midpoint, so it takes the constant already here rather than a second name for one number.
+    // float64 took 1e300 and Number.MAX_VALUE faithfully, for the reason no 8 byte float has a
+    // truthful finite bound.
+    GelReal: PG_FLOAT4_RANGE,
+    GelDoublePrecision: null,
   };
+  // `numeric`/`decimal` in either of its two numeric modes is deliberately not in the table above.
+  // Its bound is not a fixed magnitude per class but the precision each column declares for itself,
+  // which no table keyed on a class name can hold; see `declaredDecimalRange`.
 
   /**
    * The Postgres number columns that hold a non-finite double, and which of the three each holds.
@@ -1361,17 +1566,25 @@ export class SchemaAnalyzer {
    * table also answers for a v1 column and the two answers are identical rather than merely
    * compatible. non-finite-numbers.spec.ts asserts that agreement through the real analyzer.
    *
-   * Postgres only. No MySQL, SingleStore or SQLite class belongs here: MySQL refuses all three on a
-   * `float`/`double` and stores `0.00` for a `decimal`, and SQLite returns both infinities while
-   * silently turning `NaN` into NULL, which is a different answer that has to arrive whole.
+   * No MySQL, SingleStore or SQLite class belongs here: MySQL refuses all three on a `float`/
+   * `double` and stores `0.00` for a `decimal`, and SQLite returns both infinities while silently
+   * turning `NaN` into NULL, which is a different answer that has to arrive whole.
+   *
+   * Gel does belong, and is the fourth and fifth entries. Measured on a live Gel 7.1 rather than
+   * inferred from it being Postgres-backed: both `std::float32` and `std::float64` stored `nan`,
+   * `inf` and `-inf` and handed all three back as `NaN`, `Infinity` and `-Infinity`, through a cast
+   * and again through a stored property. Without them every row of such a column failed validation.
    *
    * `PgNumeric` is absent because its value is a string, and its pattern already accepts `NaN` and
-   * `Infinity`. `PgNumericNumber` states `infinity: false` on purpose; see `Column.allowsNaN`.
+   * `Infinity`. `PgNumericNumber` is absent because its answer is no longer flat: it takes `NaN` at
+   * any width and an infinity only where no precision is declared, which is a per-column question
+   * this table cannot ask. `columnConstraints` answers it beside the bound that decides it.
    */
   private static readonly PG_NON_FINITE: Record<string, { nan: boolean; infinity: boolean }> = {
     PgReal: { nan: true, infinity: true },
     PgDoublePrecision: { nan: true, infinity: true },
-    PgNumericNumber: { nan: true, infinity: false },
+    GelReal: { nan: true, infinity: true },
+    GelDoublePrecision: { nan: true, infinity: true },
   };
 
   /**
@@ -1427,6 +1640,34 @@ export class SchemaAnalyzer {
     if (nonFinite) {
       out.allowsNaN = nonFinite.nan;
       out.allowsInfinity = nonFinite.infinity;
+    }
+
+    // The two numeric modes of `numeric`/`decimal`, whose bound is the precision the column
+    // declares rather than a magnitude fixed per class. The class-name half of what
+    // `describeV1Column` reads off the same column, computed by the same function so the two
+    // cannot drift: a fact stated on one path and not the other is a schema that changes when the
+    // user upgrades drizzle, which the cross-major diff in `scripts/verify-packed.sh` fails on.
+    // numeric-precision.spec.ts asserts that agreement through the real analyzer, per dialect.
+    if (DECIMAL_NUMBER_MODE.test(ctor)) {
+      const range = decimalModeRange(column, ctor, 'number');
+      if (range) [out.min, out.max] = range;
+      // `integer: false` beside the bound, not instead of it. `isIntegerColumn` falls back to
+      // "declares both bounds" when the flag is absent, so adding a range here without the flag is
+      // what makes the emitted schema call `.int()` and refuse 1234.56 on a `decimal(10,2)`. It is
+      // stated on the SQLite column too, which carries no bound for the flag to guard, because it
+      // is true of the column either way.
+      out.integer = false;
+      // Postgres alone, and split by the declaration for the reason written out at the v1 copy of
+      // this: `NaN` goes into a `numeric` of any width, either infinity only into one carrying no
+      // precision.
+      if (ctor === 'PgNumericNumber') {
+        out.allowsNaN = true;
+        out.allowsInfinity = !declaredDecimalRange(column);
+      }
+    } else if (DECIMAL_BIGINT_MODE.test(ctor)) {
+      const range = decimalModeRange(column, ctor, 'bigint');
+      if (range) [out.min, out.max] = range;
+      out.integer = true;
     }
 
     if (/^(Pg)?UUID$/i.test(ctor) || /Uuid$/i.test(ctor)) out.format = 'uuid';
@@ -1782,8 +2023,13 @@ export class SchemaAnalyzer {
           if (/BigInt64/i.test(ctor)) return { tsType: 'bigint', dbType: 'BIGINT' };
           if (/Int53|Integer|SmallInt/i.test(ctor)) return { tsType: 'number', dbType: 'INTEGER' };
 
-          // Floating/decimal
-          if (/Real|DoublePrecision/i.test(ctor)) return { tsType: 'number', dbType: 'NUMERIC' };
+          // Floating/decimal. The two float widths were one arm answering NUMERIC for both, which
+          // is the label Postgres's own `numeric` carries and neither of these is: `real` is a
+          // `std::float32` and `doublePrecision` a `std::float64`, and the two have different
+          // magnitudes the server refuses past. They are the only two classes `gel-core` exports
+          // whose name holds either word, swept over its exports on 0.45.2.
+          if (/DoublePrecision/i.test(ctor)) return { tsType: 'number', dbType: 'DOUBLE' };
+          if (/Real/i.test(ctor)) return { tsType: 'number', dbType: 'REAL' };
           if (/Decimal/i.test(ctor)) return { tsType: 'string', dbType: 'NUMERIC' };
 
           // UUID
@@ -1941,7 +2187,9 @@ export class SchemaAnalyzer {
       // type tells them apart. v1 states a codec and reaches the same table through
       // `describeV1Column`; on 0.4x nothing set a cap at all and a longtext and a tinytext were
       // equally unconstrained.
-      const sqlKind = String((outerCol as any)?.constructor?.[Symbol.for('drizzle:entityKind')] ?? '');
+      const sqlKind = String(
+        (outerCol as any)?.constructor?.[Symbol.for('drizzle:entityKind')] ?? ''
+      );
       const sqlType =
         sqlKind.startsWith('MySql') && typeof (col as any)?.getSQLType === 'function'
           ? String((col as any).getSQLType()).toLowerCase()

--- a/packages/analyzer/test/decimal-modes.spec.ts
+++ b/packages/analyzer/test/decimal-modes.spec.ts
@@ -140,26 +140,38 @@ describe.each(Object.keys(SOURCES))('%s decimal/numeric modes on drizzle 0.4x', 
 });
 
 describe('what the modes must not pick up on the way', () => {
-  it('leaves the number mode unbounded and non-integer, as it is today', async () => {
-    // Addendum AK is open on exactly this: a `numeric(10,2)` in number mode admits 2^53 where the
-    // column enforces 10^8. Pinned as it stands so this fix cannot be read as having settled it,
-    // and so a later change to the bound is a deliberate edit here rather than a silent one.
+  it('bounds the number mode by the declared precision, on every dialect that declares one', async () => {
+    // This is the deliberate edit the previous version of this test asked for. It pinned the state
+    // addendum AK was filed against: MySQL and SingleStore carried no bound at all, and Postgres
+    // carried +/-9007199254740991, which is 2^53 on a column that stops at 10^8. Both servers were
+    // then asked and both refuse 100000000, 2147483648 and 9007199254740991 into a `(10,2)`
+    // column, so the bound is the declaration's now on all four dialects.
     //
-    // Postgres is the one dialect that already carries a bound, `PgNumericNumber` in
-    // INEXACT_RANGES; MySQL, SingleStore and SQLite carry none. Both states are recorded.
+    // The measurement, the two servers and the one deliberate divergence at the rounding boundary
+    // are written out in numeric-precision.spec.ts, which owns this fact. What is asserted here is
+    // that the four modes of this family keep answering as a family.
     const my = (await columnsOf('decimal-modes-mysql', MYSQL_SOURCE)).byName.get('d_num');
-    expect(my).toMatchObject({ tsType: 'number' });
-    expect(my?.min).toBeUndefined();
-    expect(my?.max).toBeUndefined();
-    expect(my?.integer).toBeUndefined();
+    expect(my).toMatchObject({
+      tsType: 'number',
+      integer: false,
+      min: '-99999999.99',
+      max: '99999999.99',
+    });
 
     const pg = (await columnsOf('decimal-modes-pg', PG_SOURCE)).byName.get('n_num');
     expect(pg).toMatchObject({
       tsType: 'number',
       integer: false,
-      min: '-9007199254740991',
-      max: '9007199254740991',
+      min: '-99999999.99',
+      max: '99999999.99',
     });
+
+    // SQLite declares neither number, on either major, so nothing bounds it and inventing a bound
+    // would refuse values the engine stores. It states `integer: false` and no range.
+    const sq = (await columnsOf('decimal-modes-sqlite', SQLITE_SOURCE)).byName.get('s_num');
+    expect(sq).toMatchObject({ tsType: 'number', integer: false });
+    expect(sq?.min).toBeUndefined();
+    expect(sq?.max).toBeUndefined();
   });
 
   it('leaves the string modes without a numeric format, as the 0.4x path does everywhere', async () => {

--- a/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
+++ b/packages/analyzer/test/floats-and-tuples-0.4x.spec.ts
@@ -206,9 +206,15 @@ describe('an inexact numeric column on 0.4x', () => {
     expect(cols.d).toMatchObject({ tsType: 'number', dbType: 'DOUBLE', integer: false });
     expect(cols.d.min).toBeUndefined();
     expect(cols.d.max).toBeUndefined();
+    // `numeric({ precision: 10, scale: 2, mode: 'number' })`, bounded by the width it declares
+    // rather than by what a JS number can carry. This used to read +/-9007199254740991, which is
+    // 2^53 on a column PGlite refuses 100000000 into with `22003 numeric field overflow`. The
+    // measurement and the reasoning are in numeric-precision.spec.ts, which owns this fact; the
+    // assertion is here too because this file is where the two range tables are held apart, and a
+    // `numeric` reaching neither of them is the thing it is holding apart.
     expect(cols.n).toMatchObject({
-      min: '-9007199254740991',
-      max: '9007199254740991',
+      min: '-99999999.99',
+      max: '99999999.99',
       integer: false,
     });
   });

--- a/packages/analyzer/test/non-finite-numbers.spec.ts
+++ b/packages/analyzer/test/non-finite-numbers.spec.ts
@@ -75,11 +75,26 @@ describe('the codec path, which drizzle v1 takes', () => {
     });
   });
 
-  it('admits NaN alone on a postgres numeric in number mode', () => {
+  it('splits the two on a postgres numeric in number mode, by the declared precision', () => {
+    // The split the header of this file records and the analyzer could not act on: an
+    // unconstrained `numeric` stores and returns both infinities, and a `numeric(10,2)` answers
+    // `22003 numeric field overflow` for either, while both take `NaN`. This used to be a flat
+    // `allowsInfinity: false` because nothing here read precision, which is exactly the reason the
+    // narrower of the two answers was chosen and is exactly the reason that is now gone:
+    // `declaredDecimalRange` reads it, and the two declarations are no longer the same column.
     expect(describeV1Column(v1col('number', 'numeric:number'))).toMatchObject({
       dbType: 'NUMERIC',
       allowsNaN: true,
+      allowsInfinity: true,
+    });
+    expect(
+      describeV1Column({ ...v1col('number', 'numeric:number'), precision: 10, scale: 2 })
+    ).toMatchObject({
+      dbType: 'NUMERIC',
+      allowsNaN: true,
       allowsInfinity: false,
+      min: '-99999999.99',
+      max: '99999999.99',
     });
   });
 

--- a/packages/analyzer/test/numeric-precision.spec.ts
+++ b/packages/analyzer/test/numeric-precision.spec.ts
@@ -1,0 +1,468 @@
+/**
+ * A `numeric(p, s)` column bounded by what the database enforces rather than by what a JS number
+ * can carry, on both drizzle majors, and the two other modes of the same builder.
+ *
+ * The declaration always carried the numbers. `numeric(10,2)` holds eight integer digits, and the
+ * analysis read neither `precision` nor `scale`, so the emitted schema bounded the column at
+ * +/-9007199254740991: 2^53 where the column stops at 10^8, which is a factor of ninety million.
+ * Both majors state both numbers on the column object, measured below.
+ *
+ * ## What the databases actually accept
+ *
+ * PostgreSQL 18.3 through PGlite and MySQL 8.4.11 in Docker, both on the bound-parameter path a
+ * validator guards, and the two agree value for value:
+ *
+ *   column          value                                pg              mysql
+ *   numeric(10,2)   1234.56                              accepts         accepts
+ *   numeric(10,2)   99999999.99                          accepts         accepts
+ *   numeric(10,2)   99999999.994                         accepts, 99999999.99 stored (both)
+ *   numeric(10,2)   99999999.995                         refuses         refuses
+ *   numeric(10,2)   100000000                            refuses         refuses
+ *   numeric(10,2)   2147483648                           refuses         refuses
+ *   numeric(10,2)   9007199254740991                     refuses         refuses
+ *   numeric(20,0)   99999999999999999999                 accepts         accepts
+ *   numeric(20,0)   100000000000000000000                refuses         refuses
+ *   numeric(5,3)    99.999 / 100                         accepts/refuses accepts/refuses
+ *   numeric(10)     9999999999 / 10000000000             accepts/refuses
+ *   numeric(2,5)    0.00001 / 0.001                      accepts/refuses
+ *   numeric         9007199254740991, 1e40               accepts both
+ *
+ * Postgres answers `22003 numeric field overflow` on every refusal and MySQL
+ * `ER_WARN_DATA_OUT_OF_RANGE Out of range value for column`. So the database is the arbiter here
+ * and it is stricter than `drizzle-zod`, which reads neither number: DRZL being out of step with
+ * both drizzle majors' own validators is the correct outcome rather than a divergence to fix.
+ *
+ * The bound is therefore the largest value the column can hold, `(10^p - 1)` shifted right by `s`
+ * decimal places, which is the value written out in full by every case below. One measured
+ * divergence remains and is deliberate: Postgres and MySQL both round to the scale *before* they
+ * check the integer digits, so both accept 99999999.994 into a `numeric(10,2)` and store
+ * 99999999.99, and the emitted schema refuses it. The accepted set is open at the top, so no
+ * inclusive bound expresses it; the one chosen is exactly the set of values the column can hold and
+ * hand back, and the band it turns away is the band the server would have rounded away.
+ *
+ * ## The two other modes
+ *
+ * `mode: 'bigint'` is declared `numeric(20,0)`, which holds every integer up to twenty nines.
+ * Measured above: the column takes 18446744073709551615, well past a signed 64 bit integer. Drizzle
+ * v1 stamps `dataType: 'bigint int64'` on it, so it reached the analyzer's int64 arm and was bounded
+ * at +/-9223372036854775807 and labelled a BIGINT column, and the schema then refused values the
+ * column stores and returns.
+ *
+ * `mode: 'string'` is untouched. Its value is a string carrying arbitrary precision and its check is
+ * a pattern; see `COLUMN_FORMATS.numeric` in `@drzl/validation-core`.
+ *
+ * ## Infinity
+ *
+ * Postgres takes `NaN` into a `numeric` of any width, and takes either infinity only into one
+ * carrying no precision: measured, an unconstrained `numeric` stores and returns `Infinity` and
+ * `-Infinity` while a `numeric(10,2)` answers `22003 numeric field overflow` for both. The number
+ * mode used to state `allowsInfinity: false` for every declaration, and the recorded reason was
+ * that nothing read precision, so the two were indistinguishable. They are distinguishable now and
+ * each says what its own server does.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function columnsOf(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  const t = analysis.tables[0];
+  expect(t, `no table was analyzed; issues: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  return Object.fromEntries(t!.columns.map((c) => [c.name, c]));
+}
+
+/** The same table written against each major, so one source cannot describe only one of them. */
+const MAJORS: [string, string][] = [
+  ['0.4x', 'drizzle-orm'],
+  ['v1', 'drizzle-orm-v1'],
+];
+
+/** `numeric(10,2)` holds eight integer digits and two fractional ones, and stops here. */
+const N_10_2 = '99999999.99';
+/** `numeric(20,0)`, which is how `mode: 'bigint'` is declared. Twenty nines. */
+const N_20_0 = '99999999999999999999';
+/** What a JS number holds every integer of, and the bound where no precision is declared. */
+const SAFE = '9007199254740991';
+
+const PG = (pkg: string) => `
+  import { pgTable, numeric } from '${pkg}/pg-core';
+  export const t = pgTable('t', {
+    n_num: numeric('n_num', { precision: 10, scale: 2, mode: 'number' }),
+    n_num_free: numeric('n_num_free', { mode: 'number' }),
+    n_num_p: numeric('n_num_p', { precision: 10, mode: 'number' }),
+    n_num_s: numeric('n_num_s', { scale: 2, mode: 'number' }),
+    n_num_wide: numeric('n_num_wide', { precision: 2, scale: 5, mode: 'number' }),
+    n_big: numeric('n_big', { precision: 20, scale: 0, mode: 'bigint' }),
+    n_big_free: numeric('n_big_free', { mode: 'bigint' }),
+    n_str: numeric('n_str', { precision: 10, scale: 2 }),
+  });
+`;
+
+const MYSQL = (pkg: string) => `
+  import { mysqlTable, decimal } from '${pkg}/mysql-core';
+  export const t = mysqlTable('t', {
+    d_num: decimal('d_num', { precision: 10, scale: 2, mode: 'number' }),
+    d_num_free: decimal('d_num_free', { mode: 'number' }),
+    d_big: decimal('d_big', { precision: 20, scale: 0, mode: 'bigint' }),
+  });
+`;
+
+const SINGLESTORE = (pkg: string) => `
+  import { singlestoreTable, decimal } from '${pkg}/singlestore-core';
+  export const t = singlestoreTable('t', {
+    d_num: decimal('d_num', { precision: 10, scale: 2, mode: 'number' }),
+    d_big: decimal('d_big', { precision: 20, scale: 0, mode: 'bigint' }),
+  });
+`;
+
+const SQLITE = (pkg: string) => `
+  import { sqliteTable, numeric } from '${pkg}/sqlite-core';
+  export const t = sqliteTable('t', {
+    s_num: numeric('s_num', { mode: 'number' }),
+    s_big: numeric('s_big', { mode: 'bigint' }),
+  });
+`;
+
+describe.each(MAJORS)('postgres numeric on drizzle %s', (major, pkg) => {
+  it('bounds the number mode by the precision the column declares', async () => {
+    // Addendum AK. `numeric(10,2)` admitted 2^53 where the column stops at 10^8.
+    const c = await columnsOf(`numeric-precision-pg-${major}`, PG(pkg));
+    expect(c.n_num).toMatchObject({
+      tsType: 'number',
+      dbType: 'NUMERIC',
+      integer: false,
+      min: `-${N_10_2}`,
+      max: N_10_2,
+    });
+  });
+
+  it('keeps the safe-integer bound where the declaration states no precision', async () => {
+    const c = await columnsOf(`numeric-precision-pg-${major}`, PG(pkg));
+    expect(c.n_num_free).toMatchObject({ integer: false, min: `-${SAFE}`, max: SAFE });
+    // `scale` alone renders a bare `numeric`: drizzle emits no typmod at all without a precision,
+    // so there is no constraint on the column to read. Measured on both majors through
+    // `getSQLType()`.
+    expect(c.n_num_s).toMatchObject({ min: `-${SAFE}`, max: SAFE });
+  });
+
+  it('reads a precision with no scale as the scale-zero column Postgres makes of it', async () => {
+    // `numeric(10)` is `numeric(10,0)` to the server, measured through `format_type`: it accepts
+    // 9999999999 and refuses 10000000000, and stores 0.1 as 0.
+    const c = await columnsOf(`numeric-precision-pg-${major}`, PG(pkg));
+    expect(c.n_num_p).toMatchObject({ min: '-9999999999', max: '9999999999' });
+  });
+
+  it('handles a scale wider than the precision, which Postgres allows', async () => {
+    // `numeric(2,5)` holds two significant digits five places to the right of the point. Measured:
+    // 0.00001 accepted, 0.001 refused.
+    const c = await columnsOf(`numeric-precision-pg-${major}`, PG(pkg));
+    expect(c.n_num_wide).toMatchObject({ min: '-0.00099', max: '0.00099' });
+  });
+
+  it('bounds the bigint mode by the same precision, and calls it a NUMERIC column', async () => {
+    // Addendum AL. v1 stamps `bigint int64` on this column, so it took the int64 arm: bounded at
+    // +/-9223372036854775807 and labelled BIGINT, on a column measured to accept
+    // 18446744073709551615 and 99999999999999999999.
+    const c = await columnsOf(`numeric-precision-pg-${major}`, PG(pkg));
+    expect(c.n_big).toMatchObject({
+      tsType: 'bigint',
+      dbType: 'NUMERIC',
+      integer: true,
+      min: `-${N_20_0}`,
+      max: N_20_0,
+    });
+  });
+
+  it('states no bound on a bigint mode that declares no precision', async () => {
+    const c = await columnsOf(`numeric-precision-pg-${major}`, PG(pkg));
+    expect(c.n_big_free).toMatchObject({ tsType: 'bigint', dbType: 'NUMERIC', integer: true });
+    expect(c.n_big_free.min).toBeUndefined();
+    expect(c.n_big_free.max).toBeUndefined();
+  });
+
+  it('admits the infinities only where the column carries no precision', async () => {
+    // Measured through PGlite: an unconstrained `numeric` stores and returns both infinities, and
+    // a `numeric(10,2)` answers 22003 for either. `NaN` goes into both.
+    const c = await columnsOf(`numeric-precision-pg-${major}`, PG(pkg));
+    expect(c.n_num).toMatchObject({ allowsNaN: true, allowsInfinity: false });
+    expect(c.n_num_free).toMatchObject({ allowsNaN: true, allowsInfinity: true });
+    expect(c.n_num_p).toMatchObject({ allowsNaN: true, allowsInfinity: false });
+    expect(c.n_num_s).toMatchObject({ allowsNaN: true, allowsInfinity: true });
+  });
+
+  it('leaves the string mode alone', async () => {
+    // Its value carries arbitrary precision as text and its check is a pattern, so a numeric range
+    // does not apply to it in either direction.
+    const c = await columnsOf(`numeric-precision-pg-${major}`, PG(pkg));
+    expect(c.n_str).toMatchObject({ tsType: 'string', dbType: 'NUMERIC' });
+    expect(c.n_str.min).toBeUndefined();
+    expect(c.n_str.max).toBeUndefined();
+    expect(c.n_str.allowsNaN).toBeUndefined();
+  });
+});
+
+describe.each(MAJORS)('mysql decimal on drizzle %s', (major, pkg) => {
+  it('bounds the number mode by the precision, on the path that had no bound at all', async () => {
+    const c = await columnsOf(`numeric-precision-mysql-${major}`, MYSQL(pkg));
+    expect(c.d_num).toMatchObject({
+      tsType: 'number',
+      dbType: 'NUMERIC',
+      integer: false,
+      min: `-${N_10_2}`,
+      max: N_10_2,
+    });
+  });
+
+  it('bounds the bigint mode by the precision, and calls it a NUMERIC column', async () => {
+    // The priority case of addendum AL. `decimal(20,0)` accepts twenty nines, measured on MySQL
+    // 8.4.11, and v1 bounded the column at the signed 64 bit range through its `bigint int64`
+    // dataType while calling it a BIGINT.
+    const c = await columnsOf(`numeric-precision-mysql-${major}`, MYSQL(pkg));
+    expect(c.d_big).toMatchObject({
+      tsType: 'bigint',
+      dbType: 'NUMERIC',
+      integer: true,
+      min: `-${N_20_0}`,
+      max: N_20_0,
+    });
+  });
+
+  it('states no non-finite value on any of them', async () => {
+    // MySQL refuses all three outright: `Incorrect decimal value: 'NaN'`, measured on the same
+    // server. Only Postgres stores them.
+    const c = await columnsOf(`numeric-precision-mysql-${major}`, MYSQL(pkg));
+    for (const n of ['d_num', 'd_num_free', 'd_big']) {
+      expect(c[n].allowsNaN, n).toBeUndefined();
+      expect(c[n].allowsInfinity, n).toBeUndefined();
+    }
+  });
+
+  it('reads a bare decimal as the decimal(10,0) MySQL really makes of it', async () => {
+    // Not the safe-integer fallback Postgres takes, because MySQL's `decimal` is not an
+    // unconstrained column. Measured on MySQL 8.4.11: `create table dd (v decimal)` reports
+    // `decimal(10,0)` in information_schema, and the column accepts 9999999999 while refusing
+    // 10000000000 and 9007199254740991.
+    const c = await columnsOf(`numeric-precision-mysql-${major}`, MYSQL(pkg));
+    expect(c.d_num_free).toMatchObject({ integer: false, min: '-9999999999', max: '9999999999' });
+  });
+});
+
+describe.each(MAJORS)('singlestore decimal on drizzle %s', (major, pkg) => {
+  it('answers exactly as MySQL does, which is the dialect it is wire compatible with', async () => {
+    const c = await columnsOf(`numeric-precision-singlestore-${major}`, SINGLESTORE(pkg));
+    expect(c.d_num).toMatchObject({
+      tsType: 'number',
+      integer: false,
+      min: `-${N_10_2}`,
+      max: N_10_2,
+    });
+    expect(c.d_big).toMatchObject({
+      tsType: 'bigint',
+      dbType: 'NUMERIC',
+      integer: true,
+      min: `-${N_20_0}`,
+      max: N_20_0,
+    });
+  });
+});
+
+describe.each(MAJORS)('sqlite numeric on drizzle %s', (major, pkg) => {
+  it('types both modes and states that neither holds whole numbers by accident', async () => {
+    // Addendum AL filed the number mode as "still typed unknown", which it is not: it answers
+    // `number` on both majors. What it did not state was `integer`, and `isIntegerColumn` falls
+    // back to "declares both bounds" only in that case, so this is the fact rather than a fix.
+    const c = await columnsOf(`numeric-precision-sqlite-${major}`, SQLITE(pkg));
+    expect(c.s_num).toMatchObject({ tsType: 'number', dbType: 'NUMERIC', integer: false });
+    expect(c.s_big).toMatchObject({ tsType: 'bigint', dbType: 'NUMERIC', integer: true });
+  });
+
+  it('bounds neither, not even by what a JS number carries', async () => {
+    // `numeric()` on SQLite takes no precision or scale argument at all, on either major, and
+    // NUMERIC there is an affinity rather than a type. Measured through `node:sqlite`: a `numeric`
+    // column stores 1e300 and 1e32 as REALs and hands each back unchanged, so even the
+    // safe-integer bound the other dialects fall back to would refuse rows this column returns.
+    const c = await columnsOf(`numeric-precision-sqlite-${major}`, SQLITE(pkg));
+    for (const n of ['s_num', 's_big']) {
+      expect(c[n].min, n).toBeUndefined();
+      expect(c[n].max, n).toBeUndefined();
+    }
+  });
+});
+
+describe('gel float columns', () => {
+  /**
+   * Gel exists on drizzle 0.4x alone; v1 removed `gel-core` and importing it there throws
+   * ERR_PACKAGE_PATH_NOT_EXPORTED.
+   *
+   * Measured on a live Gel 7.1 (`geldata/gel:7`) through the `gel` client, casting a literal so the
+   * server parses it, and again through a stored property on a real object type:
+   *
+   *   std::float32   NaN, Infinity and -Infinity all stored and returned unchanged
+   *   std::float32   3.4028235677973366e38 accepted, stored as 3.4028234663852886e38
+   *   std::float32   3.402823567797337e38 refused, "is out of range for type std::float32"
+   *   std::float32   1e300 refused, the same way
+   *   std::float64   all three non-finite values, 1e300 and Number.MAX_VALUE, all faithful
+   *
+   * The float32 edge is Postgres's exactly, to the double: the same value accepted, the same next
+   * double up refused, and the same rounding down of the midpoint. So `real` takes the constant
+   * this file already carries for a Postgres `real` rather than a second measurement of the same
+   * number, and `doublePrecision` takes no finite bound at all, for the reason every 8 byte float
+   * takes none.
+   */
+  const PG_FLOAT4_INPUT_MAX = '340282356779733661637539395458142568448';
+
+  const GEL = `
+    import { gelTable, real, doublePrecision, decimal } from 'drizzle-orm/gel-core';
+    export const t = gelTable('t', {
+      g_real: real('g_real'),
+      g_double: doublePrecision('g_double'),
+      g_dec: decimal('g_dec'),
+    });
+  `;
+
+  it('bounds real at the magnitude the server refuses past, and names it a REAL', async () => {
+    const c = await columnsOf('numeric-precision-gel', GEL);
+    expect(c.g_real).toMatchObject({
+      tsType: 'number',
+      dbType: 'REAL',
+      integer: false,
+      min: `-${PG_FLOAT4_INPUT_MAX}`,
+      max: PG_FLOAT4_INPUT_MAX,
+    });
+  });
+
+  it('leaves doublePrecision unbounded, and names it a DOUBLE', async () => {
+    const c = await columnsOf('numeric-precision-gel', GEL);
+    expect(c.g_double).toMatchObject({ tsType: 'number', dbType: 'DOUBLE', integer: false });
+    expect(c.g_double.min).toBeUndefined();
+    expect(c.g_double.max).toBeUndefined();
+  });
+
+  it('admits the three non-finite doubles both columns store and return', async () => {
+    // Without these the emitted schema refuses every row carrying one, which is a read-path defect
+    // on a column behaving as the server documents.
+    const c = await columnsOf('numeric-precision-gel', GEL);
+    expect(c.g_real).toMatchObject({ allowsNaN: true, allowsInfinity: true });
+    expect(c.g_double).toMatchObject({ allowsNaN: true, allowsInfinity: true });
+  });
+
+  it('leaves the decimal column, whose value is a string, alone', async () => {
+    const c = await columnsOf('numeric-precision-gel', GEL);
+    expect(c.g_dec).toMatchObject({ tsType: 'string', dbType: 'NUMERIC' });
+    expect(c.g_dec.min).toBeUndefined();
+    expect(c.g_dec.allowsNaN).toBeUndefined();
+  });
+});
+
+describe('the arm that reads a declared precision reads nothing else', () => {
+  it('is reached only by numeric and decimal in number mode, across every v1 core', async () => {
+    // `describeV1Column` reads `precision` off any column landing in the bare-number arm, with no
+    // class-name guard, and that is only sound while nothing else lands there: a `precision` on
+    // some other column would mean something else entirely. This is the sweep the comment on that
+    // read cites, run rather than written down.
+    //
+    // Every column builder each core exports, in five argument shapes, keeping the ones whose
+    // `dataType` is `number` with no semantic half.
+    // Literal specifiers rather than a template over a list of names, which the bundler cannot
+    // resolve and warns about on every run.
+    const CORES = [
+      import('drizzle-orm-v1/pg-core'),
+      import('drizzle-orm-v1/mysql-core'),
+      import('drizzle-orm-v1/sqlite-core'),
+      import('drizzle-orm-v1/singlestore-core'),
+      import('drizzle-orm-v1/mssql-core'),
+      import('drizzle-orm-v1/cockroach-core'),
+    ];
+    const SHAPES = [
+      undefined,
+      { mode: 'number' },
+      { precision: 10, scale: 2 },
+      { precision: 10, scale: 2, mode: 'number' },
+      { precision: 10 },
+    ];
+    const found = new Set<string>();
+    for (const core of CORES) {
+      const mod: Record<string, any> = await core;
+      for (const [name, fn] of Object.entries(mod)) {
+        if (typeof fn !== 'function' || /^[A-Z]/.test(name)) continue;
+        for (const args of SHAPES) {
+          let col: any;
+          try {
+            const built = args === undefined ? fn('c') : fn('c', args);
+            // A core exports more than column builders. `migrate` and friends return a promise
+            // that rejects on the nonsense arguments above, and an unhandled rejection fails the
+            // whole file rather than this call, so they are settled and skipped rather than caught.
+            if (typeof built?.then === 'function') {
+              built.catch(() => {});
+              continue;
+            }
+            col = built?.build?.({ name: 't' });
+          } catch {
+            continue;
+          }
+          if (typeof col?.dataType !== 'string') continue;
+          const [js, semantic = ''] = col.dataType.split(' ');
+          if (js !== 'number' || semantic) continue;
+          found.add(String(col.constructor?.[Symbol.for('drizzle:entityKind')] ?? '?'));
+        }
+      }
+    }
+    // A sweep that matched nothing would assert nothing, so the set is compared whole rather than
+    // filtered down to what it happens to contain.
+    expect([...found].sort()).toEqual([
+      'CockroachDecimalNumber',
+      'MsSqlDecimalNumber',
+      'MsSqlNumericNumber',
+      'MySqlDecimalNumber',
+      'PgNumericNumber',
+      'SQLiteNumericNumber',
+      'SingleStoreDecimalNumber',
+    ]);
+  });
+});
+
+describe('the two majors describe the same column identically', () => {
+  /**
+   * A fact stated on one analyzer path and not the other is a schema that changes when the user
+   * upgrades drizzle, which is what the cross-major diff in `scripts/verify-packed.sh` fails on.
+   * Every column above goes through both paths here rather than through whichever one its own
+   * `describe.each` arm happened to exercise.
+   */
+  it.each([
+    ['pg', PG],
+    ['mysql', MYSQL],
+    ['singlestore', SINGLESTORE],
+    ['sqlite', SQLITE],
+  ])('%s', async (dialect, source) => {
+    const old = await columnsOf(`numeric-precision-cross-${dialect}-old`, source('drizzle-orm'));
+    const next = await columnsOf(
+      `numeric-precision-cross-${dialect}-new`,
+      source('drizzle-orm-v1')
+    );
+    // `format` is deliberately outside this. The numeric pattern is attached by the v1 path alone
+    // and that gap is filed and waived by name in `scripts/verify-packed.sh`; it is one thing
+    // across the whole 0.4x path rather than anything this family introduced.
+    const compared = (c: Record<string, any>) =>
+      Object.fromEntries(
+        Object.entries(c).map(([k, v]) => [
+          k,
+          {
+            tsType: v.tsType,
+            dbType: v.dbType,
+            integer: v.integer,
+            min: v.min,
+            max: v.max,
+            allowsNaN: v.allowsNaN,
+            allowsInfinity: v.allowsInfinity,
+          },
+        ])
+      );
+    expect(compared(next)).toEqual(compared(old));
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -2125,15 +2125,22 @@ const ALLOWED: Record<string, Waiver> = {
   // All four libraries now carry the same signature, where zod and typebox used to differ from
   // valibot and arktype on the infinities. That convergence is the fix: the two that refused a
   // non-finite number no longer do.
-  // NaN and not the infinities, and the asymmetry is the point. Postgres takes NaN into a numeric
-  // whether or not it carries a precision, and takes an infinity only when it does not: a
-  // `numeric(10,2)` answers `22003 numeric field overflow`. The analyzer does not read precision
-  // or scale at all, so it cannot tell the two declarations apart, and accepting would make the
-  // schema admit what the server refuses for the commoner one. Narrower on purpose (AW).
+  // Two facts, and the second one is new. Postgres takes NaN into a numeric whether or not it
+  // carries a precision, so DRZL is looser there and right to be. It now also **refuses** what the
+  // column refuses: `numeric(10,2)` answers `22003 numeric field overflow` for 2147483648, and
+  // official accepts it because neither drizzle major nor `drizzle-zod` reads precision or scale.
+  // Being out of step with them is the correct outcome when the database is the arbiter (AK).
   //
-  // arktype on update is excepted because official already accepts NaN there, so there is nothing
-  // to waive. It is the one cell of the twelve that reports parity.
-  'pg/c_numeric_n': { libs: LIB_NAMES, modes: MODE_NAMES, except: ['update/arktype'], why: 'Postgres stores NaN in a numeric column and returns it; official refuses the value the database hands back', divergence: { '*/*': `L: NaN | T: ` } },
+  // The infinity half of the old note is gone, and so is its reason. It read "the analyzer does not
+  // read precision or scale at all, so it cannot tell the two declarations apart". It reads both
+  // now, so the split it could not make is the split it makes: an unconstrained `numeric` takes
+  // both infinities and one carrying a precision answers 22003, which is exactly `allowsInfinity =
+  // !declaredPrecision`. A recorded reason that stops being true is a reason to revisit the
+  // decision it justified, not a sentence to leave standing.
+  //
+  // No `except` any more. It named update/arktype as the one cell of twelve reporting parity, and
+  // that cell diverges now: official accepts the value the column refuses there too.
+  'pg/c_numeric_n': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'Postgres stores NaN in a numeric column and returns it, and refuses a value past the declared precision; official reads no precision so it accepts what the column will not hold', divergence: { 'select,insert/*': `L: NaN | T: 2147483648`, 'update/zod,valibot,typebox': `L: NaN | T: 2147483648`, 'update/arktype': `L:  | T: 2147483648` } },
   'pg/c_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'no finite bound is true of an 8 byte float, which holds every finite JS number. Non-finite values were added on top: Postgres stores NaN and both infinities in a float column and returns them, and a Select schema refusing what the database hands back fails on real rows (AW).', divergence: { 'select,insert/*': `L: 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/zod,valibot,typebox': `L: 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; MySQL REAL is a synonym for DOUBLE', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
@@ -7288,11 +7295,10 @@ const ALLOWED: Record<string, Entry> = {
     official: 'a number within +/-8388607, which refuses rows the column returns',
     filed: 'not a defect: the database is the arbiter, see the same key in the v1 pass',
   },
-  // NaN and not the infinities, because Postgres takes an infinity into a numeric only when the
-  // column carries no precision and the analyzer does not read precision at all. arktype on update
-  // is excepted: official already accepts NaN there, so there is nothing to waive. See the v1 copy
-  // of this entry for the full reasoning.
-  'pg/c_numeric_n': { libs: LIB_NAMES, modes: MODE_NAMES, except: ['update/arktype'], divergence: { '*/*': `L: NaN | T: ` }, drzl: 'a number, plus the NaN Postgres stores in a numeric column', official: 'a number, refusing the NaN the database hands back', filed: 'not a defect: as pg/c_real' },
+  // The analyzer reads precision and scale now, so this bounds where the column bounds and refuses
+  // 2147483648, which `numeric(10,2)` answers 22003 for. Official reads neither number, so it
+  // accepts a value the column will not hold. See the v1 copy for the full reasoning (AK).
+  'pg/c_numeric_n': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { 'select,insert/*': `L: NaN | T: 2147483648`, 'update/zod,valibot,typebox': `L: NaN | T: 2147483648`, 'update/arktype': `L:  | T: 2147483648` }, drzl: 'a number bounded by the declared precision, plus the NaN Postgres stores', official: 'an unbounded number that refuses the NaN the database hands back', filed: 'not a defect: the database is the arbiter, as pg/c_real' },
   // Not `as pg/c_real` in the signature, which it was until MySQL was measured: the two 4 byte
   // floats have different edges, and `3.4028235e38` is the probe that says so.
   'mysql/m_float': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,valibot,typebox': `L: 9000000, 2147483648, 9007199254740993 | T: `, 'update/arktype': `L: 9000000, 2147483648, 9007199254740993 | T: NaN`, 'select,insert/arktype': `L: 9000000, 2147483648, 9007199254740993 | T: ` }, drzl: 'as pg/c_real, at the narrower MySQL edge', official: 'as pg/c_real', filed: 'as pg/c_real' },


### PR DESCRIPTION
Addenda AK and AL, both Tier A, one family: the analyzer typing or bounding a numeric column more loosely than the column is.

## Measured first

PostgreSQL 18.3 via PGlite, MySQL 8.4.11 in Docker, SQLite via `node:sqlite`, Gel 7.1. Bound-parameter path.

| column | value | Postgres | MySQL |
|---|---|---|---|
| `numeric(10,2)` | `99999999.99` | accepts | accepts |
| `numeric(10,2)` | `99999999.994` | **accepts**, stores `99999999.99` | **accepts**, stores `99999999.99` |
| `numeric(10,2)` | `99999999.995` | refuses `22003` | refuses |
| `numeric(10,2)` | `2147483648`, `9007199254740991` | refuses `22003` | refuses |
| `numeric(10,2)` | `NaN` / `Infinity` | **accepts** / refuses `22003` | refuses / refuses |
| `numeric` (no typmod) | `1e40`, `NaN`, `±Infinity` | accepts all | n/a |
| bare `decimal` | `9999999999` / `10000000000` | n/a | accepts / refuses; it is `decimal(10,0)` |
| SQLite `numeric` | `1e300` | stored REAL, handed back unchanged | n/a |
| Gel `float32` | `3.4028235677973366e38` / next float up | accepts / refuses | |

**AK answered:** the database refuses past the declared precision. So bounding by precision is right, and **being out of step with `drizzle-zod` is the correct outcome**, since neither drizzle major reads precision or scale either. The database is the arbiter, not the first-party module.

## Two AL entries were no longer defects

Re-measuring found this; trusting the filing would not have.

- **`decimal({mode:'bigint'})` "typed number"** is false: measured `bigint` on both majors, fixed by an earlier commit. What was *still* wrong is different: v1 stamps `dataType: 'bigint int64'`, so the column carried an **int64 bound and a `BIGINT` label** while it actually holds `18446744073709551615` and twenty nines. The schema refused values the column returns.
- **SQLite `numeric({mode:'number'})` "still unknown"** is false: measured `number`. It stated no `integer` flag, which is what was added.

Same columns, real defects, wrong descriptions.

## What changed

| case | v1 codec path | 0.4x class-name path |
|---|---|---|
| pg `numeric(p,s)` number | bounds from precision; `allowsInfinity = !declaredPrecision` | new `DECIMAL_NUMBER_MODE` branch; removed from `INEXACT_RANGES` and `PG_NON_FINITE` |
| mysql/singlestore `decimal` number | same arm | same branch |
| pg / mysql `decimal` bigint | new guard, `NUMERIC` not `BIGINT` | new branch |
| sqlite `numeric` | unreachable | `integer` stated, no bound |
| gel `real`/`doublePrecision` | gel-core absent on v1 | REAL/DOUBLE split, range and non-finite entries |

**Both paths compute the bound with one shared function** off the same column, rather than two tables that have to agree. The cross-major test asserts they answer identically per dialect, and the shared function is why it never fired.

Measurement forced two extras: a bare MySQL/SingleStore `decimal` is `decimal(10,0)` rather than the safe-integer fallback, and SQLite takes **no** bound, because a 2^53 bound would refuse the `1e300` it hands back.

## BC's infinity decision, revisited because its reason expired

BC recorded: *the analyzer does not read precision or scale at all, so it cannot tell the two declarations apart.* It reads both now. The split it could not make is the split it makes: an unconstrained `numeric` takes both infinities, one carrying a precision answers `22003`. So `allowsInfinity = !declaredPrecision`.

A recorded reason that stops being true is a reason to reopen the decision it justified, not a sentence to leave standing.

## Running the schemas, not diffing them

Every value asked of the database and of all four libraries in three modes, nullable and not, both majors, TypeBox twice (`Value.Check` and `TypeCompiler`): 15 checks per value.

```
pg 0.4x   150 -> 36      mysql 0.4x  102 -> 18      gel 0.4x  96 -> 0
pg v1     165 -> 36      mysql v1    120 -> 18
```

The 108 residual disagreements are three named causes, none new:

1. **60** — `99999999.994` on `(10,2)`. Both servers round to scale *before* checking digits, so the accepted set is open at the top and no inclusive bound expresses it. **A deliberate narrowing**, and the bound chosen is exactly the set the column can hold and hand back.
2. **30** — `1e30` on an *unconstrained* numeric, which keeps the safe-integer bound. Pre-existing, out of scope, would need its own decision.
3. **18** — `TypeCompiler` only: it emits `BigInt(99999999999999999999)` from a *number* literal, which rounds up. `Value.Check` is correct. An upstream TypeBox defect, present on master today.

## Ledger

One entry, both passes, and it flips direction. It used to record only DRZL being **looser** (accepting a `NaN` official refuses); it now also records DRZL being **stricter**, refusing `2147483648` that official accepts because the column answers `22003` for it.

The `except: ['update/arktype']` added by BC is gone: it named the one cell of twelve reporting parity, and that cell diverges now.

Ground truth improved: **DRZL 1067 to 1069** agreeing with Postgres against drizzle-orm's 1013, closer on 56, further on 0. JSON Schema 890 to 892.

**All four size budgets went down**, none raised:

```
zod 277 (420)   valibot 353->352 (540)   arktype 275 (280)   typebox 444->443 (460)
```

## Cases no gate can see, even now

Only `pg/c_numeric_n` is in the fixture, and only not-null. Unreachable: pg `numeric({mode:'bigint'})`; mysql `decimal` number and bigint; every SingleStore column; sqlite `numeric` number and bigint; all of Gel. Worth knowing rather than implying coverage that does not exist.

## Not settled

- **MSSQL** `decimal` documents a different default width and no server was available; left unchanged on the safe-integer fallback.
- The **`1e30` gap** on an unconstrained numeric is real, pre-existing, and needs its own decision.
- The **TypeBox `TypeCompiler` bigint bound** defect is upstream; worth filing separately.

## Tests

`numeric-precision.spec.ts`, 38 tests, **29 failed / 9 passed** on unmodified sources. Three existing tests pinned the old behaviour and were deliberately updated; `decimal-modes` says outright that a bound change should be a deliberate edit there.

`pnpm verify:packed`, `build`, `-r test`, `typecheck`, `lint`, `docs build` all green.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
