### PR TITLE
fix(analyzer): bound mssql tinyint, and pin a cockroach bit to its width

### DIFF
--- a/.changeset/mssql-cockroach-gel-columns.md
+++ b/.changeset/mssql-cockroach-gel-columns.md
@@ -1,0 +1,75 @@
+---
+'@drzl/analyzer': patch
+---
+
+An MSSQL `tinyint` is bounded where SQL Server bounds it, a Cockroach `bit(n)` stops being
+indistinguishable from a `varbit(n)`, and both dialects' bit columns stop being labelled `BINARY`.
+
+**`tinyint` on MSSQL accepted -1, 3.7, 256 and 9007199254740991.** Drizzle stamps
+`dataType: 'number uint8'` on `MsSqlTinyInt`, and the semantic range table named `int8`, `int16`,
+`int24`, `int32`, `int53`, `uint53` and `int64` and no `uint8`. The column fell through to the bare
+number arm, which labels it `NUMERIC`, states `integer: false` and applies the safe-integer bounds.
+MSSQL exists only on drizzle v1, so unlike MySQL's `tinyint` there was no class-name table behind it
+to supply the right answer.
+
+Measured on SQL Server 2022 (`mcr.microsoft.com/mssql/server:2022-latest`), one `tinyint` column,
+each value sent as its own INSERT:
+
+| value              | server                                  |
+| ------------------ | --------------------------------------- |
+| `-1`               | refused, Msg 220 arithmetic overflow    |
+| `0`                | accepted                                |
+| `255`              | accepted                                |
+| `256`              | refused, Msg 220                        |
+| `9007199254740991` | refused, Msg 8115                       |
+| `3.7`              | accepted, and the row reads back as `3` |
+
+So the column holds whole numbers from 0 to 255 and hands back nothing else: the five rows written
+above read back as 0, 1, 3, 255, 255. It is `TINYINT`, `integer: true`, `0` to `255` now.
+`drizzle-orm/zod` at 1.0.0-rc.4 bounds the same column identically and refuses `-1`, `3.7` and `256`,
+so official agrees with the server. Unsigned is the whole difference from `int8` beside it: SQL
+Server's `tinyint` holds 0 to 255 where MySQL's holds -128 to 127, and drizzle names the two
+accordingly. Swept over every column builder all six v1 cores export, MSSQL's `tinyint` is the only
+one stating `uint8`.
+
+**A Cockroach `bit(3)` accepted `''` and `'1'`.** The `exact` flag on a bit-string shape was computed
+as `codec === 'bit'`, which is Postgres's spelling, and Cockroach columns carry no codec at all, so
+both `bit` and `varbit` came back `exact: false` and a fixed-width column was described as a maximum.
+Measured on CockroachDB v24.3.5 (`cockroachdb/cockroach:v24.3.5`):
+
+| column      | value         | server                                                      |
+| ----------- | ------------- | ----------------------------------------------------------- |
+| `bit(3)`    | `''`          | refused, "bit string length 0 does not match type BIT(3)"   |
+| `bit(3)`    | `'1'`         | refused, length 1 does not match                            |
+| `bit(3)`    | `'10'`        | refused, length 2 does not match                            |
+| `bit(3)`    | `'101'`       | accepted, and SELECT hands back the string `'101'`          |
+| `bit(3)`    | `'1011'`      | refused, length 4 does not match                            |
+| `varbit(8)` | `''`          | accepted                                                    |
+| `varbit(8)` | `'1'`         | accepted                                                    |
+| `varbit(8)` | `'10101010'`  | accepted, and SELECT hands back `'10101010'`                |
+| `varbit(8)` | `'101010101'` | refused, "bit string length 9 too large for type VARBIT(8)" |
+
+`drizzle-orm/zod` at 1.0.0-rc.4 answers the same for both columns. `CockroachBit` is exact now and
+`CockroachVarbit` is not, discriminated on the class rather than on a codec neither of them has.
+
+**Both are labelled `BIT` rather than `BINARY`.** That label is the one this package gives a MySQL
+`binary(n)`, a run of arbitrary bytes handed over as a string, and a Cockroach bit column is a string
+of `0` and `1` like the Postgres `bit(n)` it shares an arm with. A `datetime` column in
+`{ mode: 'string' }` moved for the same reason: the semantic had no arm, so it reached the bare
+string arm and came back `TEXT`, while the class-name path already answered `TIMESTAMP` for the same
+0.4x column. Both relabels change no emitted output, verified rather than argued: the same analysis
+emitted through all five generators with the old label and the new one is byte-identical in every
+one.
+
+**The fixtures that hid this are built by drizzle now.** `gel-types.spec.ts` built its table out of
+`class GelInteger {}` and a bare `drizzle:Columns` object and never called `gelTable`, so it could
+only ever show that the analyzer agreed with a class list someone had typed out. It builds a real
+`gelTable` now, and it asserts that its fixture names every column builder `gel-core` exports, which
+is the check a hand-written list cannot make. `mssql` and `cockroach` had no analyzer fixture at all;
+they have one, built by `mssqlTable` and `cockroachTable` over every builder each core exports, which
+is what found both defects above. One of them was a fixture bug in its own right: the cockroach bit
+fixture passed `{ dimensions: 3 }`, which is Postgres's argument shape, and cockroach ignores it, so
+the column reaching the analyzer was a default `bit` of width 1 and the declared 3 never existed.
+
+No generator changed. The facts are stated on the `Column` and the existing `min`/`max`/`integer` and
+bit-string rendering carries them, in all five.

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -600,6 +600,7 @@ export function describeV1Column(column: any): Partial<Column> | null {
 
   switch (semantic) {
     case 'int8':
+    case 'uint8':
     case 'int16':
     case 'int24':
     case 'int32':
@@ -628,8 +629,22 @@ export function describeV1Column(column: any): Partial<Column> | null {
       // `mediumint` alone: they fell through to the bare-number arm below, whose safe-integer
       // bounds then *overrode* the correct ones the class-name table had supplied, so a tinyint
       // went from +/-127 to +/-9007199254740991 and stopped being an integer at all.
+      //
+      // `uint8` is that same defect one width later, and it had nowhere else to fall: mssql is
+      // v1-only, so no class-name table supplies anything for it. A `MsSqlTinyInt` states
+      // `dataType: 'number uint8'`, reached the bare-number arm, and came back NUMERIC with
+      // `integer: false` and the safe-integer bounds, so the emitted schema accepted -1, 3.7, 256
+      // and 9007199254740991. Measured on SQL Server 2022: that column refuses -1 and 256 with
+      // Msg 220 and 9007199254740991 with Msg 8115, accepts 0 and 255, and stores 3 for 3.7.
+      // `drizzle-orm/zod` at 1.0.0-rc.4 bounds the same column 0 to 255 and calls it an integer.
+      //
+      // Unsigned, which is the whole difference from `int8` beside it: SQL Server's `tinyint`
+      // holds 0 to 255 where MySQL's holds -128 to 127, and drizzle names the two accordingly.
+      // The only builder on any of the six v1 cores stating `uint8` is mssql's `tinyint`, swept
+      // over every builder each core exports.
       const range = {
         int8: ['-128', '127'],
+        uint8: ['0', '255'],
         int16: ['-32768', '32767'],
         int24: ['-8388608', '8388607'],
         int32: ['-2147483648', '2147483647'],
@@ -643,7 +658,7 @@ export function describeV1Column(column: any): Partial<Column> | null {
       out.integer = true;
       out.tsType = js === 'bigint' ? 'bigint' : 'number';
       out.dbType =
-        semantic === 'int8'
+        semantic === 'int8' || semantic === 'uint8'
           ? 'TINYINT'
           : semantic === 'int16'
             ? 'SMALLINT'
@@ -744,6 +759,16 @@ export function describeV1Column(column: any): Partial<Column> | null {
       out.dbType = codec?.startsWith('timestamp') ? 'TIMESTAMP' : 'DATE';
       break;
     case 'timestamp':
+    // `datetime` is the same fact under MySQL's name for it, and it had no arm, so every column
+    // stating it fell to the bare-string arm and was labelled TEXT. The columns that reach this
+    // are the string modes of `datetime` on mssql, mysql and singlestore, plus mssql's
+    // `datetime2` and `datetimeoffset`, swept over every builder the six v1 cores export; the
+    // `{ mode: 'date' }` half of the same builders states `object date` and takes the arm above.
+    // A label only, since `dbType` is read outside this file in exactly one place,
+    // `isIntegerColumn`, which the generators consult for a `tsType` of `number`. It matters
+    // because the class-name path already answers TIMESTAMP for the same 0.4x column, and the
+    // two majors disagreeing about a column is what the cross-major diff exists to catch.
+    case 'datetime':
       out.tsType = js === 'string' ? 'string' : 'Date';
       out.dbType = 'TIMESTAMP';
       break;
@@ -781,7 +806,11 @@ export function describeV1Column(column: any): Partial<Column> | null {
       const entity = String(column?.constructor?.[Symbol.for('drizzle:entityKind')] ?? '');
       const bytes = entity.startsWith('MySql') || entity.startsWith('SingleStore');
       out.tsType = 'string';
-      out.dbType = codec === 'bit' ? 'BIT' : 'BINARY';
+      // The label follows the family rather than the codec. Cockroach's `bit`/`varbit` carry no
+      // codec, so `codec === 'bit'` called both of them BINARY, which is the label this file
+      // gives a MySQL `binary(n)`: a run of arbitrary bytes. They are strings of '0' and '1',
+      // like the Postgres `bit(n)` beside them, and are labelled the same way.
+      out.dbType = bytes ? 'BINARY' : 'BIT';
       out.shape = bytes
         ? { kind: 'byteString', length: declaredLength(column) }
         : {
@@ -789,7 +818,19 @@ export function describeV1Column(column: any): Partial<Column> | null {
             length: declaredLength(column),
             // A Postgres `bit(3)` holds exactly three digits; a Cockroach `varbit(16)` holds at
             // most that many, which is why `''` is valid there and not here.
-            exact: codec === 'bit',
+            //
+            // `codec === 'bit'` alone was Postgres's answer applied to everything, and Cockroach
+            // states no codec, so both of its builders came back `exact: false` and a `bit(3)`
+            // was indistinguishable from a `varbit(3)`. Measured on CockroachDB v24.3.5: a
+            // `bit(3)` refuses '', '1', '10' and '1011' with "bit string length n does not match
+            // type BIT(3)" and takes '101'; a `varbit(8)` takes '', '1' and '10101010' and
+            // refuses nine digits with "too large for type VARBIT(8)". `drizzle-orm/zod` at
+            // 1.0.0-rc.4 answers the same for both columns.
+            //
+            // The class rather than a prefix, because `CockroachVarbit` starts with neither
+            // `CockroachBit` nor anything else this could key on without catching the varying
+            // half too.
+            exact: codec === 'bit' || entity === 'CockroachBit',
           };
       break;
     }

--- a/packages/analyzer/test/binary-varbinary.spec.ts
+++ b/packages/analyzer/test/binary-varbinary.spec.ts
@@ -156,16 +156,48 @@ describe('drizzle v1, the four column classes that share a dataType with a Postg
     });
   });
 
-  it('leaves Cockroach bit and varbit where they were', () => {
+  it('separates a Cockroach bit from a Cockroach varbit', () => {
+    // Both used to answer `exact: false`, because `exact` was `codec === 'bit'` and neither of
+    // these carries a codec, so `bit(8)` and `varbit(8)` were the same column to this file.
+    //
+    // GROUND TRUTH, CockroachDB v24.3.5 (`cockroachdb/cockroach:v24.3.5`), on `bit(3)` and
+    // `varbit(8)` in one table:
+    //
+    //   bit(3)      ''           refused, "bit string length 0 does not match type BIT(3)"
+    //   bit(3)      '1'          refused, length 1 does not match
+    //   bit(3)      '101'        accepted, read back as the string '101'
+    //   bit(3)      '1011'       refused, length 4 does not match
+    //   varbit(8)   ''           accepted
+    //   varbit(8)   '1'          accepted
+    //   varbit(8)   '10101010'   accepted, read back as '10101010'
+    //   varbit(8)   '101010101'  refused, "bit string length 9 too large for type VARBIT(8)"
+    //
+    // So the fixed-width one is exact and the varying one is a maximum, which is the same split
+    // Postgres draws and which the codec was standing in for. `drizzle-orm/zod` at 1.0.0-rc.4
+    // agrees with the server on all eight values.
+    //
+    // Both entity kinds are asserted here rather than only the one that changed, because the
+    // discriminator has to distinguish them: an arm matching a `Cockroach` prefix would have made
+    // `varbit` exact too and this file would still have been green on the half that moved.
     expect(describeV1Column(v1col('CockroachBit', undefined, 8))?.shape).toEqual({
       kind: 'bitstring',
       length: 8,
-      exact: false,
+      exact: true,
     });
     expect(describeV1Column(v1col('CockroachVarbit', undefined, 8))?.shape).toEqual({
       kind: 'bitstring',
       length: 8,
       exact: false,
     });
+  });
+
+  it('labels both of them BIT, as it labels the Postgres one', () => {
+    // They used to be BINARY, which is the label this file gives a MySQL `binary(n)`: a run of
+    // arbitrary bytes handed over as a string. A cockroach `bit` is a string of '0' and '1', per
+    // the server readings above, and is labelled like the Postgres bit it behaves as.
+    expect(describeV1Column(v1col('CockroachBit', undefined, 8))?.dbType).toBe('BIT');
+    expect(describeV1Column(v1col('CockroachVarbit', undefined, 8))?.dbType).toBe('BIT');
+    expect(describeV1Column(v1col('MySqlBinary', 'binary', 16))?.dbType).toBe('BINARY');
+    expect(describeV1Column(v1col('SingleStoreBinary', undefined, 16))?.dbType).toBe('BINARY');
   });
 });

--- a/packages/analyzer/test/gel-types.spec.ts
+++ b/packages/analyzer/test/gel-types.spec.ts
@@ -1,102 +1,337 @@
 /**
- * The `/^Gel/i` name-matching arm, driven by hand-written classes.
+ * Gel columns, built by `gelTable` and the real column builders, as a user would write them.
  *
- * This file is deliberately NOT the coverage that matters. It builds a table out of
- * `class GelInteger {}` and friends, so all it can ever show is that the arm agrees with a class
- * list someone typed out, and a type drizzle ships that nobody thought to type out is invisible
- * to it: `GelBoolean` was missing here for exactly that reason, and a real `boolean()` column
- * came back `unknown`. `uncovered-dialects.spec.ts` runs the same arm against a real `gelTable`
- * and is where an expectation traced to a live server lives. What is left here is the ordering
- * of the regexes, which a class list does exercise: `GelTimestampTz` must not be caught by the
- * `Timestamp` case, and `GelLocalDateString` must not be caught by the `Text` one.
+ * This file used to build its table out of `class GelInteger {}` and a bare
+ * `Symbol.for('drizzle:Columns')` object. Nothing in it ever called `gelTable`, so all it could
+ * ever show was that the analyzer's regex table agreed with a class list someone had typed out,
+ * and a type drizzle ships that nobody thought to type out was invisible to it. That is not
+ * hypothetical: `GelBoolean` was missing from the list, and a real `boolean()` column came back
+ * `unknown` while this file passed. A fixture written from the implementation can only ever
+ * confirm the implementation.
+ *
+ * So the fixture is built by the builders now, and one test asserts that it names **every column
+ * builder `gel-core` exports**, which is the part a hand-written class list cannot do: a builder
+ * added by a later drizzle release fails that test by name rather than going unnoticed.
+ *
+ * What the old file was really covering, the ordering of the regexes in the `/^Gel/i` arm, is
+ * still covered and is now covered by columns that ship: `timestamptz()` must not be caught by
+ * the `Timestamp` case, and `localDate()` must not be caught by the `Text` one.
  */
 import { describe, it, expect } from 'vitest';
-import { SchemaAnalyzer } from '../src/index';
+import { createRequire } from 'node:module';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { SchemaAnalyzer, type Analysis, type Column } from '../src/index';
 
-describe('Analyzer Gel (EdgeDB) coarse type inference', () => {
-  it('maps common Gel constructor names to ts types', async () => {
-    const dir = path.resolve(__dirname, 'fixtures');
-    await fs.mkdir(dir, { recursive: true });
-    const schema = path.join(dir, 'gel-types.mjs');
-    const code = `
-class GelInteger {}
-class GelSmallInt {}
-class GelInt53 {}
-class GelBigInt64 {}
-class GelText {}
-class GelUUID {}
-class GelJson {}
-class GelReal {}
-class GelDoublePrecision {}
-class GelDecimal {}
-class GelBytes {}
-class GelBoolean {}
-class GelTimestamp {}
-class GelTimestampTz {}
-class GelLocalDateString {}
-class GelLocalTime {}
-class GelDateDuration {}
-class GelRelDuration {}
-class GelDuration {}
+const dir = path.resolve(__dirname, 'fixtures');
 
-const table = {};
-table[Symbol.for('drizzle:Name')] = 'gel_table';
-table[Symbol.for('drizzle:Columns')] = {
-  i: new GelInteger(),
-  si: new GelSmallInt(),
-  i53: new GelInt53(),
-  bi64: new GelBigInt64(),
-  t: new GelText(),
-  u: new GelUUID(),
-  j: new GelJson(),
-  r: new GelReal(),
-  dp: new GelDoublePrecision(),
-  dec: new GelDecimal(),
-  b: new GelBytes(),
-  flag: new GelBoolean(),
-  ts: new GelTimestamp(),
-  tstz: new GelTimestampTz(),
-  ld: new GelLocalDateString(),
-  lt: new GelLocalTime(),
-  dd: new GelDateDuration(),
-  rd: new GelRelDuration(),
-  d: new GelDuration(),
-};
-
-export { table as gel_table };
+/**
+ * Every column builder `gel-core` exports, each one used once, plus `.array()` on top of one of
+ * them. Written out rather than generated so it reads as a schema; the coverage test below is
+ * what holds it to the core's own export list.
+ */
+const GEL_SOURCE = `
+  import {
+    gelTable, integer, smallint, bigint, bigintT, boolean, text, uuid, json,
+    real, doublePrecision, decimal, bytes, timestamp, timestamptz,
+    localDate, localTime, dateDuration, relDuration, duration,
+  } from 'drizzle-orm/gel-core';
+  export const t = gelTable('t', {
+    i: integer('i'),
+    si: smallint('si'),
+    i53: bigint('i53'),
+    b64: bigintT('b64'),
+    flag: boolean('flag'),
+    name: text('name'),
+    u: uuid('u'),
+    payload: json('payload'),
+    r: real('r'),
+    dp: doublePrecision('dp'),
+    dec: decimal('dec'),
+    b: bytes('b'),
+    ts: timestamp('ts'),
+    tstz: timestamptz('tstz'),
+    ld: localDate('ld'),
+    lt: localTime('lt'),
+    dd: dateDuration('dd'),
+    rd: relDuration('rd'),
+    d: duration('d'),
+    tags: text('tags').array(),
+  });
 `;
-    await fs.writeFile(schema, code, 'utf8');
-    const a = new SchemaAnalyzer(schema);
-    const res = await a.analyze();
-    const t = res.tables.find((t) => t.name === 'gel_table');
-    expect(t).toBeTruthy();
-    const get = (n: string) => new Map(t!.columns.map((c) => [c.name, c.tsType])).get(n);
-    expect(get('i')).toBe('number');
-    expect(get('si')).toBe('number');
-    expect(get('i53')).toBe('number');
-    expect(get('bi64')).toBe('bigint');
-    expect(get('t')).toBe('string');
-    expect(get('u')).toBe('string');
-    expect(get('j')).toBe('any');
-    expect(get('r')).toBe('number');
-    expect(get('dp')).toBe('number');
-    expect(get('dec')).toBe('string');
-    expect(get('b')).toBe('Uint8Array');
-    expect(get('flag')).toBe('boolean');
-    // `GelTimestampTz` is a `Date` and must be matched before the `Timestamp` case, which is why
-    // both are here and not just one.
-    expect(get('tstz')).toBe('Date');
-    // The `cal::` and duration family. Each one's value is an instance of a class from the `gel`
-    // package, which DRZL cannot import and therefore cannot check; see the live-server
-    // measurement in `uncovered-dialects.spec.ts` for what each one really returns.
-    expect(get('ts')).toBe('unknown');
-    expect(get('ld')).toBe('unknown');
-    expect(get('lt')).toBe('unknown');
-    expect(get('dd')).toBe('unknown');
-    expect(get('rd')).toBe('unknown');
-    expect(get('d')).toBe('unknown');
+
+/** The builders in the fixture above, which the coverage test compares against the core. */
+const NAMED_BUILDERS = [
+  'integer',
+  'smallint',
+  'bigint',
+  'bigintT',
+  'boolean',
+  'text',
+  'uuid',
+  'json',
+  'real',
+  'doublePrecision',
+  'decimal',
+  'bytes',
+  'timestamp',
+  'timestamptz',
+  'localDate',
+  'localTime',
+  'dateDuration',
+  'relDuration',
+  'duration',
+];
+
+let cached: { analysis: Analysis; byName: Map<string, Column> } | undefined;
+
+async function gel() {
+  if (cached) return cached;
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, 'gel-types.mjs');
+  await fs.writeFile(file, GEL_SOURCE, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  const table = analysis.tables[0];
+  expect(table, `no table analyzed; issues: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  cached = { analysis, byName: new Map(table.columns.map((c) => [c.name, c])) };
+  return cached;
+}
+
+describe('the fixture is built by drizzle, not by hand', () => {
+  it('names every column builder gel-core exports', async () => {
+    // The whole reason this file changed. `check`, `foreignKey` and `primaryKey` also answer to
+    // `.build`, and none of them builds a column, so they are named as the exclusions they are.
+    const mod: Record<string, unknown> = await import('drizzle-orm/gel-core');
+    const NOT_COLUMNS = new Set(['check', 'foreignKey', 'primaryKey']);
+    const builders: string[] = [];
+    for (const [name, fn] of Object.entries(mod)) {
+      if (typeof fn !== 'function' || /^[A-Z]/.test(name) || NOT_COLUMNS.has(name)) continue;
+      // A column builder answers to `.build`; a table or schema helper does not. Several need an
+      // argument before they will build at all, so more than one shape is tried.
+      const shapes: unknown[][] = [[], [{ mode: 'number' }], [{ length: 4 }], [{ dimensions: 3 }]];
+      for (const args of shapes) {
+        try {
+          const built = (fn as (...a: unknown[]) => { build?: unknown })('probe', ...args);
+          if (built && typeof built.build === 'function') {
+            builders.push(name);
+            break;
+          }
+        } catch {
+          // A builder that refuses these arguments is tried with the next shape.
+        }
+      }
+    }
+    expect([...builders].sort()).toEqual([...NAMED_BUILDERS].sort());
+  });
+
+  it('reaches the drizzle column classes those builders produce', async () => {
+    // A fixture can name twenty builders and still exercise five classes, if several share one.
+    // These share two: `bigint()` builds a `GelInt53` while `bigintT()` builds the 64 bit one, and
+    // `text()` and `text().array()` are both a `GelText`. Asserted as the whole set so that a
+    // release which merges two builders into one class, or splits one into two, fails here.
+    await gel();
+    const mod = (await import(path.join(dir, 'gel-types.mjs'))) as unknown as Record<
+      string,
+      Record<symbol, Record<string, { baseColumn?: object }>>
+    >;
+    const columns = mod.t[Symbol.for('drizzle:Columns')];
+    const classes = new Set(
+      Object.values(columns).map((c) => (c.baseColumn ?? c).constructor.name)
+    );
+    expect([...classes].sort()).toEqual([
+      'GelBigInt64',
+      'GelBoolean',
+      'GelBytes',
+      'GelDateDuration',
+      'GelDecimal',
+      'GelDoublePrecision',
+      'GelDuration',
+      'GelInt53',
+      'GelInteger',
+      'GelJson',
+      'GelLocalDateString',
+      'GelLocalTime',
+      'GelReal',
+      'GelRelDuration',
+      'GelSmallInt',
+      'GelText',
+      'GelTimestamp',
+      'GelTimestampTz',
+      'GelUUID',
+    ]);
+  });
+
+  it('is analyzed as gel, with every column reaching the analysis', async () => {
+    const { analysis } = await gel();
+    expect(analysis.dialect).toBe('gel');
+    expect(analysis.tables[0].columns).toHaveLength(20);
   });
 });
 
+describe('Gel columns, through the real builders', () => {
+  it('types every column whose JavaScript type it can state', async () => {
+    // Every column of the fixture, keyed by name rather than counted, so a change that repairs
+    // one and breaks another fails here naming both.
+    const EXPECTED: Record<string, string> = {
+      i: 'number',
+      si: 'number',
+      i53: 'number',
+      b64: 'bigint',
+      flag: 'boolean',
+      name: 'string',
+      u: 'string',
+      payload: 'any',
+      r: 'number',
+      dp: 'number',
+      dec: 'string',
+      b: 'Uint8Array',
+      ts: 'unknown',
+      tstz: 'Date',
+      ld: 'unknown',
+      lt: 'unknown',
+      dd: 'unknown',
+      rd: 'unknown',
+      d: 'unknown',
+      tags: 'string',
+    };
+    const { byName } = await gel();
+    const actual = Object.fromEntries([...byName.values()].map((c) => [c.name, c.tsType]));
+    expect(actual).toEqual(EXPECTED);
+  });
+
+  it('keeps the regexes in an order real columns depend on', async () => {
+    // The one thing the hand-written class list did cover, now covered by columns drizzle builds.
+    // `GelTimestampTz` must be matched before the `Timestamp` case or a timestamptz stops being a
+    // `Date`, and `GelLocalDateString` must not be caught by the `Text` one or a localDate becomes
+    // a string, which is the answer the server refuses.
+    const { byName } = await gel();
+    expect(byName.get('tstz')).toMatchObject({ tsType: 'Date', dbType: 'TIMESTAMPTZ' });
+    expect(byName.get('ts')?.tsType).toBe('unknown');
+    expect(byName.get('ld')?.tsType).toBe('unknown');
+    expect(byName.get('name')).toMatchObject({ tsType: 'string', dbType: 'TEXT' });
+  });
+
+  it('types a boolean column as a boolean, so its validator refuses what is not one', async () => {
+    // The column the hand-written list did not have. `GelBoolean` fell off the end of the arm to
+    // `unknown` and the emitted field was `z.unknown()`: measured through the emitted zod schema,
+    // the column accepted 'yes', 12345 and { a: 1 }. A live Gel 7.1 hands back a JS `true`.
+    const { byName, analysis } = await gel();
+    expect(byName.get('flag')).toMatchObject({ tsType: 'boolean', dbType: 'BOOLEAN' });
+    expect(
+      analysis.issues.some((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN' && /"flag"/.test(i.message))
+    ).toBe(false);
+  });
+
+  it('describes the two float widths by what the server refuses past', async () => {
+    // `real` is a `std::float32` and `doublePrecision` a `std::float64`, and both used to answer
+    // NUMERIC with no bound at all. Measured on a live Gel 7.1: the float32 edge is Postgres's
+    // exactly, and no finite bound is truthful for the 8 byte width.
+    const { byName } = await gel();
+    expect(byName.get('r')).toMatchObject({
+      tsType: 'number',
+      dbType: 'REAL',
+      integer: false,
+      min: '-340282356779733661637539395458142568448',
+      max: '340282356779733661637539395458142568448',
+      allowsNaN: true,
+      allowsInfinity: true,
+    });
+    expect(byName.get('dp')).toMatchObject({ tsType: 'number', dbType: 'DOUBLE', integer: false });
+    expect(byName.get('dp')?.max).toBeUndefined();
+  });
+
+  it('gives uuid its format, json its value space, and an array its element', async () => {
+    const { byName } = await gel();
+    expect(byName.get('u')).toMatchObject({ tsType: 'string', format: 'uuid' });
+    expect(byName.get('payload')?.shape).toEqual({ kind: 'json' });
+    expect(byName.get('tags')).toMatchObject({ tsType: 'string', arrayDimensions: 1 });
+  });
+});
+
+describe('the cal:: and duration family, which is deliberately left unknown', () => {
+  it('states nothing, and says so per column', async () => {
+    // GROUND TRUTH, a live Gel 7.1 (`geldata/gel:7`, sys::get_version_as_str() -> 7.1+08db576)
+    // read and written through `drizzle-orm/gel` 0.45.2 on `gel@2.2.0`:
+    //
+    //   column        gel-core declares        SELECT hands back    INSERT accepts
+    //   timestamp     data: LocalDateTime      LocalDateTime        LocalDateTime
+    //   localDate     data: LocalDate          LocalDate            LocalDate
+    //   localTime     data: LocalTime          LocalTime            LocalTime
+    //   dateDuration  data: DateDuration       RelativeDuration     DateDuration
+    //   relDuration   data: RelativeDuration   RelativeDuration     RelativeDuration
+    //   duration      data: Duration           RelativeDuration     Duration
+    //
+    // A string was refused on INSERT by that server for all six and returned by it for none, so
+    // the `string` these used to be answered with was wrong in both directions rather than loose.
+    const { byName, analysis } = await gel();
+    for (const n of ['ts', 'ld', 'lt', 'dd', 'rd', 'd']) {
+      expect(byName.get(n)?.tsType, n).toBe('unknown');
+      expect(
+        analysis.issues.some(
+          (i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN' && i.message.includes(`"${n}"`)
+        ),
+        `no unknown-column warning for ${n}`
+      ).toBe(true);
+    }
+    expect(
+      analysis.issues.find((i) => i.message.includes('"ts"'))?.message,
+      'the warning identifies the Gel type, not just the column'
+    ).toContain('cal::local_datetime');
+  });
+
+  it('carries no mapFromDriverValue, so the driver value reaches the caller untouched', async () => {
+    // The reason the class identity above is the whole answer. Drizzle's base `Column` defines
+    // an identity `mapFromDriverValue`, and none of these six overrides it, so nothing converts
+    // the driver's `LocalDateTime` into anything a validator could describe. `timestamptz` is
+    // checked beside them as the control: it does not override it either, and its driver value
+    // really is a JS `Date`, which is why that one is typed and these are not.
+    const mod = await import('drizzle-orm/gel-core');
+    const table = (mod.gelTable as never as (n: string, c: Record<string, unknown>) => never)(
+      'probe',
+      {
+        ts: (mod.timestamp as never as (n: string) => never)('ts'),
+        ld: (mod.localDate as never as (n: string) => never)('ld'),
+        lt: (mod.localTime as never as (n: string) => never)('lt'),
+        dd: (mod.dateDuration as never as (n: string) => never)('dd'),
+        rd: (mod.relDuration as never as (n: string) => never)('rd'),
+        d: (mod.duration as never as (n: string) => never)('d'),
+      }
+    );
+    const columns = (table as never as Record<symbol, Record<string, object>>)[
+      Symbol.for('drizzle:Columns')
+    ];
+    for (const [name, col] of Object.entries(columns)) {
+      // Walk to whichever class in the chain owns the method, rather than testing for its
+      // presence: every column has one by inheritance and almost none defines one.
+      let proto = Object.getPrototypeOf(col);
+      let owner = '';
+      while (proto) {
+        if (Object.prototype.hasOwnProperty.call(proto, 'mapFromDriverValue')) {
+          owner = proto.constructor?.name ?? '';
+          break;
+        }
+        proto = Object.getPrototypeOf(proto);
+      }
+      expect(owner, `${name} defines its own mapFromDriverValue`).toBe('Column');
+    }
+  });
+
+  it('cannot be checked, because `gel` is an optional peer a generated module may not have', async () => {
+    // The justification for leaving six columns `unknown`, asserted rather than asserted in prose.
+    // A runtime check for these would have to name `LocalDateTime` and friends, which live in the
+    // `gel` package. drizzle-orm declares that package as an OPTIONAL peer dependency, so a schema
+    // can use `gel-core` without it being installed at all, and a generated module that imported
+    // it would fail to load for those users. It is not installed here either.
+    const req = createRequire(path.join(__dirname, '..', 'package.json'));
+    // Through the resolved entry point rather than `drizzle-orm/package.json`, which the
+    // package's own `exports` map does not expose.
+    const root = path.dirname(req.resolve('drizzle-orm'));
+    const drizzlePkg = JSON.parse(await fs.readFile(path.join(root, 'package.json'), 'utf8')) as {
+      peerDependencies?: Record<string, string>;
+      peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+    };
+    expect(drizzlePkg.peerDependencies?.gel, '`gel` is a peer of drizzle-orm').toBeTruthy();
+    expect(drizzlePkg.peerDependenciesMeta?.gel?.optional, '`gel` is an OPTIONAL peer').toBe(true);
+    expect(() => req.resolve('gel'), '`gel` resolves here after all').toThrow();
+  });
+});

--- a/packages/analyzer/test/mssql-cockroach-columns.spec.ts
+++ b/packages/analyzer/test/mssql-cockroach-columns.spec.ts
@@ -1,0 +1,478 @@
+/**
+ * The mssql and cockroach dialects, against real `mssqlTable` and `cockroachTable` schemas.
+ *
+ * `uncovered-dialects.spec.ts` said these two "cannot be reached from here at all", because the
+ * workspace resolves `drizzle-orm` to 0.45.2 and neither core exists on that major. That stopped
+ * being true when `drizzle-orm-v1`, an alias of 1.0.0-rc.4, became a devDependency of this
+ * package: the two cores are reachable, and the analyzer facts for them belong here beside every
+ * other dialect's rather than only in a generator package.
+ *
+ * Every fixture below is built by the real column builders, and one test per dialect asserts the
+ * fixture names **every column builder the core exports**. That is the check a hand-written class
+ * list cannot make, and its absence is what let the whole boolean and string family of both
+ * dialects sit at `unknown` while `gel-types.spec.ts` passed green against classes typed out by
+ * hand.
+ *
+ * GROUND TRUTH. Every bound and every width asserted here was taken from a server, not from a
+ * class name:
+ *
+ *   SQL Server 2022 (`mcr.microsoft.com/mssql/server:2022-latest`), on a `tinyint` column:
+ *     -1                 refused, Msg 220, arithmetic overflow
+ *      0                 accepted
+ *      255               accepted
+ *      256               refused, Msg 220
+ *      9007199254740991  refused, Msg 8115
+ *      3.7               accepted, and the row reads back as 3
+ *
+ *   CockroachDB v24.3.5 (`cockroachdb/cockroach:v24.3.5`), on `bit(3)` and `varbit(8)`:
+ *     bit(3)     ''        refused, "bit string length 0 does not match type BIT(3)"
+ *     bit(3)     '1'       refused, length 1 does not match
+ *     bit(3)     '10'      refused, length 2 does not match
+ *     bit(3)     '101'     accepted, and read back as the string '101'
+ *     bit(3)     '1011'    refused, length 4 does not match
+ *     varbit(8)  ''        accepted
+ *     varbit(8)  '1'       accepted
+ *     varbit(8)  '10101010' accepted, read back as '10101010'
+ *     varbit(8)  '101010101' refused, "bit string length 9 too large for type VARBIT(8)"
+ *
+ * `drizzle-orm/zod` at 1.0.0-rc.4 was asked the same questions and agrees with both servers on
+ * all of them, which is recorded here because official agreeing is evidence and official
+ * disagreeing would have been a reason to look again.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer, type Analysis, type Column } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+/** Every column builder `mssql-core` exports, each one used at least once, modes included. */
+const MSSQL_SOURCE = `
+  import {
+    mssqlTable, bigint, binary, bit, char, date, datetime, datetime2, datetimeoffset, decimal,
+    float, int, nchar, ntext, numeric, nvarchar, real, smallint, text, time, tinyint, varbinary,
+    varchar,
+  } from 'drizzle-orm-v1/mssql-core';
+  export const t = mssqlTable('t', {
+    c_int: int('c_int'),
+    c_tinyint: tinyint('c_tinyint'),
+    c_smallint: smallint('c_smallint'),
+    c_bigint: bigint('c_bigint', { mode: 'number' }),
+    c_bigint64: bigint('c_bigint64', { mode: 'bigint' }),
+    c_bit: bit('c_bit'),
+    c_decimal: decimal('c_decimal', { precision: 10, scale: 2 }),
+    c_decimal_num: decimal('c_decimal_num', { precision: 10, scale: 2, mode: 'number' }),
+    c_decimal_big: decimal('c_decimal_big', { precision: 20, scale: 0, mode: 'bigint' }),
+    c_numeric: numeric('c_numeric', { precision: 10, scale: 2 }),
+    c_numeric_num: numeric('c_numeric_num', { precision: 10, scale: 2, mode: 'number' }),
+    c_numeric_big: numeric('c_numeric_big', { precision: 20, scale: 0, mode: 'bigint' }),
+    c_float: float('c_float'),
+    c_real: real('c_real'),
+    c_varchar: varchar('c_varchar', { length: 120 }),
+    c_nvarchar: nvarchar('c_nvarchar', { length: 120 }),
+    c_char: char('c_char', { length: 4 }),
+    c_nchar: nchar('c_nchar', { length: 4 }),
+    c_text: text('c_text'),
+    c_ntext: ntext('c_ntext'),
+    c_date: date('c_date'),
+    c_date_str: date('c_date_str', { mode: 'string' }),
+    c_datetime: datetime('c_datetime'),
+    c_datetime_str: datetime('c_datetime_str', { mode: 'string' }),
+    c_datetime2: datetime2('c_datetime2'),
+    c_datetime2_str: datetime2('c_datetime2_str', { mode: 'string' }),
+    c_dto: datetimeoffset('c_dto'),
+    c_dto_str: datetimeoffset('c_dto_str', { mode: 'string' }),
+    c_time: time('c_time'),
+    c_time_str: time('c_time_str', { mode: 'string' }),
+    c_binary: binary('c_binary', { length: 16 }),
+    c_varbinary: varbinary('c_varbinary', { length: 32 }),
+  });
+`;
+
+/** Every column builder `cockroach-core` exports, plus `cockroachEnum` and `.array()`. */
+const COCKROACH_SOURCE = `
+  import {
+    cockroachTable, bigint, bit, bool, boolean, char, cockroachEnum, date, decimal,
+    doublePrecision, float, geometry, inet, int2, int4, int8, interval, jsonb, numeric, real,
+    smallint, string, text, time, timestamp, uuid, varbit, varchar, vector,
+  } from 'drizzle-orm-v1/cockroach-core';
+  export const mood = cockroachEnum('mood', ['sad', 'ok', 'happy']);
+  export const t = cockroachTable('t', {
+    c_int2: int2('c_int2'),
+    c_int4: int4('c_int4'),
+    c_int8: int8('c_int8', { mode: 'number' }),
+    c_smallint: smallint('c_smallint'),
+    c_bigint: bigint('c_bigint', { mode: 'number' }),
+    c_bigint64: bigint('c_bigint64', { mode: 'bigint' }),
+    c_bool: bool('c_bool'),
+    c_boolean: boolean('c_boolean'),
+    c_decimal: decimal('c_decimal', { precision: 10, scale: 2 }),
+    c_decimal_num: decimal('c_decimal_num', { precision: 10, scale: 2, mode: 'number' }),
+    c_decimal_big: decimal('c_decimal_big', { precision: 20, scale: 0, mode: 'bigint' }),
+    c_numeric: numeric('c_numeric', { precision: 10, scale: 2 }),
+    c_real: real('c_real'),
+    c_float: float('c_float'),
+    c_double: doublePrecision('c_double'),
+    c_varchar: varchar('c_varchar', { length: 120 }),
+    c_char: char('c_char', { length: 4 }),
+    c_text: text('c_text'),
+    c_string: string('c_string'),
+    c_uuid: uuid('c_uuid'),
+    c_jsonb: jsonb('c_jsonb'),
+    c_date: date('c_date'),
+    c_date_date: date('c_date_date', { mode: 'date' }),
+    c_timestamp: timestamp('c_timestamp'),
+    c_timestamp_str: timestamp('c_timestamp_str', { mode: 'string' }),
+    c_time: time('c_time'),
+    c_interval: interval('c_interval'),
+    c_inet: inet('c_inet'),
+    c_bit: bit('c_bit', { length: 3 }),
+    c_varbit: varbit('c_varbit', { length: 8 }),
+    c_geometry: geometry('c_geometry', { type: 'point', mode: 'tuple' }),
+    c_geometry_xy: geometry('c_geometry_xy', { type: 'point', mode: 'xy' }),
+    c_vector: vector('c_vector', { dimensions: 3 }),
+    c_enum: mood('c_enum'),
+    c_tags: text('c_tags').array(),
+  });
+`;
+
+/**
+ * The builders each fixture names. Compared against the core's own exports below, which is the
+ * whole point: a builder a later drizzle release adds fails that comparison by name.
+ */
+const MSSQL_BUILDERS = [
+  'bigint',
+  'binary',
+  'bit',
+  'char',
+  'date',
+  'datetime',
+  'datetime2',
+  'datetimeoffset',
+  'decimal',
+  'float',
+  'int',
+  'nchar',
+  'ntext',
+  'numeric',
+  'nvarchar',
+  'real',
+  'smallint',
+  'text',
+  'time',
+  'tinyint',
+  'varbinary',
+  'varchar',
+];
+
+const COCKROACH_BUILDERS = [
+  'bigint',
+  'bit',
+  'bool',
+  'boolean',
+  'char',
+  'date',
+  'decimal',
+  'doublePrecision',
+  'float',
+  'geometry',
+  'inet',
+  'int2',
+  'int4',
+  'int8',
+  'interval',
+  'jsonb',
+  'numeric',
+  'real',
+  'smallint',
+  'string',
+  'text',
+  'time',
+  'timestamp',
+  'uuid',
+  'varbit',
+  'varchar',
+  'vector',
+];
+
+const cache = new Map<string, { analysis: Analysis; byName: Map<string, Column> }>();
+
+async function analyzed(name: string, source: string) {
+  const hit = cache.get(name);
+  if (hit) return hit;
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `v1-${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  const table = analysis.tables[0];
+  expect(table, `no table analyzed; issues: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  const out = { analysis, byName: new Map(table.columns.map((c) => [c.name, c])) };
+  cache.set(name, out);
+  return out;
+}
+
+const mssql = () => analyzed('mssql', MSSQL_SOURCE);
+const cockroach = () => analyzed('cockroach', COCKROACH_SOURCE);
+
+/**
+ * Every column builder a core exports, found by building one and asking whether the result is a
+ * column builder. `check`, `foreignKey` and `primaryKey` answer to `.build` too and build no
+ * column, so they are named as the exclusions they are.
+ */
+async function columnBuildersOf(spec: string): Promise<string[]> {
+  const mod: Record<string, unknown> = await import(spec);
+  const NOT_COLUMNS = new Set(['check', 'foreignKey', 'primaryKey']);
+  const shapes: unknown[][] = [
+    [],
+    [{ mode: 'number' }],
+    [{ length: 4 }],
+    [{ precision: 10, scale: 2 }],
+    [{ dimensions: 3 }],
+    [{ type: 'point', mode: 'tuple' }],
+  ];
+  const found: string[] = [];
+  for (const [name, fn] of Object.entries(mod)) {
+    if (typeof fn !== 'function' || /^[A-Z]/.test(name) || NOT_COLUMNS.has(name)) continue;
+    for (const args of shapes) {
+      try {
+        const built = (fn as (...a: unknown[]) => { build?: unknown })('probe', ...args);
+        if (built && typeof built.build === 'function') {
+          found.push(name);
+          break;
+        }
+      } catch {
+        // Tried with the next argument shape.
+      }
+    }
+  }
+  return found.sort();
+}
+
+describe('the fixtures are built by drizzle, not by hand', () => {
+  it('names every column builder mssql-core exports', async () => {
+    expect(await columnBuildersOf('drizzle-orm-v1/mssql-core')).toEqual([...MSSQL_BUILDERS].sort());
+  });
+
+  it('names every column builder cockroach-core exports', async () => {
+    expect(await columnBuildersOf('drizzle-orm-v1/cockroach-core')).toEqual(
+      [...COCKROACH_BUILDERS].sort()
+    );
+  });
+});
+
+describe('mssql, against a real mssqlTable', () => {
+  it('is identified as mssql and types every column', async () => {
+    const { analysis } = await mssql();
+    expect(analysis.dialect).toBe('mssql');
+    expect(analysis.tables[0].columns).toHaveLength(32);
+    expect(analysis.tables[0].columns.filter((c) => c.tsType === 'unknown')).toEqual([]);
+    expect(analysis.issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN')).toEqual([]);
+  });
+
+  it('bounds tinyint where SQL Server bounds it, as a whole number from 0', async () => {
+    // The one column this fixture found wrong. `MsSqlTinyInt` states `dataType: 'number uint8'`
+    // and the semantic range table named int8, int16, int24, int32, int53, uint53 and int64 and
+    // no uint8, so it fell through to the bare-number arm: NUMERIC, `integer: false`, and the
+    // safe-integer bounds. Measured through the emitted schema, that column accepted -1, 3.7,
+    // 256 and 9007199254740991, every one of which the server above refuses.
+    //
+    // Unsigned, which is what separates it from MySQL's `tinyint`: SQL Server's holds 0 to 255
+    // where MySQL's holds -128 to 127, and drizzle names them `uint8` and `int8` accordingly.
+    const { byName } = await mssql();
+    expect(byName.get('c_tinyint')).toMatchObject({
+      tsType: 'number',
+      dbType: 'TINYINT',
+      integer: true,
+      min: '0',
+      max: '255',
+    });
+  });
+
+  it('describes every other column as the builder states it', async () => {
+    const { byName } = await mssql();
+    const actual = Object.fromEntries(
+      [...byName.values()].map((c) => [c.name, `${c.tsType}/${c.dbType}`])
+    );
+    expect(actual).toEqual({
+      c_int: 'number/INTEGER',
+      c_tinyint: 'number/TINYINT',
+      c_smallint: 'number/SMALLINT',
+      c_bigint: 'number/BIGINT',
+      c_bigint64: 'bigint/BIGINT',
+      c_bit: 'boolean/BOOLEAN',
+      c_decimal: 'string/NUMERIC',
+      c_decimal_num: 'number/NUMERIC',
+      c_decimal_big: 'bigint/NUMERIC',
+      c_numeric: 'string/NUMERIC',
+      c_numeric_num: 'number/NUMERIC',
+      c_numeric_big: 'bigint/NUMERIC',
+      c_float: 'number/DOUBLE',
+      c_real: 'number/REAL',
+      c_varchar: 'string/TEXT',
+      c_nvarchar: 'string/TEXT',
+      c_char: 'string/TEXT',
+      c_nchar: 'string/TEXT',
+      c_text: 'string/TEXT',
+      c_ntext: 'string/TEXT',
+      c_date: 'Date/DATE',
+      c_date_str: 'string/DATE',
+      c_datetime: 'Date/DATE',
+      // The two modes of one builder state two different semantics, read off the columns:
+      // `datetime()` says `object date` and `datetime({ mode: 'string' })` says `string datetime`.
+      // The label follows the semantic drizzle states rather than the builder's name.
+      c_datetime_str: 'string/TIMESTAMP',
+      c_datetime2: 'Date/DATE',
+      c_datetime2_str: 'string/TIMESTAMP',
+      c_dto: 'Date/DATE',
+      c_dto_str: 'string/TIMESTAMP',
+      c_time: 'Date/DATE',
+      c_time_str: 'string/TIME',
+      c_binary: 'Buffer/BYTEA',
+      c_varbinary: 'Buffer/BYTEA',
+    });
+  });
+
+  it('keeps the string family typed, capped, and free of a borrowed byte budget', async () => {
+    const { byName } = await mssql();
+    for (const n of ['c_varchar', 'c_nvarchar', 'c_char', 'c_nchar', 'c_text', 'c_ntext']) {
+      expect(byName.get(n)?.tsType, `${n} is a string`).toBe('string');
+    }
+    expect(byName.get('c_varchar')?.maxLength).toBe(120);
+    expect(byName.get('c_nvarchar')?.maxLength).toBe(120);
+    expect(byName.get('c_char')?.maxLength).toBe(4);
+    expect(byName.get('c_nchar')?.maxLength).toBe(4);
+    // MySQL's intrinsic TEXT caps are a MySQL fact. SQL Server's `text` holds 2 GB, so borrowing
+    // MySQL's 65535 here would refuse rows this server stores.
+    expect(byName.get('c_text')?.maxBytes).toBeUndefined();
+    expect(byName.get('c_ntext')?.maxBytes).toBeUndefined();
+  });
+
+  it('bounds the integer widths and the 4 byte float', async () => {
+    const { byName } = await mssql();
+    expect(byName.get('c_int')).toMatchObject({
+      integer: true,
+      min: '-2147483648',
+      max: '2147483647',
+    });
+    expect(byName.get('c_smallint')).toMatchObject({ integer: true, min: '-32768', max: '32767' });
+    expect(byName.get('c_bigint64')).toMatchObject({
+      integer: true,
+      min: '-9223372036854775808',
+      max: '9223372036854775807',
+    });
+    // Measured on SQL Server 2022: a `real` stores 3.4028234663852886e38, the largest finite
+    // float32, and refuses the next candidate up with "Arithmetic overflow error for type real",
+    // which is MySQL's edge rather than Postgres's.
+    expect(byName.get('c_real')).toMatchObject({
+      integer: false,
+      min: '-340282346638528859811704183484516925440',
+      max: '340282346638528859811704183484516925440',
+    });
+    // 8 byte, so no finite bound is truthful.
+    expect(byName.get('c_float')?.max).toBeUndefined();
+  });
+});
+
+describe('cockroach, against a real cockroachTable', () => {
+  it('is identified as cockroach and types every column', async () => {
+    const { analysis } = await cockroach();
+    expect(analysis.dialect).toBe('cockroach');
+    expect(analysis.tables[0].columns).toHaveLength(35);
+    expect(analysis.tables[0].columns.filter((c) => c.tsType === 'unknown')).toEqual([]);
+    expect(analysis.issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN')).toEqual([]);
+  });
+
+  it('separates a fixed-width bit from a varying one', async () => {
+    // `exact` was computed as `codec === 'bit'`, and cockroach columns carry no codec at all, so
+    // every one of them came back `exact: false` and a `bit(3)` was indistinguishable from a
+    // `varbit(3)`. The server distinguishes them, per the widths in the header: `bit(3)` refuses
+    // '' and '1' and `varbit(8)` accepts both.
+    //
+    // The width had a second problem that only a real builder shows. Cockroach's `bit` takes
+    // `{ length: n }`, and the fixture this replaces passed `{ dimensions: 3 }`, which cockroach
+    // ignores: it built a default `bit`, whose SQL type is plain `bit` and whose width is 1. A
+    // hand-written column object cannot have that kind of bug, and cannot catch it either.
+    const { byName } = await cockroach();
+    expect(byName.get('c_bit')).toMatchObject({
+      tsType: 'string',
+      dbType: 'BIT',
+      shape: { kind: 'bitstring', length: 3, exact: true },
+    });
+    expect(byName.get('c_varbit')).toMatchObject({
+      tsType: 'string',
+      dbType: 'BIT',
+      shape: { kind: 'bitstring', length: 8, exact: false },
+    });
+  });
+
+  it('describes every column as the builder states it', async () => {
+    const { byName } = await cockroach();
+    const actual = Object.fromEntries(
+      [...byName.values()].map((c) => [c.name, `${c.tsType}/${c.dbType}`])
+    );
+    expect(actual).toEqual({
+      c_int2: 'number/SMALLINT',
+      c_int4: 'number/INTEGER',
+      c_int8: 'number/BIGINT',
+      c_smallint: 'number/SMALLINT',
+      c_bigint: 'number/BIGINT',
+      c_bigint64: 'bigint/BIGINT',
+      c_bool: 'boolean/BOOLEAN',
+      c_boolean: 'boolean/BOOLEAN',
+      c_decimal: 'string/NUMERIC',
+      c_decimal_num: 'number/NUMERIC',
+      c_decimal_big: 'bigint/NUMERIC',
+      c_numeric: 'string/NUMERIC',
+      c_real: 'number/REAL',
+      c_float: 'number/DOUBLE',
+      c_double: 'number/DOUBLE',
+      c_varchar: 'string/TEXT',
+      c_char: 'string/TEXT',
+      c_text: 'string/TEXT',
+      c_string: 'string/TEXT',
+      c_uuid: 'string/UUID',
+      c_jsonb: 'any/JSON',
+      c_date: 'string/DATE',
+      c_date_date: 'Date/DATE',
+      c_timestamp: 'Date/DATE',
+      c_timestamp_str: 'string/TIMESTAMP',
+      c_time: 'string/TIME',
+      c_interval: 'string/INTERVAL',
+      c_inet: 'string/INET',
+      c_bit: 'string/BIT',
+      c_varbit: 'string/BIT',
+      c_geometry: '[number, number]/GEOMETRY',
+      c_geometry_xy: '{ x: number; y: number }/GEOMETRY',
+      c_vector: 'number[]/VECTOR',
+      c_enum: 'string/TEXT',
+      c_tags: 'string/TEXT',
+    });
+  });
+
+  it('keeps the shaped columns shaped', async () => {
+    const { byName } = await cockroach();
+    expect(byName.get('c_jsonb')?.shape).toEqual({ kind: 'json' });
+    expect(byName.get('c_geometry')?.shape).toEqual({ kind: 'tuple', length: 2 });
+    expect(byName.get('c_geometry_xy')?.shape).toEqual({
+      kind: 'numberObject',
+      fields: ['x', 'y'],
+    });
+    expect(byName.get('c_vector')?.shape).toEqual({ kind: 'numberVector', length: 3 });
+    expect(byName.get('c_tags')).toMatchObject({ tsType: 'string', arrayDimensions: 1 });
+    expect(byName.get('c_enum')?.enumValues).toEqual(['sad', 'ok', 'happy']);
+  });
+
+  it('bounds a real where Postgres does, not where MySQL does', async () => {
+    // CockroachDB's `real` is a FLOAT4 and it speaks the Postgres wire protocol, so it inherits
+    // the Postgres edge: inserting the largest finite float32 makes the column hand back
+    // 3.4028235e+38, a double above that float32, which MySQL's bound would refuse.
+    const { byName } = await cockroach();
+    expect(byName.get('c_real')).toMatchObject({
+      integer: false,
+      min: '-340282356779733661637539395458142568448',
+      max: '340282356779733661637539395458142568448',
+    });
+    expect(byName.get('c_float')?.max).toBeUndefined();
+    expect(byName.get('c_double')?.max).toBeUndefined();
+  });
+});

--- a/packages/analyzer/test/uncovered-dialects.spec.ts
+++ b/packages/analyzer/test/uncovered-dialects.spec.ts
@@ -1,18 +1,23 @@
 /**
  * SingleStore and Gel against real drizzle-orm, rather than against hand-written classes.
  *
- * `singlestore-types.spec.ts` and `gel-types.spec.ts` already claim to cover these two, but both
- * build a fake table out of `class SingleStoreVarchar {}` and a bare `Symbol.for('drizzle:Columns')`
- * object. Nothing in either file ever calls `singlestoreTable` or `gelTable`, so what they test is
- * that the analyzer's own regex table agrees with a class list someone typed out by hand. Every
- * type drizzle really ships that nobody thought to type out is invisible to them, and that is not
- * hypothetical: `GelBoolean` is missing from `gel-types.spec.ts`, and a real `boolean()` column
- * comes back `unknown`, which is measured below.
+ * `singlestore-types.spec.ts` and `gel-types.spec.ts` already claimed to cover these two, and both
+ * built a fake table out of `class SingleStoreVarchar {}` and a bare `Symbol.for('drizzle:Columns')`
+ * object. Neither ever called `singlestoreTable` or `gelTable`, so what they tested is that the
+ * analyzer's own regex table agrees with a class list someone typed out by hand. Every type
+ * drizzle really ships that nobody thought to type out is invisible to that, and it was not
+ * hypothetical: `GelBoolean` was missing from `gel-types.spec.ts`, and a real `boolean()` column
+ * came back `unknown` while it passed. `gel-types.spec.ts` builds its table with `gelTable` now
+ * and holds itself to `gel-core`'s own export list; `singlestore-types.spec.ts` still does not,
+ * which is what the SingleStore half of this file is for.
  *
- * `mssql` and `cockroach` are the other two dialects in the public `Dialect` union with no
- * coverage. They exist only in drizzle v1, which is not in this workspace, so they cannot be
- * reached from here at all; they are measured and reported in
- * `.superpowers/sdd/2026-08-03-top-100/task-5-report.md` instead.
+ * `mssql` and `cockroach` are the other two dialects in the public `Dialect` union. This header
+ * used to say they "cannot be reached from here at all", because they exist only in drizzle v1
+ * and the workspace resolves `drizzle-orm` to 0.45.2. That stopped being true when
+ * `drizzle-orm-v1`, an alias of 1.0.0-rc.4, became a devDependency of this package: both cores
+ * import, and `mssql-cockroach-columns.spec.ts` builds a real `mssqlTable` and `cockroachTable`
+ * beside this file. The original measurement is in
+ * `.superpowers/sdd/2026-08-03-top-100/task-5-report.md`.
  *
  * Everything here runs the real `SchemaAnalyzer` over a real drizzle schema module. Where an
  * assertion pins output that is wrong, the comment says so and says what the right answer is.
@@ -230,7 +235,9 @@ describe('SingleStore, against a real singlestoreTable', () => {
     expect(byName.get('vec')?.tsType).toBe('number[]');
     expect(byName.get('vec')?.shape).toEqual({ kind: 'numberVector', length: 3 });
     // And the warning it used to raise is gone, because there is nothing left to warn about.
-    expect(analysis.issues.some((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN' && /"vec"/.test(i.message))).toBe(false);
+    expect(
+      analysis.issues.some((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN' && /"vec"/.test(i.message))
+    ).toBe(false);
   });
 
   it('types the default decimal mode as the string the driver returns', async () => {

--- a/packages/generator-typebox/package.json
+++ b/packages/generator-typebox/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@sinclair/typebox": "^0.34.0",
+    "drizzle-orm-v1": "npm:drizzle-orm@1.0.0-rc.4",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/packages/generator-typebox/test/mssql-cockroach-columns.spec.ts
+++ b/packages/generator-typebox/test/mssql-cockroach-columns.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * The two mssql and cockroach columns whose description changed, run through TypeBox.
+ *
+ * Built by the real column builders, described by the real analyzer, emitted by the real
+ * generator, then imported and executed. Nothing here reads the emitted text: a schema that
+ * parses is not a schema that validates, and TypeBox in particular will accept an option it does
+ * not understand for a given type and then ignore it, which is why this package checks by running.
+ *
+ * Both paths, deliberately. `Value.Check` walks the schema and `TypeCompiler` generates a checker
+ * from it, and they are two different implementations of the same question: a constraint the
+ * compiler does not emit code for passes `Value.Check` and validates nothing in the code a user
+ * actually runs.
+ *
+ * Every value below is one a server took or refused. See the header of
+ * `packages/analyzer/test/mssql-cockroach-columns.spec.ts` for the two readings in full: SQL
+ * Server 2022 on a `tinyint`, and CockroachDB v24.3.5 on a `bit(3)` and a `varbit(8)`.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer, type Analysis, type Column } from '@drzl/analyzer';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+import { TypeBoxGenerator } from '../src/index';
+
+const dir = path.join(__dirname, '.tmp-mssql-cockroach');
+
+const MSSQL_SOURCE = `
+  import { mssqlTable, int, tinyint, varchar } from 'drizzle-orm-v1/mssql-core';
+  export const t = mssqlTable('t', {
+    id: int('id'),
+    ti: tinyint('ti'),
+    name: varchar('name', { length: 120 }),
+  });
+`;
+
+const COCKROACH_SOURCE = `
+  import { cockroachTable, bit, boolean, text, varbit } from 'drizzle-orm-v1/cockroach-core';
+  export const t = cockroachTable('t', {
+    flag: boolean('flag'),
+    body: text('body'),
+    bt: bit('bt', { length: 3 }),
+    vb: varbit('vb', { length: 8 }),
+  });
+`;
+
+interface Emitted {
+  byName: Map<string, Column>;
+  schemas: Record<string, { properties: Record<string, unknown> }>;
+}
+
+const cache = new Map<string, Emitted>();
+
+async function dialect(name: string, source: string): Promise<Emitted> {
+  const hit = cache.get(name);
+  if (hit) return hit;
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.schema.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const analysis: Analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze(
+    {}
+  );
+  const table = analysis.tables[0];
+  expect(table, `no table analyzed; issues: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+
+  const outDir = path.join(dir, `${name}-out`);
+  await new TypeBoxGenerator(analysis).generate({ outDir } as never);
+  const emitted = path.join(outDir, `t-${process.pid}.ts`);
+  await fs.rename(path.join(outDir, 't.typebox.ts'), emitted);
+  const schemas = await import(emitted);
+
+  const out: Emitted = { byName: new Map(table.columns.map((c) => [c.name, c])), schemas };
+  cache.set(name, out);
+  return out;
+}
+
+const mssql = () => dialect('mssql', MSSQL_SOURCE);
+const cockroach = () => dialect('cockroach', COCKROACH_SOURCE);
+
+/** The select-side field for one column, checked by walking the schema. */
+const walks = (e: Emitted, col: string, v: unknown) =>
+  Value.Check(e.schemas.SelecttSchema.properties[col] as never, v);
+
+/** The same field, checked by the code TypeCompiler generates from it. */
+const compiles = (e: Emitted, col: string, v: unknown) =>
+  TypeCompiler.Compile(e.schemas.SelecttSchema.properties[col] as never).Check(v);
+
+/** Both paths must agree, and the agreed answer is what is asserted. */
+function accepts(e: Emitted, col: string, v: unknown, why: string): boolean {
+  const a = walks(e, col, v);
+  const b = compiles(e, col, v);
+  expect(b, `${col}: Value.Check and TypeCompiler disagree on ${why}`).toBe(a);
+  return a;
+}
+
+beforeAll(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('mssql tinyint, through the emitted TypeBox schema', () => {
+  it('takes what SQL Server stored and refuses what it turned away', async () => {
+    const a = await mssql();
+    expect(a.byName.get('ti')).toMatchObject({
+      tsType: 'number',
+      dbType: 'TINYINT',
+      integer: true,
+      min: '0',
+      max: '255',
+    });
+    expect(accepts(a, 'ti', 0, 'the 0 the server stored')).toBe(true);
+    expect(accepts(a, 'ti', 200, 'a value inside the width')).toBe(true);
+    expect(accepts(a, 'ti', 255, 'the 255 the server stored')).toBe(true);
+    expect(accepts(a, 'ti', -1, 'refused with Msg 220')).toBe(false);
+    expect(accepts(a, 'ti', 256, 'refused with Msg 220')).toBe(false);
+    expect(accepts(a, 'ti', 9007199254740991, 'refused with Msg 8115')).toBe(false);
+    expect(accepts(a, 'ti', 3.7, 'a fraction, which the column never returns')).toBe(false);
+    expect(accepts(a, 'ti', '5', 'a string in a numeric column')).toBe(false);
+  });
+
+  it('leaves the columns beside it alone', async () => {
+    // A guard against a fix that reaches further than its column: `int` keeps the 32 bit width
+    // and `varchar(120)` keeps its cap.
+    const a = await mssql();
+    expect(accepts(a, 'id', -2147483648, 'the bottom of an int32')).toBe(true);
+    expect(accepts(a, 'id', 2147483648, 'past the top of an int32')).toBe(false);
+    expect(accepts(a, 'name', 'a'.repeat(120), 'the longest value the server took')).toBe(true);
+    expect(accepts(a, 'name', 'a'.repeat(121), 'the value the server refused')).toBe(false);
+  });
+});
+
+describe('cockroach bit and varbit, through the emitted TypeBox schema', () => {
+  it('holds a bit(3) to exactly three digits', async () => {
+    const a = await cockroach();
+    expect(a.byName.get('bt')?.shape).toEqual({ kind: 'bitstring', length: 3, exact: true });
+    expect(accepts(a, 'bt', '101', 'the value the server returned')).toBe(true);
+    expect(accepts(a, 'bt', '', 'refused, length 0 does not match BIT(3)')).toBe(false);
+    expect(accepts(a, 'bt', '1', 'refused, length 1 does not match BIT(3)')).toBe(false);
+    expect(accepts(a, 'bt', '10', 'refused, length 2 does not match BIT(3)')).toBe(false);
+    expect(accepts(a, 'bt', '1011', 'refused, length 4 does not match BIT(3)')).toBe(false);
+    expect(accepts(a, 'bt', '102', 'a digit that is neither 0 nor 1')).toBe(false);
+    expect(accepts(a, 'bt', 101, 'a number rather than the string the driver returns')).toBe(false);
+  });
+
+  it('holds a varbit(8) to at most eight', async () => {
+    const a = await cockroach();
+    expect(a.byName.get('vb')?.shape).toEqual({ kind: 'bitstring', length: 8, exact: false });
+    expect(accepts(a, 'vb', '', 'the empty string the server accepted')).toBe(true);
+    expect(accepts(a, 'vb', '1', 'one digit, which varbit takes')).toBe(true);
+    expect(accepts(a, 'vb', '10101010', 'the value the server returned')).toBe(true);
+    expect(accepts(a, 'vb', '101010101', 'nine digits, past the declared width')).toBe(false);
+  });
+
+  it('keeps the boolean and string families the two dialects lost', async () => {
+    // The families the filed defect was about, checked here through the second generator and the
+    // second checking path rather than taken on trust from the zod suite.
+    const a = await cockroach();
+    expect(accepts(a, 'flag', true, 'the true the server returned')).toBe(true);
+    expect(accepts(a, 'flag', 1, 'the integer the server refused')).toBe(false);
+    expect(accepts(a, 'flag', 'yes', 'a string in a bool column')).toBe(false);
+    expect(accepts(a, 'body', 'body text', 'a row the server returned')).toBe(true);
+    expect(accepts(a, 'body', 12345, 'a number in a string column')).toBe(false);
+  });
+});

--- a/packages/generator-zod/test/mssql-cockroach-types.spec.ts
+++ b/packages/generator-zod/test/mssql-cockroach-types.spec.ts
@@ -97,8 +97,12 @@ const COCKROACH_SOURCE = `
     tm: time('tm'),
     iv: interval('iv'),
     ip: inet('ip'),
-    bt: bit('bt', { dimensions: 3 }),
-    vb: varbit('vb', { dimensions: 8 }),
+    // A length, not a dimensions. This fixture passed dimensions for a round, and cockroach
+    // ignores it: the column that reached the analyzer was a default bit, whose SQL type is a
+    // bare "bit" and whose width is 1, so the declared 3 and 8 never existed. Postgres is the
+    // builder that takes dimensions, and copying its call shape is how it got here.
+    bt: bit('bt', { length: 3 }),
+    vb: varbit('vb', { length: 8 }),
     g: geometry('g', { type: 'point', mode: 'tuple' }),
     vec: vector('vec', { dimensions: 3 }),
     m: mood('m'),
@@ -240,12 +244,51 @@ describe('mssql, against a real mssqlTable on drizzle v1', () => {
     expect(accepts(name, 12345), 'a number in a varchar column').toBe(false);
 
     expect(accepts(field(a, 'code'), 'ab  '), 'the padded char(4) the server returned').toBe(true);
-    expect(accepts(field(a, 'ncode'), 'cd  '), 'the padded nchar(4) the server returned').toBe(true);
+    expect(accepts(field(a, 'ncode'), 'cd  '), 'the padded nchar(4) the server returned').toBe(
+      true
+    );
     expect(accepts(field(a, 'code'), 'abcde'), 'past the char(4) width').toBe(false);
 
     expect(accepts(field(a, 'body'), 'body text')).toBe(true);
     expect(accepts(field(a, 'nbody'), 'nbody text')).toBe(true);
     expect(accepts(field(a, 'body'), { a: 1 }), 'an object in a text column').toBe(false);
+  });
+
+  it('holds tinyint to the whole numbers 0 to 255 SQL Server stores', async () => {
+    // `MsSqlTinyInt` states `dataType: 'number uint8'`, and the semantic range table had no
+    // `uint8`, so the column fell to the bare-number arm: NUMERIC, `integer: false`, and the
+    // safe-integer bounds. mssql is v1-only, so there was no class-name table to override it the
+    // way MySQL's `tinyint` is overridden.
+    //
+    // GROUND TRUTH, SQL Server 2022 (`mcr.microsoft.com/mssql/server:2022-latest`), one `tinyint`
+    // column, each value sent as its own INSERT:
+    //
+    //   -1                 refused, Msg 220 arithmetic overflow
+    //    0                 accepted
+    //    255               accepted
+    //    256               refused, Msg 220
+    //    9007199254740991  refused, Msg 8115
+    //    3.7               accepted, and the stored row reads back as 3
+    //
+    // The select schema describes what the column hands back, and it hands back whole numbers in
+    // 0 to 255: the five rows written above read back as 0, 1, 3, 255, 255. `drizzle-orm/zod` at
+    // 1.0.0-rc.4 refuses -1, 3.7 and 256 for the same column, so official agrees.
+    const a = await mssql();
+    expect(a.byName.get('ti')).toMatchObject({
+      tsType: 'number',
+      dbType: 'TINYINT',
+      integer: true,
+      min: '0',
+      max: '255',
+    });
+    const ti = field(a, 'ti');
+    expect(accepts(ti, 0), 'the 0 the server stored').toBe(true);
+    expect(accepts(ti, 255), 'the 255 the server stored').toBe(true);
+    expect(accepts(ti, 3), 'the row 3.7 was stored as').toBe(true);
+    expect(accepts(ti, -1), 'the value the server refused with Msg 220').toBe(false);
+    expect(accepts(ti, 256), 'the value the server refused with Msg 220').toBe(false);
+    expect(accepts(ti, 9007199254740991), 'the value the server refused with Msg 8115').toBe(false);
+    expect(accepts(ti, 3.7), 'a fraction, which this column never hands back').toBe(false);
   });
 
   it('keeps a real column at the float32 edge SQL Server stops at', async () => {
@@ -333,6 +376,39 @@ describe('cockroach, against a real cockroachTable on drizzle v1', () => {
     expect(accepts(tags, []), 'the empty array the server returned').toBe(true);
     expect(accepts(tags, 'a'), 'the bare string the server refused').toBe(false);
     expect(accepts(tags, [1, 2]), 'numbers in a string[] column').toBe(false);
+  });
+
+  it('holds bit to its exact width and varbit to a maximum', async () => {
+    // `exact` was `codec === 'bit'`, and cockroach carries no codec, so both came back
+    // `exact: false` and `bit(3)` accepted what only a `varbit` takes.
+    //
+    // GROUND TRUTH, CockroachDB v24.3.5 (`cockroachdb/cockroach:v24.3.5`), one table with a
+    // `bit(3)` and a `varbit(8)`, each value sent as its own INSERT:
+    //
+    //   bit(3)      ''           refused, "bit string length 0 does not match type BIT(3)"
+    //   bit(3)      '1'          refused, length 1 does not match
+    //   bit(3)      '10'         refused, length 2 does not match
+    //   bit(3)      '101'        accepted, and SELECT hands back the string '101'
+    //   bit(3)      '1011'       refused, length 4 does not match
+    //   varbit(8)   ''           accepted
+    //   varbit(8)   '1'          accepted
+    //   varbit(8)   '10101010'   accepted, and SELECT hands back '10101010'
+    //   varbit(8)   '101010101'  refused, "bit string length 9 too large for type VARBIT(8)"
+    const a = await cockroach();
+    expect(a.byName.get('bt')?.shape).toEqual({ kind: 'bitstring', length: 3, exact: true });
+    expect(a.byName.get('vb')?.shape).toEqual({ kind: 'bitstring', length: 8, exact: false });
+
+    const bt = field(a, 'bt');
+    expect(accepts(bt, '101'), 'the value the server stored and returned').toBe(true);
+    expect(accepts(bt, ''), 'the empty string the server refused').toBe(false);
+    expect(accepts(bt, '1'), 'one digit, refused as length 1').toBe(false);
+    expect(accepts(bt, '1011'), 'four digits, refused as length 4').toBe(false);
+
+    const vb = field(a, 'vb');
+    expect(accepts(vb, ''), 'the empty string the server accepted').toBe(true);
+    expect(accepts(vb, '1'), 'one digit, which varbit takes').toBe(true);
+    expect(accepts(vb, '10101010'), 'the value the server returned').toBe(true);
+    expect(accepts(vb, '101010101'), 'nine digits, past the declared width').toBe(false);
   });
 
   it('bounds a real column where Postgres does, not where MySQL does', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.52
+      drizzle-orm-v1:
+        specifier: npm:drizzle-orm@1.0.0-rc.4
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(supports-color@7.2.0)(typescript@5.9.3)


### PR DESCRIPTION
Addenda V and W. **Neither reproduces.** Both were fixed by earlier commits and the filings had gone stale. Converting the specs to real builder-built fixtures found two different Tier A defects in the same dialects.

## What the measurement said

Real `mssqlTable` / `cockroachTable` / `gelTable`, real analyzer, on master before any change:

| dialect | columns | `unknown` | boolean family | string family |
|---|---|---|---|---|
| mssql | 32 | **0** | `bit` to `boolean` | all 6 to `string`, caps intact |
| cockroach | 35 | **0** | `bool`/`boolean` to `boolean` | all 4 plus `text[]` |
| gel | 20 | 6 | `boolean()` to `boolean` | `text` to `string` |

`V1_ONLY_ENTITY_KINDS` already lets both dialects past the codec gate (`194eb72`); gel's boolean was fixed in `2dccd51`.

## The two defects the fixtures found

**1. mssql `tinyint` was unbounded.** It states `dataType: 'number uint8'` and the range table had `int8 int16 int24 int32 int53 uint53 int64` with no `uint8`, so it fell to the bare-number arm at plus or minus 2^53. mssql is v1-only, so no class-name table backstopped it.

SQL Server 2022 in Docker: `-1` refused (Msg 220), `255` accepted, `256` refused (Msg 220), `9007199254740991` refused (Msg 8115), `3.7` accepted and stored as `3`. `drizzle-orm/zod` bounds it 0..255. Now `TINYINT`, integer, `'0'`..`'255'`.

**2. cockroach `bit(n)` was not exact width.** `exact` was keyed on `codec === 'bit'`, and **cockroach carries no codec at all**, so `bit` and `varbit` were both inexact.

CockroachDB v24.3.5: `bit(3)` refuses `''`, `'1'`, `'10'`, `'1011'` and takes `'101'`; `varbit(8)` takes `''` through 8 digits and refuses 9. Official agrees on all eight.

The same absent codec had these labelled `BINARY`, which is what a MySQL `binary(n)` of arbitrary bytes is called. The label now keys on whether the column holds bytes.

## The fixtures are the point

`gel-types.spec.ts` built `class GelInteger {}` and a bare `drizzle:Columns` object; it never called `gelTable`. And an existing spec passed `bit('bt', { dimensions: 3 })` — **that is Postgres's argument shape**. Cockroach ignores it, so the column reaching the analyzer was a default `bit` of width 1 and the declared 3 never existed.

A hand-written column object cannot have that bug and cannot catch it either. Both new specs are built over **every** column builder the respective core exports, with a test asserting the fixture reaches every class they produce.

I checked the gel conversion is not vacuous: reverting the two gel analyzer arms makes the new file fail 4 of 11 tests naming all seven originally filed columns.

## The `unknown` deliberately kept

The six gel temporal columns stay `unknown`, and the precedent was rechecked rather than inherited. `gel` is an **optional** peer of drizzle-orm (`peerDependenciesMeta.gel.optional: true`) and does not resolve in this workspace at all, so a generated module importing `LocalDateTime` would fail to load for any user with `gel-core` and no driver. `unknown` also preserves the per-column warning carrying `getSQLType()`.

That justification is now a test rather than a comment. An honest `unknown` beats a wrong type; an `unknown` that could have been typed is the defect being fixed, so each remaining one is justified.

## What running the schemas proved

Not diffed as text. `tinyint`, `bit(3)` and `varbit(8)` executed against the exact values the two servers took and refused. zod and TypeBox as permanent specs, TypeBox through both `Value.Check` and `TypeCompiler` with the helper asserting the two paths **agree** before asserting the answer; they agreed on all 25.

arktype, valibot and JSON Schema via ajv ran as a one-off measurement, 45/45 agreeing with both servers. Permanent specs there would mean adding `drizzle-orm-v1` as a devDependency to two more packages. **That is a coverage gap I am flagging, not hiding.**

Both relabels proven inert: the same analysis through all five generators with old and new `dbType` is byte-identical.

## Scope

Six lines of behaviour in `describeV1Column`; everything else is comments and tests. Only the codec path changed, since both dialects are v1-only and `V1_ONLY_ENTITY_KINDS` already routes them. Gel is class-name-path-only and unchanged.

## About the green gate

`pnpm verify:packed` exits 0 with **zero ledger movement**, and I diffed the full logs against master: the only differences are 9 `Analysis complete in NNms` timing lines. Sizes byte-identical, no budget raised.

**Say it plainly: none of these three dialects has a fixture in that gate, so it did not exercise a single line this changes.** Its only value here is that pg, mysql and sqlite did not move. The evidence for the fixes is the new specs and the two real servers.

## Found in passing, reported not fixed

- `PgHalfVector` states `dataType: "array halfvector"`, so the v1 `case 'halfvec'` never matches and is dead code. No user-visible defect: the class-name path answers and the shape still arrives.
- `PgMacaddr8` is labelled `TEXT` rather than `MACADDR8`. Label only.
- mssql `datetime()` in date mode is labelled `DATE` not `TIMESTAMP`, because drizzle states `object date` for it and `string datetime` for the same builder's string mode. I did not override drizzle's own semantic on a guess.
- `singlestore-types.spec.ts` is still hand-written, though SingleStore has builder-built coverage elsewhere.

## Tests

10 new tests fail on unmodified sources (analyzer 6, zod 2, typebox 2), all pass after. `pnpm -r test`: 1352 passed across 12 packages. `build`, `typecheck`, `lint`, `docs build` green.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
