### PR TITLE
feat(trpc): generate a tRPC v11 router per table

### DIFF
--- a/.changeset/trpc-generator.md
+++ b/.changeset/trpc-generator.md
@@ -1,0 +1,65 @@
+---
+'@drzl/generator-trpc': minor
+'@drzl/cli': minor
+---
+
+A tRPC generator, `@drzl/generator-trpc`, and the CLI wiring for it.
+
+`drzl generate` takes a `{ kind: 'trpc' }` generator, `drzl generate:trpc <schema>` runs it without
+a config, and `drzl watch --pipeline generate-trpc` rebuilds only it. The package is an **optional**
+dependency of `@drzl/cli`, like the json-schema generator: a package that has never been published
+cannot publish through npm's trusted-publisher flow, so its first version goes out by hand, and
+naming it as a hard dependency in the same release would break `npm i @drzl/cli` until it exists.
+
+**Targets tRPC v11**, determined from the registry rather than from memory: `latest` is 11.x, majors
+1 through 11 are published and there is no 12, and `next` points behind `latest`, so there is not
+even a pre-release train to aim at. Every construct emitted was run against a real 11.18.0 install.
+
+Three kinds of file per run. `trpc.ts` holds the single `initTRPC` instance the whole tree shares,
+which has no counterpart in the oRPC output and is not optional: tRPC's builder carries the context
+type with it, so a router built from its own `initTRPC.create()` cannot share middleware and cannot
+be soundly merged. `<table>.ts` is one router per table. `index.ts` builds `appRouter` with
+`router()` and exports `type AppRouter`, which is the entire client contract.
+
+Per table: `list` and `byId` as queries, `create`, `update` and `delete` as mutations, each with an
+`.output(...)` schema, plus one `listBy<Column>` query per single-column foreign key under
+`includeRelations`. Reads are queries and writes are mutations because a tRPC client caches and
+batches queries over `GET` and never puts a mutation there.
+
+**The primary key is read off the schema.** A `varchar` key called `isbn` produces
+`byId({ isbn: string })`. A composite key produces `byId({ orgId, userId })`. A table with **no**
+primary key gets `list` and `create` only, rather than a fabricated `id`. A read-only relation gets
+`list` and `byId` only, and no insert or update schema is imported for it. The emitted tree is
+compiled by `tsc` under `strict` and `moduleResolution: nodenext` for every one of those shapes and
+for all three validators, and stood up as a real HTTP server and driven with real requests, in this
+package's own test suite.
+
+TypeBox cannot be used with this generator, and that is measured rather than assumed: tRPC v11
+recognises a validator through Standard Schema, and `@sinclair/typebox` 0.34 puts no `~standard` key
+on what `Type.Object()` returns. `validation.library` accepts zod, valibot and arktype, all three of
+which were run through a real router.
+
+---
+
+Three CLI wiring defects, all of the same species, found by generating output and reading it rather
+than by reading the wiring:
+
+- **`databaseInjection` was documented and unreachable.** It has been on the oRPC generator's
+  documented options since it was added, and `GeneratorSchema` had no such key. That schema is not
+  strict, so zod stripped it in silence and the option did nothing at all when set from a config
+  file. It is in the schema now, and passed by both router branches.
+- **`watch` never passed `servicesDir`.** `generate` computes it from the `service` generator's
+  `path` and passes it; `watch`'s oRPC branch did not, so a rebuild emitted a service import
+  pointing at the default directory whatever the config said. The first save after starting
+  `drzl watch` silently replaced a correct import with a wrong one.
+- **`databaseInjection` reached only one of the two generators that have to agree about it.** A
+  router in injection mode emits `Service.getById(ctx.db, id)`, and only a service generated in the
+  same mode has a `db` parameter to receive it. It is declared once on the router generator and
+  pushed onto the `service` generator by `resolveConfig`, the same mechanism that already pulls
+  `validation.affix` the other way. `@drzl/generator-service` honours the flag only while emitting
+  real Drizzle queries, so pairing it with `dataAccess: 'stub'` now warns instead of emitting calls
+  that cannot compile.
+
+The tRPC branches of `generate` and `watch` build their options through one shared function, and
+`packages/cli/test/trpc-branch-parity.spec.ts` runs both commands over a config that sets every
+option and compares the bytes, because reading the two branches is what missed all three above.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Runtime
 - `packages/analyzer`: schema analysis
 - `packages/cli`: CLI (`drzl`)
 - `packages/generator-orpc`: oRPC router generator
+- `packages/generator-trpc`: tRPC v11 router generator
 - `packages/generator-service`: typed service generator
 - `packages/generator-zod`: Zod generator
 - `packages/generator-valibot`: Valibot generator

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,6 +48,7 @@ export default {
           { text: 'Analyze', link: '/cli/analyze' },
           { text: 'Generate', link: '/cli/generate' },
           { text: 'Generate (oRPC)', link: '/cli/generate-orpc' },
+          { text: 'Generate (tRPC)', link: '/cli/generate-trpc' },
           { text: 'Watch', link: '/cli/watch' },
         ],
       },
@@ -56,6 +57,7 @@ export default {
         collapsed: false,
         items: [
           { text: 'oRPC', link: '/generators/orpc' },
+          { text: 'tRPC', link: '/generators/trpc' },
           { text: 'Service', link: '/generators/service' },
           { text: 'Zod', link: '/generators/zod' },
           { text: 'Valibot', link: '/generators/valibot' },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,6 +136,39 @@ Options:
 - `--template <name>` (default `standard`): can be `standard` or a custom path
 - `--includeRelations`: include relation endpoints
 
+### generate:trpc
+
+Quickly generate tRPC v11 routers without a config.
+
+::: code-group
+
+```bash [pnpm]
+pnpm dlx @drzl/cli generate:trpc <schema> -o src/api --template standard --includeRelations
+```
+
+```bash [npm]
+npx @drzl/cli generate:trpc <schema> -o src/api --template standard --includeRelations
+```
+
+```bash [yarn]
+yarn dlx @drzl/cli generate:trpc <schema> -o src/api --template standard --includeRelations
+```
+
+```bash [bun]
+bunx @drzl/cli generate:trpc <schema> -o src/api --template standard --includeRelations
+```
+
+:::
+
+Options:
+
+- `-o, --outDir <dir>` (default `src/api`)
+- `--template <name>` (default `standard`): `standard` or `service`
+- `--includeRelations`: include a lookup per single-column foreign key
+- `--servicesDir <dir>` (default `src/services`): only consulted by `--template service`
+
+See [Generate (tRPC)](/cli/generate-trpc).
+
 ### watch
 
 Watch schema (and template paths) and regenerate on changes.
@@ -200,6 +233,7 @@ See also:
 - Config reference: [/guide/configuration](/guide/configuration)
 - Generators:
   - [/generators/orpc](/generators/orpc)
+  - [/generators/trpc](/generators/trpc)
   - [/generators/service](/generators/service)
   - [/generators/zod](/generators/zod)
   - [/generators/valibot](/generators/valibot)

--- a/docs/cli/generate-trpc.md
+++ b/docs/cli/generate-trpc.md
@@ -1,0 +1,60 @@
+# Generate (tRPC)
+
+Quickly generate tRPC v11 routers without a config.
+
+Usage:
+
+::: code-group
+
+```bash [pnpm]
+pnpm dlx @drzl/cli generate:trpc <schema> -o src/api --template standard --includeRelations
+```
+
+```bash [npm]
+npx @drzl/cli generate:trpc <schema> -o src/api --template standard --includeRelations
+```
+
+```bash [yarn]
+yarn dlx @drzl/cli generate:trpc <schema> -o src/api --template standard --includeRelations
+```
+
+```bash [bun]
+bunx @drzl/cli generate:trpc <schema> -o src/api --template standard --includeRelations
+```
+
+:::
+
+Options:
+
+- `-o, --outDir <dir>` (default `src/api`)
+- `--template <name>` (default `standard`): `standard` for stub handlers, `service` to delegate to
+  the classes `@drzl/generator-service` writes
+- `--includeRelations`: include a `listBy<Column>` query per single-column foreign key
+- `--servicesDir <dir>` (default `src/services`): where the service generator writes. Only consulted
+  by `--template service`.
+
+This command takes no config file, so it cannot reuse generated validation schemas or wire up
+database injection. For those, use [`drzl generate`](/cli/generate) with a `{ kind: 'trpc' }` entry.
+See the [tRPC generator](/generators/trpc) for the full option set.
+
+The generator ships as `@drzl/generator-trpc`, an optional dependency of the CLI. If it is not
+installed, this command says so and names the package to install.
+
+## What lands on disk
+
+```
+src/api/
+  trpc.ts      the shared initTRPC instance, Context, router, publicProcedure
+  users.ts     one router per table
+  posts.ts
+  index.ts     appRouter, and the AppRouter type your client is parameterised by
+```
+
+Serve it with any tRPC adapter:
+
+```ts
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import { appRouter } from './src/api/index.js';
+
+createHTTPServer({ router: appRouter, createContext: () => ({}) }).listen(3000);
+```

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -27,6 +27,7 @@ bunx @drzl/cli watch -c drzl.config.ts --pipeline all --debounce 200 [--json]
 Options:
 
 - `-c, --config <path>`
-- `--pipeline <name>`: `all | analyze | generate-orpc` (default `all`)
+- `--pipeline <name>`: `all | analyze | generate-orpc | generate-trpc` (default `all`)
+  Anything other than `all` or `analyze` runs exactly one generator kind and skips the rest.
 - `--debounce <ms>`: debounce milliseconds (default `200`)
 - `--json`: emit structured JSON logs

--- a/docs/generators/orpc.md
+++ b/docs/generators/orpc.md
@@ -42,10 +42,18 @@ validation: { library: 'valibot' },
 databaseInjection: {
   enabled: true,
   databaseType: 'Database',
-  databaseTypeImport: { name: 'Database', from: 'src/db/db' },
+  // Resolved by *your* compiler from the emitted file, so it is relative to the output
+  // directory, not to the project root. A bare `src/db/db` is a package specifier to both Node
+  // and tsc, and resolves to nothing. `databaseType` alone also takes an inline
+  // `import('...').T` type, which needs no import statement at all.
+  databaseTypeImport: { name: 'Database', from: '../db/db.js' },
 },
-servicesDir: 'src/services',
 ```
+
+`servicesDir` is not set here: the CLI derives it from the `service` generator's `path`. Declare
+`databaseInjection` on this generator only, too. It describes a contract between the router and the
+services, so the CLI pushes it onto the `service` generator, which has to be in `dataAccess:
+'drizzle'` mode to honour it.
 
 In the generated router:
 

--- a/docs/generators/trpc.md
+++ b/docs/generators/trpc.md
@@ -1,0 +1,268 @@
+# tRPC Generator
+
+Generates [tRPC v11](https://trpc.io) routers per table, backed by the validation schemas DRZL
+already generates (Zod, Valibot, ArkType).
+
+```bash
+npm install -D @drzl/generator-trpc
+```
+
+It is an optional dependency of `@drzl/cli`, so a normal install may or may not have brought it
+along. `drzl generate` tells you which package to install if it is missing.
+
+## What it emits
+
+Three kinds of file, into `path` (or `outDir` if you do not set one):
+
+| File | What it is |
+| --- | --- |
+| `trpc.ts` | the shared base: one `initTRPC` instance, the `Context` type, `router`, `publicProcedure`, `createCallerFactory` |
+| `<table>.ts` | one router per table |
+| `index.ts` | `appRouter`, and the `AppRouter` type your client is parameterised by |
+
+The base module has no counterpart in the oRPC output, and it is not optional. oRPC's `os` is a
+free import, so any file can build a procedure on its own. tRPC's builder carries the context type,
+the transformer and the error formatter with it: a router built from its own `initTRPC.create()`
+has its own context type, cannot share middleware, and cannot be soundly merged. Every tRPC project
+has exactly one of these, and a generated tree is not an exception.
+
+Likewise `index.ts` is not a barrel. A nested tRPC router has to be built by `router()`, and
+`export type AppRouter` is the entire client contract:
+
+```ts
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import type { AppRouter } from './api/index.js';
+
+const trpc = createTRPCClient<AppRouter>({ links: [httpBatchLink({ url: '/trpc' })] });
+await trpc.users.list.query();
+await trpc.users.create.mutate({ email: 'ada@example.com' });
+```
+
+## Procedures
+
+| Procedure | Kind | Input | Output |
+| --- | --- | --- | --- |
+| `list` | `query` | none | `Select[]` |
+| `byId` | `query` | the primary key columns | `Select \| null` |
+| `create` | `mutation` | the insert schema | `Select` |
+| `update` | `mutation` | the primary key columns, plus `data` as the update schema | `Select` |
+| `delete` | `mutation` | the primary key columns | `boolean` |
+| `listBy<Column>` | `query` | one foreign key column | `Select[]` |
+
+Reads are queries and writes are mutations, which is not a naming convention: a tRPC client caches
+and batches queries over `GET`, and a mutation is never issued over `GET`, so declaring a write as a
+query puts it somewhere a proxy or a browser may cache it.
+
+`listBy<Column>` is emitted only under `includeRelations`, one per single-column foreign key, named
+after the column rather than the table it points at. Two keys frequently reference the same table
+(`authorId` and `editorId` both pointing at `users`), and naming by table would emit one procedure
+twice.
+
+### Output schemas
+
+Every procedure declares `.output(...)`. tRPC typechecks a handler's return against its output
+parser, so the contract is enforced at compile time as well as at run time. That is also why the
+stub handlers for `create` and `update` throw rather than returning their input: the input is the
+*insert* shape, where generated and defaulted columns are optional, and the output is the *select*
+shape, where they are required. A body that only throws has type `never`, which honours any
+contract and says plainly that the work is not done.
+
+TypeBox is the one validator DRZL generates that cannot be used here. tRPC recognises a validator
+through Standard Schema, and `@sinclair/typebox` does not implement it. `validation.library` accepts
+`zod`, `valibot` and `arktype`.
+
+## Primary keys
+
+The key is read off your schema. A `varchar` primary key called `isbn` produces
+`byId({ isbn: string })`, not `byId({ id: number })`.
+
+| Your table | What you get |
+| --- | --- |
+| single-column key | `byId`, `update`, `delete` take that column, at its real type |
+| composite key | the same three, taking every column of the key |
+| **no primary key** | only `list` and `create` |
+
+A table with no primary key cannot address a row, so the procedures that would have needed one are
+absent rather than given an `id` the table does not have. `create` stays: inserting a row does not
+require being able to find it again.
+
+A **materialized view**, or anything else the analyzer marks read-only, gets `list` and `byId` only.
+The database refuses every write to one, so a `create` procedure on it would describe an operation
+that always fails, and no insert or update schema is emitted or imported for it.
+
+## Context and the database
+
+Without `databaseInjection`, the emitted `Context` is left open and nothing generated reads it:
+
+```ts
+export type Context = Record<string, unknown>;
+```
+
+With it, the base module gains a typed context and a guarded procedure builder, and every generated
+procedure is built on that builder rather than on `publicProcedure`:
+
+```ts
+generators: [
+  {
+    kind: 'trpc',
+    template: 'service',
+    databaseInjection: {
+      enabled: true,
+      databaseType: 'Database',
+      // Relative to the output directory, because your compiler resolves it from the emitted
+      // file. A project-relative `src/db/client.js` is a package specifier to Node and to tsc.
+      databaseTypeImport: { name: 'Database', from: '../db/client.js' },
+    },
+  },
+],
+```
+
+```ts
+// trpc.ts
+export interface Context {
+  db?: Database;
+}
+
+export const dbProcedure = t.procedure.use(async ({ ctx, next }) => {
+  if (!ctx.db) {
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: '...' });
+  }
+  return next({ ctx: { db: ctx.db } });
+});
+```
+
+`db` is optional on `Context` and required by `dbProcedure`. That split lets your adapter build a
+context without a handle, for a health check or a public route, while every generated procedure sees
+one that is present. You supply it from `createContext`:
+
+```ts
+createHTTPServer({ router: appRouter, createContext: () => ({ db }) });
+```
+
+`databaseInjection` describes a contract between two generators, so it is declared once, on the
+router, and the CLI pushes it onto the `service` generator. Note that `@drzl/generator-service`
+honours it only while emitting real Drizzle queries: its stub bodies take no database parameter
+whatever they are told, so pair it with `dataAccess: 'drizzle'`. `drzl generate` warns if you do not.
+
+## Templates
+
+`template` is a closed set, not a module path.
+
+- `standard` (default) emits stubs: `list` returns `[]`, `byId` returns `null`, `delete` returns
+  `true`, and `create` and `update` throw.
+- `service` delegates to the classes `@drzl/generator-service` writes, and is the tRPC counterpart
+  of pointing the oRPC generator at `@drzl/template-orpc-service`.
+
+There is no custom-template hook API. `ORPCTemplateHooks` hands back oRPC source text
+(`os.handler(...)`, `ORPCError`, `os.$context()`), none of which is valid tRPC, so neither built-in
+template package can be reused and a custom one written against that interface would emit a file
+that does not compile. An API shaped for tRPC is worth designing; borrowing one is not.
+
+In `service` mode, `byId`, `update` and `delete` fall back to a throwing stub when the key cannot be
+expressed as the single `number` that generator's methods take, which is any composite key and any
+non-numeric one. The procedures are still emitted, still take the real key and still declare the
+real output, so the client surface does not change shape from table to table; only the body says
+that you have to wire it. The emitted file names the reason.
+
+## Validation reuse
+
+Identical to the [oRPC generator](/generators/orpc#validation-reuse). With
+`validation.useShared`, the routers import `Insert<Table>Schema`, `Update<Table>Schema` and
+`Select<Table>Schema` from `validation.importPath` instead of declaring their own, and the CLI
+copies the `affix` from whichever sibling generator produces `validation.library`, so the names
+cannot drift. Only the schemas a given router actually mentions are imported.
+
+## Columns DRZL cannot type
+
+A column the analyzer could not derive a type for gets the library's permissive type, and the
+emitted file says which ones:
+
+```ts
+// No validated type for this column: payload.
+// DRZL could not derive one from the schema, so the router accepts any value there.
+```
+
+The router still works; it just does not check that field. `drzl generate` also lists these columns
+on stdout.
+
+## Example
+
+```ts
+// drzl.config.ts
+export default defineConfig({
+  schema: 'src/db/schema.ts',
+  outDir: 'src/api',
+  generators: [
+    { kind: 'zod', path: 'src/validators/zod' },
+    { kind: 'service', path: 'src/services', dataAccess: 'drizzle', schemaImportPath: 'src/db/schema' },
+    {
+      kind: 'trpc',
+      path: 'src/trpc',
+      template: 'service',
+      includeRelations: true,
+      validation: { useShared: true, library: 'zod', importPath: 'src/validators/zod' },
+      databaseInjection: {
+        enabled: true,
+        // Emitted verbatim, so an inline `import(...)` type needs no import statement. The
+        // `databaseTypeImport` form above is the alternative; its `from` is resolved by your
+        // compiler from the *emitted* file, not from the project root.
+        databaseType: "import('drizzle-orm/node-postgres').NodePgDatabase",
+      },
+    },
+  ],
+});
+```
+
+```bash
+drzl generate
+```
+
+::: warning Running oRPC and tRPC together
+Both router generators default to `outDir` and both write an `index.ts` there, so a config with both
+needs a `path` on at least one of them.
+:::
+
+## Options
+
+```ts
+interface GenerateOptions {
+  outputDir: string;
+  template?: 'standard' | 'service';
+  includeRelations?: boolean;
+  naming?: { routerSuffix?: string; procedureCase?: 'camel' | 'kebab' | 'snake' };
+  format?: { enabled?: boolean; engine?: 'auto' | 'prettier' | 'biome'; configPath?: string };
+  outputHeader?: { enabled?: boolean; text?: string };
+  importExtension?: 'js' | 'ts' | 'none';
+  validation?: {
+    useShared?: boolean;
+    library?: 'zod' | 'valibot' | 'arktype';
+    importPath?: string;
+    schemaSuffix?: string;
+    affix?: AffixOptions;
+  };
+  databaseInjection?: {
+    enabled?: boolean;
+    databaseType?: string;
+    databaseTypeImport?: { name: string; from: string };
+  };
+  servicesDir?: string;
+}
+```
+
+The router file is named after the table; the exported router is named after the table plus
+`naming.routerSuffix`, which defaults to `Router`. So `users` produces `users.ts` exporting
+`usersRouter`, and setting `routerSuffix: 'Router'` produces `usersRouter.ts` exporting
+`usersRouter`.
+
+## Generated Output License
+
+- You own the generated output. DRZL grants you a worldwide, royalty-free, irrevocable license to
+  use, copy, modify, and distribute the generated files under your project's license.
+- A short header is added by default. Configure via `outputHeader` in `drzl.config.ts`:
+  - `outputHeader.enabled = false` to disable
+  - `outputHeader.text = '...'` to customize
+
+::: tip Need something else?
+If this generator doesn't cover what you need, DM me on X (https://x.com/omardulaimidev) and we can
+scope it together.
+:::

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -15,12 +15,9 @@ export default defineConfig({
       kind: 'service',
       path: 'src/services',
       dataAccess: 'drizzle',
-      schemaImportPath: 'src/db/schema',
-      databaseInjection: {
-        enabled: true,
-        databaseType: 'Database',
-        databaseTypeImport: { name: 'Database', from: 'src/db/db' },
-      },
+      // The same module `schema` above names, so the emitted services import the tables
+      // themselves. Point it at the directory or at the file; either resolves.
+      schemaImportPath: 'src/db/schemas',
     },
     {
       kind: 'orpc',
@@ -30,13 +27,52 @@ export default defineConfig({
       validation: { library: 'valibot' },
       databaseInjection: {
         enabled: true,
-        databaseType: 'Database',
-        databaseTypeImport: { name: 'Database', from: 'src/db/db' },
+        databaseType: "import('drizzle-orm/node-postgres').NodePgDatabase",
       },
-      servicesDir: 'src/services',
     },
   ],
 });
+```
+
+Two things are deliberately *not* written twice here.
+
+`servicesDir` is derived from the `service` generator's `path`, so naming it on the router as well
+is how the two drift apart.
+
+`databaseInjection` is declared on the router generator alone and pushed onto the `service`
+generator for you, because it describes a contract between the two: the router emits
+`Service.getById(ctx.db, id)`, and only a service generated in the same mode has a `db` parameter to
+receive it. It needs `dataAccess: 'drizzle'` on the service generator, because that generator's stub
+bodies take no database parameter whatever they are told; `drzl generate` warns if you pair it with
+`stub`.
+
+### Naming the database type
+
+`databaseType` is emitted verbatim, so an inline `import(...)` type as above needs no import
+statement and cannot resolve to the wrong file. The two-key form is available when you would rather
+name it once:
+
+```ts
+databaseInjection: {
+  enabled: true,
+  databaseType: 'Database',
+  // Resolved by *your* compiler from the emitted file, so it is relative to the output
+  // directory, not to the project root. A bare `src/db/db` is a package specifier to both
+  // Node and tsc, and resolves to nothing.
+  databaseTypeImport: { name: 'Database', from: '../db/client.js' },
+},
+```
+
+## Router generators share `outDir`
+
+Both `orpc` and `trpc` write to the top-level `outDir` by default, and both write an `index.ts`
+there, so a config that runs both needs a `path` on at least one of them:
+
+```ts
+generators: [
+  { kind: 'orpc' },                    // -> outDir
+  { kind: 'trpc', path: 'src/trpc' },  // -> its own directory
+],
 ```
 
 ## Choosing which tables to generate for
@@ -142,9 +178,9 @@ export type UserProfiles = z.output<typeof SelectUserProfilesSchema>;
 - A config that would emit a name TypeScript cannot parse, or two exports in one file with
   the same name, is rejected before any file is written.
 
-### Sharing names with the oRPC generator
+### Sharing names with a router generator
 
-An oRPC generator with `validation.useShared` imports those schemas by name, so both
+An `orpc` or `trpc` generator with `validation.useShared` imports those schemas by name, so both
 generators have to agree. You do not have to say it twice: when exactly one other generator
 produces the library named in `validation.library`, its `affix` is copied over automatically.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,6 +68,7 @@
     "url": "https://github.com/sponsors/omar-dulaimi"
   },
   "optionalDependencies": {
-    "@drzl/generator-json-schema": "workspace:^"
+    "@drzl/generator-json-schema": "workspace:^",
+    "@drzl/generator-trpc": "workspace:^"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import cliProgress from 'cli-progress';
 import { Command } from 'commander';
 import * as path from 'node:path';
 import ora from 'ora';
+import { trpcOptions } from './trpc-options.js';
 import { validationOptions } from './validation-options';
 import {
   computeGeneratorOutputDirs,
@@ -154,12 +155,40 @@ program
             templateOptions: g.templateOptions,
             importExtension: g.importExtension,
             validation: g.validation,
+            // Documented on this generator since it was added and never reachable from a config
+            // file, because the config schema had no such key and zod stripped it in silence.
+            databaseInjection: g.databaseInjection,
             servicesDir,
             onProgress: ({ index }) => progress.update(index),
           });
           progress.stop();
           ora().succeed(chalk.green(`Generated (${g.kind}): ${files.length} files`));
           files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+        } else if (g.kind === 'trpc') {
+          try {
+            // An optional dependency, like the json-schema generator and unlike oRPC. A package
+            // that has never been published cannot publish through npm's trusted-publisher OIDC
+            // flow, so its first version has to go out by hand; naming it as a hard dependency of
+            // the CLI in the same release breaks `npm i @drzl/cli` for everyone until it exists.
+            // A missing optional dependency is skipped by the installer rather than failing it,
+            // which is why this one really can be absent on an ordinary install.
+            const { TRPCGenerator } = await loadGenerator(
+              '@drzl/generator-trpc',
+              () => import('@drzl/generator-trpc')
+            );
+            const gen = new TRPCGenerator(analysis);
+            const { files } = await gen.generate({
+              ...trpcOptions(g, cfg, servicesDir),
+              onProgress: ({ index }: { index: number }) => progress.update(index),
+            });
+            progress.stop();
+            ora().succeed(chalk.green(`Generated (trpc): ${files.length} files`));
+            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+          } catch (e: any) {
+            progress.stop();
+            reportGeneratorFailure(g.kind, e);
+            process.exit(1);
+          }
         } else if (g.kind === 'service') {
           try {
             const { ServiceGenerator } = await loadGenerator(
@@ -176,6 +205,11 @@ program
               dbImportPath: g.dbImportPath,
               schemaImportPath: g.schemaImportPath,
               importExtension: g.importExtension,
+              // The other half of `databaseInjection`. A router generator in injection mode
+              // emits `Service.getById(ctx.db, id)`, and only a service generated in the same
+              // mode has a `db` parameter to receive it. This branch never passed the option, so
+              // the two halves of one generated project disagreed about the signature.
+              databaseInjection: g.databaseInjection,
             });
             progress.stop();
             ora().succeed(chalk.green(`Generated (service): ${files.length} files`));
@@ -355,10 +389,48 @@ program
   });
 
 program
+  .command('generate:trpc')
+  .argument('<schema>', 'path to drizzle schema (TS)')
+  .option('-o, --outDir <dir>', 'output directory', 'src/api')
+  .option('--template <name>', 'standard | service', 'standard')
+  .option('--includeRelations', 'include relation endpoints')
+  .option('--servicesDir <dir>', 'where the service generator writes', 'src/services')
+  .action(async (schema: string, opts: any) => {
+    try {
+      const analyzer = new SchemaAnalyzer(schema);
+      const analysis = await analyzer.analyze({
+        includeRelations: !!opts.includeRelations,
+        validateConstraints: true,
+      });
+      const { TRPCGenerator } = await loadGenerator(
+        '@drzl/generator-trpc',
+        () => import('@drzl/generator-trpc')
+      );
+      const gen = new TRPCGenerator(analysis);
+      const { files } = await gen.generate({
+        outputDir: opts.outDir,
+        template: opts.template,
+        includeRelations: !!opts.includeRelations,
+        // Only consulted by `--template service`, and passed unconditionally so this command
+        // cannot become the branch that forgets it.
+        servicesDir: opts.servicesDir,
+      });
+      console.log(
+        chalk.green(`Generated:`),
+        files.map((f: string) => chalk.cyan(f)).join(', ')
+      );
+      maybeShowSponsorMessage({ reason: 'generate:trpc' });
+    } catch (e: any) {
+      reportGeneratorFailure('trpc', e);
+      process.exit(1);
+    }
+  });
+
+program
   .command('watch')
   .description('Watch schema and regenerate on changes')
   .option('-c, --config <path>', 'path to drzl.config')
-  .option('--pipeline <name>', 'all | analyze | generate-orpc', 'all')
+  .option('--pipeline <name>', 'all | analyze | generate-orpc | generate-trpc', 'all')
   .option('--debounce <ms>', 'debounce ms', '200')
   .option('--json', 'emit JSON logs', false)
   .option('--poll', 'force polling (helps WSL/Docker/remote FS)', false)
@@ -489,11 +561,20 @@ program
 
         const newFiles: string[] = [];
 
+        // Must match the `g.path ?? 'src/services'` the service branch below uses, or a router
+        // template that imports services spells a path nothing ever wrote. `generate` has always
+        // computed this; `watch` did not, so a rebuild silently emitted the default.
+        const servicesDir =
+          cfg.generators.find((x: { kind: string }) => x.kind === 'service')?.path ??
+          'src/services';
+
+        const PIPELINE_KINDS: Record<string, string> = {
+          'generate-orpc': 'orpc',
+          'generate-trpc': 'trpc',
+        };
+
         for (const g of cfg.generators) {
-          if (
-            opts.pipeline !== 'all' &&
-            !(opts.pipeline === 'generate-orpc' && g.kind === 'orpc')
-          ) {
+          if (opts.pipeline !== 'all' && PIPELINE_KINDS[opts.pipeline] !== g.kind) {
             continue;
           }
 
@@ -509,6 +590,8 @@ program
               templateOptions: g.templateOptions,
               importExtension: g.importExtension,
               validation: g.validation,
+              databaseInjection: g.databaseInjection,
+              servicesDir,
             });
             opts.json
               ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
@@ -517,6 +600,27 @@ program
                   files.map((f: string) => chalk.cyan(f)).join(', ')
                 );
             newFiles.push(...files);
+          } else if (g.kind === 'trpc') {
+            try {
+              const { TRPCGenerator } = await loadGenerator(
+                '@drzl/generator-trpc',
+                () => import('@drzl/generator-trpc')
+              );
+              const gen = new TRPCGenerator(analysis);
+              // The same builder `generate` uses, so the two dispatch loops cannot disagree
+              // about what this generator is given.
+              const { files } = await gen.generate(trpcOptions(g, cfg, servicesDir));
+              opts.json
+                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
+                : console.log(
+                    chalk.green(`Generated (trpc): ${files.length} files`),
+                    files.map((f: string) => chalk.cyan(f)).join(', ')
+                  );
+              newFiles.push(...files);
+            } catch (e: any) {
+              reportGeneratorFailure(g.kind, e);
+              return;
+            }
           } else if (g.kind === 'service') {
             try {
               const { ServiceGenerator } = await loadGenerator(
@@ -533,6 +637,7 @@ program
                 dbImportPath: g.dbImportPath,
                 schemaImportPath: g.schemaImportPath,
                 importExtension: g.importExtension,
+                databaseInjection: g.databaseInjection,
               });
               opts.json
                 ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
@@ -702,11 +807,17 @@ program
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
     const target = path.resolve(process.cwd(), 'drzl.config.ts');
+    // One router generator, not both: they default to the same `outDir` and would each write an
+    // `index.ts` there, so a scaffold naming both would emit a config whose second generator
+    // silently overwrote the first. Swapping the kind is a one-word edit; running both needs a
+    // `path` on one of them, which is what the comment says.
     const template = `export default {
   schema: 'src/db/schema.ts',
   outDir: 'src/api',
   analyzer: { includeRelations: true, validateConstraints: true },
   generators: [
+    // For tRPC instead: { kind: 'trpc', template: 'standard', includeRelations: true }
+    // To run both, give one of them its own \`path\`; they share \`outDir\` otherwise.
     { kind: 'orpc', template: 'standard', includeRelations: true }
   ]
 } as const\n`;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -71,7 +71,7 @@ export const AffixSchema = z
 export const ImportExtensionSchema = z.enum(IMPORT_EXTENSIONS);
 
 export const GeneratorSchema = z.object({
-  kind: z.enum(['orpc', 'service', 'zod', 'valibot', 'arktype', 'typebox', 'json-schema']),
+  kind: z.enum(['orpc', 'trpc', 'service', 'zod', 'valibot', 'arktype', 'typebox', 'json-schema']),
   /**
    * Overrides the top-level `importExtension` for this generator alone, for a project whose
    * generated directories are compiled by different tsconfigs.
@@ -146,7 +146,24 @@ export const GeneratorSchema = z.object({
    * Omitting it reproduces the output of every previous release exactly.
    */
   affix: AffixSchema.optional(),
-  // orpc validation sharing
+  /**
+   * How the router generators reach a database handle: through the request context, rather than
+   * through a module-level import in the service layer.
+   *
+   * Documented on the oRPC generator since it was added and, until now, absent from this schema
+   * entirely. `GeneratorSchema` is not strict, so zod stripped the key without a word and the
+   * option did nothing at all when set from a config file. It was only ever reachable by calling
+   * the generator's API directly.
+   */
+  databaseInjection: z
+    .object({
+      enabled: z.boolean().optional(),
+      /** The type annotation for the injected handle, e.g. `DrizzleD1Database`. */
+      databaseType: z.string().optional(),
+      databaseTypeImport: z.object({ name: z.string(), from: z.string() }).optional(),
+    })
+    .optional(),
+  // router validation sharing (orpc, trpc)
   validation: z
     .object({
       useShared: z.boolean().default(false).optional(),
@@ -241,6 +258,27 @@ export function defineConfig<T extends DrzlConfigInput>(cfg: T): T {
 
 type GeneratorConfig = DrzlConfig['generators'][number];
 
+/** The generators that emit an RPC router, and so share `outDir` and `validation`. */
+const ROUTER_KINDS = new Set(['orpc', 'trpc']);
+
+/**
+ * Where the tRPC generator writes.
+ *
+ * `outDir` by default, exactly like oRPC, so a config that names one router generator puts its
+ * output where the top-level setting says. `path` is the escape hatch, and a config that runs
+ * *both* router generators needs it: they would otherwise write two different `index.ts` files to
+ * the same directory and the second would win.
+ *
+ * Exported because `computeGeneratorOutputDirs` has to agree with the dispatch in cli.ts about
+ * this, and the watcher ignoring the wrong directory is an infinite regeneration loop.
+ */
+export function trpcOutDir(
+  g: { path?: string },
+  cfg: { outDir: string }
+): string {
+  return g.path ?? cfg.outDir;
+}
+
 function sharedSchemaNames(opts: { affix?: AffixOptions; schemaSuffix?: string }): string[] {
   const resolved = resolveAffix(opts);
   return NAME_MODES.map((mode) => schemaName(mode, AFFIX_PROBE_TABLE, resolved));
@@ -271,7 +309,47 @@ export function resolveConfig(cfg: DrzlConfig): { config: DrzlConfig; warnings: 
   }));
 
   for (const g of generators) {
-    if (g.kind !== 'orpc') continue;
+    // Both router generators import the validation generators' exports by name, so both have to
+    // spell them the way the sibling generator wrote them.
+    if (!ROUTER_KINDS.has(g.kind)) continue;
+
+    /**
+     * `databaseInjection` describes a contract between two generators, not a setting of one.
+     *
+     * A router in injection mode emits `Service.getById(ctx.db, id)`, and only a service
+     * generated in the same mode has a `db` parameter to receive it. Declared once on the router
+     * and pushed onto the service generator here, exactly as `validation.affix` is pulled the
+     * other way, because the alternative is writing the same block twice and a project that
+     * compiles in halves and not as a whole.
+     *
+     * `@drzl/generator-service` honours the flag only while emitting real Drizzle queries: its
+     * stub bodies take no database whatever they are told. That combination cannot be repaired
+     * from here without changing what an existing config emits, so it is reported instead.
+     */
+    if (g.databaseInjection?.enabled) {
+      for (const s of generators.filter((x) => x.kind === 'service')) {
+        if (!s.databaseInjection) {
+          s.databaseInjection = g.databaseInjection;
+        } else if (!s.databaseInjection.enabled) {
+          warnings.push(
+            `drzl config: the "${g.kind}" generator sets databaseInjection.enabled while the ` +
+              `"service" generator sets it to false. The router will call ` +
+              `Service.method(ctx.db, ...) against services that take no database parameter, so ` +
+              `the generated project will not compile. Set both, or neither.`
+          );
+        }
+        if ((s.dataAccess ?? 'stub') === 'stub') {
+          warnings.push(
+            `drzl config: the "${g.kind}" generator sets databaseInjection.enabled, so its ` +
+              `handlers call Service.method(ctx.db, ...). The "service" generator emits stub ` +
+              `bodies, which take no database parameter whatever this option says, so those ` +
+              `calls will not compile. Set dataAccess: 'drizzle' on the "service" generator, or ` +
+              `drop databaseInjection.`
+          );
+        }
+      }
+    }
+
     const v = g.validation;
     if (!v?.useShared) continue;
 
@@ -303,7 +381,7 @@ export function resolveConfig(cfg: DrzlConfig): { config: DrzlConfig; warnings: 
       const mine = sharedSchemaNames({ schemaSuffix: v.schemaSuffix });
       if (mine.join(',') !== theirs.join(',')) {
         warnings.push(
-          `drzl config: the "orpc" generator's validation.schemaSuffix ` +
+          `drzl config: the "${g.kind}" generator's validation.schemaSuffix ` +
             `(${JSON.stringify(v.schemaSuffix ?? 'Schema')}) does not match the "${library}" ` +
             `generator's schemaSuffix (${JSON.stringify(sibling.schemaSuffix ?? 'Schema')}). ` +
             `The router will import ${mine.join(', ')} but the "${library}" generator exports ` +
@@ -320,7 +398,7 @@ export function resolveConfig(cfg: DrzlConfig): { config: DrzlConfig; warnings: 
     });
     if (mine.join(',') !== theirs.join(',')) {
       throw new Error(
-        `drzl config: the "orpc" generator imports shared ${library} schemas, but its ` +
+        `drzl config: the "${g.kind}" generator imports shared ${library} schemas, but its ` +
           `validation.affix disagrees with the "${library}" generator's own naming. The router ` +
           `would import ${mine.join(', ')} while the "${library}" generator exports ` +
           `${theirs.join(', ')}. Make them match, or drop validation.affix and let it be ` +
@@ -403,6 +481,7 @@ export function computeGeneratorOutputDirs(cfg: DrzlConfig, cwd = process.cwd())
   const dirs = new Set<string>();
   dirs.add(abs(cfg.outDir)); // orpc
   for (const g of cfg.generators) {
+    if (g.kind === 'trpc') dirs.add(abs(trpcOutDir(g, cfg)));
     if (g.kind === 'service') dirs.add(abs(g.path ?? 'src/services'));
     if (g.kind === 'zod') dirs.add(abs(g.path ?? 'src/validators/zod'));
     if (g.kind === 'valibot') dirs.add(abs(g.path ?? 'src/validators/valibot'));
@@ -422,7 +501,10 @@ export function resolveTemplateDirsSync(cfg: DrzlConfig, cwd = process.cwd()): s
 
   for (const g of cfg.generators) {
     const t = g.template;
-    if (!t || t === 'standard' || t === 'minimal') continue;
+    // Built-in template names, not packages. `service` is the tRPC generator's, and without it
+    // here every run would try to resolve a package called "service" and then watch a directory
+    // of that name, neither of which exists.
+    if (!t || t === 'standard' || t === 'minimal' || t === 'service') continue;
 
     // Try package resolution relative to cwd
     let pkgDir: string | null = null;

--- a/packages/cli/src/shims.d.ts
+++ b/packages/cli/src/shims.d.ts
@@ -17,3 +17,6 @@ declare module '@drzl/generator-arktype' {
 declare module '@drzl/generator-typebox' {
   export const TypeBoxGenerator: any;
 }
+declare module '@drzl/generator-trpc' {
+  export const TRPCGenerator: any;
+}

--- a/packages/cli/src/trpc-options.ts
+++ b/packages/cli/src/trpc-options.ts
@@ -1,0 +1,52 @@
+/**
+ * The options `@drzl/generator-trpc` receives, built in one place.
+ *
+ * `generate` and `watch` each dispatch over `cfg.generators` in their own loop, and every branch
+ * in both assembles its own options object by hand. Three documented options have already been
+ * found dead that way: `typedJson` never reached typebox, `coerceDates` and `applyDefaults`
+ * reached nothing but zod, and `servicesDir` is passed by `generate`'s oRPC branch and not by
+ * `watch`'s, so a watch rebuild emits a service import pointing at the default directory whatever
+ * the config says. None of those is visible in the wiring: the option parses, the generator
+ * defaults it, and the feature simply does nothing.
+ *
+ * One builder means the two call sites are the same object by construction rather than by review.
+ * It also gives the drift something to be asserted against, which is what
+ * `packages/cli/test/trpc-branch-parity.spec.ts` does by running both commands and comparing the
+ * bytes they wrote.
+ */
+import { trpcOutDir } from './config.js';
+
+/** A generator entry from the config, loosely typed because the config schema owns its shape. */
+type GeneratorConfig = {
+  path?: string;
+  template?: unknown;
+  includeRelations?: unknown;
+  naming?: unknown;
+  outputHeader?: unknown;
+  format?: unknown;
+  importExtension?: unknown;
+  validation?: unknown;
+  databaseInjection?: unknown;
+};
+
+export function trpcOptions(
+  g: GeneratorConfig,
+  cfg: { outDir: string },
+  servicesDir: string
+): Record<string, unknown> {
+  return {
+    outputDir: trpcOutDir(g, cfg),
+    template: g.template,
+    includeRelations: g.includeRelations,
+    naming: g.naming,
+    outputHeader: g.outputHeader,
+    format: g.format,
+    importExtension: g.importExtension,
+    validation: g.validation,
+    databaseInjection: g.databaseInjection,
+    // Where the service generator is actually writing, so `template: 'service'` emits an import
+    // of a module that exists. The generator defaults this to `src/services`, which is right only
+    // by coincidence for a config that puts them elsewhere.
+    servicesDir,
+  };
+}

--- a/packages/cli/test/config.spec.ts
+++ b/packages/cli/test/config.spec.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { loadConfig, defineConfig, ConfigSchema, resolveConfig } from '../src/config';
+import {
+  computeGeneratorOutputDirs,
+  ConfigSchema,
+  defineConfig,
+  loadConfig,
+  resolveConfig,
+  trpcOutDir,
+} from '../src/config';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -245,5 +252,124 @@ describe('@drzl/cli config affix', () => {
     expect(withoutExtension(config)).toEqual(withoutExtension(before));
     expect(config.generators.map((g) => g.importExtension)).toEqual(['js', 'js']);
     expect(warnings).toEqual([]);
+  });
+});
+
+describe('@drzl/cli config: the trpc generator', () => {
+  const base = (generators: any[]) => ({ schema: 'src/db/schema.ts', generators });
+
+  it('is a kind the schema accepts', () => {
+    expect(() => ConfigSchema.parse(base([{ kind: 'trpc' }]))).not.toThrow();
+  });
+
+  it('writes to outDir by default and to path when given one', () => {
+    const cfg = ConfigSchema.parse({ ...base([{ kind: 'trpc' }]), outDir: 'src/api' });
+    expect(trpcOutDir(cfg.generators[0], cfg)).toBe('src/api');
+    const withPath = ConfigSchema.parse({
+      ...base([{ kind: 'trpc', path: 'src/trpc' }]),
+      outDir: 'src/api',
+    });
+    expect(trpcOutDir(withPath.generators[0], withPath)).toBe('src/trpc');
+  });
+
+  it('is watched-around, so a rebuild does not retrigger itself', () => {
+    // The watcher ignores every generator's output directory. A tRPC directory missing from that
+    // list is an infinite regeneration loop, not a cosmetic omission.
+    const cfg = ConfigSchema.parse({
+      ...base([{ kind: 'trpc', path: 'src/trpc' }]),
+      outDir: 'src/api',
+    });
+    const dirs = computeGeneratorOutputDirs(cfg, '/proj');
+    expect(dirs).toContain(path.join('/proj', 'src/trpc'));
+  });
+
+  it('inherits the sibling validation generator affix, exactly as orpc does', () => {
+    const { config } = resolveConfig(
+      ConfigSchema.parse(
+        base([
+          { kind: 'zod', affix: { tableCase: 'pascal' } },
+          {
+            kind: 'trpc',
+            validation: { useShared: true, library: 'zod', importPath: '../validators/zod' },
+          },
+        ])
+      )
+    );
+    const trpc = config.generators.find((g) => g.kind === 'trpc')!;
+    expect(trpc.validation?.affix?.tableCase).toBe('pascal');
+  });
+
+  it('refuses an affix that disagrees with the generator it imports from', () => {
+    expect(() =>
+      resolveConfig(
+        ConfigSchema.parse(
+          base([
+            { kind: 'zod', affix: { tableCase: 'pascal' } },
+            {
+              kind: 'trpc',
+              validation: {
+                useShared: true,
+                library: 'zod',
+                importPath: '../validators/zod',
+                affix: { tableCase: 'preserve' },
+              },
+            },
+          ])
+        )
+      )
+    ).toThrow(/"trpc" generator imports shared zod schemas/);
+  });
+
+  it('pushes databaseInjection onto the service generator that has to match it', () => {
+    // A router in injection mode calls `Service.getById(ctx.db, id)`. Declaring the block twice is
+    // how the two halves drift into a project that compiles separately and not together.
+    const { config, warnings } = resolveConfig(
+      ConfigSchema.parse(
+        base([
+          { kind: 'service', dataAccess: 'drizzle', schemaImportPath: 'src/db/schema' },
+          {
+            kind: 'trpc',
+            template: 'service',
+            databaseInjection: { enabled: true, databaseType: 'Database' },
+          },
+        ])
+      )
+    );
+    const service = config.generators.find((g) => g.kind === 'service')!;
+    expect(service.databaseInjection).toEqual({ enabled: true, databaseType: 'Database' });
+    expect(warnings).toEqual([]);
+  });
+
+  it('says so when injection is asked of a service generator that emits stubs', () => {
+    // `@drzl/generator-service` honours the flag only while emitting real Drizzle queries. Its
+    // stub bodies take no database parameter whatever they are told, so the router's calls would
+    // not compile.
+    const { warnings } = resolveConfig(
+      ConfigSchema.parse(
+        base([
+          { kind: 'service' },
+          { kind: 'trpc', template: 'service', databaseInjection: { enabled: true } },
+        ])
+      )
+    );
+    expect(warnings.join('\n')).toMatch(/emits stub bodies/);
+  });
+
+  it('keeps databaseInjection through a parse, rather than stripping it in silence', () => {
+    // It was documented on the oRPC generator and absent from this schema, so zod dropped the key
+    // and the option did nothing at all when set from a config file.
+    const parsed = ConfigSchema.parse(
+      base([
+        {
+          kind: 'orpc',
+          databaseInjection: {
+            enabled: true,
+            databaseType: 'Database',
+            databaseTypeImport: { name: 'Database', from: 'src/db/db' },
+          },
+        },
+      ])
+    );
+    expect(parsed.generators[0].databaseInjection?.databaseTypeImport?.from).toBe('src/db/db');
   });
 });

--- a/packages/cli/test/every-entry-loads.spec.ts
+++ b/packages/cli/test/every-entry-loads.spec.ts
@@ -8,7 +8,7 @@
  * survived because nothing in this repo had ever loaded a CJS build: every other test imports
  * from source, and vitest resolves those imports through vite against the workspace, so an
  * in-process `import` says nothing about what tsup emitted. One package is covered by
- * `packages/validation-core/test/no-bundled-formatter.spec.ts`; this covers the other eleven.
+ * `packages/validation-core/test/no-bundled-formatter.spec.ts`; this covers the other twelve.
  *
  * Hence a child process, plain Node, absolute paths into `dist`: `require()` for the CommonJS
  * twin and `import()` for the ESM entry, with the two export surfaces then compared, because a
@@ -31,11 +31,11 @@
  * **What this does and does not prove.** The child inherits the Node running the tests, which in
  * this repo is 22.13 or newer, because pnpm 11 declares that floor and the workspace cannot be
  * installed below it. From Node 22.12 onwards `require()` of an ES module is allowed, so a green
- * run in this block can be carried by a feature the packages do not advertise: eleven manifests
+ * run in this block can be carried by a feature the packages do not advertise: twelve manifests
  * say `engines.node: ">=18.17.0"` and `@drzl/cli` says `">=22"`, and every one of those floors
  * predates 22.12. That last sentence is checked rather than trusted, by the first test below,
  * because the previous version of this paragraph asserted a number that was wrong for one of the
- * twelve. So a green run here means the bundles load on the Node this repo develops on, and says
+ * set. So a green run here means the bundles load on the Node this repo develops on, and says
  * nothing about the floor the packages claim. The gap is measured rather than left to a comment,
  * at the bottom of this file.
  *
@@ -114,7 +114,7 @@ interface Entry {
  *
  * `exports` when there is one, `main` otherwise. The twin is taken from the `require` condition
  * where the map declares it and derived from the ESM filename where it does not, which is nine of
- * the twelve packages: they publish a `.cjs` that no condition names.
+ * the thirteen packages: they publish a `.cjs` that no condition names.
  */
 function entryPoints(m: Manifest): Entry[] {
   const bins = new Set(Object.values(m.bin ?? {}).map(rel));
@@ -143,8 +143,8 @@ function entryPoints(m: Manifest): Entry[] {
 /**
  * Loads both formats of every entry and reports what each exported, or how it failed.
  *
- * One child per package: `execFileSync` is synchronous and twelve processes cost less than
- * twenty-four. Written to a temp directory rather than into the package, because resolution for
+ * One child per package: `execFileSync` is synchronous and thirteen processes cost less than
+ * twenty-six. Written to a temp directory rather than into the package, because resolution for
  * an absolute path does not consult the caller's location and a probe file left in `dist` would
  * be published by `files: ["dist"]`.
  */
@@ -240,6 +240,7 @@ it('found every publishable package', () => {
     'generator-json-schema',
     'generator-orpc',
     'generator-service',
+    'generator-trpc',
     'generator-typebox',
     'generator-valibot',
     'generator-zod',
@@ -253,7 +254,7 @@ it('found every publishable package', () => {
 it('advertises a Node floor older than require(esm) everywhere', () => {
   // The premise of the table at the bottom of this file, and of the header's claim about it,
   // turned into something that fails rather than something a reader has to believe. The floors
-  // are not uniform: eleven manifests say 18.17.0 and @drzl/cli says 22, and a comment that said
+  // are not uniform: twelve manifests say 18.17.0 and @drzl/cli says 22, and a comment that said
   // otherwise shipped once already.
   const tooNew = publishable
     .map(({ dir, manifest }) => {
@@ -335,7 +336,7 @@ describe.each(cases)('$name $entry.subpath', ({ dir, version, entry }) => {
 /**
  * The same CommonJS files, on the Node the packages say they run on.
  *
- * `engines.node` names a floor below 22.12 in all twelve manifests: eleven say `">=18.17.0"` and
+ * `engines.node` names a floor below 22.12 in all thirteen manifests: twelve say `">=18.17.0"` and
  * `@drzl/cli` says `">=22"`, which still predates it. That is asserted further up rather than
  * left as a sentence here. `require()` of an ES module did not exist before 22.12, so a bundle
  * that needs it throws `ERR_REQUIRE_ESM` on the advertised floor. The block above cannot see that,
@@ -348,7 +349,7 @@ describe.each(cases)('$name $entry.subpath', ({ dir, version, entry }) => {
  * Ten of these entries used to fail here, all for one reason: each CommonJS bundle did
  * `require("@drzl/<sibling>")` and every DRZL package was `"type": "module"` with an ESM `main`
  * and no `exports` map, so the only file a sibling `require` could reach was an ES module. The
- * eleven library manifests now carry an `exports` map whose `require` condition names the `.cjs`
+ * twelve library manifests now carry an `exports` map whose `require` condition names the `.cjs`
  * beside the `.js`, and the chain resolves to CommonJS the whole way down.
  *
  * One entry still fails, and not for a reason DRZL owns: `@drzl/cli`'s own bundle requires
@@ -371,6 +372,7 @@ const ON_THE_ADVERTISED_ENGINE_FLOOR: Record<string, 'loads' | 'ERR_REQUIRE_ESM'
   'generator-json-schema .': 'loads',
   'generator-orpc .': 'loads',
   'generator-service .': 'loads',
+  'generator-trpc .': 'loads',
   'generator-typebox .': 'loads',
   'generator-valibot .': 'loads',
   'generator-zod .': 'loads',

--- a/packages/cli/test/package-metadata.spec.ts
+++ b/packages/cli/test/package-metadata.spec.ts
@@ -92,6 +92,7 @@ it('found every publishable package', () => {
     'generator-json-schema',
     'generator-orpc',
     'generator-service',
+    'generator-trpc',
     'generator-typebox',
     'generator-valibot',
     'generator-zod',

--- a/packages/cli/test/trpc-branch-parity.spec.ts
+++ b/packages/cli/test/trpc-branch-parity.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * `generate` and `watch` hand the tRPC generator the same options, confirmed on the bytes.
+ *
+ * The CLI dispatches over `cfg.generators` twice, once per command, and every branch in both loops
+ * assembles its own options object by hand. An option added to one is simply absent from the
+ * other, and nothing says so: the config parses, the generator defaults the missing value, and the
+ * feature does nothing. Three options were found dead that way before this file existed, and a
+ * fourth was found while writing it, `servicesDir`, which `generate`'s oRPC branch passed and
+ * `watch`'s did not, so a watch rebuild emitted a service import pointing somewhere the config
+ * never named.
+ *
+ * Reading the two branches is what missed all four. So this runs both commands over a config that
+ * sets every option the generator takes, and compares what landed on disk. A reviewer cannot check
+ * this by eye and neither can a reader of the wiring.
+ *
+ * Requires a build. CI builds before testing; locally, run `pnpm build` first.
+ */
+import { execFile, spawn } from 'node:child_process';
+import { existsSync, promises as fs } from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const run = promisify(execFile);
+const CLI = path.resolve(import.meta.dirname, '..', 'dist', 'cli.js');
+const ROOT = path.join(import.meta.dirname, '.trpc-parity-tmp');
+
+const SCHEMA = `
+import { pgTable, integer, serial, text, varchar } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+export const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  authorId: integer('author_id').references(() => users.id),
+  title: varchar('title', { length: 200 }).notNull(),
+});
+`;
+
+/**
+ * Every option the tRPC branch is supposed to forward, all set to something other than the
+ * generator's own default, so a dropped one changes the output rather than coinciding with it.
+ */
+const CONFIG = `export default {
+  schema: './src/db/schema.ts',
+  outDir: './unused-by-trpc',
+  generators: [
+    { kind: 'zod', path: './out/zod' },
+    { kind: 'service', path: './out/svc', dataAccess: 'drizzle', schemaImportPath: 'src/db/schema' },
+    {
+      kind: 'trpc',
+      path: './out/trpc',
+      template: 'service',
+      includeRelations: true,
+      naming: { routerSuffix: 'Api', procedureCase: 'snake' },
+      outputHeader: { text: 'parity fixture' },
+      format: { enabled: false },
+      importExtension: 'none',
+      validation: { useShared: true, library: 'zod', importPath: 'out/zod' },
+      databaseInjection: {
+        enabled: true,
+        databaseType: 'Database',
+        databaseTypeImport: { name: 'Database', from: '../../src/db/client.js' },
+      },
+    },
+  ],
+};
+`;
+
+/** Every emitted file under `dir`, as a path-to-contents map. */
+async function tree(dir: string): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const name of (await fs.readdir(dir)).sort()) {
+    out[name] = await fs.readFile(path.join(dir, name), 'utf8');
+  }
+  return out;
+}
+
+let fromGenerate: Record<string, string>;
+let fromWatch: Record<string, string>;
+const dir = path.join(ROOT, 'parity');
+const trpcOut = path.join(dir, 'out', 'trpc');
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.rm(ROOT, { recursive: true, force: true });
+  await fs.mkdir(path.join(dir, 'src', 'db'), { recursive: true });
+  await fs.writeFile(path.join(dir, 'src', 'db', 'schema.ts'), SCHEMA, 'utf8');
+  await fs.writeFile(path.join(dir, 'drzl.config.ts'), CONFIG, 'utf8');
+
+  await run(process.execPath, [CLI, 'generate'], { cwd: dir, maxBuffer: 20 * 1024 * 1024 });
+  fromGenerate = await tree(trpcOut);
+
+  await fs.rm(path.join(dir, 'out'), { recursive: true, force: true });
+
+  // `watch` builds once on start, which is the run being compared. `--poll` for the same reason
+  // the other watch test uses it: inotify does not reach chokidar reliably on WSL or in Docker.
+  const child = spawn(process.execPath, [CLI, 'watch', '--pipeline', 'generate-trpc', '--poll'], {
+    cwd: dir,
+    stdio: 'ignore',
+  });
+  try {
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline) {
+      if (existsSync(path.join(trpcOut, 'index.ts'))) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    // A short settle, so a file half-written when index.ts appeared is complete before it is read.
+    await new Promise((r) => setTimeout(r, 500));
+    fromWatch = await tree(trpcOut);
+  } finally {
+    child.kill('SIGTERM');
+  }
+}, 180_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe('the tRPC branch in generate and in watch', () => {
+  it('writes the same set of files', () => {
+    expect(Object.keys(fromWatch)).toEqual(Object.keys(fromGenerate));
+    expect(Object.keys(fromGenerate)).toEqual([
+      'index.ts',
+      'posts_api.ts',
+      'trpc.ts',
+      'users_api.ts',
+    ]);
+  });
+
+  it('writes the same bytes', () => {
+    expect(fromWatch).toEqual(fromGenerate);
+  });
+
+  it('honoured every option the fixture set, so the comparison was not of two defaults', () => {
+    // Without this, two branches that both dropped the same option would still agree and this
+    // file would pass on output neither of them shaped.
+    const router = fromGenerate['users_api.ts'];
+    expect(router, 'outputHeader.text').toContain('// parity fixture');
+    expect(router, 'importExtension: none').toContain("from './trpc'");
+    expect(router, 'naming.routerSuffix + procedureCase').toContain('export const users_api =');
+    expect(router, 'naming.procedureCase: snake').toContain('by_id:');
+    expect(router, 'validation.useShared').toContain("from '../zod/index'");
+    expect(router, 'template: service + servicesDir').toContain(
+      "from '../svc/userService'"
+    );
+    expect(router, 'databaseInjection').toContain('dbProcedure');
+    expect(router, 'databaseInjection').toContain('UserService.getAll(ctx.db)');
+    expect(fromGenerate['posts_api.ts'], 'includeRelations').toContain('list_by_author_id:');
+    expect(fromGenerate['trpc.ts'], 'databaseTypeImport').toContain(
+      "import type { Database } from '../../src/db/client.js';"
+    );
+    // format.enabled false, so nothing rewrote the quotes above and made those checks vacuous.
+    expect(router, 'format.enabled: false').toContain("from 'zod'");
+  });
+
+  it('leaves the top-level outDir alone when the generator names its own path', () => {
+    // `outDir` is oRPC's by default and tRPC's too, so a config running both has to be able to
+    // separate them. The fixture points `path` elsewhere and no oRPC generator is configured.
+    expect(existsSync(path.join(dir, 'unused-by-trpc'))).toBe(false);
+  });
+});

--- a/packages/generator-trpc/README.md
+++ b/packages/generator-trpc/README.md
@@ -1,0 +1,104 @@
+# @drzl/generator-trpc
+
+Generate [tRPC v11](https://trpc.io) routers from a Drizzle schema, one router per table, wired to
+the validation schemas DRZL already generates.
+
+```bash
+npm install -D @drzl/generator-trpc
+```
+
+`@trpc/server` is the consumer's own dependency; nothing here imports it. This package emits source
+text.
+
+## Use it through the CLI
+
+```ts
+// drzl.config.ts
+export default {
+  schema: 'src/db/schema.ts',
+  outDir: 'src/api',
+  generators: [{ kind: 'trpc', template: 'standard', includeRelations: true }],
+};
+```
+
+```bash
+drzl generate
+```
+
+Or with no config at all:
+
+```bash
+drzl generate:trpc src/db/schema.ts -o src/api
+```
+
+## What lands on disk
+
+| File | What it is |
+| --- | --- |
+| `trpc.ts` | the shared base: one `initTRPC` instance, `Context`, `router`, `publicProcedure`, `createCallerFactory` |
+| `<table>.ts` | one router per table |
+| `index.ts` | `appRouter`, and the `AppRouter` type your client is parameterised by |
+
+```ts
+// src/api/users.ts
+import { z } from 'zod';
+import { publicProcedure, router } from './trpc.js';
+
+export const InsertusersSchema = z.object({ email: z.string() });
+export const UpdateusersSchema = z.object({ email: z.string().optional() }).partial();
+export const SelectusersSchema = z.object({ id: z.number(), email: z.string() });
+
+export const usersRouter = router({
+  list: publicProcedure.output(z.array(SelectusersSchema)).query(async () => {
+    return [];
+  }),
+  byId: publicProcedure
+    .input(z.object({ id: z.number() }))
+    .output(SelectusersSchema.nullable())
+    .query(async ({ input: _input }) => {
+      return null;
+    }),
+  // ... create, update, delete
+});
+```
+
+Serve it with any tRPC adapter:
+
+```ts
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import { appRouter } from './src/api/index.js';
+
+createHTTPServer({ router: appRouter, createContext: () => ({}) }).listen(3000);
+```
+
+## Procedures
+
+`list` and `byId` are queries; `create`, `update` and `delete` are mutations. Every procedure
+declares an `.output(...)`, which tRPC typechecks the handler's return against.
+
+The primary key is read off your schema, at its real type and with every column of a composite key.
+A table with **no** primary key gets only `list` and `create`, rather than a fabricated `id`. A
+read-only relation gets only `list` and `byId`.
+
+`includeRelations` adds one `listBy<Column>` query per single-column foreign key.
+
+Use it directly if you prefer:
+
+```ts
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { TRPCGenerator } from '@drzl/generator-trpc';
+
+const analysis = await new SchemaAnalyzer('src/db/schema.ts').analyze({ includeRelations: true });
+const { files } = await new TRPCGenerator(analysis).generate({ outputDir: 'src/api' });
+```
+
+Full documentation: <https://use-drzl.github.io/drzl/generators/trpc>
+
+## Generated Output License
+
+You own the generated output. DRZL grants you a worldwide, royalty-free, irrevocable license to use,
+copy, modify, and distribute the generated files under your project's license.
+
+## License
+
+Apache-2.0

--- a/packages/generator-trpc/package.json
+++ b/packages/generator-trpc/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@drzl/generator-trpc",
+  "version": "0.1.0",
+  "private": false,
+  "license": "Apache-2.0",
+  "description": "Generate tRPC v11 routers from a Drizzle schema, one router per table, wired to DRZL's validation schemas.",
+  "keywords": [
+    "drizzle",
+    "drizzle-orm",
+    "trpc",
+    "codegen",
+    "router"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup src/index.ts --dts --format esm,cjs --external prettier --clean",
+    "lint": "eslint . --ext .ts",
+    "test": "vitest run --testTimeout=20000"
+  },
+  "dependencies": {
+    "@drzl/analyzer": "workspace:^",
+    "@drzl/validation-core": "workspace:^"
+  },
+  "devDependencies": {
+    "@trpc/server": "^11.18.0",
+    "arktype": "^2.1.29",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "valibot": "^1.1.0",
+    "zod": "^4.4.3"
+  },
+  "engines": {
+    "node": ">=18.17.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/use-drzl/drzl",
+    "directory": "packages/generator-trpc"
+  },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/omar-dulaimi"
+  }
+}

--- a/packages/generator-trpc/src/index.ts
+++ b/packages/generator-trpc/src/index.ts
@@ -1,0 +1,890 @@
+import type { Analysis, Column, Table } from '@drzl/analyzer';
+import type { AffixOptions, ImportExtension } from '@drzl/validation-core';
+import {
+  formatCode,
+  importSpecifier,
+  resolveAffix,
+  resolveConfiguredImport,
+  schemaName,
+} from '@drzl/validation-core';
+
+/**
+ * tRPC v11.
+ *
+ * Determined from the registry rather than from memory. `npm view @trpc/server dist-tags` puts
+ * `latest` on 11.x, majors 1 through 11 are published and there is no 12 at all, and the `next`
+ * tag points *behind* `latest`, so there is not even a v12 pre-release train to aim at. v11
+ * reworked v10's builder internals and moved `createCaller` onto `t.createCallerFactory`, so a
+ * generator written from a v10 memory would emit code that neither typechecks nor runs. Every
+ * construct this file emits was executed against a real 11.x install before it was written down.
+ */
+export const TRPC_MAJOR = 11;
+
+export type Case = 'camel' | 'kebab' | 'snake';
+
+export interface NamingOptions {
+  routerSuffix?: string;
+  procedureCase?: Case;
+}
+
+/**
+ * Which handler bodies the routers get.
+ *
+ * `standard` emits stubs. `service` delegates to the classes `@drzl/generator-service` writes, and
+ * is the tRPC counterpart of pointing the oRPC generator at `@drzl/template-orpc-service`.
+ *
+ * Deliberately a closed set rather than oRPC's loadable template modules. `ORPCTemplateHooks`
+ * hands back oRPC source text (`os.handler(...)`, `ORPCError`, `os.$context()`), none of which is
+ * valid tRPC, so neither built-in template package can be reused here and a custom one written
+ * against that interface would emit a file that does not compile. A hook API for tRPC should be
+ * designed for tRPC rather than borrowed, so this ships without one instead of shipping one that
+ * only appears to work.
+ */
+export type TemplateName = 'standard' | 'service';
+
+export interface GenerateOptions {
+  outputDir: string;
+  template?: TemplateName;
+  includeRelations?: boolean;
+  naming?: NamingOptions;
+  onProgress?: (info: { index: number; total: number; table: string; filePath: string }) => void;
+  format?: { enabled?: boolean; engine?: 'auto' | 'prettier' | 'biome'; configPath?: string };
+  outputHeader?: { enabled?: boolean; text?: string };
+  /**
+   * How every relative specifier this generator invents spells its extension: each router's
+   * import of the shared base module, the barrel's import of each router, the service import and
+   * `validation.importPath`. Defaults to `'js'`, the only form that resolves under every
+   * `moduleResolution` without a compiler flag.
+   */
+  importExtension?: ImportExtension;
+  validation?: {
+    useShared?: boolean;
+    library?: 'zod' | 'valibot' | 'arktype';
+    importPath?: string;
+    schemaSuffix?: string;
+    /**
+     * How the validation generator named its exports, which is what spells the names imported
+     * from `importPath`. The CLI copies it from the sibling validation generator when unset, so
+     * the two cannot drift. Local aliases stay `Insert<tsName>Schema`, so the router body reads
+     * the same either way.
+     */
+    affix?: AffixOptions;
+  };
+  databaseInjection?: {
+    enabled?: boolean;
+    databaseType?: string;
+    databaseTypeImport?: { name: string; from: string };
+  };
+  /** Where `@drzl/generator-service` is writing, for `template: 'service'`. */
+  servicesDir?: string;
+}
+
+/**
+ * Libraries a tRPC router can actually be built from.
+ *
+ * TypeBox is absent, and that is measured rather than assumed. tRPC v11 recognises a validator by
+ * way of Standard Schema, and `@sinclair/typebox` 0.34 puts no `~standard` key on what
+ * `Type.Object()` returns, so it is not a parser tRPC accepts. zod, valibot and arktype all carry
+ * it, and all three were run through a real router before this list was written. The standalone
+ * typebox generator is unaffected; it is only unusable here.
+ */
+type Lib = 'zod' | 'valibot' | 'arktype';
+
+interface LibDialect {
+  number: string;
+  string: string;
+  boolean: string;
+  date: string;
+  unknown: string;
+  enum: (vals: string[]) => string;
+  nullable: (base: string) => string;
+  optional: (base: string) => string;
+  object: (body: string) => string;
+  /** The same object on one line. A key input reads better without the wrapping. */
+  objectInline: (body: string) => string;
+  tuple?: (length: number) => string;
+  numberObject?: (fields: string[]) => string;
+  /** ArkType field values are strings, so they are JSON-encoded rather than emitted bare. */
+  fieldIsString?: boolean;
+  /** Applied to the whole update schema, where the library has a shorthand for it. */
+  partialUpdate?: (schema: string) => string;
+
+  /**
+   * The three below build a *JavaScript expression* out of a schema identifier, for `.input()`
+   * and `.output()`. They are separate from `nullable` above, which builds a *field value*, and
+   * for ArkType the two are genuinely different languages: a field is a quoted DSL fragment where
+   * nullable is written `(X | null)`, while an expression is a `Type` object where the same thing
+   * is `X.or('null')`. Emitting the field form into an expression position is a syntax error, and
+   * it is the mistake the shape of this interface exists to make impossible.
+   */
+  arrayOf: (schema: string) => string;
+  nullableOf: (schema: string) => string;
+  booleanSchema: string;
+}
+
+const q = (v: string) => JSON.stringify(v);
+
+/** The import each library's emitted expressions need, keyed the same way as `LIBS`. */
+const LIB_IMPORTS: Record<Lib, string> = {
+  zod: "import { z } from 'zod';",
+  valibot: "import * as v from 'valibot';",
+  arktype: "import { type } from 'arktype';",
+};
+
+/**
+ * Whether a finished file body actually mentions a library, so its import is emitted only where
+ * it is used.
+ *
+ * An unused import is not cosmetic here. `noUnusedLocals` fails on it, `verbatimModuleSyntax`
+ * keeps it, and a module that imports a package the consumer did not install throws on load
+ * rather than when the unused thing is touched. A router for a read-only table with no primary
+ * key really does reference no `z.` at all, because every expression left in it is built from the
+ * imported select schema.
+ */
+const LIB_USAGE: Record<Lib, RegExp> = {
+  zod: /\bz\./,
+  valibot: /\bv\./,
+  arktype: /\btype\(/,
+};
+
+const LIBS: Record<Lib, LibDialect> = {
+  zod: {
+    number: 'z.number()',
+    string: 'z.string()',
+    boolean: 'z.boolean()',
+    date: 'z.date()',
+    unknown: 'z.unknown()',
+    tuple: (n) => `z.tuple([${Array.from({ length: n }, () => 'z.number()').join(', ')}])`,
+    numberObject: (fields) => `z.object({ ${fields.map((f) => `${f}: z.number()`).join(', ')} })`,
+    enum: (vals) => `z.enum([${vals.map(q).join(', ')}] as const)`,
+    nullable: (b) => `${b}.nullable()`,
+    optional: (b) => `${b}.optional()`,
+    object: (body) => `z.object({\n${body}\n})`,
+    objectInline: (body) => `z.object({ ${body} })`,
+    partialUpdate: (s) => `${s}.partial()`,
+    arrayOf: (s) => `z.array(${s})`,
+    nullableOf: (s) => `${s}.nullable()`,
+    booleanSchema: 'z.boolean()',
+  },
+  valibot: {
+    number: 'v.number()',
+    string: 'v.string()',
+    boolean: 'v.boolean()',
+    date: 'v.date()',
+    unknown: 'v.unknown()',
+    tuple: (n) => `v.tuple([${Array.from({ length: n }, () => 'v.number()').join(', ')}])`,
+    numberObject: (fields) => `v.object({ ${fields.map((f) => `${f}: v.number()`).join(', ')} })`,
+    enum: (vals) => `v.picklist([${vals.map(q).join(', ')}] as const)`,
+    nullable: (b) => `v.nullable(${b})`,
+    optional: (b) => `v.optional(${b})`,
+    object: (body) => `v.object({\n${body}\n})`,
+    objectInline: (body) => `v.object({ ${body} })`,
+    arrayOf: (s) => `v.array(${s})`,
+    nullableOf: (s) => `v.nullable(${s})`,
+    booleanSchema: 'v.boolean()',
+  },
+  arktype: {
+    number: 'number',
+    string: 'string',
+    boolean: 'boolean',
+    date: 'Date',
+    unknown: 'unknown',
+    // The surrounding encode adds the quotes, so the union is built with the inner quoting
+    // ArkType expects. Emitting `'${...}'` here produces `''admin' | 'user''`, which does not parse.
+    enum: (vals) => vals.map((x) => `'${x.replace(/'/g, "\\'")}'`).join(' | '),
+    nullable: (b) => `(${b} | null)`,
+    optional: (b) => `${b}?`,
+    object: (body) => `type({\n${body}\n})`,
+    objectInline: (body) => `type({ ${body} })`,
+    fieldIsString: true,
+    arrayOf: (s) => `${s}.array()`,
+    nullableOf: (s) => `${s}.or('null')`,
+    booleanSchema: `type('boolean')`,
+  },
+};
+
+/**
+ * Whether the analyzer failed to give this column a type worth checking.
+ *
+ * Asked of the column rather than of the emitted expression, because by the time an expression
+ * exists it has been wrapped in `nullable` and `optional` and no longer equals the library's
+ * `unknown` token. A column in this state gets a validator that accepts anything, which is a real
+ * hole in the router's contract, so the emitted file names them rather than leaving a reader to
+ * spot one `z.unknown()` among forty fields.
+ */
+function isWide(column: Column): boolean {
+  if (column.enumValues && column.enumValues.length) return false;
+  if (column.shape?.kind === 'tuple' || column.shape?.kind === 'numberObject') return false;
+  return !['number', 'string', 'boolean', 'Date'].includes(column.tsType);
+}
+
+function mapExpr(column: Column, lib: Lib, mode: 'insert' | 'update' | 'select'): string {
+  const d = LIBS[lib];
+  let base = (() => {
+    if (column.enumValues && column.enumValues.length) return d.enum(column.enumValues);
+    if (column.shape?.kind === 'tuple' && d.tuple) return d.tuple(column.shape.length);
+    if (column.shape?.kind === 'numberObject' && d.numberObject) {
+      return d.numberObject(column.shape.fields);
+    }
+    switch (column.tsType) {
+      case 'number':
+        return d.number;
+      case 'string':
+        return d.string;
+      case 'boolean':
+        return d.boolean;
+      case 'Date':
+        return d.date;
+      default:
+        return d.unknown;
+    }
+  })();
+  if (column.nullable) base = d.nullable(base);
+  if (mode !== 'select') {
+    const optional = mode === 'update' || column.nullable || column.hasDefault;
+    if (optional) base = d.optional(base);
+  }
+  return base;
+}
+
+/**
+ * One `name: <expr>` entry, with the library's field encoding applied.
+ *
+ * The key is quoted only where it has to be. A column named with anything that is not a bare
+ * identifier produces invalid object syntax unquoted, which is why the sibling generators quote
+ * unconditionally; quoting only when needed matters here because a formatter is an *optional*
+ * peer, so the unquoted-where-possible form is what a consumer without prettier actually reads,
+ * and this generator puts a whole key object on one line where the difference shows.
+ */
+function field(column: Column, lib: Lib, mode: 'insert' | 'update' | 'select'): string {
+  const d = LIBS[lib];
+  const expr = mapExpr(column, lib, mode);
+  return `${objectKey(column.name)}: ${d.fieldIsString ? JSON.stringify(expr) : expr}`;
+}
+
+function objectKey(name: string): string {
+  return isIdent(name) ? name : JSON.stringify(name);
+}
+
+function renderSchema(table: Table, lib: Lib, mode: 'insert' | 'update' | 'select'): string {
+  const d = LIBS[lib];
+  const cols = table.columns.filter((c) => (mode === 'select' ? true : !c.isGenerated));
+  const body = cols.map((c) => `  ${field(c, lib, mode)},`).join('\n');
+  const schema = d.object(body);
+  return mode === 'update' && d.partialUpdate ? d.partialUpdate(schema) : schema;
+}
+
+function toCase(s: string, c?: Case): string {
+  if (!c) return s;
+  const parts = s
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]/g, ' ')
+    .split(/\s+/);
+  if (c === 'camel') {
+    return parts
+      .map((p, i) =>
+        i === 0 ? p.toLowerCase() : p.charAt(0).toUpperCase() + p.slice(1).toLowerCase()
+      )
+      .join('');
+  }
+  if (c === 'kebab') return parts.map((p) => p.toLowerCase()).join('-');
+  if (c === 'snake') return parts.map((p) => p.toLowerCase()).join('_');
+  return s;
+}
+
+const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+const singularize = (s: string) =>
+  s.endsWith('ies') ? s.slice(0, -3) + 'y' : s.endsWith('s') ? s.slice(0, -1) : s;
+const isIdent = (s: string) => /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(s);
+
+/** The module every router imports its `router` and procedure builders from. */
+export const BASE_MODULE = 'trpc';
+
+/**
+ * The columns that address one row, or `null` when nothing does.
+ *
+ * A table with no primary key genuinely cannot be addressed, and the oRPC generator's answer is
+ * to emit `z.object({ id: z.number() })` regardless, which names a column that may not exist and
+ * types it as a number when it may be a uuid. That is not reproduced here: the key is read off
+ * `primaryKey`, every column of it, at its real type, and a table without one loses the
+ * procedures that would have needed it rather than gaining a fictional `id`.
+ *
+ * A composite key keeps all of its columns, so `byId` takes `{ orgId, userId }`. The procedure is
+ * still called `byId`: the alternative is a client surface whose procedure names change with the
+ * shape of a key, and a caller holding the key does not care how many parts it has.
+ */
+function keyColumns(table: Table): Column[] | null {
+  const names = table.primaryKey?.columns ?? [];
+  if (!names.length) return null;
+  const cols = names.map((n) => table.columns.find((c) => c.name === n));
+  if (cols.some((c) => !c)) return null;
+  return cols as Column[];
+}
+
+interface Procedure {
+  /** The exported key, before `procedureCase` is applied. */
+  name: string;
+  /** `query` for a read, `mutation` for a write. */
+  kind: 'query' | 'mutation';
+  input?: string;
+  output: string;
+  /** The handler's parameter list, `''` when it needs nothing. */
+  params: string;
+  body: string[];
+}
+
+/** Everything the render functions need that is only knowable once paths are resolved. */
+interface RenderContext {
+  /** Absolute output directory. */
+  out: string;
+  /** Absolute services directory, for `template: 'service'`. */
+  services: string;
+}
+
+export class TRPCGenerator {
+  constructor(private analysis: Analysis) {}
+
+  async generate(opts: GenerateOptions) {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const out = path.resolve(process.cwd(), opts.outputDir);
+    const ctx: RenderContext = {
+      out,
+      services: path.resolve(process.cwd(), opts.servicesDir ?? 'src/services'),
+    };
+    await fs.mkdir(out, { recursive: true });
+
+    const files: string[] = [];
+    const write = async (filePath: string, content: string) => {
+      const formatted = await formatCode(
+        buildHeader(opts.outputHeader) + content,
+        filePath,
+        opts.format
+      );
+      await fs.writeFile(filePath, formatted, 'utf8');
+      files.push(filePath);
+    };
+
+    // The base is emitted whether or not there are tables: it is what a consumer imports to stand
+    // a server up, and an empty schema is one that will not stay empty.
+    const basePath = path.join(out, `${BASE_MODULE}.ts`);
+    await write(basePath, renderBase(opts));
+
+    const routers: Array<{ table: Table; filePath: string; exportName: string }> = [];
+    const total = this.analysis.tables.length;
+    let index = 0;
+    for (const table of this.analysis.tables) {
+      const base = `${table.tsName}${opts.naming?.routerSuffix ?? ''}`;
+      const filePath = path.join(out, `${toCase(base, opts.naming?.procedureCase)}.ts`);
+      if (filePath === basePath) {
+        throw new Error(
+          `@drzl/generator-trpc: the router for table "${table.name}" would be written to ` +
+            `${filePath}, which is the shared tRPC base module this generator also writes. Set ` +
+            `naming.routerSuffix to move it out of the way.`
+        );
+      }
+      await write(filePath, renderRouter(table, opts, ctx));
+      routers.push({ table, filePath, exportName: routerExportName(table, opts.naming) });
+      index++;
+      opts.onProgress?.({ index, total, table: table.name, filePath });
+    }
+
+    await write(path.join(out, 'index.ts'), renderBarrel(routers, ctx, path, opts));
+    return { files };
+  }
+}
+
+export default TRPCGenerator;
+
+/**
+ * The one `initTRPC` instance the whole generated tree shares.
+ *
+ * This file has no counterpart in the oRPC output and is the largest structural difference
+ * between the two generators. oRPC's `os` is a free import from `@orpc/server`, so every router
+ * file can build procedures without coordinating with any other. tRPC's builder carries the
+ * context type, the transformer and the error formatter with it, so a router built from its own
+ * `initTRPC.create()` is a router with its own context type: merging two of them is unsound and
+ * middleware cannot be shared across them at all. Every tRPC project has exactly one of these,
+ * and a generated tree is not an exception.
+ */
+function renderBase(opts: GenerateOptions): string {
+  const injection = opts.databaseInjection?.enabled === true;
+  const dbType = opts.databaseInjection?.databaseType ?? 'unknown';
+  const typeImport = opts.databaseInjection?.databaseTypeImport
+    ? `import type { ${opts.databaseInjection.databaseTypeImport.name} } from '${opts.databaseInjection.databaseTypeImport.from}';\n`
+    : '';
+
+  // `TRPCError` is referenced only by the database middleware, so it is imported only with it.
+  const trpcImport = injection
+    ? `import { initTRPC, TRPCError } from '@trpc/server';`
+    : `import { initTRPC } from '@trpc/server';`;
+
+  const context = injection
+    ? `/**
+ * What your \`createContext\` hands every procedure.
+ *
+ * \`db\` is optional here and required by \`dbProcedure\` below. That split is what lets an adapter
+ * build a context without a handle, for a health check or a public route, while every generated
+ * procedure still sees one that is present.
+ */
+export interface Context {
+  db?: ${dbType};
+}`
+    : `/**
+ * What your \`createContext\` hands every procedure. Nothing generated reads it, so it is left
+ * open; narrow it to the shape your own context really has.
+ */
+export type Context = Record<string, unknown>;`;
+
+  const middleware = injection
+    ? `
+/**
+ * The builder every generated procedure is built from: it refuses to run without a database
+ * handle, and narrows \`ctx.db\` from optional to present for everything downstream.
+ */
+export const dbProcedure = t.procedure.use(async ({ ctx, next }) => {
+  if (!ctx.db) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'No database handle on the tRPC context. Provide one from createContext.',
+    });
+  }
+  return next({ ctx: { db: ctx.db } });
+});
+`
+    : '';
+
+  return `// Generated by @drzl/generator-trpc
+// The shared tRPC base. Every generated router imports from here.
+${trpcImport}
+${typeImport}
+${context}
+
+const t = initTRPC.context<Context>().create();
+
+export const router = t.router;
+export const mergeRouters = t.mergeRouters;
+export const middleware = t.middleware;
+/** Needed to call this router in-process, from a test or from SSR. */
+export const createCallerFactory = t.createCallerFactory;
+export const publicProcedure = t.procedure;
+${middleware}`;
+}
+
+function renderRouter(table: Table, opts: GenerateOptions, ctx: RenderContext): string {
+  const lib: Lib = (opts.validation?.library ?? 'zod') as Lib;
+  const d = LIBS[lib];
+  const service = opts.template === 'service';
+  const injection = opts.databaseInjection?.enabled === true;
+  const builder = injection ? 'dbProcedure' : 'publicProcedure';
+
+  const insertName = `Insert${table.tsName}Schema`;
+  const updateName = `Update${table.tsName}Schema`;
+  const selectName = `Select${table.tsName}Schema`;
+
+  // A materialized view refuses every write, so a create, update or delete procedure on one
+  // describes an operation the database always rejects, and its insert and update schemas
+  // describe rows that can never be written. The validation generators already omit those
+  // schemas for a read-only table, so importing them here would import nothing.
+  const writable = !table.readOnly;
+  const key = keyColumns(table);
+
+  const Service = `${cap(singularize(table.tsName))}Service`;
+  // `@drzl/generator-service` types its key parameter as exactly one `number`
+  // (`getById(id: number)`, `update(id, data)`), so a call built from any other key does not
+  // typecheck against it. Rather than emit that call, or drop the procedures and give every table
+  // a differently shaped client, those fall back to the throwing stub the standard template uses.
+  const serviceKeyable = !!key && key.length === 1 && key[0].tsType === 'number';
+  const keyArg = key && key.length === 1 ? `input.${key[0].name}` : '';
+  const dbArg = injection ? 'ctx.db, ' : '';
+  const wiredParams = injection ? '{ ctx, input }' : '{ input }';
+
+  const procedures: Procedure[] = [];
+  const notImplemented = (what: string) =>
+    `throw new Error('Not implemented: ${what} ${table.tsName}.');`;
+
+  // list ---------------------------------------------------------------------------------------
+  procedures.push({
+    name: 'list',
+    kind: 'query',
+    output: d.arrayOf(selectName),
+    params: service && injection ? '{ ctx }' : '',
+    body: service ? [`return await ${Service}.getAll(${injection ? 'ctx.db' : ''});`] : ['return [];'],
+  });
+
+  const keyInput = key
+    ? d.objectInline(key.map((c) => field(c, lib, 'select')).join(', '))
+    : undefined;
+
+  if (key && keyInput) {
+    const wired = service && serviceKeyable;
+
+    // byId -------------------------------------------------------------------------------------
+    procedures.push({
+      name: 'byId',
+      kind: 'query',
+      input: keyInput,
+      output: d.nullableOf(selectName),
+      params: wired ? wiredParams : '{ input: _input }',
+      body: wired
+        ? [`return await ${Service}.getById(${dbArg}${keyArg});`]
+        : service
+          ? [serviceKeyNote(table), notImplemented('byId')]
+          : ['return null;'],
+    });
+
+    if (writable) {
+      // update ---------------------------------------------------------------------------------
+      const updateInput = d.objectInline(
+        [...key.map((c) => field(c, lib, 'select')), `data: ${updateName}`].join(', ')
+      );
+      procedures.push({
+        name: 'update',
+        kind: 'mutation',
+        input: updateInput,
+        output: selectName,
+        params: wired ? wiredParams : '{ input: _input }',
+        body: wired
+          ? [`return await ${Service}.update(${dbArg}${keyArg}, input.data);`]
+          : service
+            ? [serviceKeyNote(table), notImplemented('update')]
+            : [notImplemented('update')],
+      });
+
+      // delete ---------------------------------------------------------------------------------
+      procedures.push({
+        name: 'delete',
+        kind: 'mutation',
+        input: keyInput,
+        output: d.booleanSchema,
+        params: wired ? wiredParams : '{ input: _input }',
+        body: wired
+          ? [`return await ${Service}.delete(${dbArg}${keyArg});`]
+          : service
+            ? [serviceKeyNote(table), notImplemented('delete')]
+            : ['return true;'],
+      });
+    }
+  }
+
+  if (writable) {
+    // create -------------------------------------------------------------------------------------
+    // Emitted with or without a primary key: inserting a row does not require being able to
+    // address one afterwards.
+    //
+    // The stub throws rather than returning the input. The input is the *insert* shape, where
+    // generated and defaulted columns are optional, and `.output()` declares the *select* shape,
+    // where they are required. tRPC typechecks a handler's return against its output parser,
+    // measured, so returning the input is a compile error and not a loose placeholder. A body
+    // that only throws has type `never`, which honours any contract and says plainly that the
+    // work is not done.
+    procedures.push({
+      name: 'create',
+      kind: 'mutation',
+      input: insertName,
+      output: selectName,
+      params: service ? wiredParams : '{ input: _input }',
+      body: service
+        ? [`return await ${Service}.create(${dbArg}input);`]
+        : [notImplemented('create')],
+    });
+  }
+
+  // relation lookups -----------------------------------------------------------------------------
+  if (opts.includeRelations) {
+    const taken = new Set(procedures.map((p) => p.name));
+    procedures.push(...relationProcedures(table, lib, selectName, taken, service));
+  }
+
+  // Ordered so a reader finds the CRUD set where they expect it, independent of the order the
+  // branches above happened to push them in.
+  const order = ['list', 'byId', 'create', 'update', 'delete'];
+  const rank = (n: string) => (order.indexOf(n) === -1 ? order.length : order.indexOf(n));
+  procedures.sort((a, b) => rank(a.name) - rank(b.name));
+
+  const routerName = routerExportName(table, opts.naming);
+  const entries = procedures
+    .map((p) => {
+      const rawKey = toCase(p.name, opts.naming?.procedureCase);
+      const propKey = isIdent(rawKey) ? rawKey : JSON.stringify(rawKey);
+      return [
+        `  ${propKey}: ${builder}`,
+        ...(p.input ? [`    .input(${p.input})`] : []),
+        `    .output(${p.output})`,
+        `    .${p.kind}(async (${p.params}) => {`,
+        ...p.body.map((line) => `      ${line}`),
+        `    }),`,
+      ].join('\n');
+    })
+    .join('\n');
+
+  const body = `export const ${routerName} = router({\n${entries}\n});\n`;
+
+  const useShared = !!opts.validation?.useShared && !!opts.validation?.importPath;
+  const declared: string[] = [];
+  if (!useShared) {
+    if (writable) {
+      declared.push(`export const ${insertName} = ${renderSchema(table, lib, 'insert')};`);
+      declared.push(`export const ${updateName} = ${renderSchema(table, lib, 'update')};`);
+    }
+    declared.push(`export const ${selectName} = ${renderSchema(table, lib, 'select')};`);
+  }
+
+  const decided = [...declared, body].join('\n\n');
+
+  const imports: string[] = [];
+  if (useShared) {
+    // Only the schemas this file actually mentions. A read-only table never references the insert
+    // or update schema, and the validation generators do not emit those for one, so importing
+    // them would be an import that resolves to nothing.
+    const sharedAffix = resolveAffix({
+      affix: opts.validation?.affix,
+      schemaSuffix: opts.validation?.schemaSuffix,
+    });
+    const wanted: Array<['insert' | 'update' | 'select', string]> = (
+      [
+        ['insert', insertName],
+        ['update', updateName],
+        ['select', selectName],
+      ] as Array<['insert' | 'update' | 'select', string]>
+    ).filter(([, local]) => decided.includes(local));
+    if (wanted.length) {
+      // `importPath` is resolved against the directory the routers are written to. Emitting it
+      // verbatim turns a project-relative value such as `src/validators/zod`, which is how the
+      // rest of the config names directories, into a *bare* specifier naming a package that does
+      // not exist, and the import resolves to nothing.
+      const spec = resolveConfiguredImport(
+        opts.validation!.importPath!,
+        ctx.out,
+        process.cwd(),
+        opts.importExtension
+      );
+      const names = wanted
+        .map(([mode, local]) => {
+          const exported = schemaName(mode, table.tsName, sharedAffix);
+          // With no affix configured the exported name already *is* the local alias, and the
+          // oRPC generator emits `X as X` for it regardless. Harmless, and still noise in a file
+          // a user reads, so the alias appears only when it renames something.
+          return exported === local ? local : `${exported} as ${local}`;
+        })
+        .join(', ');
+      imports.push(`import { ${names} } from '${spec}';`);
+    }
+  }
+
+  imports.push(
+    `import { ${[builder, 'router'].sort().join(', ')} } from '${importSpecifier(
+      `./${BASE_MODULE}.ts`,
+      opts.importExtension
+    )}';`
+  );
+
+  if (service) {
+    imports.push(`import { ${Service} } from '${serviceImportSpecifier(table, ctx, opts)}';`);
+  }
+
+  // Decided against the finished text, which is the only thing that knows whether the library
+  // survived into it.
+  if (LIB_USAGE[lib].test(decided)) imports.unshift(LIB_IMPORTS[lib]);
+
+  const wide = table.columns.filter(isWide).map((c) => c.name);
+  const wideNote = wide.length
+    ? `// No validated type for ${wide.length === 1 ? 'this column' : 'these columns'}: ${wide.join(', ')}.\n` +
+      `// DRZL could not derive one from the schema, so the router accepts any value there.\n`
+    : '';
+
+  return `// Generated by @drzl/generator-trpc
+// Router for table: ${table.name}
+${wideNote}${imports.join('\n')}
+
+${decided}`;
+}
+
+/**
+ * One lookup per single-column foreign key: `listByAuthorId({ authorId })`.
+ *
+ * Named after the column, not the referenced table, because two keys frequently point at the same
+ * table (`authorId` and `editorId` both referencing `users`) and naming by table would emit one
+ * key twice.
+ *
+ * Restricted to single-column keys returning rows of *this* table, whose select schema is already
+ * in scope. The inverse direction, which returns another table's rows, is deliberately absent: it
+ * needs the other router module's select schema, that import is circular whenever both directions
+ * exist, and a cycle between router modules costs more in tRPC than in oRPC. It is not only a
+ * load-order problem there but a typing one, because `typeof appRouter` is what a client infers
+ * its entire API from, and a circular router graph resolves to `any` or to TS7022. The lookups are
+ * absent rather than half-working.
+ */
+function relationProcedures(
+  table: Table,
+  lib: Lib,
+  selectSchemaName: string,
+  taken: Set<string>,
+  service: boolean
+): Procedure[] {
+  const d = LIBS[lib];
+  const out: Procedure[] = [];
+  for (const fk of table.foreignKeys ?? []) {
+    if (fk.columns.length !== 1) continue;
+    const colName = fk.columns[0];
+    const column = table.columns.find((c) => c.name === colName);
+    if (!column) continue;
+
+    const name = `listBy${cap(colName)}`;
+    if (taken.has(name)) continue;
+    taken.add(name);
+
+    out.push({
+      name,
+      kind: 'query',
+      input: d.objectInline(field(column, lib, 'select')),
+      output: d.arrayOf(selectSchemaName),
+      params: '{ input: _input }',
+      body: [
+        `// Rows of ${table.name} whose ${JSON.stringify(colName)} matches _input.${colName}.`,
+        // In `service` mode every other procedure really does reach the database, so a lookup
+        // quietly answering with an empty array would read as "no matching rows". There is no
+        // generated service method for it, so it says so instead. In `standard` mode everything
+        // is a stub and `[]` is consistent with `list`.
+        service ? `throw new Error('Not implemented: ${name} ${table.tsName}.');` : 'return [];',
+      ],
+    });
+  }
+  return out;
+}
+
+/**
+ * The barrel, which in tRPC is not a barrel.
+ *
+ * oRPC's index file exports a plain object literal. This one calls `router()` on the per-table
+ * routers, because a nested tRPC router is a router rather than an object, and it exports
+ * `type AppRouter`: that type is the entire client contract, the thing
+ * `createTRPCClient<AppRouter>()` is parameterised by, and without it the generated tree is a
+ * server with no way to talk to it.
+ */
+function renderBarrel(
+  routers: Array<{ table: Table; filePath: string; exportName: string }>,
+  ctx: RenderContext,
+  path: typeof import('node:path'),
+  opts: GenerateOptions
+): string {
+  const baseSpec = importSpecifier(`./${BASE_MODULE}.ts`, opts.importExtension);
+  const reExports =
+    `export { createCallerFactory, publicProcedure, router } from '${baseSpec}';\n` +
+    (opts.databaseInjection?.enabled === true
+      ? `export { dbProcedure } from '${baseSpec}';\n`
+      : '') +
+    `export type { Context } from '${baseSpec}';\n`;
+
+  if (!routers.length) {
+    return `// Generated by @drzl/generator-trpc
+// No tables detected in analysis. Add tables to your schema and regenerate.
+import { router } from '${baseSpec}';
+
+export const appRouter = router({});
+
+/** The type a tRPC client is parameterised by: \`createTRPCClient<AppRouter>()\`. */
+export type AppRouter = typeof appRouter;
+
+${reExports}`;
+  }
+
+  const entries = routers.map(({ filePath, exportName, table }) => ({
+    rel: importSpecifier(
+      './' + path.relative(ctx.out, filePath).replace(/\\/g, '/'),
+      opts.importExtension
+    ),
+    exportName,
+    // The namespace a client reaches this table's procedures through: `trpc.userProfiles.list`.
+    // `tsName` verbatim, because it is already a valid identifier and it is the name the user
+    // wrote in their schema. The oRPC barrel lowercases this key, turning `userProfiles` into
+    // `userprofiles`: harmless in an object literal nobody reads, and not harmless when the key
+    // is the public API of a typed client.
+    key: table.tsName,
+  }));
+
+  const importLines = entries
+    .map(({ rel, exportName }) => `import { ${exportName} } from '${rel}';`)
+    .join('\n');
+  const bodyLines = entries
+    .map(({ key, exportName }) => `  ${isIdent(key) ? key : JSON.stringify(key)}: ${exportName},`)
+    .join('\n');
+
+  return `// Generated by @drzl/generator-trpc
+import { router } from '${baseSpec}';
+${importLines}
+
+export const appRouter = router({
+${bodyLines}
+});
+
+/** The type a tRPC client is parameterised by: \`createTRPCClient<AppRouter>()\`. */
+export type AppRouter = typeof appRouter;
+
+${reExports}`;
+}
+
+/** Why a service-backed procedure is a stub, stated in the file rather than only in the docs. */
+function serviceKeyNote(table: Table): string {
+  const cols = table.primaryKey?.columns ?? [];
+  const shape =
+    cols.length > 1
+      ? `has a composite primary key (${cols.join(', ')})`
+      : `has a non-numeric primary key (${cols[0]})`;
+  return (
+    `// ${table.name} ${shape}, and @drzl/generator-service types its key parameter as one ` +
+    `number.\n// Wire this to your own lookup.`
+  );
+}
+
+function routerExportName(table: Table, naming?: NamingOptions): string {
+  const base = `${table.tsName}${naming?.routerSuffix ?? 'Router'}`;
+  const c = naming?.procedureCase;
+  // Kebab is not a valid identifier; fall back to camel for an exported const.
+  return toCase(base, c === 'kebab' ? 'camel' : c);
+}
+
+/**
+ * Spell the import of a generated service module.
+ *
+ * `path.relative` returns a bare `services` whenever the services directory sits inside the router
+ * output directory, and a specifier without a leading `./` is a *bare* specifier: Node looks for a
+ * package of that name and never considers the directory next door. The prefix is added explicitly
+ * rather than relying on what `path.relative` happens to return, and the extension goes through
+ * the same helper every other specifier here uses.
+ */
+function serviceImportSpecifier(table: Table, ctx: RenderContext, opts: GenerateOptions): string {
+  const rel = relativePosix(ctx.out, ctx.services);
+  const dir = !rel ? '.' : rel.startsWith('.') ? rel : `./${rel}`;
+  return importSpecifier(`${dir}/${singularize(table.tsName)}Service.ts`, opts.importExtension);
+}
+
+/**
+ * `path.relative`, without importing `node:path` at module scope.
+ *
+ * This package is bundled to ESM and CJS by tsup and its one entry point is a class whose methods
+ * `await import()` what they need, so nothing here may reach for `require`. The two inputs are
+ * always absolute paths produced by `path.resolve`, which is a small enough contract to satisfy
+ * directly.
+ */
+function relativePosix(from: string, to: string): string {
+  const norm = (p: string) => p.replace(/\\/g, '/').replace(/\/+$/, '');
+  const a = norm(from).split('/');
+  const b = norm(to).split('/');
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return [...Array.from({ length: a.length - i }, () => '..'), ...b.slice(i)].join('/');
+}
+
+function buildHeader(h?: { enabled?: boolean; text?: string }) {
+  if (h && h.enabled === false) return '';
+  const text = h?.text?.trim();
+  const lines = text
+    ? text.split(/\r?\n/).map((l) => `// ${l}`)
+    : [
+        '// Generated by DRZL (@drzl/*)',
+        "// Generated output is granted to you under your project's license.",
+        '// You may use, copy, modify, and distribute without attribution.',
+      ];
+  return lines.join('\n') + '\n\n';
+}

--- a/packages/generator-trpc/test/barrel.spec.ts
+++ b/packages/generator-trpc/test/barrel.spec.ts
@@ -1,0 +1,105 @@
+import type { ImportExtension } from '@drzl/validation-core';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TRPCGenerator } from '../src';
+import { analysis, posts, users } from './fixtures';
+
+/** Every `from '...'` specifier a file imports from, in order. */
+function specifiers(source: string): string[] {
+  return [...source.matchAll(/from ['"]([^'"]+)['"]/g)].map((m) => m[1]);
+}
+
+async function generateInto(importExtension?: ImportExtension, tables = [users]) {
+  const dir = await mkdtemp(join(tmpdir(), 'drzl-trpc-barrel-'));
+  await new TRPCGenerator(analysis(tables)).generate({
+    outputDir: dir,
+    importExtension,
+    format: { enabled: false },
+  });
+  return {
+    dir,
+    barrel: await readFile(join(dir, 'index.ts'), 'utf8'),
+    router: await readFile(join(dir, `${tables[0].tsName}.ts`), 'utf8'),
+  };
+}
+
+describe('the app router', () => {
+  it('is a real router rather than an object literal', async () => {
+    // oRPC's index file exports a plain object, which is all oRPC needs. A nested tRPC router has
+    // to be built by `router()`, and `typeof appRouter` is the entire client contract: without it
+    // the generated tree is a server nothing can be typed against.
+    const { barrel } = await generateInto(undefined, [users, posts]);
+    expect(barrel).toContain('export const appRouter = router({');
+    expect(barrel).toContain('export type AppRouter = typeof appRouter;');
+    expect(barrel).toContain('  users: usersRouter,');
+    expect(barrel).toContain('  posts: postsRouter,');
+  });
+
+  it('re-exports what a consumer needs to stand a server up', async () => {
+    const { barrel } = await generateInto();
+    expect(barrel).toContain('export { createCallerFactory, publicProcedure, router }');
+    expect(barrel).toContain("export type { Context } from './trpc.js'");
+  });
+
+  it('re-exports the database procedure only when there is one', async () => {
+    const { barrel } = await generateInto();
+    expect(barrel).not.toContain('dbProcedure');
+
+    const dir = await mkdtemp(join(tmpdir(), 'drzl-trpc-barrel-db-'));
+    await new TRPCGenerator(analysis([users])).generate({
+      outputDir: dir,
+      format: { enabled: false },
+      databaseInjection: { enabled: true, databaseType: 'Database' },
+    });
+    expect(await readFile(join(dir, 'index.ts'), 'utf8')).toContain('export { dbProcedure }');
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('keeps the table name as written for the client namespace', async () => {
+    // This key is the public API: `trpc.userProfiles.list.query()`. The oRPC barrel lowercases
+    // it, which turns `userProfiles` into `userprofiles`; harmless in an object nobody reads, and
+    // not harmless when a typed client is spelled through it.
+    const profiles = { ...users, name: 'user_profiles', tsName: 'userProfiles' };
+    const { barrel } = await generateInto(undefined, [profiles as never]);
+    expect(barrel).toContain('  userProfiles: userProfilesRouter,');
+  });
+});
+
+describe('import extensions', () => {
+  const cases: [ImportExtension | undefined, string, string][] = [
+    // Unset has to behave exactly like 'js'.
+    [undefined, './trpc.js', './users.js'],
+    ['js', './trpc.js', './users.js'],
+    ['none', './trpc', './users'],
+    ['ts', './trpc.ts', './users.ts'],
+  ];
+
+  for (const [importExtension, base, router] of cases) {
+    it(`spells both the base and the router with ${importExtension ?? 'unset'}`, async () => {
+      const { dir, barrel, router: routerFile } = await generateInto(importExtension);
+      try {
+        // The barrel reaches the base and every router; a router reaches only the base.
+        expect(specifiers(barrel)).toEqual([base, router, base, base]);
+        expect(specifiers(routerFile)).toContain(base);
+        // Whatever a specifier spells, it has to land on a file that exists.
+        expect(existsSync(join(dir, 'trpc.ts'))).toBe(true);
+        expect(existsSync(join(dir, 'users.ts'))).toBe(true);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it('emits the .js form the default promises', async () => {
+    const { dir, barrel } = await generateInto();
+    try {
+      expect(barrel).toContain("from './users.js'");
+      expect(barrel).not.toContain("from './users'");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/generator-trpc/test/fixtures.ts
+++ b/packages/generator-trpc/test/fixtures.ts
@@ -1,0 +1,74 @@
+import type { Analysis, Column, Table } from '@drzl/analyzer';
+
+export function col(name: string, tsType: string, over: Partial<Column> = {}): Column {
+  return {
+    name,
+    tsType,
+    dbType: tsType.toUpperCase(),
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  } as Column;
+}
+
+export function table(name: string, over: Partial<Table> & { columns: Column[] }): Table {
+  return {
+    name,
+    tsName: name,
+    unique: [],
+    indexes: [],
+    ...over,
+  } as Table;
+}
+
+export function analysis(tables: Table[]): Analysis {
+  return { dialect: 'sqlite', tables, enums: [], relations: [], issues: [] };
+}
+
+/** A serial primary key and one required column: the shape every other fixture varies from. */
+export const users = table('users', {
+  columns: [
+    col('id', 'number', { hasDefault: true, isGenerated: true }),
+    col('email', 'string'),
+    col('bio', 'string', { nullable: true }),
+  ],
+  primaryKey: { columns: ['id'] },
+});
+
+/** A single-column foreign key, for the relation lookups. */
+export const posts = table('posts', {
+  columns: [
+    col('id', 'number', { hasDefault: true, isGenerated: true }),
+    col('authorId', 'number'),
+    col('title', 'string'),
+  ],
+  primaryKey: { columns: ['id'] },
+  foreignKeys: [{ columns: ['authorId'], foreignTable: 'users', foreignColumns: ['id'] }],
+});
+
+/** A natural, non-numeric primary key. */
+export const books = table('books', {
+  columns: [col('isbn', 'string'), col('title', 'string')],
+  primaryKey: { columns: ['isbn'] },
+});
+
+/** A composite primary key, which no single scalar addresses. */
+export const memberships = table('memberships', {
+  columns: [col('orgId', 'number'), col('userId', 'number'), col('role', 'string')],
+  primaryKey: { columns: ['orgId', 'userId'] },
+});
+
+/** No primary key at all, so no row can be addressed. */
+export const auditLog = table('audit_log', {
+  tsName: 'auditLog',
+  columns: [col('at', 'Date'), col('what', 'string')],
+});
+
+/** A materialized view: readable, and refuses every write. */
+export const activeUsers = table('active_users', {
+  tsName: 'activeUsers',
+  columns: [col('id', 'number'), col('email', 'string')],
+  primaryKey: { columns: ['id'] },
+  readOnly: true,
+});

--- a/packages/generator-trpc/test/formatting.spec.ts
+++ b/packages/generator-trpc/test/formatting.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * The output is formatted, and stays valid when it is not.
+ *
+ * `formatCode` is shared with every other DRZL generator and prettier is an *optional* peer, so
+ * "no formatter installed" is a supported state rather than a broken install. A wired-up call
+ * that silently stopped formatting would look exactly like success to every other spec here,
+ * because unformatted output still parses, still typechecks and is asserted on nowhere else.
+ *
+ * Compared against what prettier makes of the same file rather than against a fixed string, so
+ * this stays honest without pinning prettier's style.
+ */
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TRPCGenerator } from '../src';
+import { analysis, users } from './fixtures';
+
+async function emit(format?: { enabled?: boolean }) {
+  // A temp directory, so no .prettierrc above the workspace can affect the comparison.
+  const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-trpc-fmt-'));
+  await new TRPCGenerator(analysis([users])).generate({ outputDir, format } as never);
+  const read = (n: string) => fs.readFile(path.join(outputDir, n), 'utf8');
+  return {
+    router: await read('users.ts'),
+    barrel: await read('index.ts'),
+    base: await read('trpc.ts'),
+    at: path.join(outputDir, 'users.ts'),
+  };
+}
+
+describe('emitted tRPC output', () => {
+  it('is formatted by prettier, not merely written out', async () => {
+    const formatted = await emit();
+    const raw = await emit({ enabled: false });
+    const prettier = await import('prettier');
+    expect(formatted.router).toBe(
+      await prettier.format(raw.router, { parser: 'typescript', filepath: raw.at })
+    );
+    // Agreement would also be satisfied by output that needs no formatting, so the raw form has
+    // to differ for the comparison above to have proved anything.
+    expect(formatted.router).not.toBe(raw.router);
+  });
+
+  it('formats the base module and the app router too', async () => {
+    const formatted = await emit();
+    const raw = await emit({ enabled: false });
+    const prettier = await import('prettier');
+    expect(formatted.base).not.toBe(raw.base);
+    expect(formatted.barrel).not.toBe(raw.barrel);
+    expect(formatted.barrel).toBe(
+      await prettier.format(raw.barrel, { parser: 'typescript', filepath: 'index.ts' })
+    );
+  });
+
+  it('honours format.enabled false', async () => {
+    const { router } = await emit({ enabled: false });
+    expect(router).toMatch(/from '/);
+  });
+
+  it('emits parseable TypeScript with the formatter off', async () => {
+    // The formatter is the last step, so a syntax error it would have thrown on is a syntax error
+    // that reaches the user's disk when they have no prettier installed.
+    const ts = await import('typescript');
+    const raw = await emit({ enabled: false });
+    for (const [name, source] of Object.entries({
+      router: raw.router,
+      barrel: raw.barrel,
+      base: raw.base,
+    })) {
+      const sf = ts.createSourceFile(`${name}.ts`, source, ts.ScriptTarget.ES2022, true);
+      expect(
+        (sf as unknown as { parseDiagnostics: unknown[] }).parseDiagnostics ?? [],
+        name
+      ).toHaveLength(0);
+    }
+  });
+});

--- a/packages/generator-trpc/test/generator.spec.ts
+++ b/packages/generator-trpc/test/generator.spec.ts
@@ -1,0 +1,116 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TRPCGenerator } from '../src';
+import { analysis, col, table, users } from './fixtures';
+
+async function emit(tables = [users], opts: Record<string, unknown> = {}) {
+  const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-trpc-'));
+  const { files } = await new TRPCGenerator(analysis(tables)).generate({
+    outputDir,
+    ...opts,
+  } as never);
+  const read = (name: string) => fs.readFile(path.join(outputDir, name), 'utf8');
+  return { outputDir, files, read };
+}
+
+describe('@drzl/generator-trpc', () => {
+  it('emits the shared base, one router per table and the app router', async () => {
+    const { files, read } = await emit();
+    expect(files.map((f) => path.basename(f))).toEqual(['trpc.ts', 'users.ts', 'index.ts']);
+
+    // The base is what makes the tree one tRPC application rather than several. A router built
+    // from its own initTRPC instance has its own context type, so merging is unsound and
+    // middleware cannot be shared.
+    const base = await read('trpc.ts');
+    expect(base).toContain('initTRPC.context<Context>().create()');
+    expect(base).toContain('export const router = t.router;');
+    expect(base).toContain('export const publicProcedure = t.procedure;');
+
+    const router = await read('users.ts');
+    expect(router).toContain('export const usersRouter = router({');
+    expect(router).toMatch(/from ['"]\.\/trpc\.js['"]/);
+  });
+
+  it('declares its own schemas when validation is not shared', async () => {
+    const { read } = await emit();
+    const router = await read('users.ts');
+    expect(router).toContain('export const InsertusersSchema');
+    expect(router).toContain('export const UpdateusersSchema');
+    expect(router).toContain('export const SelectusersSchema');
+  });
+
+  it('imports shared validation schemas under the configured affix', async () => {
+    const userProfiles = table('user_profiles', {
+      tsName: 'userProfiles',
+      columns: [
+        col('id', 'number', { hasDefault: true, isGenerated: true }),
+        col('email', 'string'),
+      ],
+      primaryKey: { columns: ['id'] },
+    });
+    const { read } = await emit([userProfiles], {
+      validation: {
+        useShared: true,
+        library: 'zod',
+        importPath: '../validators/zod',
+        affix: { tableCase: 'pascal', schema: { prefix: { insert: 'Create' }, suffix: 'Doc' } },
+      },
+    });
+    const router = await read('userProfiles.ts');
+    expect(router).toContain('CreateUserProfilesDoc as InsertuserProfilesSchema');
+    expect(router).toContain('UpdateUserProfilesDoc as UpdateuserProfilesSchema');
+    expect(router).toContain('SelectUserProfilesDoc as SelectuserProfilesSchema');
+    // Local aliases never leave the file, so an affix change cannot rewrite the router body.
+    expect(router).not.toContain('export const InsertuserProfilesSchema');
+  });
+
+  it('resolves a project-relative importPath against the output directory', async () => {
+    // Emitted verbatim, `src/validators/zod` is a *bare* specifier: Node looks for a package of
+    // that name and never considers the directory. The same defect was found and fixed in the
+    // oRPC generator, and is the reason this goes through resolveConfiguredImport.
+    const cwd = process.cwd();
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-trpc-rel-'));
+    try {
+      process.chdir(root);
+      await fs.mkdir(path.join(root, 'src', 'validators', 'zod'), { recursive: true });
+      await new TRPCGenerator(analysis([users])).generate({
+        outputDir: 'src/api',
+        validation: { useShared: true, library: 'zod', importPath: 'src/validators/zod' },
+      });
+      const router = await fs.readFile(path.join(root, 'src', 'api', 'users.ts'), 'utf8');
+      expect(router).toMatch(/from ["']\.\.\/validators\/zod\/index\.js["']/);
+    } finally {
+      process.chdir(cwd);
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('emits a usable app router when the schema has no tables', async () => {
+    const { files, read } = await emit([]);
+    expect(files.map((f) => path.basename(f))).toEqual(['trpc.ts', 'index.ts']);
+    const barrel = await read('index.ts');
+    expect(barrel).toContain('export const appRouter = router({});');
+    expect(barrel).toContain('export type AppRouter = typeof appRouter;');
+  });
+
+  it('names the router export after the table, with the router suffix', async () => {
+    // The file keeps the oRPC spelling, `users.ts`, so the two generators lay their output out
+    // the same way. The export does not: `export const users = router({...})` inside `users.ts`
+    // reads as a table, and `usersRouter` is what every tRPC codebase calls this. The suffix is
+    // therefore applied to the export whether or not it was configured, and once when it was.
+    expect(await (await emit()).read('users.ts')).toContain('export const usersRouter');
+    const suffixed = await emit([users], { naming: { routerSuffix: 'Router' } });
+    expect(await suffixed.read('usersRouter.ts')).toContain('export const usersRouter =');
+  });
+
+  it('refuses to overwrite its own base module with a router', async () => {
+    // A table called `trpc` would otherwise silently clobber the file every other router imports.
+    const trpcTable = table('trpc', { columns: [col('id', 'number')] });
+    await expect(emit([trpcTable])).rejects.toThrow(/shared tRPC base module/);
+    // And the escape hatch named in the message has to actually work.
+    const { read } = await emit([trpcTable], { naming: { routerSuffix: 'Router' } });
+    expect(await read('trpcRouter.ts')).toContain('export const trpcRouter =');
+  });
+});

--- a/packages/generator-trpc/test/imports.spec.ts
+++ b/packages/generator-trpc/test/imports.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * Every emitted module imports what it uses, and nothing else.
+ *
+ * Two defects in this repository were modules that threw on import, and an import of a package a
+ * consumer did not install throws at load rather than when the unused thing is touched. An unused
+ * import is also a hard error under `noUnusedLocals`, and `verbatimModuleSyntax` keeps it, so a
+ * spare specifier is not cosmetic in the tree this output lands in.
+ */
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TRPCGenerator } from '../src';
+import { activeUsers, analysis, auditLog, users } from './fixtures';
+
+async function emit(tables: unknown[], opts: Record<string, unknown> = {}) {
+  const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-trpc-imp-'));
+  await new TRPCGenerator(analysis(tables as never)).generate({
+    outputDir,
+    format: { enabled: false },
+    ...opts,
+  } as never);
+  const read = (name: string) => fs.readFile(path.join(outputDir, name), 'utf8');
+  return read;
+}
+
+/** The names an import statement binds, across every import in the file. */
+function imported(source: string): string[] {
+  const names: string[] = [];
+  for (const m of source.matchAll(/import (?:type )?\{([^}]*)\} from/g)) {
+    for (const part of m[1].split(',')) {
+      const name = part.trim().split(/\s+as\s+/).pop()?.trim();
+      if (name) names.push(name);
+    }
+  }
+  for (const m of source.matchAll(/import \* as (\w+) from/g)) names.push(m[1]);
+  return names;
+}
+
+/** Whether a binding is referenced anywhere other than the line that imports it. */
+function isUsed(source: string, name: string): boolean {
+  const withoutImports = source.replace(/^import .*$/gm, '');
+  return new RegExp(`\\b${name}\\b`).test(withoutImports);
+}
+
+describe('the base module', () => {
+  it('imports TRPCError only when the database middleware needs it', async () => {
+    const plain = await (await emit([users]))('trpc.ts');
+    expect(imported(plain)).toEqual(['initTRPC']);
+
+    const injected = await (
+      await emit([users], { databaseInjection: { enabled: true, databaseType: 'Database' } })
+    )('trpc.ts');
+    expect(imported(injected)).toEqual(['initTRPC', 'TRPCError']);
+    expect(injected).toContain('new TRPCError(');
+  });
+
+  it('imports the database type when one is configured', async () => {
+    const source = await (
+      await emit([users], {
+        databaseInjection: {
+          enabled: true,
+          databaseType: 'Database',
+          databaseTypeImport: { name: 'Database', from: '../db/client.js' },
+        },
+      })
+    )('trpc.ts');
+    expect(source).toContain("import type { Database } from '../db/client.js';");
+    expect(source).toContain('db?: Database;');
+  });
+});
+
+describe('a router module', () => {
+  it('binds nothing it does not reference', async () => {
+    for (const table of [users, activeUsers, auditLog]) {
+      const source = await (await emit([table]))(`${table.tsName}.ts`);
+      const unused = imported(source).filter((n) => !isUsed(source, n));
+      expect(unused, `${table.name} imports these and never uses them`).toEqual([]);
+    }
+  });
+
+  it('imports only the shared schemas it mentions', async () => {
+    // A read-only relation has no insert or update schema: the validation generators do not emit
+    // one, because the database refuses every write it would describe. Importing them would be an
+    // import that resolves to nothing.
+    const read = await emit([activeUsers], {
+      validation: { useShared: true, library: 'zod', importPath: '../validators/zod' },
+    });
+    const source = await read('activeUsers.ts');
+    expect(source).toContain('import { SelectactiveUsersSchema } from');
+    expect(source).not.toContain('InsertactiveUsersSchema');
+    expect(source).not.toContain('UpdateactiveUsersSchema');
+  });
+
+  it('renames on import only when the affix renamed something', async () => {
+    // With no affix the exported name already is the local alias, and `X as X` is noise in a file
+    // someone reads. The oRPC generator emits it unconditionally.
+    const plain = await (
+      await emit([users], {
+        validation: { useShared: true, library: 'zod', importPath: '../validators/zod' },
+      })
+    )('users.ts');
+    expect(plain).not.toMatch(/(\w+) as \1\b/);
+
+    const renamed = await (
+      await emit([users], {
+        validation: {
+          useShared: true,
+          library: 'zod',
+          importPath: '../validators/zod',
+          affix: { tableCase: 'pascal' },
+        },
+      })
+    )('users.ts');
+    expect(renamed).toContain('SelectUsersSchema as SelectusersSchema');
+  });
+
+  it('leaves out the validation library when no expression uses it', async () => {
+    // A read-only table with no primary key has exactly one procedure, `list`, whose output under
+    // arktype is `Select.array()`: built entirely from the imported schema, so nothing in the file
+    // says `type(`.
+    const readOnlyNoKey = { ...auditLog, readOnly: true };
+    const read = await emit([readOnlyNoKey], {
+      validation: { useShared: true, library: 'arktype', importPath: '../validators/arktype' },
+    });
+    const source = await read('auditLog.ts');
+    expect(source).not.toContain("from 'arktype'");
+    expect(imported(source).filter((n) => !isUsed(source, n))).toEqual([]);
+  });
+
+  it('still imports the library when an expression does use it', async () => {
+    const read = await emit([users], {
+      validation: { useShared: true, library: 'arktype', importPath: '../validators/arktype' },
+    });
+    const source = await read('users.ts');
+    expect(source).toContain("import { type } from 'arktype';");
+    expect(source).toContain('type({ id: "number" })');
+  });
+
+  it('binds the procedure builder the file actually uses', async () => {
+    const plain = await (await emit([users]))('users.ts');
+    expect(plain).toContain("import { publicProcedure, router } from './trpc.js';");
+    expect(plain).not.toContain('dbProcedure');
+
+    const injected = await (
+      await emit([users], { databaseInjection: { enabled: true, databaseType: 'Database' } })
+    )('users.ts');
+    expect(injected).toContain("import { dbProcedure, router } from './trpc.js';");
+    expect(injected).not.toContain('publicProcedure');
+  });
+});

--- a/packages/generator-trpc/test/output-typechecks.spec.ts
+++ b/packages/generator-trpc/test/output-typechecks.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * The emitted tree compiles, with the real tRPC and the real validator installed.
+ *
+ * This is the check that was missing from the oRPC generator for its entire life. Its `create` and
+ * `update` stubs declared `.output(SelectSchema)` and returned the input, which is the *insert*
+ * shape, so every generated router failed `tsc --strict` and nothing noticed because nothing ever
+ * compiled the output. tRPC constrains a handler's return against its output parser in exactly the
+ * same way, measured, so the same mistake would be the same defect here.
+ *
+ * Real `tsc`, real `node_modules`, under `strict` and `moduleResolution: nodenext`, which is the
+ * combination the generated `.js` specifiers exist for.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, promises as fs } from 'node:fs';
+import path from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { TRPCGenerator } from '../src';
+import {
+  activeUsers,
+  analysis,
+  auditLog,
+  books,
+  memberships,
+  posts,
+  users,
+} from './fixtures';
+
+const pkgRoot = path.resolve(import.meta.dirname, '..');
+const workRoot = path.join(pkgRoot, 'test', 'tmp', 'typecheck');
+const tsc = path.join(pkgRoot, 'node_modules', '.bin', 'tsc');
+
+/** Every table shape this generator has a branch for, compiled together. */
+const tables = [users, posts, books, memberships, auditLog, activeUsers];
+
+afterAll(async () => {
+  await fs.rm(workRoot, { recursive: true, force: true });
+});
+
+/**
+ * Emit into a directory under this package, so Node's resolver reaches the `@trpc/server`, `zod`,
+ * `valibot` and `arktype` this package installs. A temp directory elsewhere would resolve none of
+ * them and the compile would prove nothing.
+ */
+async function compile(label: string, opts: Record<string, unknown>) {
+  const dir = path.join(workRoot, label);
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(dir, { recursive: true });
+  await new TRPCGenerator(analysis(tables)).generate({
+    outputDir: path.join(dir, 'api'),
+    ...opts,
+  } as never);
+
+  const tsconfig = path.join(dir, 'tsconfig.json');
+  await fs.writeFile(
+    tsconfig,
+    JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          noUnusedLocals: true,
+          noUnusedParameters: true,
+          target: 'es2022',
+          module: 'nodenext',
+          moduleResolution: 'nodenext',
+          skipLibCheck: true,
+        },
+        include: ['api/**/*.ts'],
+      },
+      null,
+      2
+    )
+  );
+  // The generated `.js` specifiers only resolve under nodenext from a module package.
+  await fs.writeFile(path.join(dir, 'package.json'), '{"name":"probe","type":"module"}');
+
+  try {
+    execFileSync(tsc, ['-p', tsconfig], { cwd: dir, stdio: 'pipe' });
+    return '';
+  } catch (e) {
+    const err = e as { stdout?: Buffer; stderr?: Buffer };
+    return `${err.stdout?.toString() ?? ''}${err.stderr?.toString() ?? ''}`;
+  }
+}
+
+describe('the emitted tree', () => {
+  it('has a tsc to run', () => {
+    // Without this the cases below would report an empty diagnostic list for a compiler that
+    // never started, and pass on nothing at all.
+    expect(existsSync(tsc), `no tsc at ${tsc}; run pnpm install`).toBe(true);
+  });
+
+  for (const library of ['zod', 'valibot', 'arktype'] as const) {
+    it(`compiles under strict nodenext with ${library}`, async () => {
+      expect(await compile(library, { validation: { library } })).toBe('');
+    });
+  }
+
+  it('compiles with relation lookups', async () => {
+    expect(await compile('relations', { includeRelations: true })).toBe('');
+  });
+
+  it('compiles with the database middleware', async () => {
+    expect(
+      await compile('injected', {
+        databaseInjection: { enabled: true, databaseType: '{ readonly tag: "db" }' },
+      })
+    ).toBe('');
+  });
+
+  it('compiles with no unused locals or parameters anywhere', async () => {
+    // Asserted by the tsconfig above rather than by a separate case: `noUnusedLocals` is what
+    // turns a spare import into a compile error, and it is on for every case in this file.
+    expect(await compile('unused', { includeRelations: true })).toBe('');
+  });
+
+  it('would have said so if the tree did not compile', async () => {
+    // Every case above passes by producing no output, which a compiler that never ran also does.
+    // So the exact mistake that shipped in the oRPC generator is planted into a compiling tree
+    // and has to be reported: `create` returning its input, which is the insert shape where the
+    // declared output is the select shape.
+    const dir = path.join(workRoot, 'canary');
+    await compile('canary', {});
+    const router = path.join(dir, 'api', 'users.ts');
+    const source = await fs.readFile(router, 'utf8');
+    // Quote style is whatever prettier resolved from the nearest config, so the pattern cannot
+    // assume one. A silent no-match here would leave a compiling tree and pass this test on it.
+    const planted = source.replace(
+      /throw new Error\(['"]Not implemented: create users\.['"]\);/,
+      'return _input;'
+    );
+    expect(planted, 'the mistake was never planted').not.toBe(source);
+    await fs.writeFile(router, planted);
+    let diagnostics = '';
+    try {
+      execFileSync(tsc, ['-p', path.join(dir, 'tsconfig.json')], { cwd: dir, stdio: 'pipe' });
+    } catch (e) {
+      const err = e as { stdout?: Buffer };
+      diagnostics = err.stdout?.toString() ?? '';
+    }
+    expect(diagnostics, 'tsc accepted the insert shape where select was declared').toContain(
+      'is not assignable'
+    );
+    expect(diagnostics).toContain('users.ts');
+  });
+}, 180_000);

--- a/packages/generator-trpc/test/procedures.spec.ts
+++ b/packages/generator-trpc/test/procedures.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * Which procedures a table gets, and what each one takes.
+ *
+ * The oRPC generator answers "how do I address one row" with `z.object({ id: z.number() })` for
+ * every table, whatever its primary key is or whether it has one. That is wrong three ways: it
+ * names a column that need not exist, types a uuid key as a number, and hands a composite key one
+ * of its two halves. Each case below is a table that generator would have got wrong.
+ */
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TRPCGenerator } from '../src';
+import {
+  activeUsers,
+  analysis,
+  auditLog,
+  books,
+  memberships,
+  posts,
+  users,
+} from './fixtures';
+
+/**
+ * Emitted with the formatter off, so every assertion below reads the generator's own output.
+ *
+ * Prettier reflows a short chain onto one line and a long one across five, and rewrites quotes,
+ * so an assertion against formatted text is really an assertion about prettier's line budget:
+ * adding a column to a fixture would move an unrelated expectation. That the formatter still runs
+ * at all is asserted in formatting.spec.ts, which is the only place it should be.
+ */
+async function router(t = users, opts: Record<string, unknown> = {}) {
+  const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-trpc-proc-'));
+  await new TRPCGenerator(analysis([t])).generate({
+    outputDir,
+    format: { enabled: false },
+    ...opts,
+  } as never);
+  return fs.readFile(path.join(outputDir, `${t.tsName}.ts`), 'utf8');
+}
+
+/** The procedure keys the router object declares, in order. */
+function procedures(source: string): string[] {
+  const body = source.slice(source.indexOf('= router({'));
+  return [...body.matchAll(/^ {2}([A-Za-z_$][\w$]*|"[^"]+"): (?:public|db)Procedure\b/gm)].map(
+    (m) => m[1].replace(/"/g, '')
+  );
+}
+
+/** The chain for one procedure: from its key to wherever the next one starts. */
+function chain(source: string, name: string): string {
+  const body = source.slice(source.indexOf('= router({'));
+  const start = body.search(new RegExp(`^ {2}"?${name}"?: `, 'm'));
+  expect(start, `no procedure named ${name} in:\n${source}`).toBeGreaterThanOrEqual(0);
+  const rest = body.slice(start + 1);
+  const next = rest.search(/^ {2}[A-Za-z_$"]/m);
+  return body.slice(start, next === -1 ? undefined : start + 1 + next);
+}
+
+describe('the CRUD set', () => {
+  it('is list, byId, create, update, delete for an ordinary table', async () => {
+    expect(procedures(await router())).toEqual(['list', 'byId', 'create', 'update', 'delete']);
+  });
+
+  it('reads with query and writes with mutation', async () => {
+    const source = await router();
+    // A query is what a tRPC client caches and batches over GET; a mutation is what it will not
+    // put on a GET, which matters because a proxy may cache one and never the other.
+    expect(chain(source, 'list')).toContain('.query(');
+    expect(chain(source, 'byId')).toContain('.query(');
+    for (const write of ['create', 'update', 'delete']) {
+      expect(chain(source, write), write).toContain('.mutation(');
+    }
+  });
+
+  it('takes no input on list and the insert schema on create', async () => {
+    const source = await router();
+    expect(chain(source, 'list')).not.toContain('.input(');
+    expect(chain(source, 'create')).toContain('.input(InsertusersSchema)');
+  });
+
+  it('takes the update schema under `data`, beside the key, on update', async () => {
+    expect(chain(await router(), 'update')).toContain(
+      '.input(z.object({ id: z.number(), data: UpdateusersSchema }))'
+    );
+  });
+
+  it('declares an output schema on every procedure', async () => {
+    const source = await router();
+    expect(chain(source, 'list')).toContain('.output(z.array(SelectusersSchema))');
+    expect(chain(source, 'byId')).toContain('.output(SelectusersSchema.nullable())');
+    expect(chain(source, 'create')).toContain('.output(SelectusersSchema)');
+    expect(chain(source, 'update')).toContain('.output(SelectusersSchema)');
+    expect(chain(source, 'delete')).toContain('.output(z.boolean())');
+  });
+});
+
+describe('the primary key', () => {
+  it('is read off the schema rather than assumed to be a number called id', async () => {
+    const source = await router(books);
+    expect(chain(source, 'byId')).toContain('.input(z.object({ isbn: z.string() }))');
+    expect(chain(source, 'delete')).toContain('.input(z.object({ isbn: z.string() }))');
+    expect(source).not.toContain('z.number()');
+  });
+
+  it('carries every column of a composite key', async () => {
+    const source = await router(memberships);
+    const expected = '.input(z.object({ orgId: z.number(), userId: z.number() }))';
+    expect(chain(source, 'byId')).toContain(expected);
+    expect(chain(source, 'delete')).toContain(expected);
+    // Still called byId: a caller holding the key does not care how many parts it has, and a
+    // client whose procedure names change with the shape of a key is worse than a long input.
+    expect(procedures(source)).toContain('byId');
+  });
+
+  it('takes the whole composite key beside the patch on update', async () => {
+    expect(chain(await router(memberships), 'update')).toContain(
+      '.input(z.object({ orgId: z.number(), userId: z.number(), data: UpdatemembershipsSchema }))'
+    );
+  });
+});
+
+describe('a table with no primary key', () => {
+  it('loses exactly the procedures that would have needed one', async () => {
+    // Not `list` and not `create`: reading every row and inserting a new one need no way to
+    // address an existing one.
+    expect(procedures(await router(auditLog))).toEqual(['list', 'create']);
+  });
+
+  it('invents no id column to stand in for the key it does not have', async () => {
+    const source = await router(auditLog);
+    expect(source).not.toContain('byId');
+    expect(source).not.toMatch(/\bid\b/);
+  });
+});
+
+describe('a read-only relation', () => {
+  it('gets no write procedures, because the database refuses every write to one', async () => {
+    expect(procedures(await router(activeUsers))).toEqual(['list', 'byId']);
+  });
+
+  it('declares no insert or update schema for rows that can never be written', async () => {
+    const source = await router(activeUsers);
+    expect(source).not.toContain('InsertactiveUsersSchema');
+    expect(source).not.toContain('UpdateactiveUsersSchema');
+    expect(source).toContain('SelectactiveUsersSchema');
+  });
+});
+
+describe('relation lookups', () => {
+  it('are absent unless asked for', async () => {
+    expect(procedures(await router(posts))).not.toContain('listByAuthorId');
+  });
+
+  it('add one query per single-column foreign key, named after the column', async () => {
+    const source = await router(posts, { includeRelations: true });
+    expect(procedures(source)).toContain('listByAuthorId');
+    const lookup = chain(source, 'listByAuthorId');
+    expect(lookup).toContain('.input(z.object({ authorId: z.number() }))');
+    expect(lookup).toContain('.output(z.array(SelectpostsSchema))');
+    expect(lookup).toContain('.query(');
+  });
+
+  it('leaves the CRUD set exactly as it was', async () => {
+    // Appended, never substituted, so the client surface is the same with the flag on and off
+    // apart from the additions.
+    expect(procedures(await router(posts, { includeRelations: true }))).toEqual([
+      ...procedures(await router(posts)),
+      'listByAuthorId',
+    ]);
+  });
+});
+
+describe('stubs', () => {
+  it('throw from create and update rather than returning the input', async () => {
+    // The input is the insert or update shape, where generated and defaulted columns are
+    // optional; `.output()` declares the select shape, where they are required. tRPC typechecks a
+    // handler's return against its output parser, so returning the input is a compile error and
+    // not a loose placeholder. A body that only throws has type `never`.
+    const source = await router();
+    for (const name of ['create', 'update']) {
+      expect(chain(source, name), name).toMatch(/throw new Error\(/);
+      expect(chain(source, name), name).not.toMatch(/return\s+_?input/);
+    }
+  });
+
+  it('answer the reads that have a valid empty answer', async () => {
+    const source = await router();
+    expect(chain(source, 'list')).toContain('return [];');
+    expect(chain(source, 'byId')).toContain('return null;');
+    expect(chain(source, 'delete')).toContain('return true;');
+  });
+});
+
+describe('naming', () => {
+  it('applies procedureCase to the procedure keys', async () => {
+    const source = await router(users, { naming: { procedureCase: 'snake' } });
+    expect(procedures(source)).toContain('by_id');
+  });
+
+  it('quotes a key that is not an identifier rather than emitting invalid syntax', async () => {
+    const source = await router(users, { naming: { procedureCase: 'kebab' } });
+    expect(source).toContain('"by-id":');
+  });
+});
+
+describe('a column DRZL cannot type', () => {
+  it('gets a validator that accepts anything, and the file says so', async () => {
+    const wide = {
+      ...posts,
+      columns: [...posts.columns, { ...posts.columns[2], name: 'meta', tsType: 'Buffer' }],
+    };
+    const source = await router(wide as never);
+    expect(source).toContain('meta: z.unknown()');
+    expect(source).toContain('No validated type for this column: meta.');
+  });
+
+  it('says nothing when every column is typed', async () => {
+    expect(await router()).not.toContain('No validated type');
+  });
+});

--- a/packages/generator-trpc/test/runtime.spec.ts
+++ b/packages/generator-trpc/test/runtime.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * The emitted router is stood up as a real tRPC server and driven over HTTP.
+ *
+ * A generated module that looks right and does not run is the recurring failure in this
+ * repository, and typechecking cannot see any of it: whether `export const router = t.router`
+ * survives being destructured off the builder, whether a router built in one module can be nested
+ * by another, whether `.input()` actually rejects a bad payload rather than merely being present,
+ * whether the barrel loads at all. So this generates, writes a real service layer beside it,
+ * starts `@trpc/server`'s standalone adapter on a real port, and makes real requests.
+ *
+ * `importExtension: 'none'` because the module graph here is loaded by vite, which resolves
+ * `./trpc` to `./trpc.ts`. The `.js` form the default emits is the one that resolves under a real
+ * `tsc`, and it is compiled under all four moduleResolution settings in output-typechecks.spec.ts.
+ */
+import type { Server } from 'node:http';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { TRPCGenerator } from '../src';
+import { analysis, users } from './fixtures';
+
+const pkgRoot = path.resolve(import.meta.dirname, '..');
+const workDir = path.join('test', 'tmp', 'runtime');
+const absWork = path.join(pkgRoot, workDir);
+
+/** An in-memory stand-in for what `@drzl/generator-service` writes, with the same signatures. */
+const SERVICE = `
+export interface Row { id: number; email: string; bio: string | null }
+const rows: Row[] = [];
+let next = 1;
+
+export class UserService {
+  static async getAll(): Promise<Row[]> {
+    return rows;
+  }
+  static async getById(id: number): Promise<Row | null> {
+    return rows.find((r) => r.id === id) ?? null;
+  }
+  static async create(input: { email: string; bio?: string | null }): Promise<Row> {
+    const row: Row = { id: next++, email: input.email, bio: input.bio ?? null };
+    rows.push(row);
+    return row;
+  }
+  static async update(id: number, data: { email?: string; bio?: string | null }): Promise<Row> {
+    const row = rows.find((r) => r.id === id);
+    if (!row) throw new Error('no such row');
+    Object.assign(row, data);
+    return row;
+  }
+  static async delete(id: number): Promise<boolean> {
+    const at = rows.findIndex((r) => r.id === id);
+    if (at !== -1) rows.splice(at, 1);
+    return at !== -1;
+  }
+}
+`;
+
+let server: Server;
+let origin: string;
+/** Every request and response, printed when the suite runs with DRZL_TRPC_TRANSCRIPT set. */
+const transcript: string[] = [];
+
+async function call(
+  method: 'GET' | 'POST',
+  procedure: string,
+  input?: unknown
+): Promise<{ status: number; body: any }> {
+  const url =
+    method === 'GET'
+      ? `${origin}/${procedure}${input === undefined ? '' : `?input=${encodeURIComponent(JSON.stringify(input))}`}`
+      : `${origin}/${procedure}`;
+  const res = await fetch(url, {
+    method,
+    ...(method === 'POST'
+      ? { headers: { 'content-type': 'application/json' }, body: JSON.stringify(input ?? {}) }
+      : {}),
+  });
+  const body = await res.json();
+  transcript.push(
+    `${method} /${procedure}${input === undefined ? '' : ` ${JSON.stringify(input)}`}\n` +
+      `  -> ${res.status} ${JSON.stringify(body)}`
+  );
+  return { status: res.status, body };
+}
+
+beforeAll(async () => {
+  await fs.rm(absWork, { recursive: true, force: true });
+  await fs.mkdir(path.join(absWork, 'services'), { recursive: true });
+  await fs.writeFile(path.join(absWork, 'services', 'userService.ts'), SERVICE, 'utf8');
+
+  await new TRPCGenerator(analysis([users])).generate({
+    outputDir: path.join(workDir, 'api'),
+    template: 'service',
+    servicesDir: path.join(workDir, 'services'),
+    importExtension: 'none',
+  });
+
+  const barrel = pathToFileURL(path.join(absWork, 'api', 'index.ts')).href;
+  // `any` because the module is generated at run time: there is no declaration for it to resolve
+  // against, and its real types are checked by `tsc` in output-typechecks.spec.ts instead.
+  const { appRouter } = (await import(/* @vite-ignore */ barrel)) as { appRouter: any };
+  const { createHTTPServer } = await import('@trpc/server/adapters/standalone');
+  // The adapter hands back the `node:http` server, so it is listened on directly rather than
+  // through the adapter's own `listen`, which does not report when it is ready.
+  server = createHTTPServer({ router: appRouter, createContext: () => ({}) }) as unknown as Server;
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  origin = `http://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}`;
+}, 60_000);
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+  if (process.env.DRZL_TRPC_TRANSCRIPT) console.log(transcript.join('\n'));
+  await fs.rm(absWork, { recursive: true, force: true });
+});
+
+describe('a generated router, over HTTP', () => {
+  it('answers a query before anything has been written', async () => {
+    const { status, body } = await call('GET', 'users.list');
+    expect(status).toBe(200);
+    expect(body.result.data).toEqual([]);
+  });
+
+  it('accepts a mutation and returns the row it created', async () => {
+    const { status, body } = await call('POST', 'users.create', { email: 'ada@example.com' });
+    expect(status).toBe(200);
+    // The row carries the generated `id` the input never had, which is the whole reason a stub
+    // cannot answer this by returning its input.
+    expect(body.result.data).toEqual({ id: 1, email: 'ada@example.com', bio: null });
+  });
+
+  it('reads back what the mutation wrote', async () => {
+    await call('POST', 'users.create', { email: 'grace@example.com', bio: 'compiler' });
+    const list = await call('GET', 'users.list');
+    expect(list.body.result.data).toEqual([
+      { id: 1, email: 'ada@example.com', bio: null },
+      { id: 2, email: 'grace@example.com', bio: 'compiler' },
+    ]);
+
+    const one = await call('GET', 'users.byId', { id: 2 });
+    expect(one.body.result.data).toEqual({ id: 2, email: 'grace@example.com', bio: 'compiler' });
+  });
+
+  it('answers byId with null for a row that is not there', async () => {
+    const { body } = await call('GET', 'users.byId', { id: 999 });
+    expect(body.result.data).toBeNull();
+  });
+
+  it('applies a patch through update', async () => {
+    const { body } = await call('POST', 'users.update', { id: 1, data: { bio: 'analyst' } });
+    expect(body.result.data).toEqual({ id: 1, email: 'ada@example.com', bio: 'analyst' });
+  });
+
+  it('deletes, and says so', async () => {
+    expect((await call('POST', 'users.delete', { id: 1 })).body.result.data).toBe(true);
+    expect((await call('GET', 'users.byId', { id: 1 })).body.result.data).toBeNull();
+  });
+
+  it('rejects a payload the input schema refuses, before the handler runs', async () => {
+    // The point of wiring DRZL's schemas into `.input()`. A schema that is merely present, and
+    // not enforced, looks identical in the source.
+    const { status, body } = await call('POST', 'users.create', { email: 42 });
+    expect(status).toBe(400);
+    expect(body.error.data.code).toBe('BAD_REQUEST');
+  });
+
+  it('rejects a query missing its key', async () => {
+    const { status, body } = await call('GET', 'users.byId', {});
+    expect(status).toBe(400);
+    expect(body.error.data.code).toBe('BAD_REQUEST');
+  });
+
+  it('refuses to serve a mutation over GET', async () => {
+    // tRPC's own rule, and the reason `create` is declared a mutation rather than a query: a
+    // proxy or a browser may cache a GET and must never cache a write.
+    const res = await fetch(`${origin}/users.create?input=${encodeURIComponent('{"email":"x"}')}`);
+    expect(res.status).toBe(405);
+  });
+});
+
+describe('the generated module graph', () => {
+  it('loads without side effects that throw', async () => {
+    // Two defects in this repository were modules that threw on import. A second load of the
+    // barrel, of the base and of a router has to be uneventful.
+    for (const file of ['index.ts', 'trpc.ts', 'users.ts']) {
+      const href = pathToFileURL(path.join(absWork, 'api', file)).href;
+      await expect(import(/* @vite-ignore */ `${href}?reload`)).resolves.toBeTruthy();
+    }
+  });
+
+  it('exports the app router type surface a client is built from', async () => {
+    const barrel = pathToFileURL(path.join(absWork, 'api', 'index.ts')).href;
+    const mod = (await import(/* @vite-ignore */ barrel)) as Record<string, unknown>;
+    expect(Object.keys(mod).sort()).toEqual([
+      'appRouter',
+      'createCallerFactory',
+      'publicProcedure',
+      'router',
+    ]);
+  });
+
+  it('can be called in-process through the exported caller factory', async () => {
+    // The path SSR and server components take, which never goes near HTTP.
+    const barrel = pathToFileURL(path.join(absWork, 'api', 'index.ts')).href;
+    const { appRouter, createCallerFactory } = (await import(/* @vite-ignore */ barrel)) as any;
+    const caller = createCallerFactory(appRouter)({});
+    const created = await caller.users.create({ email: 'katherine@example.com' });
+    expect(created.email).toBe('katherine@example.com');
+    expect(await caller.users.byId({ id: created.id })).toEqual(created);
+  });
+});

--- a/packages/generator-trpc/test/service-template.spec.ts
+++ b/packages/generator-trpc/test/service-template.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * `template: 'service'`, which wires the routers to the classes `@drzl/generator-service` writes.
+ *
+ * That generator types its key parameter as exactly one `number`, in both of its modes:
+ * `getById(id: number)`, `update(id, data)`, `delete(id)`. So a call built from a composite key,
+ * or from a `varchar` primary key, does not typecheck against it. Emitting that call anyway is
+ * how a generator ships output that reads correctly and does not compile, which is the failure
+ * this repository keeps finding after release.
+ */
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TRPCGenerator } from '../src';
+import { analysis, books, memberships, posts, users } from './fixtures';
+
+async function router(t = users, opts: Record<string, unknown> = {}) {
+  const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-trpc-svc-'));
+  await new TRPCGenerator(analysis([t])).generate({
+    outputDir,
+    template: 'service',
+    format: { enabled: false },
+    ...opts,
+  } as never);
+  return fs.readFile(path.join(outputDir, `${t.tsName}.ts`), 'utf8');
+}
+
+describe('a numeric single-column key', () => {
+  it('reaches the service for every procedure', async () => {
+    const source = await router();
+    expect(source).toContain('return await UserService.getAll();');
+    expect(source).toContain('return await UserService.getById(input.id);');
+    expect(source).toContain('return await UserService.create(input);');
+    expect(source).toContain('return await UserService.update(input.id, input.data);');
+    expect(source).toContain('return await UserService.delete(input.id);');
+  });
+
+  /**
+   * Both directories are project-relative, so this runs from a project root rather than from a
+   * temp output directory: the specifier is what `path.relative` makes of the two, and pointing
+   * one of them at /tmp measures the distance to this package instead.
+   */
+  async function fromProjectRoot(opts: Record<string, unknown> = {}) {
+    const cwd = process.cwd();
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-trpc-proj-'));
+    try {
+      process.chdir(root);
+      await new TRPCGenerator(analysis([users])).generate({
+        outputDir: 'src/api',
+        template: 'service',
+        format: { enabled: false },
+        ...opts,
+      } as never);
+      return await fs.readFile(path.join(root, 'src', 'api', 'users.ts'), 'utf8');
+    } finally {
+      process.chdir(cwd);
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }
+
+  it('imports the singular service module the service generator writes', async () => {
+    // `users` produces `userService.ts` exporting `UserService`. A specifier without `./` is a
+    // bare one, which Node resolves in node_modules and never next door.
+    expect(await fromProjectRoot()).toContain(
+      "import { UserService } from '../services/userService.js';"
+    );
+  });
+
+  it('follows servicesDir rather than assuming src/services', async () => {
+    expect(await fromProjectRoot({ servicesDir: 'src/data' })).toContain(
+      "from '../data/userService.js'"
+    );
+  });
+
+  it('keeps a leading ./ when the services sit inside the output directory', async () => {
+    // `path.relative` returns a bare `services` here, which is a *package* specifier to Node.
+    expect(await fromProjectRoot({ servicesDir: 'src/api/services' })).toContain(
+      "from './services/userService.js'"
+    );
+  });
+
+  it('destructures only what the handler reads', async () => {
+    const source = await router();
+    // No `ctx` without injection: the service reaches its own database.
+    expect(source).not.toContain('{ ctx');
+    expect(source).toContain('.query(async () => {');
+  });
+});
+
+describe('database injection', () => {
+  it('passes the handle from context as the first argument', async () => {
+    const source = await router(users, {
+      databaseInjection: { enabled: true, databaseType: 'Database' },
+    });
+    expect(source).toContain('return await UserService.getAll(ctx.db);');
+    expect(source).toContain('return await UserService.getById(ctx.db, input.id);');
+    expect(source).toContain('return await UserService.update(ctx.db, input.id, input.data);');
+    expect(source).toContain('.query(async ({ ctx }) => {');
+    expect(source).toContain('.mutation(async ({ ctx, input }) => {');
+  });
+
+  it('builds every procedure on the guarded builder', async () => {
+    const source = await router(users, {
+      databaseInjection: { enabled: true, databaseType: 'Database' },
+    });
+    expect(source).not.toContain('publicProcedure');
+    expect(source.match(/dbProcedure/g)?.length).toBeGreaterThan(1);
+  });
+});
+
+describe('a key the service layer cannot express', () => {
+  it('falls back to a throwing stub for a composite key, and says why', async () => {
+    const source = await router(memberships);
+    // list and create still reach the service: neither needs a key.
+    expect(source).toContain('return await MembershipService.getAll();');
+    expect(source).toContain('return await MembershipService.create(input);');
+    for (const method of ['getById', 'update(', 'delete(']) {
+      expect(source, method).not.toContain(`MembershipService.${method}`);
+    }
+    expect(source).toContain('has a composite primary key (orgId, userId)');
+    expect(source).toMatch(/throw new Error\('Not implemented: byId memberships\.'\)/);
+  });
+
+  it('does the same for a non-numeric key', async () => {
+    const source = await router(books);
+    expect(source).toContain('has a non-numeric primary key (isbn)');
+    expect(source).not.toContain('BookService.getById');
+    expect(source).toContain('return await BookService.getAll();');
+  });
+
+  it('keeps the client surface the same shape either way', async () => {
+    // The procedures are still there and still take the real key. Only the body differs, which
+    // is what keeps one table's client from looking different to another's.
+    const source = await router(books);
+    expect(source).toContain('.input(z.object({ isbn: z.string() }))');
+    expect(source).toContain('.output(SelectbooksSchema.nullable())');
+  });
+});
+
+describe('relation lookups in service mode', () => {
+  it('say they are unimplemented rather than answering with no rows', async () => {
+    // Every other procedure in this file really does reach the database, so an empty array from a
+    // lookup would read as "no matching rows". In standard mode everything is a stub and `[]` is
+    // consistent with `list`.
+    const wired = await router(posts, { includeRelations: true });
+    expect(wired).toMatch(/throw new Error\('Not implemented: listByAuthorId posts\.'\)/);
+
+    const stub = await router(posts, { includeRelations: true, template: 'standard' });
+    expect(stub).not.toContain('Not implemented: listByAuthorId');
+    expect(stub).toContain('return [];');
+  });
+});

--- a/packages/generator-trpc/tsconfig.json
+++ b/packages/generator-trpc/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src", "test"],
+  "exclude": ["test/tmp"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@drzl/generator-json-schema':
         specifier: workspace:^
         version: link:../generator-json-schema
+      '@drzl/generator-trpc':
+        specifier: workspace:^
+        version: link:../generator-trpc
 
   packages/generator-arktype:
     dependencies:
@@ -210,6 +213,34 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/generator-trpc:
+    dependencies:
+      '@drzl/analyzer':
+        specifier: workspace:^
+        version: link:../analyzer
+      '@drzl/validation-core':
+        specifier: workspace:^
+        version: link:../validation-core
+    devDependencies:
+      '@trpc/server':
+        specifier: ^11.18.0
+        version: 11.18.0(typescript@5.9.3)
+      arktype:
+        specifier: ^2.1.29
+        version: 2.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(supports-color@7.2.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      valibot:
+        specifier: ^1.1.0
+        version: 1.4.2(typescript@5.9.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/generator-typebox:
     dependencies:
@@ -1338,6 +1369,12 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@trpc/server@11.18.0':
+    resolution: {integrity: sha512-JAvXOuNTxgXjIDfQaOvDq1j66LMNfDJUH1IU7Slfn8EvRv2EkH6ehu3A7zpYhjO0syHHiYg77v2lG2JFJgvw7Q==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.7.2'
 
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
@@ -4111,6 +4148,10 @@ snapshots:
   '@sinclair/typebox@0.34.52': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@trpc/server@11.18.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@tsconfig/node10@1.0.11': {}
 

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -402,6 +402,26 @@ export default {
     // that DRZL generated, so running only that one exercised no cross-module specifier and
     // missed the service import being emitted bare and extensionless.
     { kind: 'orpc', template: '@drzl/template-orpc-service', includeRelations: true },
+    // Its own `path`, because oRPC claims `outDir`. The service template and the shared-schema
+    // option are what put this tree through the specifier sweep below, which is the only stage
+    // that compiles the emitted `.js` imports the way a consumer's compiler will under bundler,
+    // node16 and nodenext.
+    //
+    // No `databaseInjection` here, and the reason is a real constraint rather than an omission.
+    // Injection is a contract between a router and a service: the router emits
+    // `Service.get(ctx.db, id)` and only a service generated in the same mode takes that
+    // parameter. There is one service generator in this config and two routers, and oRPC above
+    // does not inject, so no single service can satisfy both. Setting it here emitted ten
+    // TS2554s. The config also runs `dataAccess: 'stub'`, whose bodies take no database whatever
+    // the flag says, which the CLI warns about. Injection is covered by the generator's own
+    // tests; what this entry is here for is the specifier sweep.
+    {
+      kind: 'trpc',
+      path: './src/generated/trpc',
+      template: 'service',
+      includeRelations: true,
+      validation: { useShared: true },
+    },
   ],
 };
 CONFIG
@@ -428,7 +448,7 @@ node -e "
 # consumer who wants formatted output does, and it makes this run cover the peer resolving from
 # a real install. The stage further down removes it again to cover the other case.
 npm install --no-audit --no-fund --loglevel=error \
-  "$TARS"/*.tgz drizzle-orm zod valibot arktype @orpc/server typescript tsx prettier >/dev/null
+  "$TARS"/*.tgz drizzle-orm zod valibot arktype @orpc/server @trpc/server typescript tsx prettier >/dev/null
 
 if [ ! -e node_modules/.bin/drzl ]; then
   echo "FAIL: the drzl bin did not resolve after a real install." >&2
@@ -454,6 +474,21 @@ done
 # The relation endpoint the foreign key above should have produced.
 grep -q 'listByAuthorId' src/generated/api/posts.ts || {
   echo "FAIL: includeRelations did not emit a lookup for the authorId foreign key." >&2
+  exit 1
+}
+grep -q 'listByAuthorId' src/generated/trpc/posts.ts || {
+  echo "FAIL: the tRPC router emitted no relation lookup for the authorId foreign key." >&2
+  exit 1
+}
+
+# The addressing procedures have to take the table's real key. The sibling oRPC generator emits
+# `z.object({ id: z.number() })` for every table whatever its key is, which names a column that
+# need not exist and types a uuid as a number, and this is the check that stops the tRPC one
+# regressing to the same shape. `books` is keyed on a varchar `isbn` in the dialect fixture
+# below, so a hardcoded numeric `id` fails there rather than here; here it is enough that the
+# key columns reach the router at all.
+grep -q 'byId' src/generated/trpc/posts.ts || {
+  echo "FAIL: the tRPC router emitted no byId procedure for a table that has a primary key." >&2
   exit 1
 }
 
@@ -579,6 +614,15 @@ CONFIG
     echo "FAIL [$dialect]: no relation lookup emitted for the authorId foreign key." >&2
     exit 1
   }
+  # The tRPC addressing input, against the same natural key. A generator that hardcodes
+  # `{ id: number }` passes every typecheck in this file and fails the moment a table is keyed on
+  # anything else, so the column name has to appear in the router that addresses by it.
+  if [ -f "src/dia-$dialect/trpc/books.ts" ]; then
+    grep -q 'isbn' "src/dia-$dialect/trpc/books.ts" || {
+      echo "FAIL [$dialect]: the tRPC books router does not address by the real key 'isbn'." >&2
+      exit 1
+    }
+  fi
 
   cat > "tsconfig.$dialect.json" <<EOF
 {
@@ -616,6 +660,7 @@ export default {
     { kind: 'zod', path: './src/unformatted/zod' },
     { kind: 'service', path: './src/unformatted/services' },
     { kind: 'orpc' },
+    { kind: 'trpc', path: './src/unformatted/trpc' },
   ],
 };
 CONFIG
@@ -634,6 +679,14 @@ mv node_modules/.prettier-hidden node_modules/prettier
 grep -q "export \* from './users.zod.js';" src/unformatted/zod/index.ts || {
   echo "FAIL: the unformatted barrel is not what the generator emits. Was:" >&2
   cat src/unformatted/zod/index.ts >&2
+  exit 1
+}
+# The tRPC entry point is not a barrel: it calls `router()` and exports `type AppRouter`, which
+# is the entire contract a typed client infers its API from. So the check is on that, not on a
+# re-export line, and it is the exact unformatted bytes for the same reason as above.
+grep -q "export type AppRouter = typeof appRouter;" src/unformatted/trpc/index.ts || {
+  echo "FAIL: the unformatted tRPC entry point does not export the router type. Was:" >&2
+  cat src/unformatted/trpc/index.ts >&2
   exit 1
 }
 cat > tsconfig.unformatted.json <<'EOF'


### PR DESCRIPTION
Plan item 27. tRPC is the largest ecosystem DRZL did not serve; `@drzl/generator-orpc` was the smaller neighbour and the template.

## tRPC v11, from the registry

`npm view @trpc/server dist-tags` puts `latest` on **11.18.0**, and `next` points at 11.13.0, *behind* latest, so there is not even a v12 pre-release train. Every construct was run before being written down, not recalled.

## The addressing procedures take the table's real key

This is the deliberate divergence from the sibling generator. oRPC emits `z.object({ id: z.number() })` for **every** table whatever its key is, which names a column that need not exist, types a uuid as a number, and hands a composite key one of its halves.

```
varchar key `isbn`   ->  byId({ isbn: z.string() })
composite key        ->  all its columns
no primary key       ->  byId, update and delete are not emitted
```

`create` stays in that last case: inserting does not require addressing. A read-only relation gets `list`/`byId` only, and no insert or update schema is emitted or imported.

There is a gate assertion on the dialect fixture's `books` table, keyed on a `varchar` `isbn`, precisely because a hardcoded `{ id: number }` passes every typecheck in this repo and fails only on a table keyed on something else.

## Design decisions and why

**Writes are mutations**, not by convention: a tRPC client caches and batches queries over GET and never issues a mutation there, so a write declared as a query lands somewhere a proxy may cache it. Confirmed over the wire, GET on `users.create` answers **405**.

**Output schemas on every procedure**, because tRPC typechecks the handler return against the output parser. A committed canary plants the exact oRPC defect (a `create` that returns its input) into a compiling tree and fails if `tsc` accepts it. That is also why the stubs throw rather than returning their input.

**TypeBox is excluded, measured**: `@sinclair/typebox@0.34` puts no `~standard` key on what `Type.Object()` returns, so tRPC cannot consume it. zod, valibot and arktype each went through a real router.

**A shared base module**, unlike oRPC. `os` is a free import there so every file stands alone; tRPC's builder carries the context type, so a router built from its own `initTRPC.create()` cannot share middleware and cannot be soundly merged. So `trpc.ts` holds one `initTRPC`, and `index.ts` is **not** a barrel: it calls `router()` and exports `type AppRouter`, which is the entire contract a typed client infers its API from. `tsName` is kept verbatim as the key for the same reason (oRPC lowercases it, turning `userProfiles` into `userprofiles`; harmless in an object nobody reads, not harmless as a typed client's public API).

**No custom-template hook API.** `ORPCTemplateHooks` returns oRPC source text, so a custom template written against it would emit code that does not compile. `template` is a closed set here.

## Three CLI wiring defects, found by generating and reading output

The CLI builds a separate options object per generator branch by hand, which has produced three silent defects in this repo before. Grepping every branch found three more:

1. **`databaseInjection` was documented and unreachable.** `GeneratorSchema` had no such key and is not strict, so zod stripped it silently. It has been in the oRPC docs since it was added and never did anything from a config file.
2. **`watch` never passed `servicesDir`.** `generate` computes it and watch's oRPC branch did not, so the first save after starting `drzl watch` silently replaced a correct service import with the default.
3. **`databaseInjection` reached only one of the two generators that must agree.** A router in injection mode emits `Service.getById(ctx.db, id)`, and only a service generated in the same mode has that parameter.

Both tRPC branches call one `trpcOptions()` builder, and a test locks them together. I confirmed by running both commands over a config setting every option and diffing bytes, not by reading.

## What was actually run

A **real tRPC server from generated output**, on a real port, with real `fetch`:

```
GET  /users.list                                -> 200 []
POST /users.create {"email":"ada@example.com"}  -> 200 {"id":1,"email":"ada@example.com","bio":null}
GET  /users.byId {"id":2}                       -> 200 {...}
POST /users.update {"id":1,"data":{"bio":"…"}}  -> 200 {...}
POST /users.delete {"id":1}                     -> 200 true
POST /users.create {"email":42}                 -> 400 BAD_REQUEST
GET  /users.byId {}                             -> 400 BAD_REQUEST
GET  /users.create?input=…                      -> 405
```

Plus in-process calls through `createCallerFactory` (the SSR path), and re-importing every emitted module to prove none throws on load. Real `tsc` under `strict` + `noUnusedLocals` + `noUnusedParameters` + `nodenext` over six table shapes, three validators, with relations and with injection, plus a canary proving the harness fails when it should.

## Gate coverage added

Four stages: tarball contents, the specifier sweep under bundler/node16/nodenext, the no-formatter stage (asserting the entry point still exports `AppRouter`), and the `isbn` grep above.

Two of my own config mistakes were caught by it and are worth noting: I wrote `databaseInjection: true` where the schema takes an object, and I set injection on a config where one service generator serves two routers in different modes, which cannot compile. The second is a real constraint and is now written down beside the config.

The gate also caught **two documented configs that do not compile** — one mine, one pre-existing that the `databaseInjection` fix turned from dead into live.

## Deliberately absent

**Cross-table relation lookups** (`users.listPosts`). They need another router module's select schema, and that import is circular whenever both directions exist. In tRPC a cycle costs more than in oRPC: `typeof appRouter` is what the client infers the whole API from, and a circular graph resolves to `any` or TS7022. Emitting them only under `validation.useShared` would work, but behaviour differing by config is worse than a consistent, explained omission.

**`databaseInjection` with `dataAccess: 'stub'`** is inherently incoherent, since stub bodies take no `db` whatever they are told. The CLI warns rather than emitting calls that cannot compile.

## Tests

80 new in `generator-trpc`, 12 in the CLI. `pnpm -r test`: **1455 tests, 161 files, all green.** `verify:packed`, `build`, `typecheck`, `lint`, `docs build` all pass. Sizes unchanged; the new package is an optionalDependency of `@drzl/cli`, as `generator-json-schema` is, because a never-published package cannot publish by OIDC and a hard dep in the same release breaks `npm i @drzl/cli`.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
