### PR TITLE
feat(validation): nested insert and select schemas for related tables

### DIFF
--- a/.changeset/nested-relation-schemas.md
+++ b/.changeset/nested-relation-schemas.md
@@ -1,0 +1,74 @@
+---
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-arktype': minor
+'@drzl/generator-typebox': minor
+'@drzl/cli': minor
+---
+
+Relations-aware nested schemas: `nestedSchemas: true` emits `NestedInsert<Table>` and
+`NestedSelect<Table>` beside the flat ones, the table plus one key per relation, so
+`{ ...user, posts: [...] }` can be validated whole. All four validation generators, off by default,
+and with it off the output is byte-for-byte unchanged.
+
+**Nothing in the Drizzle ecosystem describes that payload**, which was measured rather than
+assumed. Against `drizzle-orm/{zod,valibot,arktype,typebox-legacy}` at 1.0.0-rc.4 and against the
+0.4x `drizzle-zod`/`drizzle-valibot`/`drizzle-typebox`/`drizzle-arktype` packages,
+`createInsertSchema(users)` returns `['id', 'name']` and never a `posts` key, in every mode and
+every library. Passing the `relations()` object as the second argument lands it in the refine slot,
+where its keys are not column names and it is dropped; passing it first throws inside `getColumns`.
+Grepping both majors for `Relational|withRelations|createRelationSchema|createNestedSchema` finds
+nothing. And the payload is not merely unvalidated:
+`db.insert(users).values({ name: 'a', posts: [{ title: 't' }] })` emits
+`insert into "users" ("id", "name") values (default, $1)` on both majors, so the children are
+silently never written.
+
+**The child's foreign key is omitted from a nested insert.** `posts.authorId` does not exist until
+the user is inserted, so requiring it makes the schema unusable and permitting it admits a payload
+no correct nested write can honour. It is dropped only where the relation says which column it is,
+meaning the child has exactly one foreign key back to the parent; two or more is ambiguous and
+nothing is dropped, with a comment above the arm saying why. The plain insert schema is untouched,
+and a nested select drops nothing, since the row really comes back carrying its key.
+
+**`one` is not emitted on insert.** Its foreign key is on the outer object, so admitting the arm
+would mean making that column optional, and an optional NOT NULL foreign key also admits a row with
+neither a key nor a nested parent, which the database refuses. **There is no nested update schema
+at all**: the payload has no single meaning without an operation vocabulary Drizzle does not have,
+and an update schema drops the primary key, so a child in one carries nothing that identifies which
+row it patches.
+
+**Cycles terminate by depth rather than by recursion.** `nestedDepth` defaults to 1 and is capped
+at 3, and nesting is expanded inline, so `users -> posts -> users` and a self-referencing
+`managerId` both simply stop. All four libraries can express a cyclic schema and each does it
+differently, measured by running them: zod through a property getter, valibot through `v.lazy`,
+ArkType only inside a `scope` (a plain forward reference throws `Cannot access 'Post' before
+initialization` at module load), TypeBox only inside a `Type.Module` (a bare `Type.Ref` constructs
+happily and then throws `Unable to dereference schema with $id` the first time anything checks a
+value). Two of the four therefore fail as a broken module rather than as a wrong schema, and inline
+expansion needs none of the four mechanisms and no explicit type annotation.
+
+Nested shapes are rendered from the columns rather than derived from the sibling schema, because
+deriving does not work in three of the four and fails loudly in only one of those three. Measured:
+zod's `.omit()` **throws** `.omit() cannot be used on object schemas containing refinements`, so
+every table with a row-level CHECK would emit a module that threw on import; valibot's `v.omit`
+over a `v.pipe` silently drops the checks; and TypeBox's `Type.Omit` over the `Type.Intersect` a
+row check emits rewrites the check branch into an empty object and keeps every property required.
+
+---
+
+Two CLI wiring defects of the class the shared options builder was created to remove, both found by
+generating output and reading it rather than by reading the wiring:
+
+- **`watch` never moved onto the shared builder.** Its zod, valibot and arktype branches still
+  assembled six keys by hand, so `coerceDates`, `applyDefaults`, `typedJson`, `typedColumns` and
+  `duplicateFinder` were all dropped on a rebuild: the first save after starting `drzl watch`
+  silently replaced correct output with output generated from defaults. All three now call
+  `validationOptions`, the same function `generate` uses.
+- **`watch` had no typebox or json-schema branch at all.** Those two generators were configured,
+  ran under `drzl generate`, and were then skipped by every watch rebuild, so their directories went
+  stale from the first save onward with nothing said.
+
+`packages/cli/test/nested-branch-parity.e2e.spec.ts` runs both commands over a config that sets the
+option for every generator and compares what landed on disk, because reading the two loops is what
+missed both.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -64,6 +64,7 @@ export default {
           { text: 'ArkType', link: '/generators/arktype' },
           { text: 'TypeBox', link: '/generators/typebox' },
           { text: 'JSON Schema', link: '/generators/json-schema' },
+          { text: 'Nested Relations', link: '/generators/nested-relations' },
           { text: 'Adapters (Overview)', link: '/adapters/overview' },
           { text: 'Router Adapters', link: '/adapters/router' },
         ],

--- a/docs/generators/arktype.md
+++ b/docs/generators/arktype.md
@@ -317,3 +317,10 @@ A batch that passes can still collide with rows already stored. This checks the 
 round trip.
 
 Off by default: generated code ships in your bundle.
+
+## Nested relation schemas
+
+`nestedSchemas: true` also emits `NestedInsert<Table>` and `NestedSelect<Table>`, the table plus one
+key per relation, so `{ ...user, posts: [...] }` can be validated whole. Nothing in the Drizzle
+ecosystem describes that payload, and `db.insert` drops the relation key silently rather than
+refusing it. See [Nested Relation Schemas](/generators/nested-relations).

--- a/docs/generators/nested-relations.md
+++ b/docs/generators/nested-relations.md
@@ -1,0 +1,225 @@
+# Nested Relation Schemas
+
+Validate a whole nested payload, `{ ...user, posts: [...] }`, rather than the parent and each child
+separately.
+
+```ts
+{ kind: 'zod', path: 'src/validators/zod', nestedSchemas: true }
+```
+
+Available on all four validation generators, off by default. With it off, the emitted output is
+byte-for-byte what it was before.
+
+A whole config, with every generator that takes the option:
+
+```ts
+export default {
+  schema: 'src/db/schema.ts',
+  outDir: 'src/api',
+  generators: [
+    { kind: 'zod', path: 'src/validators/zod', nestedSchemas: true },
+    { kind: 'valibot', path: 'src/validators/valibot', nestedSchemas: true },
+    { kind: 'arktype', path: 'src/validators/arktype', nestedSchemas: true },
+    { kind: 'typebox', path: 'src/validators/typebox', nestedSchemas: true, nestedDepth: 2 },
+  ],
+};
+```
+
+## Why this exists
+
+**Nothing in the Drizzle ecosystem describes this payload.** Measured against
+`drizzle-orm/{zod,valibot,arktype,typebox-legacy}` at 1.0.0-rc.4 and against
+`drizzle-zod`/`drizzle-valibot`/`drizzle-typebox`/`drizzle-arktype` on the 0.4x line,
+`createInsertSchema(users)` emits `['id', 'name']` and never a `posts` key, in every mode and every
+library. Handing the `relations()` object in as a second argument does not change it either: that
+slot is the refine slot, so the object's keys are not column names and it is dropped. Handing it in
+first throws inside `getColumns`.
+
+**And the payload is not merely unvalidated, it is silently discarded.** On both majors:
+
+```ts
+db.insert(users).values({ name: 'a', posts: [{ title: 't' }] });
+// insert into "users" ("id", "name") values (default, $1)   params: ["a"]
+```
+
+The `posts` key is dropped, no error is raised, and the children are never written. A schema that
+refuses the payload you cannot execute, and describes the one you can, is the thing that was
+missing.
+
+The read side has a real producer: `db.query.users.findMany({ with: { posts: true } })` works on
+both majors and returns exactly this shape.
+
+## What it emits
+
+For a `users` / `posts` schema with `posts.authorId` referencing `users.id`:
+
+```ts
+export const NestedInsertusersSchema = z.object({
+  name: z.string(),
+  posts: z
+    .array(
+      z.object({
+        title: z.string(),
+      })
+    )
+    .optional(),
+});
+
+export type NestedInsertusersInput = z.input<typeof NestedInsertusersSchema>;
+
+export const NestedSelectusersSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  posts: z
+    .array(
+      z.object({
+        id: z.number().int(),
+        authorId: z.number().int(),
+        title: z.string(),
+      })
+    )
+    .optional(),
+});
+
+export type NestedSelectusersOutput = z.output<typeof NestedSelectusersSchema>;
+```
+
+They sit in the table's own module beside the flat schemas, and the barrel already re-exports it.
+The relation key is the **child table's Drizzle export name**, because `Relation` carries no field
+name and nothing else names the key.
+
+The other three libraries emit the same shape in their own spelling: `v.optional(v.array(...))`,
+`Type.Optional(Type.Array(...))`, and `'posts?': type({...}).array()`.
+
+## What happens to the foreign key
+
+`posts.authorId` does not exist until the user is inserted, so **it is not in the nested insert
+shape at all**.
+
+The alternatives are both worse. Requiring it makes the schema unusable: there is no value to
+supply. Permitting it as optional makes the schema accept
+`{ name: 'ada', posts: [{ title: 't', authorId: 999 }] }`, a payload no correct nested write can
+honour, since the parent is what determines that column.
+
+The column is only dropped where the relation says which column it is, which means the child has
+**exactly one** foreign key back to the parent:
+
+- **Two or more.** A `messages` table with `senderId` and `recipientId` both pointing at `users` is
+  genuinely ambiguous, and `Relation` has no field name to tell them apart. Nothing is dropped, and
+  a comment above the arm says so. You supply them.
+- **None.** A relation declared by `relations()` with no `references`, or found by the name-matching
+  heuristic, has no key to drop. The child keeps every column it declared.
+
+The **plain** insert schema is untouched in every case, so nesting never weakens the flat one. On a
+nested **select** nothing is dropped at all: the row really comes back carrying its foreign key.
+
+## `one`, `many` and `manyToMany`
+
+| Kind         | Nested insert                             | Nested select                |
+| ------------ | ----------------------------------------- | ---------------------------- |
+| `many`       | array of the child, minus its foreign key | array of the child           |
+| `manyToMany` | array of the far side                     | array of the far side        |
+| `one`        | **not emitted**                           | the parent object, or `null` |
+
+**`one` is deliberately absent from the insert schema.** In `{ ...post, author: {...} }` the foreign
+key is on the _outer_ object, `posts.authorId`, not on the nested one: the author is written first
+and the post then points at it. Admitting the arm means making `authorId` optional on the post, and
+an optional `authorId` also admits `{ title: 't' }` with neither a key nor an author, which is a row
+a NOT NULL column refuses. That would make the schema accept a write the database rejects, which is
+worse than not describing the payload.
+
+Two forms express it properly and neither is built: a union of "you gave the key" and "you gave the
+object", which is 2^n branches on a table with n `one` relations, or a row-level "exactly one of
+these" assertion, which all four libraries can carry but each spells differently. Both are open.
+
+**A `manyToMany` arm carries the far side only.** The join row's columns are the two foreign keys,
+and the two ends of the payload supply both, so there is nothing left to describe. The comment above
+the arm names the join table, since the shape cannot.
+
+**A pair of tables linked both ways gets one arm.** The key can only come from the table name, so a
+`one` and a `many` between the same pair collide; `many` wins, because it is the arm that can hold
+every related row. A relation whose key would collide with a **column** of the same name is dropped
+entirely: the columns are the row.
+
+## There is no nested update schema
+
+A nested update payload has no single meaning. `{ name: 'x', posts: [...] }` could mean replace
+every child, upsert them, or patch the ones that match, and choosing needs an operation vocabulary
+(Prisma spells it `create` / `connect` / `set` / `deleteMany`) that neither DRZL nor Drizzle has.
+
+It could not be acted on even if the meaning were fixed: an update schema drops the primary key,
+because a key identifies a row rather than changes it, so a child inside an update payload carries
+nothing that says which row it patches.
+
+## Depth, and what stops a cycle
+
+`nestedDepth` defaults to **1** and is capped at **3**.
+
+```ts
+{ kind: 'valibot', path: 'src/validators/valibot', nestedSchemas: true, nestedDepth: 2 }
+```
+
+At 2, `{ ...user, posts: [{ ...post, comments: [...] }] }` validates whole, and each level drops its
+own foreign key.
+
+Relations are frequently circular, `users -> posts -> users`, and a self-referencing table
+(`users.managerId -> users`) is the case that occurs most. **The depth is what terminates them.**
+Nesting is expanded inline, so at the last level the relation keys are simply not emitted and the
+recursion has nowhere to go.
+
+That is a deliberate choice over a genuinely recursive schema. All four libraries can express one
+and each does it differently, measured by running them:
+
+| Library         | Cyclic schema                | Behaviour                                                                                                                           |
+| --------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| zod 4.4.3       | property getter, or `z.lazy` | works, no annotation needed at runtime                                                                                              |
+| valibot 1.4.2   | `v.lazy`                     | works; TypeScript wants an explicit `GenericSchema` annotation                                                                      |
+| ArkType 2.2.3   | only inside a `scope`        | a plain forward reference throws `Cannot access 'Post' before initialization` **at module load**                                    |
+| TypeBox 0.34.52 | only inside a `Type.Module`  | a bare `Type.Ref` constructs happily and then throws `Unable to dereference schema with $id` the first time anything checks a value |
+
+Two of the four therefore have a failure mode where the generated module is broken rather than
+merely wrong, and each would need a different mechanism. Inline expansion needs none of them, needs
+no type annotation, and makes the four outputs structurally identical.
+
+The cost is size: the emitted output grows multiplicatively in the depth. A schema whose tables
+average R relations emits R^depth child shapes per root table, and both directions of a
+many-to-many count. That is why the default is 1 and the cap is 3.
+
+## Extra keys behave differently per library
+
+The four libraries disagree about a key the schema does not declare, and this feature makes that
+visible, because a foreign key omitted from a child arm is exactly such a key.
+
+| Library | An undeclared key in a child    |
+| ------- | ------------------------------- |
+| zod     | stripped from the parsed result |
+| valibot | stripped from the parsed result |
+| TypeBox | ignored; the value still passes |
+| ArkType | kept in the returned value      |
+
+None of them refuses it, so a payload that carries an `authorId` on a child validates everywhere.
+Nothing here makes the objects strict, for the same reason the flat schemas are not strict: turning
+away input the database accepts is the failure mode this project avoids.
+
+## What it interacts with
+
+- **`applyDefaults`, `coerceDates`, `typedJson`, `typedColumns`** all apply inside nested shapes,
+  because the fields are rendered through the same code path as the flat schemas. With `typedJson`
+  or `typedColumns` the type-only schema import names every table the nesting reaches, not just the
+  file's own.
+- **CHECK constraints** apply at every level: a child carries its own column checks and its own
+  row-level checks, and a check naming an omitted foreign key drops out with the column.
+- **Read-only relations** (a materialized view) get a nested select and no nested insert, matching
+  the flat schemas.
+- **A table with no relations gets nothing.** A nested schema there would be a byte-for-byte copy of
+  the flat one under a second name. The same holds per mode: a table that is only ever a child has a
+  nested select and no nested insert.
+
+## Inspecting what was detected
+
+The arms come from `analysis.relations`, so a column that merely looks like a foreign key produces
+nothing until it has a real `.references()`. To see the graph:
+
+```bash
+npx @drzl/cli analyze src/db/schemas/index.ts --relations --json
+```

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -314,3 +314,10 @@ A batch that passes can still collide with rows already stored. This checks the 
 round trip.
 
 Off by default: generated code ships in your bundle.
+
+## Nested relation schemas
+
+`nestedSchemas: true` also emits `NestedInsert<Table>` and `NestedSelect<Table>`, the table plus one
+key per relation, so `{ ...user, posts: [...] }` can be validated whole. Nothing in the Drizzle
+ecosystem describes that payload, and `db.insert` drops the relation key silently rather than
+refusing it. See [Nested Relation Schemas](/generators/nested-relations).

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -258,3 +258,10 @@ A batch that passes can still collide with rows already stored. This checks the 
 round trip.
 
 Off by default: generated code ships in your bundle.
+
+## Nested relation schemas
+
+`nestedSchemas: true` also emits `NestedInsert<Table>` and `NestedSelect<Table>`, the table plus one
+key per relation, so `{ ...user, posts: [...] }` can be validated whole. Nothing in the Drizzle
+ecosystem describes that payload, and `db.insert` drops the relation key silently rather than
+refusing it. See [Nested Relation Schemas](/generators/nested-relations).

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -612,3 +612,10 @@ A batch that passes can still collide with rows already stored. This checks the 
 round trip.
 
 Off by default: generated code ships in your bundle.
+
+## Nested relation schemas
+
+`nestedSchemas: true` also emits `NestedInsert<Table>` and `NestedSelect<Table>`, the table plus one
+key per relation, so `{ ...user, posts: [...] }` can be validated whole. Nothing in the Drizzle
+ecosystem describes that payload, and `db.insert` drops the relation key silently rather than
+refusing it. See [Nested Relation Schemas](/generators/nested-relations).

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -415,10 +415,7 @@ program
         // cannot become the branch that forgets it.
         servicesDir: opts.servicesDir,
       });
-      console.log(
-        chalk.green(`Generated:`),
-        files.map((f: string) => chalk.cyan(f)).join(', ')
-      );
+      console.log(chalk.green(`Generated:`), files.map((f: string) => chalk.cyan(f)).join(', '));
       maybeShowSponsorMessage({ reason: 'generate:trpc' });
     } catch (e: any) {
       reportGeneratorFailure('trpc', e);
@@ -658,15 +655,14 @@ program
               );
               const gen = new ZodGenerator(analysis);
               const target = g.path ?? 'src/validators/zod';
-              const files = await gen.generate({
-                outDir: target,
-                outputHeader: g.outputHeader,
-                format: g.format,
-                schemaSuffix: g.schemaSuffix,
-                fileSuffix: g.fileSuffix,
-                importExtension: g.importExtension,
-                affix: g.affix,
-              });
+              // The same builder `generate` uses. Assembled by hand here until now, and every
+              // option added since the builder existed was therefore absent from a watch rebuild:
+              // `coerceDates`, `applyDefaults`, `typedJson`, `typedColumns` and `duplicateFinder`
+              // were all dropped, so the first save after starting `drzl watch` silently replaced
+              // correct output with output generated from defaults.
+              const files = await gen.generate(
+                validationOptions(g, cfg, target, { schemaTypes: true }) as never
+              );
               opts.json
                 ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
                 : console.log(
@@ -686,15 +682,14 @@ program
               );
               const gen = new ValibotGenerator(analysis);
               const target = g.path ?? 'src/validators/valibot';
-              const files = await gen.generate({
-                outDir: target,
-                outputHeader: g.outputHeader,
-                format: g.format,
-                schemaSuffix: g.schemaSuffix,
-                fileSuffix: g.fileSuffix,
-                importExtension: g.importExtension,
-                affix: g.affix,
-              });
+              // The same builder `generate` uses. Assembled by hand here until now, and every
+              // option added since the builder existed was therefore absent from a watch rebuild:
+              // `coerceDates`, `applyDefaults`, `typedJson`, `typedColumns` and `duplicateFinder`
+              // were all dropped, so the first save after starting `drzl watch` silently replaced
+              // correct output with output generated from defaults.
+              const files = await gen.generate(
+                validationOptions(g, cfg, target, { schemaTypes: true }) as never
+              );
               opts.json
                 ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
                 : console.log(
@@ -714,19 +709,70 @@ program
               );
               const gen = new ArkTypeGenerator(analysis);
               const target = g.path ?? 'src/validators/arktype';
-              const files = await gen.generate({
-                outDir: target,
-                outputHeader: g.outputHeader,
-                format: g.format,
-                schemaSuffix: g.schemaSuffix,
-                fileSuffix: g.fileSuffix,
-                importExtension: g.importExtension,
-                affix: g.affix,
-              });
+              // The same builder `generate` uses. Assembled by hand here until now, and every
+              // option added since the builder existed was therefore absent from a watch rebuild:
+              // `coerceDates`, `applyDefaults`, `typedJson`, `typedColumns` and `duplicateFinder`
+              // were all dropped, so the first save after starting `drzl watch` silently replaced
+              // correct output with output generated from defaults.
+              const files = await gen.generate(
+                validationOptions(g, cfg, target, { schemaTypes: false }) as never
+              );
               opts.json
                 ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
                 : console.log(
                     chalk.green(`Generated (arktype): ${files.length} files`),
+                    files.map((f: string) => chalk.cyan(f)).join(', ')
+                  );
+              newFiles.push(...files);
+            } catch (e: any) {
+              reportGeneratorFailure(g.kind, e);
+              return;
+            }
+          } else if (g.kind === 'typebox') {
+            try {
+              const { TypeBoxGenerator } = await loadGenerator(
+                '@drzl/generator-typebox',
+                () => import('@drzl/generator-typebox')
+              );
+              const gen = new TypeBoxGenerator(analysis);
+              const target = g.path ?? 'src/validators/typebox';
+              // The same builder `generate` uses. Assembled by hand here until now, and every
+              // option added since the builder existed was therefore absent from a watch rebuild:
+              // `coerceDates`, `applyDefaults`, `typedJson`, `typedColumns` and `duplicateFinder`
+              // were all dropped, so the first save after starting `drzl watch` silently replaced
+              // correct output with output generated from defaults.
+              const files = await gen.generate(
+                validationOptions(g, cfg, target, { schemaTypes: true }) as never
+              );
+              opts.json
+                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
+                : console.log(
+                    chalk.green(`Generated (typebox): ${files.length} files`),
+                    files.map((f: string) => chalk.cyan(f)).join(', ')
+                  );
+              newFiles.push(...files);
+            } catch (e: any) {
+              reportGeneratorFailure(g.kind, e);
+              return;
+            }
+          } else if (g.kind === 'json-schema') {
+            try {
+              const { JsonSchemaGenerator } = await loadGenerator(
+                '@drzl/generator-json-schema',
+                () => import('@drzl/generator-json-schema')
+              );
+              const gen = new JsonSchemaGenerator(analysis);
+              const target = g.path ?? 'src/validators/json-schema';
+              const files = await gen.generate({
+                // JSON Schema is data, so nothing here references a type from the schema module.
+                ...(validationOptions(g, cfg, target, { schemaTypes: false }) as object),
+                target: g.target,
+                components: g.components,
+              } as never);
+              opts.json
+                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
+                : console.log(
+                    chalk.green(`Generated (json-schema): ${files.length} files`),
                     files.map((f: string) => chalk.cyan(f)).join(', ')
                   );
               newFiles.push(...files);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -107,6 +107,22 @@ export const GeneratorSchema = z.object({
    * fact about the table rather than the row. This checks the half that needs no database.
    */
   duplicateFinder: z.boolean().optional(),
+  /**
+   * Emit `NestedInsert<Table>` and `NestedSelect<Table>` beside the flat schemas: the table plus
+   * one key per relation, so `{ ...user, posts: [...] }` can be validated whole.
+   *
+   * Nothing in the Drizzle validator ecosystem describes that payload, and `db.insert` drops the
+   * relation key silently rather than refusing it, so the children are never written and nothing
+   * says so.
+   */
+  nestedSchemas: z.boolean().optional(),
+  /**
+   * How many levels of children a nested schema describes. Defaults to 1, capped at 3.
+   *
+   * Nesting is expanded inline rather than by reference, so this multiplies the emitted size, and
+   * it is also what terminates a cycle: `users -> posts -> users` stops here.
+   */
+  nestedDepth: z.number().int().optional(),
   naming: NamingSchema.optional(),
   outputHeader: z
     .object({
@@ -272,10 +288,7 @@ const ROUTER_KINDS = new Set(['orpc', 'trpc']);
  * Exported because `computeGeneratorOutputDirs` has to agree with the dispatch in cli.ts about
  * this, and the watcher ignoring the wrong directory is an infinite regeneration loop.
  */
-export function trpcOutDir(
-  g: { path?: string },
-  cfg: { outDir: string }
-): string {
+export function trpcOutDir(g: { path?: string }, cfg: { outDir: string }): string {
   return g.path ?? cfg.outDir;
 }
 

--- a/packages/cli/src/validation-options.ts
+++ b/packages/cli/src/validation-options.ts
@@ -24,6 +24,8 @@ type GeneratorConfig = {
   typedJson?: unknown;
   typedColumns?: unknown;
   duplicateFinder?: unknown;
+  nestedSchemas?: unknown;
+  nestedDepth?: unknown;
 };
 
 export interface GeneratorCapabilities {
@@ -55,6 +57,8 @@ export function validationOptions(
     coerceDates: g.coerceDates,
     applyDefaults: g.applyDefaults,
     duplicateFinder: g.duplicateFinder,
+    nestedSchemas: g.nestedSchemas,
+    nestedDepth: g.nestedDepth,
     // Only where the generator can act on them, so an unsupported option is absent rather than
     // present and ignored.
     ...(caps.schemaTypes

--- a/packages/cli/test/nested-branch-parity.e2e.spec.ts
+++ b/packages/cli/test/nested-branch-parity.e2e.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * `nestedSchemas` reaches every validation branch of both dispatch loops, confirmed on the output.
+ *
+ * The CLI loops over `cfg.generators` twice, once for `generate` and once for `watch`, and every
+ * branch used to assemble its own options object by hand. Three documented options were found dead
+ * that way before the shared builder existed, and the `watch` copies of the zod, valibot and
+ * arktype branches had never been moved onto it: they still passed six keys, so `coerceDates`,
+ * `applyDefaults`, `typedJson`, `typedColumns` and `duplicateFinder` were all silently dropped on
+ * a rebuild. `watch` had no typebox or json-schema branch at all, so those two directories simply
+ * went stale from the first save onward.
+ *
+ * Reading the wiring is what missed all of that. This runs both commands over a config that turns
+ * the option on for every generator that takes it, and looks at what landed on disk.
+ *
+ * Requires a build. CI builds before testing; locally, run `pnpm build` first.
+ */
+import { execFile, spawn } from 'node:child_process';
+import { existsSync, promises as fs } from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const run = promisify(execFile);
+const CLI = path.resolve(import.meta.dirname, '..', 'dist', 'cli.js');
+// Named `.tmp-*` so `packages/*/test/.tmp-*` in .gitignore catches it. `afterAll` removes it, and
+// an interrupted run does not, which is exactly how 22 generated modules once reached a merge.
+const ROOT = path.join(import.meta.dirname, '.tmp-nested-parity');
+
+const SCHEMA = `
+import { pgTable, integer, serial, text } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+export const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  authorId: integer('author_id').notNull().references(() => users.id),
+  title: text('title').notNull(),
+});
+`;
+
+/** Every generator that takes the option, each writing somewhere of its own. */
+const LIBS = ['zod', 'valibot', 'arktype', 'typebox'] as const;
+
+const CONFIG = `export default {
+  schema: './src/db/schema.ts',
+  outDir: './unused',
+  analyzer: { includeRelations: true, validateConstraints: true },
+  generators: [
+${LIBS.map((l) => `    { kind: '${l}', path: './out/${l}', nestedSchemas: true },`).join('\n')}
+  ],
+};
+`;
+
+const outFor = (dir: string, lib: string) => path.join(dir, 'out', lib);
+
+async function tree(dir: string): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const name of (await fs.readdir(dir)).sort()) {
+    out[name] = await fs.readFile(path.join(dir, name), 'utf8');
+  }
+  return out;
+}
+
+const dir = path.join(ROOT, 'parity');
+let fromGenerate: Record<string, Record<string, string>>;
+let fromWatch: Record<string, Record<string, string>>;
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.rm(ROOT, { recursive: true, force: true });
+  await fs.mkdir(path.join(dir, 'src', 'db'), { recursive: true });
+  await fs.writeFile(path.join(dir, 'src', 'db', 'schema.ts'), SCHEMA, 'utf8');
+  await fs.writeFile(path.join(dir, 'drzl.config.ts'), CONFIG, 'utf8');
+
+  await run(process.execPath, [CLI, 'generate'], { cwd: dir, maxBuffer: 20 * 1024 * 1024 });
+  fromGenerate = Object.fromEntries(
+    await Promise.all(LIBS.map(async (l) => [l, await tree(outFor(dir, l))] as const))
+  );
+
+  await fs.rm(path.join(dir, 'out'), { recursive: true, force: true });
+
+  // `watch` builds once on start, which is the run being compared. `--poll` for the same reason
+  // the other watch tests use it: inotify does not reach chokidar reliably on WSL or in Docker.
+  const child = spawn(process.execPath, [CLI, 'watch', '--poll'], { cwd: dir, stdio: 'ignore' });
+  try {
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline) {
+      if (LIBS.every((l) => existsSync(path.join(outFor(dir, l), 'index.ts')))) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    await new Promise((r) => setTimeout(r, 800));
+    fromWatch = Object.fromEntries(
+      await Promise.all(
+        LIBS.map(async (l) => {
+          const d = outFor(dir, l);
+          return [l, existsSync(d) ? await tree(d) : {}] as const;
+        })
+      )
+    );
+  } finally {
+    child.kill('SIGTERM');
+  }
+}, 240_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe('generate', () => {
+  it.each(LIBS)('emits the nested schemas for %s', (lib) => {
+    const users = fromGenerate[lib]['users.' + lib + '.ts'];
+    expect(users, `${lib} nested insert`).toContain('NestedInsertusersSchema');
+    expect(users, `${lib} nested select`).toContain('NestedSelectusersSchema');
+    // The child's foreign key is what the parent supplies, so it is not in the nested shape. The
+    // plain insert schema still has it, which is what makes this a real check rather than a
+    // coincidence of a schema that never mentioned it.
+    const from = users.indexOf('export const NestedInsertusersSchema');
+    const to = users.indexOf('export type NestedInsertusersInput');
+    expect(from, `${lib} nested insert block`).toBeGreaterThan(-1);
+    const insertBlock = users.slice(from, to);
+    expect(insertBlock, `${lib} omits the child's foreign key`).not.toContain('authorId');
+    // It is still there on the select side, where the row really comes back carrying it.
+    const selectFrom = users.indexOf('export const NestedSelectusersSchema');
+    expect(users.slice(selectFrom), `${lib} keeps it on a read`).toContain('authorId');
+    expect(fromGenerate[lib]['posts.' + lib + '.ts']).toContain('authorId');
+  });
+
+  it('emits no nested update schema anywhere', () => {
+    for (const lib of LIBS) {
+      for (const [name, code] of Object.entries(fromGenerate[lib])) {
+        expect(code, `${lib}/${name}`).not.toContain('NestedUpdate');
+      }
+    }
+  });
+});
+
+describe('watch', () => {
+  it.each(LIBS)('runs the %s branch at all', (lib) => {
+    // typebox had no watch branch before this change, so its directory was never written and a
+    // rebuild left whatever was there from the last `generate`.
+    expect(Object.keys(fromWatch[lib]), `${lib} produced no files under watch`).not.toEqual([]);
+  });
+
+  it.each(LIBS)('hands the %s branch the same options generate does', (lib) => {
+    expect(fromWatch[lib]).toEqual(fromGenerate[lib]);
+  });
+});

--- a/packages/cli/test/validation-options.spec.ts
+++ b/packages/cli/test/validation-options.spec.ts
@@ -25,6 +25,9 @@ const generator = {
   applyDefaults: true,
   typedJson: true,
   typedColumns: true,
+  duplicateFinder: true,
+  nestedSchemas: true,
+  nestedDepth: 2,
 };
 const config = { schema: 'src/db/schema.ts' };
 
@@ -46,6 +49,9 @@ describe('the shared options', () => {
       schemaPath: 'src/db/schema.ts',
       typedJson: true,
       typedColumns: true,
+      duplicateFinder: true,
+      nestedSchemas: true,
+      nestedDepth: 2,
     });
   });
 
@@ -57,7 +63,15 @@ describe('the shared options', () => {
     expect(o).not.toHaveProperty('typedJson');
     expect(o).not.toHaveProperty('typedColumns');
     // Everything else still arrives.
-    expect(o).toMatchObject({ coerceDates: 'none', applyDefaults: true, affix: generator.affix });
+    expect(o).toMatchObject({
+      coerceDates: 'none',
+      applyDefaults: true,
+      affix: generator.affix,
+      // Nesting is emitted from the analysis rather than from a type reference, so ArkType takes
+      // it like the other three.
+      nestedSchemas: true,
+      nestedDepth: 2,
+    });
   });
 
   it('defaults the output directory when the generator names none', () => {

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -9,7 +9,14 @@ import type {
   ValidationRenderer,
   ValidationGenerateOptions,
 } from '@drzl/validation-core';
+import type { NestedMode, NestedNode } from '@drzl/validation-core';
 import {
+  buildNestedPlan,
+  nestedArmNotes,
+  nestedNodeColumns,
+  nestedSchemaName,
+  nestedTypeName,
+  resolveNestedDepth,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
   insertColumns,
@@ -297,7 +304,10 @@ function atTypeForColumn(
  * one statement about the type rather than an opaque predicate beside it. `<>` has no such form
  * and is left unstated rather than approximated.
  */
-function atCardinality(c: Column, cardinalities: CardinalityCheck[]): { lower?: Bound; upper?: Bound; equals?: string } {
+function atCardinality(
+  c: Column,
+  cardinalities: CardinalityCheck[]
+): { lower?: Bound; upper?: Bound; equals?: string } {
   let lower: Bound | undefined;
   let upper: Bound | undefined;
   let equals: string | undefined;
@@ -632,16 +642,20 @@ function atRowNarrows(rows: RowCheck[], cols: Column[]): string {
     '=': '===',
     '<>': '!==',
   };
-  return rows
-    // A check naming a column this mode does not carry cannot be evaluated.
-    .filter((r) => present.has(r.left) && present.has(r.right))
-    .map((r) => {
-      const l = `o[${JSON.stringify(r.left)}]`;
-      const rt = `o[${JSON.stringify(r.right)}]`;
-      const msg = JSON.stringify(`${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`);
-      return `.narrow((o, ctx) => ${l} == null || ${rt} == null || ${l} ${OPS[r.operator]} ${rt} || ctx.mustBe(${msg}))`;
-    })
-    .join('');
+  return (
+    rows
+      // A check naming a column this mode does not carry cannot be evaluated.
+      .filter((r) => present.has(r.left) && present.has(r.right))
+      .map((r) => {
+        const l = `o[${JSON.stringify(r.left)}]`;
+        const rt = `o[${JSON.stringify(r.right)}]`;
+        const msg = JSON.stringify(
+          `${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`
+        );
+        return `.narrow((o, ctx) => ${l} == null || ${rt} == null || ${l} ${OPS[r.operator]} ${rt} || ctx.mustBe(${msg}))`;
+      })
+      .join('')
+  );
 }
 
 /**
@@ -914,7 +928,9 @@ function atCapNarrows(c: Column, mode: Mode): string {
   if (c.tsType !== 'string' || c.shape) return '';
   const out: string[] = [];
   if (c.maxLength) {
-    out.push(atNarrow(c, (v) => `[...${v}].length <= ${c.maxLength}`, `at most ${c.maxLength} characters`));
+    out.push(
+      atNarrow(c, (v) => `[...${v}].length <= ${c.maxLength}`, `at most ${c.maxLength} characters`)
+    );
   }
   if (c.maxBytes) {
     out.push(
@@ -950,12 +966,123 @@ function atLengthNarrows(lengths: LengthCheck[], cols: Column[]): string {
     .join('');
 }
 
+/** Every CHECK on a table that the shared parser understands, split by what it constrains. */
+function parsedChecksFor(table: Table) {
+  const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  return {
+    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
+    lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
+    cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),
+  };
+}
+
+/** Push a rendered block one level deeper, so the nested object reads as one. */
+function indentBlock(code: string, by = '  '): string {
+  return code
+    .split('\n')
+    .map((line) => (line ? by + line : line))
+    .join('\n');
+}
+
+/**
+ * One object of a nested payload, with its relations expanded inline.
+ *
+ * A Type instance as a property value, rather than a string reference into a `scope`. ArkType is
+ * the one library here that *cannot* express a forward reference outside a scope at all: a plain
+ * `type({ posts: () => Post.array() })` throws `Cannot access 'Post' before initialization` at
+ * module load, which is a generated file that cannot be imported. Expanding inline sidesteps the
+ * question entirely, and every form used here was run: a nested Type, `.array()` over one,
+ * `.or("null")` over one, and `.array()` over a Type that already carries a `.narrow`.
+ */
+function renderNestedObject(
+  node: NestedNode,
+  mode: NestedMode,
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
+  applyDefaults: boolean
+): string {
+  const all = mode === 'insert' ? insertColumns(node.table) : selectColumns(node.table);
+  const cols = nestedNodeColumns(all, node);
+  const { checks, sets, rows, lengths, cardinalities } = parsedChecksFor(node.table);
+  const fields = renderObjectShape(
+    cols,
+    mode,
+    coerceDates,
+    checks,
+    sets,
+    applyDefaults,
+    cardinalities
+  );
+
+  const arms = node.arms.map((arm) => {
+    const notes = nestedArmNotes(arm)
+      .map((n) => `  // ${n}\n`)
+      .join('');
+    const child = renderNestedObject(arm.child, mode, coerceDates, applyDefaults);
+    // A to-one may come back null: a relational query returns null where there is no matching
+    // row, and accepting it never turns away something the query produced. The `?` on the key is
+    // ArkType's optional, because which relations a payload carries is the caller's choice on a
+    // write and the `with` clause's on a read.
+    const value = arm.single
+      ? `${indentBlock(child).trimStart()}.or("null")`
+      : `${indentBlock(child).trimStart()}.array()`;
+    return `${notes}  ${JSON.stringify(`${arm.key}?`)}: ${value},`;
+  });
+
+  const body = [fields, ...arms].filter(Boolean).join('\n');
+  return `type({\n${body}\n})${atRowNarrows(rows, cols)}${atLengthNarrows(lengths, cols)}`;
+}
+
+/** The nested exports for one table, or nothing when it has no relations to describe. */
+function renderNestedSchemas(
+  table: Table,
+  affix: ResolvedAffix,
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
+  applyDefaults: boolean,
+  plans: Partial<Record<NestedMode, NestedNode>>
+): string {
+  const out: string[] = [];
+  for (const mode of ['insert', 'select'] as const) {
+    const plan = plans[mode];
+    if (!plan) continue;
+    const name = nestedSchemaName(mode, table.tsName, affix);
+    const tname = nestedTypeName(mode, table.tsName, affix);
+    const expr = renderNestedObject(plan, mode, coerceDates, applyDefaults);
+    out.push(`export const ${name} = ${expr};\n\nexport type ${tname} = typeof ${name}["infer"];`);
+  }
+  return out.length ? `\n${out.join('\n\n')}\n` : '';
+}
+
+/**
+ * The nested plans for one table, built once per mode.
+ *
+ * Returned as a partial map because the two modes disagree per table: a table that is only ever a
+ * child has a nested select and no nested insert, and emitting an insert one anyway would put a
+ * byte-for-byte copy of the plain insert schema in the file under a second name.
+ */
+function nestedPlansFor(
+  table: Table,
+  analysis: Analysis,
+  depth: number
+): Partial<Record<NestedMode, NestedNode>> {
+  const out: Partial<Record<NestedMode, NestedNode>> = {};
+  for (const mode of ['insert', 'select'] as const) {
+    // A read-only relation refuses every write, so it has no insert schema to nest into.
+    if (mode === 'insert' && table.readOnly) continue;
+    const plan = buildNestedPlan(table, analysis.tables, analysis.relations ?? [], mode, depth);
+    if (plan) out[mode] = plan;
+  }
+  return out;
+}
+
 function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   applyDefaults = false,
-  wantsDuplicateFinder = false
+  wantsDuplicateFinder = false,
+  nested: Partial<Record<NestedMode, NestedNode>> = {}
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -1000,14 +1127,16 @@ function renderTableSchemas(
     applyDefaults,
     cardinalities
   );
-    // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
+  // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
   // half that needs no database: whether a batch collides with itself.
   const finder = wantsDuplicateFinder
     ? renderDuplicateFinder(table, `findDuplicate${T}`, insertType)
     : undefined;
   const duplicates = finder ? `\n${finder}\n` : '';
 
-return `import { type } from 'arktype';
+  const nestedCode = renderNestedSchemas(table, affix, coerceDates, applyDefaults, nested);
+
+  return `import { type } from 'arktype';
 
 export const ${insertSchema} = type({
 ${bodyInsert}
@@ -1024,7 +1153,7 @@ ${bodySelect}
 export type ${insertType} = typeof ${insertSchema}["infer"];
 export type ${updateType} = typeof ${updateSchema}["infer"];
 export type ${selectType} = typeof ${selectSchema}["infer"];
-${duplicates}`;
+${nestedCode}${duplicates}`;
 }
 
 export interface ArkTypeGenerateOptions extends ValidationGenerateOptions {
@@ -1055,10 +1184,19 @@ export class ArkTypeGenerator implements ValidationRenderer<ArkTypeGenerateOptio
     const fileSuffix = opts.fileSuffix ?? DEFAULT_FILE_SUFFIX;
     // File names deliberately stay on the raw Drizzle export name: affixes and tableCase
     // rename identifiers, never modules, so the barrel and importPath keep resolving.
+    const nestedDepth = opts.nestedSchemas
+      ? resolveNestedDepth(opts.nestedDepth, (m) => console.warn(m))
+      : 0;
     for (const table of this.analysis.tables) {
       const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
-      const code = renderTableSchemas(table, affix, coerceDates, !!opts.applyDefaults,
-      !!opts?.duplicateFinder);
+      const code = renderTableSchemas(
+        table,
+        affix,
+        coerceDates,
+        !!opts.applyDefaults,
+        !!opts?.duplicateFinder,
+        opts.nestedSchemas ? nestedPlansFor(table, this.analysis, nestedDepth) : {}
+      );
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
         filePath,

--- a/packages/generator-arktype/test/nested-relations.spec.ts
+++ b/packages/generator-arktype/test/nested-relations.spec.ts
@@ -1,0 +1,340 @@
+/**
+ * Nested relation schemas, checked by running them.
+ *
+ * A caller inserting a parent and its children in one payload has nothing to validate it against:
+ * every first-party Drizzle validator emits column keys only, and `db.insert` drops the relation
+ * key silently rather than refusing it, so the children are never written and nothing says so.
+ *
+ * Every assertion here imports the emitted module and runs real payloads through it. ArkType is
+ * also the library that cannot express a forward reference outside a `scope`, so a generated file
+ * that got this wrong would throw on import rather than merely validate wrongly, and importing it
+ * is what this file does first.
+ *
+ * Unlike zod and valibot, ArkType keeps a key it does not declare rather than stripping it, so the
+ * assertions about what a payload comes back as differ here on purpose.
+ */
+import { execFile } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { promisify } from 'node:util';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { type as arkType } from 'arktype';
+import type { Analysis, Column, Relation, Table } from '@drzl/analyzer';
+import { ArkTypeGenerator } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (name: string, cols: Column[], over: Partial<Table> = {}): Table =>
+  ({ name, tsName: name, columns: cols, unique: [], indexes: [], checks: [], ...over }) as Table;
+
+const users = table('users', [
+  col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+  col('name'),
+]);
+const posts = table(
+  'posts',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('authorId', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+    col('title'),
+  ],
+  { foreignKeys: [{ columns: ['authorId'], foreignTable: 'users', foreignColumns: ['id'] }] }
+);
+const comments = table(
+  'comments',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('postId', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+    col('body'),
+  ],
+  { foreignKeys: [{ columns: ['postId'], foreignTable: 'posts', foreignColumns: ['id'] }] }
+);
+/** The cycle that really happens: a table pointing at itself. */
+const staff = table(
+  'staff',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('managerId', { tsType: 'number', dbType: 'INTEGER', integer: true, nullable: true }),
+    col('label'),
+  ],
+  { foreignKeys: [{ columns: ['managerId'], foreignTable: 'staff', foreignColumns: ['id'] }] }
+);
+
+const RELATIONS: Relation[] = [
+  { kind: 'one', from: 'posts', to: 'users' },
+  { kind: 'many', from: 'users', to: 'posts' },
+  { kind: 'one', from: 'comments', to: 'posts' },
+  { kind: 'many', from: 'posts', to: 'comments' },
+  { kind: 'one', from: 'staff', to: 'staff' },
+  { kind: 'many', from: 'staff', to: 'staff' },
+];
+
+const analysis = (): Analysis => ({
+  dialect: 'postgres',
+  tables: [users, posts, comments, staff],
+  enums: [],
+  relations: RELATIONS,
+  issues: [],
+});
+
+let seq = 0;
+
+/** Emit the whole fixture and import one table's module. */
+async function emit(
+  opts: Record<string, unknown>,
+  which = 'users'
+): Promise<{ mod: Record<string, any>; text: string; dir: string }> {
+  const dir = path.join(__dirname, '.tmp-nested', `run-${process.pid}-${seq++}`);
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis()).generate({ outDir: dir, ...opts } as never);
+  const file = path.join(dir, `${which}.arktype.ts`);
+  return { mod: await import(file), text: await fs.readFile(file, 'utf8'), dir };
+}
+
+const ok = (schema: any, value: unknown) => !(schema(value) instanceof arkType.errors);
+
+/** The declared keys of a Type, read off its JSON form since ArkType exposes no `.shape`. */
+const keysOf = (schema: any): string[] => {
+  const j = schema.json ?? {};
+  return [
+    ...(j.required ?? []).map((r: any) => r.key),
+    ...(j.optional ?? []).map((o: any) => o.key),
+  ].sort();
+};
+
+/** The declared keys of the object sitting under one relation arm. */
+const armKeys = (schema: any, key: string): { required: string[]; optional: string[] } => {
+  const j = schema.json ?? {};
+  const entry = [...(j.required ?? []), ...(j.optional ?? [])].find((e: any) => e.key === key);
+  if (!entry) throw new Error(`no arm ${key} in ${JSON.stringify(j)}`);
+  // An array arm carries the element under `sequence`; a to-one arm is the object itself, possibly
+  // beside a null branch.
+  const value = entry.value;
+  const obj =
+    value.sequence ??
+    (Array.isArray(value) ? value.find((b: any) => b.required || b.optional) : value);
+  return {
+    required: (obj.required ?? []).map((r: any) => r.key),
+    optional: (obj.optional ?? []).map((o: any) => o.key),
+  };
+};
+const out = (schema: any, value: unknown) => {
+  const r = schema(value);
+  if (r instanceof arkType.errors) throw new Error(String(r));
+  return r;
+};
+
+describe('off by default', () => {
+  it('emits nothing nested and no extra bytes', async () => {
+    const plain = await emit({});
+    expect(Object.keys(plain.mod).some((k) => k.startsWith('Nested'))).toBe(false);
+    expect(plain.text).not.toContain('Nested');
+    // Byte-for-byte identical to a run that named the option and turned it off, which is the
+    // claim the output-size budget in verify-packed.sh relies on.
+    const explicitOff = await emit({ nestedSchemas: false });
+    expect(explicitOff.text).toBe(plain.text);
+  });
+});
+
+describe('the nested insert payload', () => {
+  it('accepts a parent and its children in one object', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    expect(S, 'the nested insert schema is exported').toBeTruthy();
+    expect(ok(S, { name: 'ada', posts: [{ title: 'first' }] })).toBe(true);
+    // The children are kept rather than stripped, which is the failure mode a plain object has.
+    expect(out(S, { name: 'ada', posts: [{ title: 'first' }] })).toEqual({
+      name: 'ada',
+      posts: [{ title: 'first' }],
+    });
+  });
+
+  it('rejects an invalid child', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    expect(ok(S, { name: 'ada', posts: [{ title: 5 }] }), 'a child with the wrong type').toBe(
+      false
+    );
+    expect(ok(S, { name: 'ada', posts: [{}] }), 'a child missing a required column').toBe(false);
+    expect(ok(S, { name: 'ada', posts: {} }), 'an object where an array belongs').toBe(false);
+  });
+
+  it('does not ask for the foreign key the parent supplies', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    // `authorId` cannot be known before the user is written. A schema demanding it is unusable.
+    expect(ok(S, { name: 'ada', posts: [{ title: 'x' }] })).toBe(true);
+    // ArkType keeps an undeclared key rather than stripping it, so the omission is read off the
+    // schema's own JSON form instead of off what a parse returns.
+    expect(armKeys(S, 'posts')).toEqual({ required: ['title'], optional: [] });
+    // And the plain insert schema still requires it, so the nesting weakened nothing.
+    expect(ok(mod.InsertusersSchema, {})).toBe(false);
+  });
+
+  it('leaves the relation key optional, so a childless parent still validates', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    expect(ok(mod.NestedInsertusersSchema, { name: 'ada' })).toBe(true);
+  });
+
+  it('carries no `one` relation', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedInsertpostsSchema;
+    expect(keysOf(S)).toEqual(['authorId', 'comments', 'title']);
+    expect(keysOf(S), 'a `one` arm would weaken authorId on the post itself').not.toContain(
+      'users'
+    );
+  });
+
+  it('emits no nested update schema in any form', async () => {
+    const { mod, text } = await emit({ nestedSchemas: true });
+    expect(Object.keys(mod).filter((k) => k.startsWith('NestedUpdate'))).toEqual([]);
+    expect(text).not.toContain('NestedUpdate');
+  });
+});
+
+describe('the nested select payload', () => {
+  it('carries every relation kind, each one optional', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedSelectpostsSchema;
+    expect(keysOf(S)).toEqual(['authorId', 'comments', 'id', 'title', 'users']);
+    const row = { id: 1, authorId: 2, title: 't' };
+    expect(ok(S, row), 'a row from a query that asked for no relations').toBe(true);
+    expect(ok(S, { ...row, users: { id: 2, name: 'ada' } }), 'with: { author: true }').toBe(true);
+    expect(ok(S, { ...row, comments: [{ id: 9, postId: 1, body: 'hi' }] })).toBe(true);
+  });
+
+  it('accepts null for a to-one, which a relational query really returns', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    expect(ok(mod.NestedSelectpostsSchema, { id: 1, authorId: 2, title: 't', users: null })).toBe(
+      true
+    );
+  });
+
+  it('still rejects a row whose related object is wrong', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedSelectpostsSchema;
+    expect(ok(S, { id: 1, authorId: 2, title: 't', users: { id: 'two', name: 'ada' } })).toBe(
+      false
+    );
+    expect(ok(S, { id: 1, authorId: 2, title: 't', comments: [{ id: 9 }] })).toBe(false);
+  });
+
+  it('keeps every column of the related row, since a read returns them all', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const child = armKeys(mod.NestedSelectusersSchema, 'posts');
+    expect([...child.required, ...child.optional].sort()).toEqual(['authorId', 'id', 'title']);
+  });
+});
+
+describe('depth', () => {
+  it('stops one level down by default', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const child = armKeys(mod.NestedInsertusersSchema, 'posts');
+    expect([...child.required, ...child.optional], 'depth 1 goes no further').not.toContain(
+      'comments'
+    );
+  });
+
+  it('goes deeper when asked, and validates the grandchild', async () => {
+    const { mod } = await emit({ nestedSchemas: true, nestedDepth: 2 });
+    const S = mod.NestedInsertusersSchema;
+    const payload = {
+      name: 'ada',
+      posts: [{ title: 'first', comments: [{ body: 'hi' }] }],
+    };
+    expect(ok(S, payload)).toBe(true);
+    expect(out(S, payload)).toEqual(payload);
+    expect(ok(S, { name: 'ada', posts: [{ title: 'x', comments: [{ body: 5 }] }] })).toBe(false);
+    // The grandchild's own foreign key is omitted too.
+    expect(
+      ok(S, { name: 'ada', posts: [{ title: 'x', comments: [{ body: 'hi', postId: 1 }] }] })
+    ).toBe(true);
+  });
+});
+
+describe('a cycle', () => {
+  it('loads, validates, and stops at the depth rather than recursing', async () => {
+    const { mod } = await emit({ nestedSchemas: true, nestedDepth: 2 }, 'staff');
+    const S = mod.NestedInsertstaffSchema;
+    expect(ok(S, { label: 'root', staff: [{ label: 'a', staff: [{ label: 'b' }] }] })).toBe(true);
+    // Past the depth the key is not declared. ArkType keeps it rather than refusing it, and
+    // neither the schema nor the checker recurses forever over it.
+    expect(
+      ok(S, {
+        label: 'root',
+        staff: [{ label: 'a', staff: [{ label: 'b', staff: [{ label: 'c' }] }] }],
+      })
+    ).toBe(true);
+    // The self-referencing foreign key is what the parent supplies, so it is gone at every level.
+    const child = armKeys(S, 'staff');
+    expect([...child.required, ...child.optional]).not.toContain('managerId');
+  });
+});
+
+describe('the emitted module', () => {
+  it('imports nothing new and exports the types beside the schemas', async () => {
+    const { text } = await emit({ nestedSchemas: true });
+    // Nesting is expanded inline, so no module reaches for a sibling and no import cycle exists.
+    // Two modules that referenced each other would be a real hazard here: the initialiser runs at
+    // load, so the second one to evaluate reads an uninitialised binding and throws on import.
+    expect(text.match(/^import .*$/gm)).toEqual(["import { type } from 'arktype';"]);
+    expect(text).toContain('export type NestedInsertusersInput');
+    expect(text).toContain('export type NestedSelectusersOutput');
+  });
+
+  it('emits only the modes a table actually has relations for', async () => {
+    // `comments` is a child and nothing else: it has a `one` to posts and no `many` at all, so a
+    // nested insert would be a byte-for-byte copy of the insert schema beside it.
+    const { mod } = await emit({ nestedSchemas: true }, 'comments');
+    expect(mod.NestedInsertcommentsSchema).toBeUndefined();
+    expect(mod.NestedSelectcommentsSchema).toBeTruthy();
+    expect(ok(mod.NestedSelectcommentsSchema, { id: 1, postId: 2, body: 'hi' })).toBe(true);
+  });
+});
+
+describe('the emitted nested code compiles', () => {
+  /**
+   * Run `tsc` over the emitted directory.
+   *
+   * Not covered by `pnpm typecheck`, and that was measured rather than assumed: the generator
+   * tsconfigs include `test`, and TypeScript's wildcard include skips any directory whose name
+   * starts with a dot, which every `.tmp-*` output directory here does. A deliberate type error
+   * written into an emitted file left `tsc -p tsconfig.json` at zero errors. So this points the
+   * compiler at the directory itself, under the `nodenext` resolution the emitted `.js`
+   * specifiers exist for.
+   */
+  it('under strict nodenext', async () => {
+    const { dir } = await emit({ nestedSchemas: true, nestedDepth: 2 });
+    const cfg = path.join(dir, 'tsconfig.json');
+    await fs.writeFile(
+      cfg,
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+          target: 'ES2021',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+        },
+        include: ['.'],
+      }),
+      'utf8'
+    );
+    const tsc = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+    const { stdout } = await promisify(execFile)(process.execPath, [tsc, '-p', cfg], {
+      maxBuffer: 20 * 1024 * 1024,
+    }).catch((e: any) => ({ stdout: e.stdout || String(e) }));
+    expect(stdout.trim()).toBe('');
+  }, 60_000);
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -9,8 +9,15 @@ import type {
   ValidationRenderer,
   ValidationGenerateOptions,
 } from '@drzl/validation-core';
+import type { NestedMode, NestedNode } from '@drzl/validation-core';
 import {
+  buildNestedPlan,
   formatCode,
+  nestedArmNotes,
+  nestedNodeColumns,
+  nestedSchemaName,
+  nestedTypeName,
+  resolveNestedDepth,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
   insertColumns,
@@ -285,7 +292,10 @@ function tbShapeExpr(c: Column, mode: Mode, typedJsonRef?: string): string | und
  * of either, but a length is an integer, so `> 2` is exactly `minItems: 3` and nothing is
  * approximated by the rewrite. `<>` has no keyword at all and is left unstated.
  */
-function tbCardinalityOptions(c: Column, cardinalities: CardinalityCheck[]): Array<[string, string]> {
+function tbCardinalityOptions(
+  c: Column,
+  cardinalities: CardinalityCheck[]
+): Array<[string, string]> {
   if (!c.arrayDimensions) return [];
   const out = new Map<string, string>();
   const step = (v: string, by: number) => String(BigInt(v) + BigInt(by));
@@ -497,13 +507,148 @@ function renderObjectShape(
     .join('\n');
 }
 
+/** Every CHECK on a table that the shared parser understands, split by what it constrains. */
+function parsedChecksFor(table: Table) {
+  const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  return {
+    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
+    lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
+    cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),
+  };
+}
+
+/** Push a rendered block one level deeper, so the nested object reads as one. */
+function indentBlock(code: string, by = '  '): string {
+  return code
+    .split('\n')
+    .map((line) => (line ? by + line : line))
+    .join('\n');
+}
+
+/** The columns one node of a plan contributes, in the mode it is rendered for. */
+function nestedNodeCols(node: NestedNode, mode: NestedMode): Column[] {
+  const all = mode === 'insert' ? insertColumns(node.table) : selectColumns(node.table);
+  return nestedNodeColumns(all, node);
+}
+
+/** Every node of a plan, so the preamble decisions can see the whole of what will be emitted. */
+function nestedNodes(node: NestedNode, into: NestedNode[] = []): NestedNode[] {
+  into.push(node);
+  for (const arm of node.arms) nestedNodes(arm.child, into);
+  return into;
+}
+
+/**
+ * One object of a nested payload, with its relations expanded inline.
+ *
+ * Rendered from the columns rather than derived from the sibling schema with `Type.Omit`. Measured
+ * on TypeBox 0.34.52: `Type.Omit` over the `Type.Intersect` that a table with a row-level CHECK
+ * emits rewrites the `DrzlRowCheck` branch into an empty `Type.Object({})` and keeps every
+ * property of the first branch required, so the derived schema both lost its row check and
+ * refused rows the original accepted.
+ */
+function renderNestedObject(
+  node: NestedNode,
+  mode: NestedMode,
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
+  typedJson: { allColumns?: boolean } | undefined,
+  applyDefaults: boolean
+): string {
+  const cols = nestedNodeCols(node, mode);
+  const { checks, sets, rows, lengths, cardinalities } = parsedChecksFor(node.table);
+  const tj = typedJson
+    ? { table: node.table.tsName, mode, allColumns: typedJson.allColumns }
+    : undefined;
+  const fields = renderObjectShape(
+    cols,
+    mode,
+    coerceDates,
+    checks,
+    tj,
+    sets,
+    applyDefaults,
+    cardinalities
+  );
+
+  const arms = node.arms.map((arm) => {
+    const notes = nestedArmNotes(arm)
+      .map((n) => `  // ${n}\n`)
+      .join('');
+    const child = renderNestedObject(arm.child, mode, coerceDates, typedJson, applyDefaults);
+    // A to-one may come back null: a relational query returns null where there is no matching
+    // row, and accepting it never turns away something the query produced. Optional throughout,
+    // because which relations a payload carries is the caller's choice on a write and the `with`
+    // clause's on a read.
+    const inner = arm.single
+      ? `Type.Union([\n${indentBlock(indentBlock(child))},\n    Type.Null(),\n  ])`
+      : `Type.Array(\n${indentBlock(indentBlock(child))}\n  )`;
+    return `${notes}  ${JSON.stringify(arm.key)}: Type.Optional(${inner}),`;
+  });
+
+  const body = [fields, ...arms].filter(Boolean).join('\n');
+  return tbWrapRows(`Type.Object({\n${body}\n})`, rows, cols, lengths);
+}
+
+/** The nested exports for one table, or nothing when it has no relations to describe. */
+function renderNestedSchemas(
+  table: Table,
+  affix: ResolvedAffix,
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
+  typedJson: { allColumns?: boolean } | undefined,
+  applyDefaults: boolean,
+  plans: Partial<Record<NestedMode, NestedNode>>
+): string {
+  const out: string[] = [];
+  for (const mode of ['insert', 'select'] as const) {
+    const plan = plans[mode];
+    if (!plan) continue;
+    const name = nestedSchemaName(mode, table.tsName, affix);
+    const tname = nestedTypeName(mode, table.tsName, affix);
+    const expr = renderNestedObject(plan, mode, coerceDates, typedJson, applyDefaults);
+    out.push(`export const ${name} = ${expr};\n\nexport type ${tname} = Static<typeof ${name}>;`);
+  }
+  return out.length ? `\n${out.join('\n\n')}\n` : '';
+}
+
+/** Every table a plan reaches, so a type-only import can name all of them. */
+function nestedTables(node: NestedNode, into = new Set<string>()): Set<string> {
+  into.add(node.table.tsName);
+  for (const arm of node.arms) nestedTables(arm.child, into);
+  return into;
+}
+
+/**
+ * The nested plans for one table, built once per mode.
+ *
+ * Returned as a partial map because the two modes disagree per table: a table that is only ever a
+ * child has a nested select and no nested insert, and emitting an insert one anyway would put a
+ * byte-for-byte copy of the plain insert schema in the file under a second name.
+ */
+function nestedPlansFor(
+  table: Table,
+  analysis: Analysis,
+  depth: number
+): Partial<Record<NestedMode, NestedNode>> {
+  const out: Partial<Record<NestedMode, NestedNode>> = {};
+  for (const mode of ['insert', 'select'] as const) {
+    // A read-only relation refuses every write, so it has no insert schema to nest into.
+    if (mode === 'insert' && table.readOnly) continue;
+    const plan = buildNestedPlan(table, analysis.tables, analysis.relations ?? [], mode, depth);
+    if (plan) out[mode] = plan;
+  }
+  return out;
+}
+
 function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   typedJson?: { schemaSpecifier: string; allColumns?: boolean },
   applyDefaults = false,
-  wantsDuplicateFinder = false
+  wantsDuplicateFinder = false,
+  nested: Partial<Record<NestedMode, NestedNode>> = {}
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -562,15 +707,33 @@ function renderTableSchemas(
     cardinalities
   );
 
+  // A nested shape references the columns of *other* tables, so those tables have to be named here
+  // too or the reference would not resolve. Without this the module compiled fine until `typedJson`
+  // and `nestedSchemas` were combined, and then named an identifier nothing imported.
+  const referenced = new Set<string>([T]);
+  for (const plan of Object.values(nested)) {
+    if (plan) for (const name of nestedTables(plan)) referenced.add(name);
+  }
   const schemaImport = typedJson
-    ? `import type { ${T} } from '${typedJson.schemaSpecifier}';\n`
+    ? `import type { ${[...referenced].join(', ')} } from '${typedJson.schemaSpecifier}';\n`
     : '';
+
+  // Every column and every check the nested shapes will emit, alongside this table's own. Both
+  // preambles below are conditional, so a json column or a row check reachable only through a
+  // relation would otherwise name `DrzlJsonValue` or the `DrzlRowCheck` kind and never define or
+  // register it: the first is a compile error, the second a TypeBox throw at validation time.
+  const nestedByMode = (['insert', 'select'] as const).flatMap((m) => {
+    const plan = nested[m];
+    return plan ? nestedNodes(plan).map((n) => [nestedNodeCols(n, m), m, n.table] as const) : [];
+  });
 
   // Emitted only where a json column exists, and not when `typedJson` has replaced it with the
   // inferred type, so a file never carries an unused declaration.
   const needsJson =
     !typedJson &&
-    [...insertCols, ...updateCols, ...selectCols].some((c) => c.shape?.kind === 'json');
+    [...insertCols, ...updateCols, ...selectCols, ...nestedByMode.flatMap(([cs]) => cs)].some(
+      (c) => c.shape?.kind === 'json'
+    );
 
   const rowCols = [insertCols, updateCols, selectCols].map(
     (cols) => new Set(cols.map((c) => c.name))
@@ -586,20 +749,39 @@ function renderTableSchemas(
       ] as Array<[Column[], Mode]>
     ).some(([cs, m]) =>
       cs.some(
-        (c) =>
-          tbNeedsCapKind(c) || tbNeedsNonFiniteKind(c) || tbNeedsDateKind(c, m, coerceDates)
+        (c) => tbNeedsCapKind(c) || tbNeedsNonFiniteKind(c) || tbNeedsDateKind(c, m, coerceDates)
       )
-    );
+    ) ||
+    nestedByMode.some(([cs, m, tbl]) => {
+      const present = new Set(cs.map((c) => c.name));
+      const own = parsedChecksFor(tbl);
+      return (
+        own.rows.some((r) => present.has(r.left) && present.has(r.right)) ||
+        own.lengths.some((k) => present.has(k.column)) ||
+        cs.some(
+          (c) => tbNeedsCapKind(c) || tbNeedsNonFiniteKind(c) || tbNeedsDateKind(c, m, coerceDates)
+        )
+      );
+    });
   const rowImport = needsRows ? `, Kind, TypeRegistry` : '';
 
-    // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
+  // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
   // half that needs no database: whether a batch collides with itself.
   const finder = wantsDuplicateFinder
     ? renderDuplicateFinder(table, `findDuplicate${T}`, insertType)
     : undefined;
   const duplicates = finder ? `\n${finder}\n` : '';
 
-return `import { Type${rowImport} } from '@sinclair/typebox';
+  const nestedCode = renderNestedSchemas(
+    table,
+    affix,
+    coerceDates,
+    typedJson,
+    applyDefaults,
+    nested
+  );
+
+  return `import { Type${rowImport} } from '@sinclair/typebox';
 import type { Static } from '@sinclair/typebox';
 ${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}${needsRows ? `\n${ROW_PREAMBLE}` : ''}
 export const ${insertSchema} = ${tbWrapRows(`Type.Object({\n${bodyInsert}\n})`, rows, insertCols, lengths)};
@@ -611,7 +793,7 @@ export const ${selectSchema} = ${tbWrapRows(`Type.Object({\n${bodySelect}\n})`, 
 export type ${insertType} = Static<typeof ${insertSchema}>;
 export type ${updateType} = Static<typeof ${updateSchema}>;
 export type ${selectType} = Static<typeof ${selectSchema}>;
-${duplicates}`;
+${nestedCode}${duplicates}`;
 }
 
 /**
@@ -743,9 +925,12 @@ function tbCapExpr(c: Column, base: string, mode: Mode): string {
     );
     return `Type.Intersect([${base}, ${out.join(', ')}])`;
   }
-  if (c.maxLength) out.push(branch(`at most ${c.maxLength} characters`, `[...v].length <= ${c.maxLength}`));
+  if (c.maxLength)
+    out.push(branch(`at most ${c.maxLength} characters`, `[...v].length <= ${c.maxLength}`));
   if (c.maxBytes) {
-    out.push(branch(`at most ${c.maxBytes} bytes`, `new TextEncoder().encode(v).length <= ${c.maxBytes}`));
+    out.push(
+      branch(`at most ${c.maxBytes} bytes`, `new TextEncoder().encode(v).length <= ${c.maxBytes}`)
+    );
   }
   // Intersected onto the field rather than onto the object, so a per-field comparison can still
   // see the constraint. On the object it was invisible to the parity harness, which reads
@@ -800,7 +985,9 @@ function tbWrapRows(
     .map((r) => {
       const l = `o[${JSON.stringify(r.left)}]`;
       const rt = `o[${JSON.stringify(r.right)}]`;
-      const msg = JSON.stringify(`${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`);
+      const msg = JSON.stringify(
+        `${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`
+      );
       // Null on either side means SQL never applied the comparison, so neither does this.
       return `Type.Unsafe<unknown>({
     [Kind]: 'DrzlRowCheck',
@@ -862,10 +1049,20 @@ export class TypeBoxGenerator implements ValidationRenderer<TypeBoxGenerateOptio
       );
     }
 
+    const nestedDepth = opts.nestedSchemas
+      ? resolveNestedDepth(opts.nestedDepth, (m) => console.warn(m))
+      : 0;
     for (const table of this.analysis.tables) {
       const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
-      const code = renderTableSchemas(table, affix, coerceDates, typedJson, !!opts.applyDefaults,
-      !!opts?.duplicateFinder);
+      const code = renderTableSchemas(
+        table,
+        affix,
+        coerceDates,
+        typedJson,
+        !!opts.applyDefaults,
+        !!opts?.duplicateFinder,
+        opts.nestedSchemas ? nestedPlansFor(table, this.analysis, nestedDepth) : {}
+      );
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
         filePath,

--- a/packages/generator-typebox/test/nested-relations.spec.ts
+++ b/packages/generator-typebox/test/nested-relations.spec.ts
@@ -1,0 +1,321 @@
+/**
+ * Nested relation schemas, checked by running them.
+ *
+ * A caller inserting a parent and its children in one payload has nothing to validate it against:
+ * every first-party Drizzle validator emits column keys only, and `db.insert` drops the relation
+ * key silently rather than refusing it, so the children are never written and nothing says so.
+ *
+ * Every assertion here imports the emitted module and checks real payloads against it, through
+ * both `Value.Check` and `TypeCompiler`. The two are separate implementations of the same
+ * question in TypeBox and they have disagreed here before: a `$ref` that cannot be resolved
+ * constructs happily, passes nothing, and throws out of `Value.Check`.
+ */
+import { execFile } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { promisify } from 'node:util';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+import type { Analysis, Column, Relation, Table } from '@drzl/analyzer';
+import { TypeBoxGenerator } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (name: string, cols: Column[], over: Partial<Table> = {}): Table =>
+  ({ name, tsName: name, columns: cols, unique: [], indexes: [], checks: [], ...over }) as Table;
+
+const users = table('users', [
+  col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+  col('name'),
+]);
+const posts = table(
+  'posts',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('authorId', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+    col('title'),
+  ],
+  { foreignKeys: [{ columns: ['authorId'], foreignTable: 'users', foreignColumns: ['id'] }] }
+);
+const comments = table(
+  'comments',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('postId', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+    col('body'),
+  ],
+  { foreignKeys: [{ columns: ['postId'], foreignTable: 'posts', foreignColumns: ['id'] }] }
+);
+/** The cycle that really happens: a table pointing at itself. */
+const staff = table(
+  'staff',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('managerId', { tsType: 'number', dbType: 'INTEGER', integer: true, nullable: true }),
+    col('label'),
+  ],
+  { foreignKeys: [{ columns: ['managerId'], foreignTable: 'staff', foreignColumns: ['id'] }] }
+);
+
+const RELATIONS: Relation[] = [
+  { kind: 'one', from: 'posts', to: 'users' },
+  { kind: 'many', from: 'users', to: 'posts' },
+  { kind: 'one', from: 'comments', to: 'posts' },
+  { kind: 'many', from: 'posts', to: 'comments' },
+  { kind: 'one', from: 'staff', to: 'staff' },
+  { kind: 'many', from: 'staff', to: 'staff' },
+];
+
+const analysis = (): Analysis => ({
+  dialect: 'postgres',
+  tables: [users, posts, comments, staff],
+  enums: [],
+  relations: RELATIONS,
+  issues: [],
+});
+
+let seq = 0;
+
+/** Emit the whole fixture and import one table's module. */
+async function emit(
+  opts: Record<string, unknown>,
+  which = 'users'
+): Promise<{ mod: Record<string, any>; text: string; dir: string }> {
+  const dir = path.join(__dirname, '.tmp-nested', `run-${process.pid}-${seq++}`);
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis()).generate({ outDir: dir, ...opts } as never);
+  const file = path.join(dir, `${which}.typebox.ts`);
+  return { mod: await import(file), text: await fs.readFile(file, 'utf8'), dir };
+}
+
+/**
+ * Whether a payload passes, asked of both checkers, which must agree.
+ *
+ * They are separate code paths: `Value.Check` walks the schema and `TypeCompiler` generates a
+ * function from it. A disagreement is a defect whichever way it points, so it fails here rather
+ * than being resolved in favour of one of them.
+ */
+const ok = (schema: any, value: unknown): boolean => {
+  const walked = Value.Check(schema, value);
+  const compiled = TypeCompiler.Compile(schema).Check(value);
+  expect(compiled, 'TypeCompiler and Value.Check disagree').toBe(walked);
+  return walked;
+};
+
+describe('off by default', () => {
+  it('emits nothing nested and no extra bytes', async () => {
+    const plain = await emit({});
+    expect(Object.keys(plain.mod).some((k) => k.startsWith('Nested'))).toBe(false);
+    expect(plain.text).not.toContain('Nested');
+    // Byte-for-byte identical to a run that named the option and turned it off, which is the
+    // claim the output-size budget in verify-packed.sh relies on.
+    const explicitOff = await emit({ nestedSchemas: false });
+    expect(explicitOff.text).toBe(plain.text);
+  });
+});
+
+describe('the nested insert payload', () => {
+  it('accepts a parent and its children in one object', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    expect(S, 'the nested insert schema is exported').toBeTruthy();
+    expect(ok(S, { name: 'ada', posts: [{ title: 'first' }] })).toBe(true);
+    // The children are kept rather than stripped, which is the failure mode a plain object has.
+    // TypeBox validates rather than transforms, so the payload is checked in place.
+    expect(ok(S, { name: 'ada', posts: [{ title: 'first' }, { title: 'second' }] })).toBe(true);
+  });
+
+  it('rejects an invalid child', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    expect(ok(S, { name: 'ada', posts: [{ title: 5 }] }), 'a child with the wrong type').toBe(
+      false
+    );
+    expect(ok(S, { name: 'ada', posts: [{}] }), 'a child missing a required column').toBe(false);
+    expect(ok(S, { name: 'ada', posts: {} }), 'an object where an array belongs').toBe(false);
+  });
+
+  it('does not ask for the foreign key the parent supplies', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    // `authorId` cannot be known before the user is written. A schema demanding it is unusable.
+    expect(ok(S, { name: 'ada', posts: [{ title: 'x' }] })).toBe(true);
+    expect(Object.keys(S.properties.posts.items.properties)).toEqual(['title']);
+    // And the plain insert schema still requires it, so the nesting weakened nothing.
+    expect(ok(mod.InsertusersSchema, {})).toBe(false);
+  });
+
+  it('leaves the relation key optional, so a childless parent still validates', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    expect(ok(mod.NestedInsertusersSchema, { name: 'ada' })).toBe(true);
+  });
+
+  it('carries no `one` relation', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedInsertpostsSchema;
+    expect(Object.keys(S.properties).sort()).toEqual(['authorId', 'comments', 'title']);
+    expect(
+      S.properties.users,
+      'a `one` arm would weaken authorId on the post itself'
+    ).toBeUndefined();
+  });
+
+  it('emits no nested update schema in any form', async () => {
+    const { mod, text } = await emit({ nestedSchemas: true });
+    expect(Object.keys(mod).filter((k) => k.startsWith('NestedUpdate'))).toEqual([]);
+    expect(text).not.toContain('NestedUpdate');
+  });
+});
+
+describe('the nested select payload', () => {
+  it('carries every relation kind, each one optional', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedSelectpostsSchema;
+    expect(Object.keys(S.properties).sort()).toEqual([
+      'authorId',
+      'comments',
+      'id',
+      'title',
+      'users',
+    ]);
+    const row = { id: 1, authorId: 2, title: 't' };
+    expect(ok(S, row), 'a row from a query that asked for no relations').toBe(true);
+    expect(ok(S, { ...row, users: { id: 2, name: 'ada' } }), 'with: { author: true }').toBe(true);
+    expect(ok(S, { ...row, comments: [{ id: 9, postId: 1, body: 'hi' }] })).toBe(true);
+  });
+
+  it('accepts null for a to-one, which a relational query really returns', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    expect(ok(mod.NestedSelectpostsSchema, { id: 1, authorId: 2, title: 't', users: null })).toBe(
+      true
+    );
+  });
+
+  it('still rejects a row whose related object is wrong', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedSelectpostsSchema;
+    expect(ok(S, { id: 1, authorId: 2, title: 't', users: { id: 'two', name: 'ada' } })).toBe(
+      false
+    );
+    expect(ok(S, { id: 1, authorId: 2, title: 't', comments: [{ id: 9 }] })).toBe(false);
+  });
+
+  it('keeps every column of the related row, since a read returns them all', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const child = mod.NestedSelectusersSchema.properties.posts.items;
+    expect(Object.keys(child.properties).sort()).toEqual(['authorId', 'id', 'title']);
+  });
+});
+
+describe('depth', () => {
+  it('stops one level down by default', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const child = mod.NestedInsertusersSchema.properties.posts.items;
+    expect(child.properties.comments, 'depth 1 goes no further').toBeUndefined();
+  });
+
+  it('goes deeper when asked, and validates the grandchild', async () => {
+    const { mod } = await emit({ nestedSchemas: true, nestedDepth: 2 });
+    const S = mod.NestedInsertusersSchema;
+    const payload = {
+      name: 'ada',
+      posts: [{ title: 'first', comments: [{ body: 'hi' }] }],
+    };
+    expect(ok(S, payload)).toBe(true);
+    expect(ok(S, { name: 'ada', posts: [{ title: 'x', comments: [{ body: 5 }] }] })).toBe(false);
+    // The grandchild's own foreign key is omitted too.
+    expect(
+      ok(S, { name: 'ada', posts: [{ title: 'x', comments: [{ body: 'hi', postId: 1 }] }] })
+    ).toBe(true);
+  });
+});
+
+describe('a cycle', () => {
+  it('loads, validates, and stops at the depth rather than recursing', async () => {
+    const { mod } = await emit({ nestedSchemas: true, nestedDepth: 2 }, 'staff');
+    const S = mod.NestedInsertstaffSchema;
+    expect(ok(S, { label: 'root', staff: [{ label: 'a', staff: [{ label: 'b' }] }] })).toBe(true);
+    // Past the depth the key is not declared. TypeBox's object is not strict, so the extra level
+    // is ignored rather than refused, and neither checker recurses forever over it.
+    expect(
+      ok(S, {
+        label: 'root',
+        staff: [{ label: 'a', staff: [{ label: 'b', staff: [{ label: 'c' }] }] }],
+      })
+    ).toBe(true);
+    // The self-referencing foreign key is what the parent supplies, so it is gone at every level.
+    expect(mod.NestedInsertstaffSchema.properties.staff.items.properties.managerId).toBeUndefined();
+  });
+});
+
+describe('the emitted module', () => {
+  it('imports nothing new and exports the types beside the schemas', async () => {
+    const { text } = await emit({ nestedSchemas: true });
+    // Nesting is expanded inline, so no module reaches for a sibling and no import cycle exists.
+    // Two modules that referenced each other would be a real hazard here: the initialiser runs at
+    // load, so the second one to evaluate reads an uninitialised binding and throws on import.
+    expect(text.match(/^import .*$/gm)).toEqual([
+      "import { Type } from '@sinclair/typebox';",
+      "import type { Static } from '@sinclair/typebox';",
+    ]);
+    expect(text).toContain('export type NestedInsertusersInput');
+    expect(text).toContain('export type NestedSelectusersOutput');
+  });
+
+  it('emits only the modes a table actually has relations for', async () => {
+    // `comments` is a child and nothing else: it has a `one` to posts and no `many` at all, so a
+    // nested insert would be a byte-for-byte copy of the insert schema beside it.
+    const { mod } = await emit({ nestedSchemas: true }, 'comments');
+    expect(mod.NestedInsertcommentsSchema).toBeUndefined();
+    expect(mod.NestedSelectcommentsSchema).toBeTruthy();
+    expect(ok(mod.NestedSelectcommentsSchema, { id: 1, postId: 2, body: 'hi' })).toBe(true);
+  });
+});
+
+describe('the emitted nested code compiles', () => {
+  /**
+   * Run `tsc` over the emitted directory.
+   *
+   * Not covered by `pnpm typecheck`, and that was measured rather than assumed: the generator
+   * tsconfigs include `test`, and TypeScript's wildcard include skips any directory whose name
+   * starts with a dot, which every `.tmp-*` output directory here does. A deliberate type error
+   * written into an emitted file left `tsc -p tsconfig.json` at zero errors. So this points the
+   * compiler at the directory itself, under the `nodenext` resolution the emitted `.js`
+   * specifiers exist for.
+   */
+  it('under strict nodenext', async () => {
+    const { dir } = await emit({ nestedSchemas: true, nestedDepth: 2 });
+    const cfg = path.join(dir, 'tsconfig.json');
+    await fs.writeFile(
+      cfg,
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+          target: 'ES2021',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+        },
+        include: ['.'],
+      }),
+      'utf8'
+    );
+    const tsc = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+    const { stdout } = await promisify(execFile)(process.execPath, [tsc, '-p', cfg], {
+      maxBuffer: 20 * 1024 * 1024,
+    }).catch((e: any) => ({ stdout: e.stdout || String(e) }));
+    expect(stdout.trim()).toBe('');
+  }, 60_000);
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -6,16 +6,23 @@ import type {
   RowCheck,
 } from '@drzl/validation-core';
 import type { CardinalityCheck, ColumnCheck, ColumnSet, LengthCheck } from '@drzl/validation-core';
+import type { NestedMode, NestedNode } from '@drzl/validation-core';
 import {
+  buildNestedPlan,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
+  nestedArmNotes,
+  nestedNodeColumns,
+  nestedSchemaName,
+  nestedTypeName,
   nonFiniteAccepted,
   parseCheck,
   parsesToADate,
   renderDuplicateFinder,
   resolveConfiguredImport,
+  resolveNestedDepth,
   updateColumns,
   selectColumns,
   formatCode,
@@ -84,11 +91,7 @@ function vDateExpr(
  * so they are pasted rather than parsed. `literal` spells each one, which is the only difference
  * between the number and bigint cases.
  */
-function vBounds(
-  c: Column,
-  literal: (v: string) => string,
-  checks: ColumnCheck[] = []
-): string[] {
+function vBounds(c: Column, literal: (v: string) => string, checks: ColumnCheck[] = []): string[] {
   let lo = c.min !== undefined ? { action: 'minValue', value: c.min } : undefined;
   let hi = c.max !== undefined ? { action: 'maxValue', value: c.max } : undefined;
 
@@ -377,12 +380,7 @@ function vExprForColumn(
           `v.check((val) => new TextEncoder().encode(val).length <= ${c.maxBytes}, 'at most ${c.maxBytes} bytes')`
         );
       }
-      return piped(
-        'v.string()',
-        caps.length
-          ? caps
-          : []
-      );
+      return piped('v.string()', caps.length ? caps : []);
     case 'number': {
       const bounds = vBounds(c, (v) => v, checks);
       const actions = [...(isIntegerColumn(c) ? ['v.integer()'] : []), ...bounds];
@@ -511,16 +509,149 @@ function vRowChecks(rows: RowCheck[], cols: Column[]): string[] {
     '=': '===',
     '<>': '!==',
   };
-  return rows
-    // A check naming a column this mode does not carry cannot be evaluated: an insert schema
-    // omits generated columns, so the comparison would read undefined and always pass or fail.
-    .filter((r) => present.has(r.left) && present.has(r.right))
-    .map((r) => {
-      const l = `o[${JSON.stringify(r.left)}]`;
-      const rt = `o[${JSON.stringify(r.right)}]`;
-      const msg = JSON.stringify(`${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`);
-      return `v.check((o) => ${l} == null || ${rt} == null || ${l} ${OPS[r.operator]} ${rt}, ${msg})`;
-    });
+  return (
+    rows
+      // A check naming a column this mode does not carry cannot be evaluated: an insert schema
+      // omits generated columns, so the comparison would read undefined and always pass or fail.
+      .filter((r) => present.has(r.left) && present.has(r.right))
+      .map((r) => {
+        const l = `o[${JSON.stringify(r.left)}]`;
+        const rt = `o[${JSON.stringify(r.right)}]`;
+        const msg = JSON.stringify(
+          `${r.name ? `${r.name}: ` : ''}${r.left} ${r.operator} ${r.right}`
+        );
+        return `v.check((o) => ${l} == null || ${rt} == null || ${l} ${OPS[r.operator]} ${rt}, ${msg})`;
+      })
+  );
+}
+
+/** Every CHECK on a table that the shared parser understands, split by what it constrains. */
+function parsedChecksFor(table: Table) {
+  const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  return {
+    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
+    lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
+    cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),
+  };
+}
+
+/** Push a rendered block one level deeper, so the nested object reads as one. */
+function indentBlock(code: string, by = '  '): string {
+  return code
+    .split('\n')
+    .map((line) => (line ? by + line : line))
+    .join('\n');
+}
+
+/**
+ * One object of a nested payload, with its relations expanded inline.
+ *
+ * Rendered from the columns rather than derived from the sibling schema with `v.omit`. Measured on
+ * valibot 1.4.2: `v.omit` applied to the `v.pipe(v.object(...), v.check(...))` that a table with a
+ * row-level CHECK emits returns a bare object schema and **drops the checks**, with no error. A
+ * derived nested schema would therefore have silently stopped enforcing every row-level constraint
+ * on the child.
+ */
+function renderNestedObject(
+  node: NestedNode,
+  mode: NestedMode,
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
+  applyDefaults: boolean,
+  typedColumns: boolean
+): string {
+  const all = mode === 'insert' ? insertColumns(node.table) : selectColumns(node.table);
+  const cols = nestedNodeColumns(all, node);
+  const { checks, sets, rows, lengths, cardinalities } = parsedChecksFor(node.table);
+  const tc = typedColumns ? { table: node.table.tsName, mode } : undefined;
+  const fields = renderObjectShape(
+    cols,
+    mode,
+    coerceDates,
+    checks,
+    sets,
+    applyDefaults,
+    lengths,
+    cardinalities,
+    tc
+  );
+
+  const arms = node.arms.map((arm) => {
+    const notes = nestedArmNotes(arm)
+      .map((n) => `  // ${n}\n`)
+      .join('');
+    const child = renderNestedObject(arm.child, mode, coerceDates, applyDefaults, typedColumns);
+    // A to-one may come back null: a relational query returns null where there is no matching
+    // row, and accepting it never turns away something the query produced. Optional throughout,
+    // because which relations a payload carries is the caller's choice on a write and the `with`
+    // clause's on a read.
+    const inner = arm.single
+      ? `v.nullable(\n${indentBlock(indentBlock(child))}\n  )`
+      : `v.array(\n${indentBlock(indentBlock(child))}\n  )`;
+    return `${notes}  ${JSON.stringify(arm.key)}: v.optional(${inner}),`;
+  });
+
+  const body = [fields, ...arms].filter(Boolean).join('\n');
+  return wrapRows(`v.object({\n${body}\n})`, rows, cols);
+}
+
+/** The nested exports for one table, or nothing when it has no relations to describe. */
+function renderNestedSchemas(
+  table: Table,
+  affix: ResolvedAffix,
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
+  applyDefaults: boolean,
+  typedColumns: boolean,
+  plans: Partial<Record<NestedMode, NestedNode>>
+): string {
+  const out: string[] = [];
+  for (const mode of ['insert', 'select'] as const) {
+    const plan = plans[mode];
+    if (!plan) continue;
+    const name = nestedSchemaName(mode, table.tsName, affix);
+    const tname = nestedTypeName(mode, table.tsName, affix);
+    const expr = renderNestedObject(plan, mode, coerceDates, applyDefaults, typedColumns);
+    const infer = mode === 'insert' ? 'InferInput' : 'InferOutput';
+    out.push(`export const ${name} = ${expr};\n\nexport type ${tname} = ${infer}<typeof ${name}>;`);
+  }
+  return out.length ? `\n${out.join('\n\n')}\n` : '';
+}
+
+/** Every table a plan reaches, so a type-only import can name all of them. */
+function nestedTables(node: NestedNode, into = new Set<string>()): Set<string> {
+  into.add(node.table.tsName);
+  for (const arm of node.arms) nestedTables(arm.child, into);
+  return into;
+}
+
+/** Every column a plan reaches, so the file knows whether it still needs the JSON preamble. */
+function nestedColumns(node: NestedNode, into: Column[] = []): Column[] {
+  into.push(...node.table.columns);
+  for (const arm of node.arms) nestedColumns(arm.child, into);
+  return into;
+}
+
+/**
+ * The nested plans for one table, built once per mode.
+ *
+ * Returned as a partial map because the two modes disagree per table: a table that is only ever a
+ * child has a nested select and no nested insert, and emitting an insert one anyway would put a
+ * byte-for-byte copy of the plain insert schema in the file under a second name.
+ */
+function nestedPlansFor(
+  table: Table,
+  analysis: Analysis,
+  depth: number
+): Partial<Record<NestedMode, NestedNode>> {
+  const out: Partial<Record<NestedMode, NestedNode>> = {};
+  for (const mode of ['insert', 'select'] as const) {
+    // A read-only relation refuses every write, so it has no insert schema to nest into.
+    if (mode === 'insert' && table.readOnly) continue;
+    const plan = buildNestedPlan(table, analysis.tables, analysis.relations ?? [], mode, depth);
+    if (plan) out[mode] = plan;
+  }
+  return out;
 }
 
 function renderTableSchemas(
@@ -529,7 +660,8 @@ function renderTableSchemas(
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   applyDefaults = false,
   typedColumns?: { schemaSpecifier: string },
-  wantsDuplicateFinder = false
+  wantsDuplicateFinder = false,
+  nested: Partial<Record<NestedMode, NestedNode>> = {}
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -553,8 +685,16 @@ function renderTableSchemas(
   const tjInsert = typedColumns ? { table: T, mode: 'insert' as const } : undefined;
   // A type-only import: erased at build time, so it adds no runtime dependency on the schema
   // module and cannot create an import cycle.
+  //
+  // A nested shape references the columns of *other* tables, so those tables have to be named here
+  // too or the reference would not resolve. Without this the module compiled fine until
+  // `typedColumns` and `nestedSchemas` were combined, and then named an identifier nothing imported.
+  const referenced = new Set<string>([T]);
+  for (const plan of Object.values(nested)) {
+    if (plan) for (const name of nestedTables(plan)) referenced.add(name);
+  }
   const schemaImport = typedColumns
-    ? `import type { ${T} } from '${typedColumns.schemaSpecifier}';\n`
+    ? `import type { ${[...referenced].join(', ')} } from '${typedColumns.schemaSpecifier}';\n`
     : '';
 
   const bodyInsert = renderObjectShape(
@@ -590,19 +730,31 @@ function renderTableSchemas(
     cardinalities,
     tj
   );
-  // Emitted only where a json column exists, so a file without one gains nothing unused.
-  const needsJson = [...insertCols, ...updateCols, ...selectCols].some(
+  // Emitted only where a json column exists, so a file without one gains nothing unused. The
+  // nested shapes carry other tables' columns, so a json column reachable only through a relation
+  // still needs the preamble: without this the module named `DrzlJsonValue` and never defined it.
+  const nestedCols = Object.values(nested).flatMap((plan) => (plan ? nestedColumns(plan) : []));
+  const needsJson = [...insertCols, ...updateCols, ...selectCols, ...nestedCols].some(
     (c) => c.shape?.kind === 'json'
   );
 
-    // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
+  // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
   // half that needs no database: whether a batch collides with itself.
   const finder = wantsDuplicateFinder
     ? renderDuplicateFinder(table, `findDuplicate${T}`, insertType)
     : undefined;
   const duplicates = finder ? `\n${finder}\n` : '';
 
-return `import * as v from 'valibot';
+  const nestedCode = renderNestedSchemas(
+    table,
+    affix,
+    coerceDates,
+    applyDefaults,
+    !!typedColumns,
+    nested
+  );
+
+  return `import * as v from 'valibot';
 import type { InferInput, InferOutput } from 'valibot';
 ${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}
 export const ${insertSchema} = ${wrapRows(`v.object({\n${bodyInsert}\n})`, rows, insertCols)};
@@ -614,7 +766,7 @@ export const ${selectSchema} = ${wrapRows(`v.object({\n${bodySelect}\n})`, rows,
 export type ${insertType} = InferInput<typeof ${insertSchema}>;
 export type ${updateType} = InferInput<typeof ${updateSchema}>;
 export type ${selectType} = InferOutput<typeof ${selectSchema}>;
-${duplicates}`;
+${nestedCode}${duplicates}`;
 }
 
 export interface ValibotGenerateOptions extends ValidationGenerateOptions {
@@ -662,6 +814,9 @@ export class ValibotGenerator implements ValidationRenderer<ValibotGenerateOptio
         '[drzl] typedColumns was requested but the schema path is unknown, so column types stay wide.'
       );
     }
+    const nestedDepth = opts.nestedSchemas
+      ? resolveNestedDepth(opts.nestedDepth, (m) => console.warn(m))
+      : 0;
     // File names deliberately stay on the raw Drizzle export name: affixes and tableCase
     // rename identifiers, never modules, so the barrel and importPath keep resolving.
     for (const table of this.analysis.tables) {
@@ -672,7 +827,8 @@ export class ValibotGenerator implements ValidationRenderer<ValibotGenerateOptio
         coerceDates,
         !!opts.applyDefaults,
         typedColumns,
-      !!opts?.duplicateFinder
+        !!opts?.duplicateFinder,
+        opts.nestedSchemas ? nestedPlansFor(table, this.analysis, nestedDepth) : {}
       );
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,

--- a/packages/generator-valibot/test/nested-relations.spec.ts
+++ b/packages/generator-valibot/test/nested-relations.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * Nested relation schemas, checked by running them.
+ *
+ * A caller inserting a parent and its children in one payload has nothing to validate it against:
+ * every first-party Drizzle validator emits column keys only, and `db.insert` drops the relation
+ * key silently rather than refusing it, so the children are never written and nothing says so.
+ *
+ * Every assertion here imports the emitted module and parses real payloads through it. Reading the
+ * text cannot tell a schema that admits `{ posts: [...] }` from one that strips it, and stripping
+ * is exactly what `v.object` does to a key it does not declare.
+ */
+import { execFile } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { promisify } from 'node:util';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { Analysis, Column, Relation, Table } from '@drzl/analyzer';
+import * as v from 'valibot';
+import { ValibotGenerator } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (name: string, cols: Column[], over: Partial<Table> = {}): Table =>
+  ({ name, tsName: name, columns: cols, unique: [], indexes: [], checks: [], ...over }) as Table;
+
+const users = table('users', [
+  col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+  col('name'),
+]);
+const posts = table(
+  'posts',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('authorId', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+    col('title'),
+  ],
+  { foreignKeys: [{ columns: ['authorId'], foreignTable: 'users', foreignColumns: ['id'] }] }
+);
+const comments = table(
+  'comments',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('postId', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+    col('body'),
+  ],
+  { foreignKeys: [{ columns: ['postId'], foreignTable: 'posts', foreignColumns: ['id'] }] }
+);
+/** The cycle that really happens: a table pointing at itself. */
+const staff = table(
+  'staff',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('managerId', { tsType: 'number', dbType: 'INTEGER', integer: true, nullable: true }),
+    col('label'),
+  ],
+  { foreignKeys: [{ columns: ['managerId'], foreignTable: 'staff', foreignColumns: ['id'] }] }
+);
+
+const RELATIONS: Relation[] = [
+  { kind: 'one', from: 'posts', to: 'users' },
+  { kind: 'many', from: 'users', to: 'posts' },
+  { kind: 'one', from: 'comments', to: 'posts' },
+  { kind: 'many', from: 'posts', to: 'comments' },
+  { kind: 'one', from: 'staff', to: 'staff' },
+  { kind: 'many', from: 'staff', to: 'staff' },
+];
+
+const analysis = (): Analysis => ({
+  dialect: 'postgres',
+  tables: [users, posts, comments, staff],
+  enums: [],
+  relations: RELATIONS,
+  issues: [],
+});
+
+let seq = 0;
+
+/** Emit the whole fixture and import one table's module. */
+async function emit(
+  opts: Record<string, unknown>,
+  which = 'users'
+): Promise<{ mod: Record<string, any>; text: string; dir: string }> {
+  const dir = path.join(__dirname, '.tmp-nested', `run-${process.pid}-${seq++}`);
+  await fs.mkdir(dir, { recursive: true });
+  await new ValibotGenerator(analysis()).generate({ outDir: dir, ...opts } as never);
+  const file = path.join(dir, `${which}.valibot.ts`);
+  return { mod: await import(file), text: await fs.readFile(file, 'utf8'), dir };
+}
+
+const ok = (schema: any, value: unknown) => v.safeParse(schema, value).success;
+const parse = (schema: any, value: unknown) => v.parse(schema, value);
+
+describe('off by default', () => {
+  it('emits nothing nested and no extra bytes', async () => {
+    const plain = await emit({});
+    expect(Object.keys(plain.mod).some((k) => k.startsWith('Nested'))).toBe(false);
+    expect(plain.text).not.toContain('Nested');
+    // Byte-for-byte identical to a run that named the option and turned it off, which is the
+    // claim the output-size budget in verify-packed.sh relies on.
+    const explicitOff = await emit({ nestedSchemas: false });
+    expect(explicitOff.text).toBe(plain.text);
+  });
+});
+
+describe('the nested insert payload', () => {
+  it('accepts a parent and its children in one object', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    expect(S, 'the nested insert schema is exported').toBeTruthy();
+    expect(ok(S, { name: 'ada', posts: [{ title: 'first' }] })).toBe(true);
+    // The children are kept rather than stripped, which is the failure mode a plain object has.
+    expect(parse(S, { name: 'ada', posts: [{ title: 'first' }] })).toEqual({
+      name: 'ada',
+      posts: [{ title: 'first' }],
+    });
+  });
+
+  it('rejects an invalid child', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    expect(ok(S, { name: 'ada', posts: [{ title: 5 }] }), 'a child with the wrong type').toBe(
+      false
+    );
+    expect(ok(S, { name: 'ada', posts: [{}] }), 'a child missing a required column').toBe(false);
+    expect(ok(S, { name: 'ada', posts: {} }), 'an object where an array belongs').toBe(false);
+  });
+
+  it('does not ask for the foreign key the parent supplies', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    // `authorId` cannot be known before the user is written. A schema demanding it is unusable.
+    expect(ok(S, { name: 'ada', posts: [{ title: 'x' }] })).toBe(true);
+    expect(Object.keys(S.entries.posts.wrapped.item.entries)).toEqual(['title']);
+    // And the plain insert schema still requires it, so the nesting weakened nothing.
+    expect(ok(mod.InsertusersSchema, {})).toBe(false);
+  });
+
+  it('leaves the relation key optional, so a childless parent still validates', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    expect(ok(mod.NestedInsertusersSchema, { name: 'ada' })).toBe(true);
+  });
+
+  it('carries no `one` relation', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedInsertpostsSchema;
+    expect(Object.keys(S.entries).sort()).toEqual(['authorId', 'comments', 'title']);
+    expect(S.entries.users, 'a `one` arm would weaken authorId on the post itself').toBeUndefined();
+  });
+
+  it('emits no nested update schema in any form', async () => {
+    const { mod, text } = await emit({ nestedSchemas: true });
+    expect(Object.keys(mod).filter((k) => k.startsWith('NestedUpdate'))).toEqual([]);
+    expect(text).not.toContain('NestedUpdate');
+  });
+});
+
+describe('the nested select payload', () => {
+  it('carries every relation kind, each one optional', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedSelectpostsSchema;
+    expect(Object.keys(S.entries).sort()).toEqual(['authorId', 'comments', 'id', 'title', 'users']);
+    const row = { id: 1, authorId: 2, title: 't' };
+    expect(ok(S, row), 'a row from a query that asked for no relations').toBe(true);
+    expect(ok(S, { ...row, users: { id: 2, name: 'ada' } }), 'with: { author: true }').toBe(true);
+    expect(ok(S, { ...row, comments: [{ id: 9, postId: 1, body: 'hi' }] })).toBe(true);
+  });
+
+  it('accepts null for a to-one, which a relational query really returns', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    expect(ok(mod.NestedSelectpostsSchema, { id: 1, authorId: 2, title: 't', users: null })).toBe(
+      true
+    );
+  });
+
+  it('still rejects a row whose related object is wrong', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedSelectpostsSchema;
+    expect(ok(S, { id: 1, authorId: 2, title: 't', users: { id: 'two', name: 'ada' } })).toBe(
+      false
+    );
+    expect(ok(S, { id: 1, authorId: 2, title: 't', comments: [{ id: 9 }] })).toBe(false);
+  });
+
+  it('keeps every column of the related row, since a read returns them all', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const child = mod.NestedSelectusersSchema.entries.posts.wrapped.item;
+    expect(Object.keys(child.entries).sort()).toEqual(['authorId', 'id', 'title']);
+  });
+});
+
+describe('depth', () => {
+  it('stops one level down by default', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const child = mod.NestedInsertusersSchema.entries.posts.wrapped.item;
+    expect(child.entries.comments, 'depth 1 goes no further').toBeUndefined();
+  });
+
+  it('goes deeper when asked, and validates the grandchild', async () => {
+    const { mod } = await emit({ nestedSchemas: true, nestedDepth: 2 });
+    const S = mod.NestedInsertusersSchema;
+    const payload = {
+      name: 'ada',
+      posts: [{ title: 'first', comments: [{ body: 'hi' }] }],
+    };
+    expect(ok(S, payload)).toBe(true);
+    expect(parse(S, payload)).toEqual(payload);
+    expect(ok(S, { name: 'ada', posts: [{ title: 'x', comments: [{ body: 5 }] }] })).toBe(false);
+    // The grandchild's own foreign key is omitted too.
+    expect(
+      ok(S, { name: 'ada', posts: [{ title: 'x', comments: [{ body: 'hi', postId: 1 }] }] })
+    ).toBe(true);
+  });
+});
+
+describe('a cycle', () => {
+  it('loads, validates, and stops at the depth rather than recursing', async () => {
+    const { mod } = await emit({ nestedSchemas: true, nestedDepth: 2 }, 'staff');
+    const S = mod.NestedInsertstaffSchema;
+    expect(ok(S, { label: 'root', staff: [{ label: 'a', staff: [{ label: 'b' }] }] })).toBe(true);
+    // Past the depth the key is not declared, so valibot strips it rather than checking it.
+    const parsed: any = parse(S, {
+      label: 'root',
+      staff: [{ label: 'a', staff: [{ label: 'b', staff: [{ label: 'c' }] }] }],
+    });
+    expect(parsed.staff[0].staff[0]).toEqual({ label: 'b' });
+    // The self-referencing foreign key is what the parent supplies, so it is gone at every level.
+    expect(ok(S, { label: 'root', staff: [{ label: 'a', managerId: 3 }] })).toBe(true);
+    const one: any = parse(S, { label: 'root', staff: [{ label: 'a', managerId: 3 }] });
+    expect(one.staff[0]).toEqual({ label: 'a' });
+  });
+});
+
+describe('the emitted module', () => {
+  it('imports nothing new and exports the types beside the schemas', async () => {
+    const { text } = await emit({ nestedSchemas: true });
+    // Nesting is expanded inline, so no module reaches for a sibling and no import cycle exists.
+    // Two modules that referenced each other would be a real hazard here: the initialiser runs at
+    // load, so the second one to evaluate reads an uninitialised binding and throws on import.
+    expect(text.match(/^import .*$/gm)).toEqual([
+      "import * as v from 'valibot';",
+      "import type { InferInput, InferOutput } from 'valibot';",
+    ]);
+    expect(text).toContain('export type NestedInsertusersInput');
+    expect(text).toContain('export type NestedSelectusersOutput');
+  });
+
+  it('emits only the modes a table actually has relations for', async () => {
+    // `comments` is a child and nothing else: it has a `one` to posts and no `many` at all, so a
+    // nested insert would be a byte-for-byte copy of the insert schema beside it.
+    const { mod } = await emit({ nestedSchemas: true }, 'comments');
+    expect(mod.NestedInsertcommentsSchema).toBeUndefined();
+    expect(mod.NestedSelectcommentsSchema).toBeTruthy();
+    expect(ok(mod.NestedSelectcommentsSchema, { id: 1, postId: 2, body: 'hi' })).toBe(true);
+  });
+});
+
+describe('the emitted nested code compiles', () => {
+  /**
+   * Run `tsc` over the emitted directory.
+   *
+   * Not covered by `pnpm typecheck`, and that was measured rather than assumed: the generator
+   * tsconfigs include `test`, and TypeScript's wildcard include skips any directory whose name
+   * starts with a dot, which every `.tmp-*` output directory here does. A deliberate type error
+   * written into an emitted file left `tsc -p tsconfig.json` at zero errors. So this points the
+   * compiler at the directory itself, under the `nodenext` resolution the emitted `.js`
+   * specifiers exist for.
+   */
+  it('under strict nodenext', async () => {
+    const { dir } = await emit({ nestedSchemas: true, nestedDepth: 2 });
+    const cfg = path.join(dir, 'tsconfig.json');
+    await fs.writeFile(
+      cfg,
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+          target: 'ES2021',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+        },
+        include: ['.'],
+      }),
+      'utf8'
+    );
+    const tsc = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+    const { stdout } = await promisify(execFile)(process.execPath, [tsc, '-p', cfg], {
+      maxBuffer: 20 * 1024 * 1024,
+    }).catch((e: any) => ({ stdout: e.stdout || String(e) }));
+    expect(stdout.trim()).toBe('');
+  }, 60_000);
+});

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -11,19 +11,26 @@ import type {
   LengthCheck,
   RowCheck,
 } from '@drzl/validation-core';
+import type { NestedNode, NestedMode } from '@drzl/validation-core';
 import {
   formatCode,
   parseCheck,
   renderDuplicateFinder,
   resolveConfiguredImport,
+  buildNestedPlan,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
   moduleFileName,
   moduleSpecifier,
+  nestedArmNotes,
+  nestedNodeColumns,
+  nestedSchemaName,
+  nestedTypeName,
   nonFiniteAccepted,
   resolveAffix,
+  resolveNestedDepth,
   schemaName,
   selectColumns,
   typeName,
@@ -68,7 +75,10 @@ function numericBounds(
     else if (k.operator === '<') hi = { op: 'lt', value: k.value };
   }
 
-  return [lo, hi].filter(Boolean).map((x) => `.${x!.op}(${literal(x!.value)})`).join('');
+  return [lo, hi]
+    .filter(Boolean)
+    .map((x) => `.${x!.op}(${literal(x!.value)})`)
+    .join('');
 }
 
 /**
@@ -491,13 +501,119 @@ function rowRefinements(rows: RowCheck[], cols: Column[]): string {
   );
 }
 
+/** Every CHECK on a table that the shared parser understands, split by what it constrains. */
+function parsedChecksFor(table: Table) {
+  const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  return {
+    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
+    lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
+    cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),
+  };
+}
+
+/** Push a rendered block one level deeper, so the nested object reads as one. */
+function indentBlock(code: string, by = '  '): string {
+  return code
+    .split('\n')
+    .map((line) => (line ? by + line : line))
+    .join('\n');
+}
+
+/**
+ * One object of a nested payload, with its relations expanded inline.
+ *
+ * Inline rather than by reference to a sibling schema. `.omit()` is the obvious way to say "the
+ * child's insert schema without its foreign key", and it does not work: measured on zod 4.4.3,
+ * `.omit()` on a schema carrying a `.refine()` **throws** `.omit() cannot be used on object
+ * schemas containing refinements`, so every table with a row-level CHECK would emit a module that
+ * threw the moment anything imported it. Rendering from the columns runs the same
+ * `renderObjectShape` the plain schemas use, so a nested field cannot drift from its flat twin.
+ */
+function renderNestedObject(
+  node: NestedNode,
+  mode: NestedMode,
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
+  typedJson: { allColumns?: boolean } | undefined,
+  applyDefaults: boolean
+): string {
+  const all = mode === 'insert' ? insertColumns(node.table) : selectColumns(node.table);
+  const cols = nestedNodeColumns(all, node);
+  const { checks, sets, rows, lengths, cardinalities } = parsedChecksFor(node.table);
+  const tj = typedJson
+    ? { table: node.table.tsName, mode, allColumns: typedJson.allColumns }
+    : undefined;
+  const fields = renderObjectShape(
+    cols,
+    mode,
+    coerceDates,
+    checks,
+    tj,
+    sets,
+    applyDefaults,
+    lengths,
+    cardinalities
+  );
+
+  const arms = node.arms.map((arm) => {
+    const notes = nestedArmNotes(arm)
+      .map((n) => `  // ${n}\n`)
+      .join('');
+    const child = renderNestedObject(arm.child, mode, coerceDates, typedJson, applyDefaults);
+    // A to-one may come back null: a relational query returns null where there is no matching
+    // row, and accepting it never turns away something the query produced. Optional throughout,
+    // because which relations a payload carries is the caller's choice on a write and the `with`
+    // clause's on a read.
+    const value = arm.single
+      ? `${indentBlock(child).trimStart()}.nullable()`
+      : `z.array(\n${indentBlock(indentBlock(child))}\n  )`;
+    return `${notes}  ${JSON.stringify(arm.key)}: ${value}.optional(),`;
+  });
+
+  const body = [fields, ...arms].filter(Boolean).join('\n');
+  return `z.object({\n${body}\n})${rowRefinements(rows, cols)}`;
+}
+
+/** The nested exports for one table, or nothing when it has no relations to describe. */
+function renderNestedSchemas(
+  table: Table,
+  affix: ResolvedAffix,
+  coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
+  typedJson: { allColumns?: boolean } | undefined,
+  applyDefaults: boolean,
+  plans: Partial<Record<NestedMode, NestedNode>>
+): string {
+  const out: string[] = [];
+  for (const mode of ['insert', 'select'] as const) {
+    const plan = plans[mode];
+    if (!plan) continue;
+    const name = nestedSchemaName(mode, table.tsName, affix);
+    const tname = nestedTypeName(mode, table.tsName, affix);
+    const expr = renderNestedObject(plan, mode, coerceDates, typedJson, applyDefaults);
+    const infer = mode === 'insert' ? 'input' : 'output';
+    out.push(
+      `export const ${name} = ${expr};\n\nexport type ${tname} = z.${infer}<typeof ${name}>;`
+    );
+  }
+  return out.length ? `\n${out.join('\n\n')}\n` : '';
+}
+
+/** Every table a plan reaches, so a type-only import can name all of them. */
+function nestedTables(node: NestedNode, into = new Set<string>()): Set<string> {
+  into.add(node.table.tsName);
+  for (const arm of node.arms) nestedTables(arm.child, into);
+  return into;
+}
+
 function renderTableSchemas(
   table: Table,
   affix: ResolvedAffix,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   typedJson?: { schemaSpecifier: string; allColumns?: boolean },
   applyDefaults = false,
-  wantsDuplicateFinder = false
+  wantsDuplicateFinder = false,
+  nested: Partial<Record<NestedMode, NestedNode>> = {}
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -560,8 +676,16 @@ function renderTableSchemas(
   );
   // A type-only import: it disappears at build time, so this adds no runtime dependency on the
   // schema module and cannot create an import cycle at runtime.
+  //
+  // A nested shape references the columns of *other* tables, so those tables have to be named
+  // here too or the reference would not resolve. Without this the module compiled fine until
+  // `typedJson` and `nestedSchemas` were combined, and then named an identifier nothing imported.
+  const referenced = new Set<string>([table.tsName]);
+  for (const plan of Object.values(nested)) {
+    if (plan) for (const name of nestedTables(plan)) referenced.add(name);
+  }
   const schemaImport = typedJson
-    ? `import type { ${table.tsName} } from '${typedJson.schemaSpecifier}';\n`
+    ? `import type { ${[...referenced].join(', ')} } from '${typedJson.schemaSpecifier}';\n`
     : '';
   // A materialized view refuses every write, so an insert or update schema for one would describe
   // an operation the database always rejects. The select schema is the only meaningful one.
@@ -582,21 +706,30 @@ ${bodyUpdate}
 export type ${updateType} = z.input<typeof ${updateSchema}>;
 `;
 
-    // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
+  // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
   // half that needs no database: whether a batch collides with itself.
   const finder = wantsDuplicateFinder
     ? renderDuplicateFinder(table, `findDuplicate${T}`, insertType)
     : undefined;
   const duplicates = finder ? `\n${finder}\n` : '';
 
-return `import { z } from 'zod';
+  const nestedCode = renderNestedSchemas(
+    table,
+    affix,
+    coerceDates,
+    typedJson,
+    applyDefaults,
+    nested
+  );
+
+  return `import { z } from 'zod';
 ${schemaImport}
 ${writes}export const ${selectSchema} = z.object({
 ${bodySelect}
 })${rowRefinements(rows, selectCols)};
 
 ${writeTypes}export type ${selectType} = z.output<typeof ${selectSchema}>;
-${duplicates}`;
+${nestedCode}${duplicates}`;
 }
 
 export interface ZodGenerateOptions extends ValidationGenerateOptions {
@@ -610,6 +743,28 @@ export interface ZodGenerateOptions extends ValidationGenerateOptions {
    * generated code ships in the consumer's bundle.
    */
   duplicateFinder?: boolean;
+}
+
+/**
+ * The nested plans for one table, built once per mode.
+ *
+ * Returned as a partial map because the two modes disagree per table: `comments` is a child and
+ * nothing else, so it has a nested select and no nested insert, and emitting an insert one anyway
+ * would put a byte-for-byte copy of `InsertcommentsSchema` in the file under a second name.
+ */
+function nestedPlansFor(
+  table: Table,
+  analysis: Analysis,
+  depth: number
+): Partial<Record<NestedMode, NestedNode>> {
+  const out: Partial<Record<NestedMode, NestedNode>> = {};
+  for (const mode of ['insert', 'select'] as const) {
+    // A read-only relation refuses every write, so it has no insert schema to nest into.
+    if (mode === 'insert' && table.readOnly) continue;
+    const plan = buildNestedPlan(table, analysis.tables, analysis.relations ?? [], mode, depth);
+    if (plan) out[mode] = plan;
+  }
+  return out;
 }
 
 export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
@@ -647,12 +802,22 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
         '[drzl] typedJson was requested but the schema path is unknown, so json columns keep their wide type.'
       );
     }
+    const nestedDepth = opts.nestedSchemas
+      ? resolveNestedDepth(opts.nestedDepth, (m) => console.warn(m))
+      : 0;
     // File names deliberately stay on the raw Drizzle export name: affixes and tableCase
     // rename identifiers, never modules, so the barrel and importPath keep resolving.
     for (const table of this.analysis.tables) {
       const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
-      const code = renderTableSchemas(table, affix, coerceDates, typedJson, !!opts.applyDefaults,
-      !!opts?.duplicateFinder);
+      const code = renderTableSchemas(
+        table,
+        affix,
+        coerceDates,
+        typedJson,
+        !!opts.applyDefaults,
+        !!opts?.duplicateFinder,
+        opts.nestedSchemas ? nestedPlansFor(table, this.analysis, nestedDepth) : {}
+      );
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
         filePath,

--- a/packages/generator-zod/test/nested-relations.spec.ts
+++ b/packages/generator-zod/test/nested-relations.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * Nested relation schemas, checked by running them.
+ *
+ * A caller inserting a parent and its children in one payload has nothing to validate it against:
+ * every first-party Drizzle validator emits column keys only, and `db.insert` drops the relation
+ * key silently rather than refusing it, so the children are never written and nothing says so.
+ *
+ * Every assertion here imports the emitted module and parses real payloads through it. Reading the
+ * text cannot tell a schema that admits `{ posts: [...] }` from one that strips it, and stripping
+ * is exactly what the default zod object does to a key it does not declare.
+ */
+import { execFile } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { promisify } from 'node:util';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { Analysis, Column, Relation, Table } from '@drzl/analyzer';
+import { ZodGenerator } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (name: string, cols: Column[], over: Partial<Table> = {}): Table =>
+  ({ name, tsName: name, columns: cols, unique: [], indexes: [], checks: [], ...over }) as Table;
+
+const users = table('users', [
+  col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+  col('name'),
+]);
+const posts = table(
+  'posts',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('authorId', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+    col('title'),
+  ],
+  { foreignKeys: [{ columns: ['authorId'], foreignTable: 'users', foreignColumns: ['id'] }] }
+);
+const comments = table(
+  'comments',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('postId', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+    col('body'),
+  ],
+  { foreignKeys: [{ columns: ['postId'], foreignTable: 'posts', foreignColumns: ['id'] }] }
+);
+/** The cycle that really happens: a table pointing at itself. */
+const staff = table(
+  'staff',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', integer: true, isGenerated: true }),
+    col('managerId', { tsType: 'number', dbType: 'INTEGER', integer: true, nullable: true }),
+    col('label'),
+  ],
+  { foreignKeys: [{ columns: ['managerId'], foreignTable: 'staff', foreignColumns: ['id'] }] }
+);
+
+const RELATIONS: Relation[] = [
+  { kind: 'one', from: 'posts', to: 'users' },
+  { kind: 'many', from: 'users', to: 'posts' },
+  { kind: 'one', from: 'comments', to: 'posts' },
+  { kind: 'many', from: 'posts', to: 'comments' },
+  { kind: 'one', from: 'staff', to: 'staff' },
+  { kind: 'many', from: 'staff', to: 'staff' },
+];
+
+const analysis = (): Analysis => ({
+  dialect: 'postgres',
+  tables: [users, posts, comments, staff],
+  enums: [],
+  relations: RELATIONS,
+  issues: [],
+});
+
+let seq = 0;
+
+/** Emit the whole fixture and import one table's module. */
+async function emit(
+  opts: Record<string, unknown>,
+  which = 'users'
+): Promise<{ mod: Record<string, any>; text: string; dir: string }> {
+  const dir = path.join(__dirname, '.tmp-nested', `run-${process.pid}-${seq++}`);
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis()).generate({ outDir: dir, ...opts } as never);
+  const file = path.join(dir, `${which}.zod.ts`);
+  return { mod: await import(file), text: await fs.readFile(file, 'utf8'), dir };
+}
+
+const ok = (schema: any, v: unknown) => schema.safeParse(v).success;
+
+describe('off by default', () => {
+  it('emits nothing nested and no extra bytes', async () => {
+    const plain = await emit({});
+    expect(Object.keys(plain.mod).some((k) => k.startsWith('Nested'))).toBe(false);
+    expect(plain.text).not.toContain('Nested');
+    // Byte-for-byte identical to a run that named the option and turned it off, which is the
+    // claim the output-size budget in verify-packed.sh relies on.
+    const explicitOff = await emit({ nestedSchemas: false });
+    expect(explicitOff.text).toBe(plain.text);
+  });
+});
+
+describe('the nested insert payload', () => {
+  it('accepts a parent and its children in one object', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    expect(S, 'the nested insert schema is exported').toBeTruthy();
+    expect(ok(S, { name: 'ada', posts: [{ title: 'first' }] })).toBe(true);
+    // The children are kept rather than stripped, which is the failure mode a plain object has.
+    expect(S.parse({ name: 'ada', posts: [{ title: 'first' }] })).toEqual({
+      name: 'ada',
+      posts: [{ title: 'first' }],
+    });
+  });
+
+  it('rejects an invalid child', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    expect(ok(S, { name: 'ada', posts: [{ title: 5 }] }), 'a child with the wrong type').toBe(
+      false
+    );
+    expect(ok(S, { name: 'ada', posts: [{}] }), 'a child missing a required column').toBe(false);
+    expect(ok(S, { name: 'ada', posts: {} }), 'an object where an array belongs').toBe(false);
+  });
+
+  it('does not ask for the foreign key the parent supplies', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const S = mod.NestedInsertusersSchema;
+    // `authorId` cannot be known before the user is written. A schema demanding it is unusable.
+    expect(ok(S, { name: 'ada', posts: [{ title: 'x' }] })).toBe(true);
+    expect(Object.keys(S.shape.posts.unwrap().element.shape)).toEqual(['title']);
+    // And the plain insert schema still requires it, so the nesting weakened nothing.
+    expect(ok(mod.InsertpostsSchema ?? mod.InsertusersSchema, {})).toBe(false);
+  });
+
+  it('leaves the relation key optional, so a childless parent still validates', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    expect(ok(mod.NestedInsertusersSchema, { name: 'ada' })).toBe(true);
+  });
+
+  it('carries no `one` relation', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedInsertpostsSchema;
+    expect(Object.keys(S.shape).sort()).toEqual(['authorId', 'comments', 'title']);
+    expect(S.shape.users, 'a `one` arm would weaken authorId on the post itself').toBeUndefined();
+  });
+
+  it('emits no nested update schema in any form', async () => {
+    const { mod, text } = await emit({ nestedSchemas: true });
+    expect(Object.keys(mod).filter((k) => k.startsWith('NestedUpdate'))).toEqual([]);
+    expect(text).not.toContain('NestedUpdate');
+  });
+});
+
+describe('the nested select payload', () => {
+  it('carries every relation kind, each one optional', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedSelectpostsSchema;
+    expect(Object.keys(S.shape).sort()).toEqual(['authorId', 'comments', 'id', 'title', 'users']);
+    const row = { id: 1, authorId: 2, title: 't' };
+    expect(ok(S, row), 'a row from a query that asked for no relations').toBe(true);
+    expect(ok(S, { ...row, users: { id: 2, name: 'ada' } }), 'with: { author: true }').toBe(true);
+    expect(ok(S, { ...row, comments: [{ id: 9, postId: 1, body: 'hi' }] })).toBe(true);
+  });
+
+  it('accepts null for a to-one, which a relational query really returns', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    expect(ok(mod.NestedSelectpostsSchema, { id: 1, authorId: 2, title: 't', users: null })).toBe(
+      true
+    );
+  });
+
+  it('still rejects a row whose related object is wrong', async () => {
+    const { mod } = await emit({ nestedSchemas: true }, 'posts');
+    const S = mod.NestedSelectpostsSchema;
+    expect(ok(S, { id: 1, authorId: 2, title: 't', users: { id: 'two', name: 'ada' } })).toBe(
+      false
+    );
+    expect(ok(S, { id: 1, authorId: 2, title: 't', comments: [{ id: 9 }] })).toBe(false);
+  });
+
+  it('keeps every column of the related row, since a read returns them all', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const child = mod.NestedSelectusersSchema.shape.posts.unwrap().element;
+    expect(Object.keys(child.shape).sort()).toEqual(['authorId', 'id', 'title']);
+  });
+});
+
+describe('depth', () => {
+  it('stops one level down by default', async () => {
+    const { mod } = await emit({ nestedSchemas: true });
+    const child = mod.NestedInsertusersSchema.shape.posts.unwrap().element;
+    expect(child.shape.comments, 'depth 1 goes no further').toBeUndefined();
+  });
+
+  it('goes deeper when asked, and validates the grandchild', async () => {
+    const { mod } = await emit({ nestedSchemas: true, nestedDepth: 2 });
+    const S = mod.NestedInsertusersSchema;
+    const payload = {
+      name: 'ada',
+      posts: [{ title: 'first', comments: [{ body: 'hi' }] }],
+    };
+    expect(ok(S, payload)).toBe(true);
+    expect(S.parse(payload)).toEqual(payload);
+    expect(ok(S, { name: 'ada', posts: [{ title: 'x', comments: [{ body: 5 }] }] })).toBe(false);
+    // The grandchild's own foreign key is omitted too.
+    expect(
+      ok(S, { name: 'ada', posts: [{ title: 'x', comments: [{ body: 'hi', postId: 1 }] }] })
+    ).toBe(true);
+  });
+});
+
+describe('a cycle', () => {
+  it('loads, validates, and stops at the depth rather than recursing', async () => {
+    const { mod } = await emit({ nestedSchemas: true, nestedDepth: 2 }, 'staff');
+    const S = mod.NestedInsertstaffSchema;
+    expect(ok(S, { label: 'root', staff: [{ label: 'a', staff: [{ label: 'b' }] }] })).toBe(true);
+    // Past the depth the key is not declared, so zod strips it rather than checking it.
+    const parsed = S.parse({
+      label: 'root',
+      staff: [{ label: 'a', staff: [{ label: 'b', staff: [{ label: 'c' }] }] }],
+    });
+    expect(parsed.staff[0].staff[0]).toEqual({ label: 'b' });
+    // The self-referencing foreign key is what the parent supplies, so it is gone at every level.
+    expect(ok(S, { label: 'root', staff: [{ label: 'a', managerId: 3 }] })).toBe(true);
+    expect(S.parse({ label: 'root', staff: [{ label: 'a', managerId: 3 }] }).staff[0]).toEqual({
+      label: 'a',
+    });
+  });
+});
+
+describe('the emitted module', () => {
+  it('imports nothing new and exports the types beside the schemas', async () => {
+    const { text } = await emit({ nestedSchemas: true });
+    // Nesting is expanded inline, so no module reaches for a sibling and no import cycle exists.
+    // Two modules that referenced each other would be a real hazard here: the initialiser runs at
+    // load, so the second one to evaluate reads an uninitialised binding and throws on import.
+    expect(text.match(/^import .*$/gm)).toEqual(["import { z } from 'zod';"]);
+    expect(text).toContain('export type NestedInsertusersInput');
+    expect(text).toContain('export type NestedSelectusersOutput');
+  });
+
+  it('emits only the modes a table actually has relations for', async () => {
+    // `comments` is a child and nothing else: it has a `one` to posts and no `many` at all, so a
+    // nested insert would be a byte-for-byte copy of the insert schema beside it.
+    const { mod } = await emit({ nestedSchemas: true }, 'comments');
+    expect(mod.NestedInsertcommentsSchema).toBeUndefined();
+    expect(mod.NestedSelectcommentsSchema).toBeTruthy();
+    expect(ok(mod.NestedSelectcommentsSchema, { id: 1, postId: 2, body: 'hi' })).toBe(true);
+  });
+});
+
+describe('the emitted nested code compiles', () => {
+  /**
+   * Run `tsc` over the emitted directory.
+   *
+   * Not covered by `pnpm typecheck`, and that was measured rather than assumed: the generator
+   * tsconfigs include `test`, and TypeScript's wildcard include skips any directory whose name
+   * starts with a dot, which every `.tmp-*` output directory here does. A deliberate type error
+   * written into an emitted file left `tsc -p tsconfig.json` at zero errors. So this points the
+   * compiler at the directory itself, under the `nodenext` resolution the emitted `.js`
+   * specifiers exist for.
+   */
+  it('under strict nodenext', async () => {
+    const { dir } = await emit({ nestedSchemas: true, nestedDepth: 2 });
+    const cfg = path.join(dir, 'tsconfig.json');
+    await fs.writeFile(
+      cfg,
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+          target: 'ES2021',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+        },
+        include: ['.'],
+      }),
+      'utf8'
+    );
+    const tsc = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+    const { stdout } = await promisify(execFile)(process.execPath, [tsc, '-p', cfg], {
+      maxBuffer: 20 * 1024 * 1024,
+    }).catch((e: any) => ({ stdout: e.stdout || String(e) }));
+    expect(stdout.trim()).toBe('');
+  }, 60_000);
+});

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -10,6 +10,7 @@ import type { AffixOptions } from './naming.js';
 export * from './checks.js';
 export * from './files.js';
 export * from './naming.js';
+export * from './nested.js';
 
 // Minimal local Table shape for codegen logic and tests
 export interface Table {
@@ -108,6 +109,29 @@ export interface ValidationGenerateOptions {
    */
   affix?: AffixOptions;
   coerceDates?: 'input' | 'all' | 'none';
+  /**
+   * Also emit `NestedInsert<Table>` and `NestedSelect<Table>`: the table's own schema plus one key
+   * per relation, so `{ ...user, posts: [...] }` can be validated whole.
+   *
+   * Nothing in the Drizzle validator ecosystem describes this payload. Measured across both majors
+   * and all four libraries, `createInsertSchema(users)` emits column keys only, and
+   * `db.insert(users).values({ name, posts: [...] })` drops the `posts` key without a word rather
+   * than refusing it, so the children are silently never written.
+   *
+   * Off by default, like every other option that adds bytes to the consumer's bundle. See
+   * `NestedMode` in `@drzl/validation-core` for why there is no nested update schema, and
+   * `KINDS_BY_MODE` for why a `one` relation appears on select and not on insert.
+   */
+  nestedSchemas?: boolean;
+  /**
+   * How many levels of children a nested schema describes. Defaults to 1, capped at
+   * `MAX_NESTED_DEPTH`.
+   *
+   * Nesting is expanded inline rather than by reference, so this multiplies the emitted size: a
+   * schema whose tables average R relations emits R^depth child shapes per root table. It is also
+   * what terminates a cycle, since `users -> posts -> users` simply stops here.
+   */
+  nestedDepth?: number;
   emit?: {
     select?: boolean;
     insert?: boolean;
@@ -119,6 +143,13 @@ export interface ValidationRenderer<
   TOptions extends ValidationGenerateOptions = ValidationGenerateOptions,
 > {
   readonly library: ValidationLibrary;
+  /**
+   * One table's schemas, without the nested variants even under `nestedSchemas`.
+   *
+   * Structural rather than an omission: relations live on the `Analysis` and this is handed a
+   * `Table`, so there is nothing here to read them from. `typedJson` is absent for the same
+   * reason. Nothing but the generators' own tests calls this; `generate` is the path that emits.
+   */
   renderTable(table: Table, opts?: TOptions): string;
   renderIndex?(analysis: Analysis, opts?: TOptions): string;
   generate(opts: TOptions): Promise<string[]>;

--- a/packages/validation-core/src/nested.ts
+++ b/packages/validation-core/src/nested.ts
@@ -1,0 +1,287 @@
+/**
+ * What a relations-aware nested schema describes, decided once for all four generators.
+ *
+ * A caller who inserts a parent and its children in one payload, `{ ...user, posts: [...] }`, has
+ * nothing to validate it against. Every first-party Drizzle validator emits columns only: measured
+ * at drizzle-orm 1.0.0-rc.4 and at the 0.4x `drizzle-zod`/`drizzle-valibot`/`drizzle-typebox`/
+ * `drizzle-arktype` packages, `createInsertSchema(users)` yields exactly `['id', 'name']` and never
+ * a `posts` key, in every mode and every library. Handing the relations object in as the second
+ * argument does not change that either: it lands in the refine slot and is dropped, because its
+ * keys are not column names. Handing it in first throws inside `getColumns`.
+ *
+ * And the payload is not merely unvalidated, it is silently discarded. `db.insert(users).values({
+ * name: 'a', posts: [{ title: 't' }] })` emits `insert into "users" ("id", "name") values
+ * (default, $1)` on both majors: the relation key is dropped, no error is raised, and the children
+ * are simply never written.
+ *
+ * This module states the *shape* of such a payload from the analysis. It renders nothing: each
+ * generator walks the plan and emits it in its own library, so the four cannot disagree about
+ * which relations appear or which columns a child carries.
+ */
+import type { Relation, Table } from '@drzl/analyzer';
+import { schemaName, typeName, type NameMode, type ResolvedAffix } from './naming.js';
+
+/**
+ * Which modes get a nested variant.
+ *
+ * `update` is deliberately absent, and it is the one decision here that is a refusal rather than a
+ * design. A nested update payload has no single meaning: `{ name: 'x', posts: [...] }` could mean
+ * replace every child, upsert them, or patch the ones that match, and choosing needs an operation
+ * vocabulary (Prisma spells it `create` / `connect` / `set` / `deleteMany`) that neither DRZL nor
+ * Drizzle has. Worse, it could not be acted on even if the meaning were fixed: `updateColumns`
+ * drops the primary key, so a child inside an update payload carries nothing that identifies which
+ * row it patches. A schema whose meaning the tool emitting it cannot state is worse than no schema.
+ */
+export type NestedMode = 'insert' | 'select';
+
+/** Prefix in front of the ordinary resolved name, so affixes keep working underneath it. */
+export const NESTED_PREFIX = 'Nested';
+
+/** e.g. `NestedInsertusersSchema`. */
+export function nestedSchemaName(mode: NestedMode, tsName: string, affix: ResolvedAffix): string {
+  return NESTED_PREFIX + schemaName(mode as NameMode, tsName, affix);
+}
+
+/** e.g. `NestedInsertusersInput`. */
+export function nestedTypeName(mode: NestedMode, tsName: string, affix: ResolvedAffix): string {
+  return NESTED_PREFIX + typeName(mode as NameMode, tsName, affix);
+}
+
+/**
+ * How many levels of children a nested schema describes, when nothing says.
+ *
+ * One, because one is what the payload in the plan item is: a parent and its children. Deeper is
+ * available and is not the default, because the output grows multiplicatively in this number and
+ * generated code ships in the consumer's bundle.
+ */
+export const DEFAULT_NESTED_DEPTH = 1;
+
+/**
+ * The most levels `nestedDepth` will honour.
+ *
+ * Not a taste limit. Nesting is expanded inline rather than by reference, so a schema whose tables
+ * average R relations emits R^depth child shapes per root table, and both directions of a
+ * many-to-many count. At 3 that is already an eightfold expansion of every column list in the
+ * schema; past it the emitted file stops being something a person can open.
+ */
+export const MAX_NESTED_DEPTH = 3;
+
+/** Clamp a configured depth into the range that is actually emitted, saying so if it moved. */
+export function resolveNestedDepth(
+  depth: number | undefined,
+  warn?: (msg: string) => void
+): number {
+  if (depth === undefined) return DEFAULT_NESTED_DEPTH;
+  if (!Number.isFinite(depth)) return DEFAULT_NESTED_DEPTH;
+  const whole = Math.trunc(depth);
+  const clamped = Math.min(Math.max(whole, 1), MAX_NESTED_DEPTH);
+  if (clamped !== depth && warn) {
+    warn(
+      `[drzl] nestedDepth ${depth} is outside 1..${MAX_NESTED_DEPTH} and was read as ${clamped}.`
+    );
+  }
+  return clamped;
+}
+
+/** One relation as it appears in a payload. */
+export interface NestedArm {
+  /** The key the payload uses. The child table's Drizzle export name, since nothing else names it. */
+  key: string;
+  kind: Relation['kind'];
+  /** Join table of a many-to-many, carried only so the emitted comment can name it. */
+  via?: string;
+  /** `true` when the value is one object rather than an array of them. Only a `one` relation. */
+  single: boolean;
+  /** The child payload, itself possibly carrying relations. */
+  child: NestedNode;
+  /**
+   * Something true about this arm that the shape alone does not say, emitted as a comment beside
+   * it. Absent when there is nothing to say.
+   */
+  note?: string;
+}
+
+/** One object in a nested payload: a table, minus what the enclosing parent supplies. */
+export interface NestedNode {
+  table: Table;
+  /**
+   * Columns dropped from this object because the row that encloses it supplies them.
+   *
+   * Always empty at the root and always empty in `select`, where every column of the row really is
+   * returned. On `insert` it holds the child's foreign key to its parent; see `armFor`.
+   */
+  omitted: string[];
+  arms: NestedArm[];
+}
+
+/**
+ * The relation kinds a nested payload of each mode can describe.
+ *
+ * `one` is absent from `insert`, and that is the second refusal in this file. In
+ * `{ ...post, author: {...} }` the foreign key is on the **outer** object, `posts.authorId`, not on
+ * the nested one: the author is written first and the post then points at it. So admitting the arm
+ * means making `authorId` optional on the post, and an optional `authorId` also admits
+ * `{ title: 't' }` with neither a foreign key nor an author, which is a row a NOT NULL column
+ * refuses. Adding the arm would therefore make the schema accept a write the database rejects,
+ * which is worse than not describing the payload at all.
+ *
+ * Two forms express it properly and neither is emitted here: a union of "you gave the key" and
+ * "you gave the object", which doubles per `one` relation and so is 2^n branches on a table with n
+ * of them, or a row-level "exactly one of these" assertion, which all four libraries can carry but
+ * each spells differently. Both are open.
+ *
+ * A `many` arm has no such problem: the omitted foreign key is on the child, so the outer object's
+ * own contract is untouched and the nested insert schema stays a strict extension of the plain one.
+ */
+const KINDS_BY_MODE: Record<NestedMode, ReadonlySet<Relation['kind']>> = {
+  insert: new Set(['many', 'manyToMany']),
+  select: new Set(['one', 'many', 'manyToMany']),
+};
+
+/** Arms are considered in this order, so a pair of tables linked both ways resolves predictably. */
+const KIND_ORDER: Record<Relation['kind'], number> = { many: 0, manyToMany: 1, one: 2 };
+
+/**
+ * Which of the child's columns the parent supplies, for a `many` arm.
+ *
+ * The relation states two table names and nothing else, so the columns come from the child's own
+ * foreign keys: the ones pointing back at the parent table. Exactly one such key is the case worth
+ * acting on.
+ *
+ * **Zero** means the relation was declared without a real constraint behind it, by `relations()`
+ * with no `references`, or by the name-matching heuristic. There is nothing to omit and nothing is
+ * wrong; the child simply keeps whatever columns it declared.
+ *
+ * **More than one** is genuinely ambiguous and is left alone on purpose. A `messages` table with
+ * `senderId` and `recipientId` both pointing at `users` has two candidates, and `Relation` carries
+ * no field name to tell them apart, so omitting either would silently drop a column the writer has
+ * to supply. Omitting both would drop one the parent cannot supply. The arm is still emitted, with
+ * both foreign keys present exactly as the plain insert schema has them, and a comment saying why.
+ */
+function omittedColumnsFor(parent: Table, child: Table): { omitted: string[]; note?: string } {
+  const back = (child.foreignKeys ?? []).filter((fk) => fk.foreignTable === parent.name);
+  if (back.length === 1) return { omitted: [...back[0].columns] };
+  if (back.length === 0) return { omitted: [] };
+  const named = back.map((fk) => fk.columns.join('+')).join(', ');
+  return {
+    omitted: [],
+    note:
+      `${child.tsName} has ${back.length} foreign keys to ${parent.name} (${named}), so which one ` +
+      `this relation uses is not stated. None were omitted: supply them yourself.`,
+  };
+}
+
+/**
+ * The nested payload for one table, expanded `depth` levels.
+ *
+ * Recursion is bounded rather than expressed. All four libraries can state a cyclic schema, and
+ * each does it differently: zod through a property getter, valibot through `v.lazy`, ArkType only
+ * inside a `scope` (a plain forward reference throws `Cannot access 'Post' before initialization`
+ * at module load), TypeBox only inside a `Type.Module` (a bare `Type.Ref` constructs happily and
+ * then throws `Unable to dereference schema with $id` the first time anything checks a value).
+ * Every one of those was run.
+ *
+ * None is used. Expanding inline to a fixed depth needs no recursion API, so no emitted module can
+ * throw on import from an unresolvable reference, no zod or valibot schema needs the explicit type
+ * annotation a self-referential one demands from TypeScript, and the four outputs stay structurally
+ * identical instead of diverging into four different recursion mechanisms. A cycle in the relations
+ * simply stops at the depth: `users -> posts -> users` at depth 1 emits the posts and no more.
+ */
+export function buildNestedPlan(
+  root: Table,
+  tables: readonly Table[],
+  relations: readonly Relation[],
+  mode: NestedMode,
+  depth: number
+): NestedNode | undefined {
+  const node = buildNode(root, [], tables, relations, mode, depth);
+  // A table with no relations gains nothing from a nested variant: it would be a byte-for-byte
+  // copy of the schema beside it under a second name.
+  return node.arms.length ? node : undefined;
+}
+
+function buildNode(
+  table: Table,
+  omitted: string[],
+  tables: readonly Table[],
+  relations: readonly Relation[],
+  mode: NestedMode,
+  depth: number
+): NestedNode {
+  if (depth <= 0) return { table, omitted, arms: [] };
+
+  const byDbName = new Map(tables.map((t) => [t.name, t]));
+  const allowed = KINDS_BY_MODE[mode];
+  // A relation key sits in the same object as the columns, so a column of the same name would be
+  // overwritten by it. The columns are the row and win.
+  const columnNames = new Set(table.columns.map((c) => c.name));
+  const taken = new Set<string>();
+  const arms: NestedArm[] = [];
+
+  const candidates = relations
+    .filter((r) => r.from === table.name && allowed.has(r.kind))
+    .sort((a, b) => KIND_ORDER[a.kind] - KIND_ORDER[b.kind]);
+
+  for (const rel of candidates) {
+    const child = byDbName.get(rel.to);
+    if (!child) continue;
+    const key = child.tsName;
+    if (columnNames.has(key)) continue;
+    // Two relations between the same pair of tables produce the same key, because the key can only
+    // come from the table name. The first in `KIND_ORDER` wins and the rest are dropped.
+    if (taken.has(key)) continue;
+    taken.add(key);
+
+    // Only a `many` arm has a foreign key to omit. A `one` arm's nested object is the parent row,
+    // which carries none of the child's columns, and a many-to-many keeps both foreign keys on the
+    // join table rather than on either end.
+    const { omitted: childOmitted, note } =
+      rel.kind === 'many' && mode === 'insert'
+        ? omittedColumnsFor(table, child)
+        : { omitted: [] as string[], note: undefined };
+
+    arms.push({
+      key,
+      kind: rel.kind,
+      via: rel.via,
+      single: rel.kind === 'one',
+      note,
+      child: buildNode(child, childOmitted, tables, relations, mode, depth - 1),
+    });
+  }
+
+  return { table, omitted, arms };
+}
+
+/**
+ * The comment lines that go above an arm, without their `//`.
+ *
+ * Shared so the four generators say the same thing about the same relation, and returned unmarked
+ * because each of them indents its object literal differently.
+ */
+export function nestedArmNotes(arm: NestedArm): string[] {
+  const out: string[] = [];
+  if (arm.kind === 'manyToMany') {
+    out.push(
+      `Through ${arm.via ?? 'a join table'}. The join row is not described: its columns are the ` +
+        `two foreign keys, and the two ends of this payload supply both.`
+    );
+  }
+  if (arm.note) out.push(arm.note);
+  return out;
+}
+
+/**
+ * Which columns a node contributes, given the mode's column list for its table.
+ *
+ * The list is passed in rather than derived, so this cannot drift from `insertColumns` and
+ * `selectColumns` and so `validation-core`'s entry point stays free of a cycle back into itself.
+ */
+export function nestedNodeColumns<T extends { name: string }>(
+  columnsForMode: readonly T[],
+  node: NestedNode
+): T[] {
+  if (!node.omitted.length) return [...columnsForMode];
+  const drop = new Set(node.omitted);
+  return columnsForMode.filter((c) => !drop.has(c.name));
+}

--- a/packages/validation-core/test/nested.spec.ts
+++ b/packages/validation-core/test/nested.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * The nested payload plan, which decides what all four generators emit.
+ *
+ * Nothing here renders anything. It pins the four decisions that are the whole design: which
+ * relation kinds appear in which mode, which of the child's columns the parent supplies, what a
+ * cycle does, and what happens when the relation does not say enough to answer the second question.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Relation, Table } from '@drzl/analyzer';
+import {
+  buildNestedPlan,
+  DEFAULT_NESTED_DEPTH,
+  MAX_NESTED_DEPTH,
+  nestedArmNotes,
+  nestedNodeColumns,
+  nestedSchemaName,
+  nestedTypeName,
+  resolveAffix,
+  resolveNestedDepth,
+} from '../src/index';
+
+const col = (name: string, over: Record<string, unknown> = {}) =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as never;
+
+const table = (name: string, tsName: string, cols: string[], over: Partial<Table> = {}): Table =>
+  ({
+    name,
+    tsName,
+    columns: cols.map((c) => col(c)),
+    unique: [],
+    indexes: [],
+    checks: [],
+    ...over,
+  }) as Table;
+
+const users = table('users', 'users', ['id', 'name']);
+const posts = table('posts', 'posts', ['id', 'authorId', 'title'], {
+  foreignKeys: [{ columns: ['authorId'], foreignTable: 'users', foreignColumns: ['id'] }],
+});
+const comments = table('comments', 'comments', ['id', 'postId', 'body'], {
+  foreignKeys: [{ columns: ['postId'], foreignTable: 'posts', foreignColumns: ['id'] }],
+});
+
+/** Exactly what the analyzer emits for those three tables from their foreign keys alone. */
+const REL: Relation[] = [
+  { kind: 'one', from: 'posts', to: 'users' },
+  { kind: 'many', from: 'users', to: 'posts' },
+  { kind: 'one', from: 'comments', to: 'posts' },
+  { kind: 'many', from: 'posts', to: 'comments' },
+];
+
+const TABLES = [users, posts, comments];
+
+describe('which relations a nested payload carries', () => {
+  it('puts the children on an insert and omits the foreign key they cannot know', () => {
+    const plan = buildNestedPlan(users, TABLES, REL, 'insert', 1)!;
+    expect(plan.arms.map((a) => a.key)).toEqual(['posts']);
+    expect(plan.arms[0].single).toBe(false);
+    // The whole point: `authorId` does not exist until the user is inserted.
+    expect(plan.arms[0].child.omitted).toEqual(['authorId']);
+  });
+
+  it('leaves a `one` relation off an insert entirely', () => {
+    // posts -> users is a `one`, and the foreign key for it sits on the post rather than on the
+    // user, so admitting the arm would mean weakening the post's own contract.
+    const plan = buildNestedPlan(posts, TABLES, REL, 'insert', 1)!;
+    expect(plan.arms.map((a) => a.key)).toEqual(['comments']);
+    expect(plan.arms.some((a) => a.kind === 'one')).toBe(false);
+  });
+
+  it('carries a `one` relation on a select, where the row really comes back', () => {
+    const plan = buildNestedPlan(posts, TABLES, REL, 'select', 1)!;
+    const kinds = Object.fromEntries(plan.arms.map((a) => [a.key, a.kind]));
+    expect(kinds).toEqual({ comments: 'many', users: 'one' });
+    expect(plan.arms.find((a) => a.key === 'users')!.single).toBe(true);
+    // Nothing is omitted on a read: every column of the row is returned.
+    for (const arm of plan.arms) expect(arm.child.omitted).toEqual([]);
+  });
+
+  it('emits nothing at all for a table with no relations', () => {
+    const lonely = table('logs', 'logs', ['id']);
+    expect(buildNestedPlan(lonely, [lonely], [], 'insert', 1)).toBeUndefined();
+  });
+});
+
+describe('depth', () => {
+  it('stops at the configured level', () => {
+    const one = buildNestedPlan(users, TABLES, REL, 'insert', 1)!;
+    expect(one.arms[0].child.arms).toEqual([]);
+
+    const two = buildNestedPlan(users, TABLES, REL, 'insert', 2)!;
+    expect(two.arms[0].child.arms.map((a) => a.key)).toEqual(['comments']);
+    expect(two.arms[0].child.arms[0].child.omitted).toEqual(['postId']);
+  });
+
+  it('terminates a cycle by running out of depth rather than by detecting it', () => {
+    // A self-referencing table is the cycle that really occurs: `users.managerId -> users`.
+    const selfy = table('users', 'users', ['id', 'managerId', 'name'], {
+      foreignKeys: [{ columns: ['managerId'], foreignTable: 'users', foreignColumns: ['id'] }],
+    });
+    const rels: Relation[] = [
+      { kind: 'one', from: 'users', to: 'users' },
+      { kind: 'many', from: 'users', to: 'users' },
+    ];
+    const plan = buildNestedPlan(selfy, [selfy], rels, 'insert', MAX_NESTED_DEPTH)!;
+    let node = plan;
+    let levels = 0;
+    while (node.arms.length) {
+      expect(node.arms).toHaveLength(1);
+      node = node.arms[0].child;
+      expect(node.omitted).toEqual(['managerId']);
+      levels++;
+      // A guard rather than an assertion: an unbounded plan would hang the suite instead of
+      // failing it.
+      if (levels > 20) break;
+    }
+    expect(levels).toBe(MAX_NESTED_DEPTH);
+  });
+
+  it('clamps a configured depth into the range it will honour', () => {
+    expect(resolveNestedDepth(undefined)).toBe(DEFAULT_NESTED_DEPTH);
+    expect(resolveNestedDepth(2)).toBe(2);
+    expect(resolveNestedDepth(0)).toBe(1);
+    expect(resolveNestedDepth(-4)).toBe(1);
+    expect(resolveNestedDepth(99)).toBe(MAX_NESTED_DEPTH);
+    expect(resolveNestedDepth(Number.NaN)).toBe(DEFAULT_NESTED_DEPTH);
+    const said: string[] = [];
+    resolveNestedDepth(99, (m) => said.push(m));
+    expect(said).toHaveLength(1);
+    expect(said[0]).toContain('nestedDepth');
+  });
+});
+
+describe('when the relation does not say enough', () => {
+  it('omits nothing where a child has two foreign keys to the same parent, and says why', () => {
+    const messages = table('messages', 'messages', ['id', 'senderId', 'recipientId', 'body'], {
+      foreignKeys: [
+        { columns: ['senderId'], foreignTable: 'users', foreignColumns: ['id'] },
+        { columns: ['recipientId'], foreignTable: 'users', foreignColumns: ['id'] },
+      ],
+    });
+    const rels: Relation[] = [{ kind: 'many', from: 'users', to: 'messages' }];
+    const plan = buildNestedPlan(users, [users, messages], rels, 'insert', 1)!;
+    expect(plan.arms[0].child.omitted).toEqual([]);
+    expect(plan.arms[0].note).toContain('senderId');
+    expect(plan.arms[0].note).toContain('recipientId');
+    expect(nestedArmNotes(plan.arms[0])).toHaveLength(1);
+  });
+
+  it('omits nothing where the relation has no foreign key behind it', () => {
+    // What `relations()` with no `references`, and the name-matching heuristic, produce.
+    const loose = table('notes', 'notes', ['id', 'body']);
+    const rels: Relation[] = [{ kind: 'many', from: 'users', to: 'notes' }];
+    const plan = buildNestedPlan(users, [users, loose], rels, 'insert', 1)!;
+    expect(plan.arms[0].child.omitted).toEqual([]);
+    expect(plan.arms[0].note).toBeUndefined();
+  });
+
+  it('drops a relation whose key would overwrite a column of the same name', () => {
+    const owner = table('owner', 'owner', ['id', 'posts']);
+    const rels: Relation[] = [{ kind: 'many', from: 'owner', to: 'posts' }];
+    expect(buildNestedPlan(owner, [owner, posts], rels, 'insert', 1)).toBeUndefined();
+  });
+
+  it('keeps one arm per key when a pair of tables is linked both ways', () => {
+    const rels: Relation[] = [
+      { kind: 'one', from: 'users', to: 'posts' },
+      { kind: 'many', from: 'users', to: 'posts' },
+    ];
+    const plan = buildNestedPlan(users, TABLES, rels, 'select', 1)!;
+    expect(plan.arms).toHaveLength(1);
+    // `many` wins, so the arm that can hold every related row is the one kept.
+    expect(plan.arms[0].kind).toBe('many');
+  });
+});
+
+describe('many-to-many', () => {
+  const tags = table('tags', 'tags', ['id', 'label']);
+  const rels: Relation[] = [
+    { kind: 'manyToMany', from: 'users', to: 'tags', via: 'users_tags' },
+    { kind: 'manyToMany', from: 'tags', to: 'users', via: 'users_tags' },
+  ];
+
+  it('carries the far side and omits nothing, since the join row holds both keys', () => {
+    const plan = buildNestedPlan(users, [users, tags], rels, 'insert', 1)!;
+    expect(plan.arms.map((a) => [a.key, a.kind, a.single])).toEqual([
+      ['tags', 'manyToMany', false],
+    ]);
+    expect(plan.arms[0].child.omitted).toEqual([]);
+  });
+
+  it('names the join table in the comment, since the shape cannot', () => {
+    const plan = buildNestedPlan(users, [users, tags], rels, 'insert', 1)!;
+    expect(nestedArmNotes(plan.arms[0])[0]).toContain('users_tags');
+  });
+});
+
+describe('naming', () => {
+  it('prefixes the resolved name so affixes keep applying underneath', () => {
+    const plain = resolveAffix();
+    expect(nestedSchemaName('insert', 'users', plain)).toBe('NestedInsertusersSchema');
+    expect(nestedSchemaName('select', 'users', plain)).toBe('NestedSelectusersSchema');
+    expect(nestedTypeName('insert', 'users', plain)).toBe('NestedInsertusersInput');
+    expect(nestedTypeName('select', 'users', plain)).toBe('NestedSelectusersOutput');
+
+    const affixed = resolveAffix({ affix: { tableCase: 'pascal', schema: { suffix: 'Zod' } } });
+    expect(nestedSchemaName('insert', 'users', affixed)).toBe('NestedInsertUsersZod');
+  });
+});
+
+describe('nestedNodeColumns', () => {
+  it('drops exactly what the node omits and nothing else', () => {
+    const node = { table: posts, omitted: ['authorId'], arms: [] };
+    const kept = nestedNodeColumns(posts.columns, node);
+    expect(kept.map((c) => c.name)).toEqual(['id', 'title']);
+    expect(nestedNodeColumns(posts.columns, { ...node, omitted: [] })).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
Plan item 28. Validate `{ user, posts: [...] }` in one payload.

## The claim that nothing else does this, verified

On **both** drizzle majors, `createInsertSchema(users)` returns `['id','name']` and never `posts`, in every mode and library. Passing the relations object as the second argument lands it in the refine slot and it is dropped; passing it first throws in `getColumns`. No `Relational|withRelations|createNestedSchema` anywhere in either major.

And the write path silently agrees:

```
db.insert(users).values({ name: 'a', posts: [...] })
-> insert into "users" ("id","name") values (default,$1)
```

The key is dropped without a word, so the children are never written. Reads do have a producer: `db.query...with` works on both majors.

## Cycles decided the shape, and only measuring did

| library | cyclic schema | measured |
|---|---|---|
| zod 4.4.3 | getter or `z.lazy` | works, 200 levels deep |
| valibot 1.4.2 | `v.lazy` | works; TS wants an explicit annotation |
| ArkType 2.2.3 | **only** inside `scope` | plain forward ref **throws at module load** |
| TypeBox 0.34.52 | **only** inside `Type.Module` | `Type.Ref` constructs, then `Value.Check` **throws** |

**Two of four fail as a broken module rather than a wrong schema**, and each needs a different mechanism. So nesting expands inline to a bounded depth (default 1, capped at 3): no `lazy`, no `scope`, no `Type.Module`. A cycle terminates because the last level simply does not emit the arm. No recursion API, no cross-module imports, so no import cycle and no TDZ hazard, and all four outputs are structurally identical.

Designing for zod's behaviour would have shipped two generators whose output throws on import.

Three more traps, measured, which is why shapes are re-rendered from columns rather than derived:

- **zod's `.omit()` throws** `cannot be used on object schemas containing refinements`, so any table with a row CHECK would emit a module that throws on import
- **valibot's `v.omit` over a `v.pipe` silently drops the checks**
- **TypeBox's `Type.Omit`** over the row-check `Type.Intersect` rewrites the check branch to `{}` and keeps every property required

## The foreign key

Omitted from the nested child, and **only where the relation says which column it is**. Requiring it is unusable, since it is unknown until the parent is inserted. Permitting it as optional accepts `posts: [{ authorId: 999 }]`, which no correct nested write can honour.

Two foreign keys to the same parent (`messages.senderId` and `recipientId`) is ambiguous and `Relation` carries no field name, so nothing is dropped and the arm says why. Zero foreign keys drops nothing. The plain insert schema is untouched, and a nested select drops nothing at all.

## What each relation kind emits

- **`many`** an array of the child minus its foreign key
- **`manyToMany`** an array of the far side, omitting nothing, since the join row's columns *are* the two keys and both ends supply them. The join table is named in a comment.
- **`one`** **not emitted on insert.** Its key is on the *outer* object, so admitting the arm means making a NOT NULL foreign key optional, which then admits a row with neither key nor nested parent, a write the database refuses. The correct forms (a 2^n union, or a row-level exactly-one-of) are named as deferred. It **is** emitted on select, as the object or `null`.

## No nested update, and that is the recommendation

`{ name: 'x', posts: [...] }` has no single meaning without an operation vocabulary (`create`/`connect`/`set`/`deleteMany`) that neither DRZL nor Drizzle has. Decisively, `updateColumns` drops the primary key, so a child inside an update payload carries nothing identifying which row it patches. This is the part of the sketch that should not be built.

## Two more CLI branch defects

Same class this repo keeps finding, found by generating and reading output:

- **`watch` never moved onto the shared `validationOptions`.** Its zod, valibot and arktype branches still hand-built six keys, so `coerceDates`, `applyDefaults`, `typedJson`, `typedColumns` and `duplicateFinder` were all dropped on rebuild.
- **`watch` had no typebox or json-schema branch at all**, so those directories went stale from the first save onward.

A test runs both commands and compares bytes; proved by disabling a branch and watching it fail.

## pnpm typecheck covered no emitted output at all

TypeScript's wildcard `include` skips dot-prefixed directories, and every `.tmp-*` output dir is one. **A deliberate type error planted in an emitted file left `tsc` at zero errors.** There is now a per-generator test pointing `tsc` at the emitted directory under strict `nodenext`, proved to fail by breaking the emitter.

## Size

Off by default, and the budgets are **byte-identical** to master: zod 277/420, valibot 352/540, arktype 275/280, typebox 443/460. Enabled, measured on a 3-table chain through the built CLI: roughly **+85 to 90% at depth 1** and **+125 to 150% at depth 2** (zod 4163 to 7874 to 10204 bytes).

## Tests

Written first: zod nested spec 14 failed of 16, core plan spec 15 failed of 15. Every spec runs the emitted schemas, valid and invalid nested payloads, a cycle, depth 2, a `one` arm returning `null`. TypeBox through both `Value.Check` and `TypeCompiler`, asserted to agree.

The docs page carries a runnable config that the gate's doc-config extractor picks up on its own, so nested output for all four libraries now generates and typechecks there: 11 documented configs, all passing.

`verify:packed`, `build`, `-r test`, `typecheck`, `lint`, `docs build` all green.

## Notes for review

- **About 140 lines of the diff across the four generator sources are prettier-only churn.** Master is not prettier-clean on those files and CONTRIBUTING asks for formatting, so they are reformatted; skip those hunks.
- **Extra keys diverge by library** and this feature makes it visible, since an omitted foreign key is exactly such a key: zod and valibot strip it, TypeBox ignores it, ArkType keeps it. None refuses it. Documented, deliberately not made strict.
- `renderTable(table, opts)` cannot emit nested output, since relations live on the `Analysis` and it is handed a `Table`. Only the generators' own tests call it; noted on the interface.
- The pre-existing `emit: { select, insert, update }` option in `ValidationGenerateOptions` is read by no generator at all. Untouched, but it is dead.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
