### PR TITLE
feat(cli): drzl doctor, a report of what DRZL will not check for you

### DIFF
--- a/.changeset/drzl-doctor.md
+++ b/.changeset/drzl-doctor.md
@@ -1,0 +1,68 @@
+---
+'@drzl/analyzer': minor
+'@drzl/cli': minor
+---
+
+`drzl doctor`: a human-readable report of what DRZL **cannot** type or enforce in your schema, and
+what to do about each one.
+
+Not `drzl analyze`. That prints the whole `Analysis` as JSON and leaves the reader to know which
+fields mean trouble. `doctor` prints only what will silently not work, and both of its headline
+failure modes produce a generated file that exists, compiles and validates nothing: an untypeable
+column gets a validator accepting **any** value, and a CHECK constraint DRZL will not translate is
+simply absent from the output.
+
+```
+DRZL doctor  src/db/schema.ts
+postgres, 1 table, 11 columns, 12 CHECK constraints
+
+Columns DRZL cannot type  (2)
+  These get a validator that accepts any value.
+
+  - Column "credit" on table "accounts" has no known type (SQL type numeric(12,2)), so its
+    validator will accept any value.
+    A customType has no runtime shape to read. Declare it with .$type<T>() and turn on
+    typedColumns to give the validator the type.
+
+CHECK constraints DRZL does not enforce  (9)
+  Your database still enforces these. Nothing DRZL generates does.
+
+  - CHECK "age_or" on "accounts" is not translated: contains OR. Expression: age >= 18 OR age <= 65
+```
+
+**The CHECK section reads something the analyzer does not know.** `parseCheck` lives in
+`@drzl/validation-core` and every validation generator calls it; the analyzer carries the raw
+expression through and has no opinion on it. So `Analysis.issues` cannot say "this constraint is in
+your schema and nothing DRZL emits enforces it", and until now nothing said it at all: `drzl
+generate` prints a count of untypeable columns and is silent about constraints. Measured on a
+Postgres table carrying twelve CHECKs through all five generators, nine produced no enforcement in
+any of them and DRZL reported none of the nine.
+
+Three CHECK cases are distinguished, because their fixes differ: the parser declined the expression
+(with its own reason, `contains OR`, `right side is not a literal`); the expression names a column
+the table does not have; the expression compares an array or structured column against a scalar
+literal. A constraint DRZL **does** translate is not listed, so the ones that matter are not buried.
+
+Also reported: a table with no primary key, and a composite primary key. The service generator keys
+`getById`, `update` and `delete` on `primaryKey.columns[0] ?? 'id'`, so a table with neither a key
+nor an `id` column emits a service that does not compile (measured: three `TS2339` errors under
+`tsc --strict`), and a composite key emits one matching on part of the key.
+
+**Exit `0` by default, even with findings.** A schema carrying a `customType`, or a CHECK this
+parser will not guess at, is normal and usable, and a doctor that failed every pipeline reading one
+would be switched off within a week. `--strict` exits `2` when anything is reported, and `1` is
+reserved for the case where the schema could not be read at all. `--json` emits the report with a
+stable `kind` per finding, so CI can count one category without matching on prose.
+
+Analyzer changes that go with it:
+
+- **`Issue.path` is now set.** It has been declared since the interface existed and set by nothing,
+  so a consumer wanting to group warnings by table had to read the names back out of the English in
+  `message`. `DRZL_ANL_UNKNOWN_COLUMN` carries `table.column`; `DRZL_ANL_EXTRACONFIG`,
+  `DRZL_ANL_RELATIONS`, `DRZL_ANL_REL_V2` and `DRZL_ANL_TABLE` carry the table.
+- **A Gel temporal column gets its own hint.** The six `cal::`/duration columns are left `unknown`
+  on purpose: the value is an instance of a class from the `gel` package, which DRZL cannot import,
+  so no generator could emit a check for it even knowing the name. They used to carry the generic
+  "open an issue naming the column type so it can be modelled", which sends their author to file an
+  issue the arm already answers. `customType` and genuinely unmodelled columns keep their own
+  wording.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -46,6 +46,7 @@ export default {
           { text: 'Overview', link: '/cli' },
           { text: 'Init', link: '/cli/init' },
           { text: 'Analyze', link: '/cli/analyze' },
+          { text: 'Doctor', link: '/cli/doctor' },
           { text: 'Generate', link: '/cli/generate' },
           { text: 'Generate (oRPC)', link: '/cli/generate-orpc' },
           { text: 'Generate (tRPC)', link: '/cli/generate-trpc' },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,7 @@ Jump to commands:
 
 - Init: set up a starter config → [/cli/init](/cli/init)
 - Analyze: inspect a schema → [/cli/analyze](/cli/analyze)
+- Doctor: what DRZL cannot type or enforce → [/cli/doctor](/cli/doctor)
 - Generate: run configured generators → [/cli/generate](/cli/generate)
 - Generate (oRPC): quick oRPC without config → [/cli/generate-orpc](/cli/generate-orpc)
 - Watch: watch schema and regenerate → [/cli/watch](/cli/watch)
@@ -68,6 +69,44 @@ Options:
 - `--json` (default false): print JSON to stdout (overrides `--out`)
 
 Exits non‑zero when errors are found in `issues`.
+
+### doctor
+
+Report what DRZL cannot type or enforce in your schema, and why. Not `analyze`: that prints the
+whole `Analysis` and leaves you to spot the trouble in it, this prints only what will silently not
+work.
+
+::: code-group
+
+```bash [pnpm]
+pnpm dlx @drzl/cli doctor [schema] [--json] [--strict] [-c drzl.config.ts]
+```
+
+```bash [npm]
+npx @drzl/cli doctor [schema] [--json] [--strict] [-c drzl.config.ts]
+```
+
+```bash [yarn]
+yarn dlx @drzl/cli doctor [schema] [--json] [--strict] [-c drzl.config.ts]
+```
+
+```bash [bun]
+bunx @drzl/cli doctor [schema] [--json] [--strict] [-c drzl.config.ts]
+```
+
+:::
+
+Options:
+
+- `[schema]`: path to the schema. Read from `drzl.config.*` when omitted.
+- `-c, --config <path>`: which config to read the schema path from
+- `--json`: print the report as JSON instead of prose
+- `--strict`: exit `2` when anything is reported
+
+Exits `0` by default even with findings, because a schema carrying a `customType` is normal and
+usable. Exits `1` only when the schema could not be read at all.
+
+See [Doctor](/cli/doctor).
 
 ### generate
 

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -1,0 +1,196 @@
+# Doctor
+
+Report what DRZL **cannot** type or enforce in your schema, and what to do about each one.
+
+Usage:
+
+::: code-group
+
+```bash [pnpm]
+pnpm dlx @drzl/cli doctor [schema] [--json] [--strict] [-c drzl.config.ts]
+```
+
+```bash [npm]
+npx @drzl/cli doctor [schema] [--json] [--strict] [-c drzl.config.ts]
+```
+
+```bash [yarn]
+yarn dlx @drzl/cli doctor [schema] [--json] [--strict] [-c drzl.config.ts]
+```
+
+```bash [bun]
+bunx @drzl/cli doctor [schema] [--json] [--strict] [-c drzl.config.ts]
+```
+
+:::
+
+With no `schema` argument it reads the `schema` path out of your `drzl.config.*`, so a project that
+already has one needs only `drzl doctor`.
+
+## Why this is not `analyze`
+
+[`drzl analyze`](/cli/analyze) prints the whole `Analysis` as JSON. That is a description of your
+schema, and reading trouble out of it means knowing which fields mean trouble.
+
+`doctor` is the other thing: the list of what will silently not work. Both failure modes it reports
+produce a generated file that exists, compiles and validates nothing:
+
+- a column DRZL cannot type gets a validator that accepts **any** value
+- a CHECK constraint DRZL will not translate is simply **absent** from the output
+
+## Example
+
+```bash
+npx @drzl/cli doctor src/db/schema.ts
+```
+
+```
+DRZL doctor  src/db/schema.ts
+postgres, 1 table, 11 columns, 12 CHECK constraints
+
+Columns DRZL cannot type  (2)
+  These get a validator that accepts any value.
+
+  - Column "balance" on table "accounts" has no known type (SQL type numeric(12,2)), so its
+    validator will accept any value.
+  - Column "credit" on table "accounts" has no known type (SQL type numeric(12,2)), so its
+    validator will accept any value.
+    A customType has no runtime shape to read. Declare it with .$type<T>() and turn on
+    typedColumns to give the validator the type.
+
+CHECK constraints DRZL does not enforce  (9)
+  Your database still enforces these. Nothing DRZL generates does.
+
+  - CHECK "age_or" on "accounts" is not translated: contains OR. Expression: age >= 18 OR age <=
+    65
+  - CHECK "email_re" on "accounts" is not translated: not a single comparison this version
+    understands. Expression: email ~ '^[a-z]+$'
+    Only constraints whose meaning is unambiguous are translated, because a validator enforcing
+    a guess rejects rows the database accepts. Your database still enforces this one; nothing
+    DRZL emits does.
+
+  - CHECK "tags_scalar" on "accounts" compares an array column "tags" against a scalar literal,
+    which does not describe it, so it is not translated. Expression: tags = '{}'
+    On an array column only cardinality(col) is read, since it is the one comparison that is
+    about the array rather than about an element.
+
+11 findings in src/db/schema.ts. None of these stop DRZL generating; they are what it will not
+check for you.
+```
+
+A healthy schema says so, and says what was looked at, so a clean run cannot be confused with a
+command that failed to run:
+
+```
+DRZL doctor  src/db/schema.ts
+postgres, 3 tables, 6 columns, 0 CHECK constraints
+
+Nothing to report.
+  Every column has a type DRZL can describe.
+  Every CHECK constraint is translated into the generated validators.
+  Every table has a primary key the generators can use.
+```
+
+## What it reports
+
+| Section                                 | What it means                                                                      |
+| --------------------------------------- | ---------------------------------------------------------------------------------- |
+| Columns DRZL cannot type                | The emitted validator accepts any value for this column                            |
+| CHECK constraints DRZL does not enforce | The constraint is in your schema and in your database, and in no schema DRZL emits |
+| Primary keys the generators cannot use  | `getById`, `update` and `delete` are keyed on one column                           |
+| Other findings                          | Everything else the analyzer said while reading the schema                         |
+
+Three CHECK cases are distinguished, because they have different fixes:
+
+- **Not translated.** The shared parser refused the expression and says why: `contains OR`,
+  `right side is not a literal`, and so on. See the skip list in
+  [Generators → Zod](/generators/zod#check-constraints); the same parser serves all four validation
+  generators.
+- **Names a column the table does not have.** Usually a typo, or a constraint that spans two tables.
+- **Compares an array or structured column against a scalar literal.** `tags = '{}'` on a `text[]`
+  says nothing usable about the array, so it is skipped rather than guessed at. On an array column
+  only `cardinality(col)` is read.
+
+A constraint DRZL **does** translate is not listed. `age >= 18` folds into `.gte(18)` and
+`start_date < end_date` becomes an object-level refinement, and listing those would bury the ones
+that matter.
+
+## Exit codes
+
+| Code | When                                                                             |
+| ---- | -------------------------------------------------------------------------------- |
+| `0`  | The schema was read. Findings may have been reported.                            |
+| `1`  | The schema could not be read at all: the file is missing, or importing it threw. |
+| `2`  | Findings were reported **and** `--strict` was passed.                            |
+
+**Zero by default is deliberate.** A schema carrying a `customType`, or a CHECK this parser will
+not guess at, is normal and usable, and a doctor that failed every pipeline reading one would be
+switched off within a week. `--strict` is how you opt into a gate:
+
+```yaml
+- run: npx @drzl/cli doctor --strict
+```
+
+This differs from `analyze`, which exits `2` on an error-level issue, because there `error` means
+"the JSON you asked for is not there". `doctor` always has a report to print.
+
+## `--json`
+
+```bash
+npx @drzl/cli doctor src/db/schema.ts --json
+```
+
+```json
+{
+  "schema": "src/db/schema.ts",
+  "dialect": "postgres",
+  "ok": false,
+  "counts": { "tables": 2, "columns": 5, "checks": 0, "findings": 2 },
+  "findings": [
+    {
+      "kind": "partial-primary-key",
+      "level": "warn",
+      "table": "composite",
+      "message": "Table \"composite\" has a composite primary key (a, b). ...",
+      "hint": "Treat the generated service as a starting point for this table and widen the key by hand."
+    }
+  ]
+}
+```
+
+`kind` is a stable identifier, so a CI step can count one category without matching on prose:
+
+```bash
+npx @drzl/cli doctor --json \
+  | node -e "const r=JSON.parse(require('fs').readFileSync(0,'utf8'));
+             const n=r.findings.filter(f=>f.kind==='unknown-column').length;
+             if (n) { console.error(n+' untypeable column(s)'); process.exit(1); }"
+```
+
+Values are `unknown-column`, `check-declined`, `check-unknown-column`, `check-not-scalar`,
+`no-primary-key`, `partial-primary-key` and `analyzer`.
+
+## Runnable config
+
+`doctor` needs no config of its own. It reads the `schema` path out of the one you already have:
+
+```ts
+// drzl.config.ts
+export default {
+  schema: 'src/db/schema.ts',
+  outDir: 'src/api',
+  analyzer: { includeRelations: true, validateConstraints: true },
+  generators: [{ kind: 'zod', path: 'src/validators/zod', typedColumns: true }],
+} as const;
+```
+
+```bash
+npx @drzl/cli doctor
+```
+
+`typedColumns` above is the fix `doctor` names for an untypeable column: it does not make the
+validator check the value, which nothing can do for a `customType`, but it recovers the declared
+TypeScript type so the call site is still narrowed. See
+[Generators → Zod](/generators/zod#typedjson).
+
+See also: [Analyze](/cli/analyze) · [Generate](/cli/generate)

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -10,8 +10,31 @@ export interface Issue {
   level: 'info' | 'warn' | 'error';
   message: string;
   hint?: string;
+  /**
+   * Where the issue is, as `table` or `table.column`.
+   *
+   * Declared since this interface existed and set by nothing, so every consumer wanting to group
+   * warnings by table had to read the names back out of the English in `message`. `drzl doctor` is
+   * the first such consumer and a report built by regex over prose breaks the first time a message
+   * is reworded, so the names are stated here instead.
+   *
+   * Still optional: an issue about the schema as a whole, such as an unidentifiable dialect, is
+   * about no table and says so by omitting this.
+   */
   path?: string;
 }
+
+/**
+ * Why a column has no type, where "nobody has modelled it" is not the answer.
+ *
+ * The distinction exists because it changes the advice. A column class this file has no arm for is
+ * a gap someone can close, and the warning tells its author to say so. A Gel temporal column is
+ * not: the value is an instance of a class from the `gel` package, DRZL cannot import that package,
+ * and no generator could emit a check for it even knowing the name. Leaving it `unknown` is the
+ * measured answer rather than an omission, and its warning should say that instead of asking for a
+ * bug report that is already closed.
+ */
+export type UnnameableReason = 'gel-temporal';
 
 export interface ColumnRef {
   table: string;
@@ -1237,6 +1260,7 @@ export function readRelationsV2(val: any, issues: Issue[] = []): Relation[] {
           code: 'DRZL_ANL_REL_V2',
           level: 'warn',
           message: `Relation "${fieldName}" on "${from}" names no target table and was skipped.`,
+          path: from,
         });
         continue;
       }
@@ -1250,6 +1274,34 @@ export function readRelationsV2(val: any, issues: Issue[] = []): Relation[] {
     }
   }
   return out;
+}
+
+/**
+ * What to tell the author of a column that has no type.
+ *
+ * Three different situations reach the same warning, and they do not have the same fix, so they do
+ * not get the same sentence. A `customType` and a Gel temporal are both *correctly* untyped and
+ * asking for a bug report on either wastes the reader's time; only the third case is a gap in this
+ * file.
+ */
+function unknownColumnHint(reason: 'custom' | UnnameableReason | undefined): string {
+  if (reason === 'custom') {
+    return (
+      'A customType has no runtime shape to read. Declare it with .$type<T>() and turn on ' +
+      'typedColumns to give the validator the type.'
+    );
+  }
+  if (reason === 'gel-temporal') {
+    return (
+      'A Gel temporal column holds an instance of a class from the `gel` package, which DRZL ' +
+      'cannot import, so it is left untyped on purpose rather than guessed at. Turn on ' +
+      'typedColumns to recover the declared type, and validate the value yourself.'
+    );
+  }
+  return (
+    'Open an issue naming the column type so it can be modelled, or declare it with .$type<T>() ' +
+    'and turn on typedColumns.'
+  );
 }
 
 export class SchemaAnalyzer {
@@ -1305,6 +1357,7 @@ export class SchemaAnalyzer {
         code: 'DRZL_ANL_EXTRACONFIG',
         level: 'warn',
         message: `Could not evaluate the extra-config callback for table "${tableName}": ${(e as Error).message}`,
+        path: tableName,
         hint: 'Indexes, composite keys, checks and table-level foreign keys will be missing for this table.',
       });
       return [];
@@ -1455,6 +1508,7 @@ export class SchemaAnalyzer {
         code: 'DRZL_ANL_RELATIONS',
         level: 'warn',
         message: `Could not read the relations declared in "${exportName}": ${(e as Error).message}`,
+        path: from,
         hint: 'Relations for this table will be missing from the analysis.',
       });
       return [];
@@ -1716,7 +1770,11 @@ export class SchemaAnalyzer {
     return out;
   }
 
-  private mapColumnType(column: any): { tsType: string; dbType: string } {
+  private mapColumnType(column: any): {
+    tsType: string;
+    dbType: string;
+    unnameable?: UnnameableReason;
+  } {
     const ctor = column?.constructor?.name ?? '';
     switch (ctor) {
       case 'SQLiteInteger':
@@ -2123,8 +2181,14 @@ export class SchemaAnalyzer {
           // it and rerunning `gel-types.spec.ts` and `uncovered-dialects.spec.ts`, both of which
           // stayed green. It is here so the six read as measured and decided rather than
           // forgotten, which is how they came to be `string`.
+          //
+          // `unnameable` is what separates these from a column class nobody has looked at. Both
+          // come back `unknown`, and the warning raised for them used to carry the same hint:
+          // "open an issue naming the column type so it can be modelled". For these six that hint
+          // sends the author to file an issue this arm already answers, so the marker travels with
+          // the answer rather than being recovered from the SQL type at the warning site.
           if (/Timestamp|LocalDateString|LocalTime|DateDuration|RelDuration|Duration/i.test(ctor))
-            return { tsType: 'unknown', dbType: 'UNKNOWN' };
+            return { tsType: 'unknown', dbType: 'UNKNOWN', unnameable: 'gel-temporal' };
         }
         return { tsType: 'unknown', dbType: 'UNKNOWN' };
     }
@@ -2144,7 +2208,8 @@ export class SchemaAnalyzer {
       // Everything describing the *value* reads the element; everything describing the *column*
       // (nullability, defaults, generated) stays on the outer one, which is where Drizzle keeps it.
       const { element: col, dimensions: arrayDims } = unwrapArrayColumn(outerCol);
-      let { tsType, dbType } = this.mapColumnType(col);
+      const mapped = this.mapColumnType(col);
+      let { tsType, dbType } = mapped;
       if (tsType === 'unknown' && /At$/.test(colName)) {
         // Heuristic for timestamp fields
         tsType = 'Date';
@@ -2284,10 +2349,8 @@ export class SchemaAnalyzer {
           message: `Column "${colName}" on table "${tsName}" has no known type${
             sqlType ? ` (SQL type ${sqlType})` : ''
           }, so its validator will accept any value.`,
-          hint:
-            shape === 'custom'
-              ? 'A customType has no runtime shape to read. Declare it with .$type<T>() and turn on typedColumns to give the validator the type.'
-              : 'Open an issue naming the column type so it can be modelled, or declare it with .$type<T>() and turn on typedColumns.',
+          path: `${tsName}.${colName}`,
+          hint: unknownColumnHint(shape === 'custom' ? 'custom' : mapped.unnameable),
         });
       }
 
@@ -2535,6 +2598,7 @@ export class SchemaAnalyzer {
           code: 'DRZL_ANL_TABLE',
           level: 'warn',
           message: `Failed to analyze export ${name}: ${String(e)}`,
+          path: name,
         });
       }
     }

--- a/packages/analyzer/test/issue-paths.spec.ts
+++ b/packages/analyzer/test/issue-paths.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * What an `Issue` says about *where* it came from, and whether its hint is worth following.
+ *
+ * `Issue` has carried an optional `path` since it was declared and nothing has ever set one, so
+ * every consumer that wanted to group warnings by table had to parse them out of the English in
+ * `message`. `drzl doctor` is the first such consumer, and a report built by regex over prose
+ * breaks the first time a message is reworded.
+ *
+ * The hint half is the other one. A hint that sends the user somewhere useless is worse than no
+ * hint: the six Gel temporal columns are deliberately left `unknown`, and telling their author to
+ * "open an issue naming the column type so it can be modelled" sends them to file an issue that is
+ * already answered. See the arm in `mapColumnType` for the measurement behind that decision.
+ *
+ * Everything here runs the real `SchemaAnalyzer` over a real drizzle schema module.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function analyzeSource(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  return new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+}
+
+const CUSTOM = `
+  import { pgTable, customType, serial } from 'drizzle-orm/pg-core';
+  const money = customType({ dataType: () => 'numeric(12,2)' });
+  export const accounts = pgTable('accounts', {
+    id: serial('id').primaryKey(),
+    balance: money('balance').notNull(),
+    credit: money('credit'),
+  });
+`;
+
+const GEL = `
+  import { gelTable, boolean, timestamp, localDate, localTime, dateDuration, relDuration, duration } from 'drizzle-orm/gel-core';
+  export const t = gelTable('t', {
+    flag: boolean('flag').notNull(),
+    ts: timestamp('ts').notNull(),
+    ld: localDate('ld').notNull(),
+    lt: localTime('lt').notNull(),
+    dd: dateDuration('dd').notNull(),
+    rd: relDuration('rd').notNull(),
+    d: duration('d').notNull(),
+  });
+`;
+
+describe('an unknown-column issue says where it is', () => {
+  it('carries table.column on `path`, so nothing has to read it out of the message', async () => {
+    const a = await analyzeSource('issue-path-custom', CUSTOM);
+    const unknown = a.issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN');
+    expect(unknown.length).toBe(2);
+    expect(unknown.map((i) => i.path).sort()).toEqual(['accounts.balance', 'accounts.credit']);
+  });
+});
+
+describe('the hint on an unknown column', () => {
+  it('names the documented fix for a customType', async () => {
+    const a = await analyzeSource('issue-path-custom', CUSTOM);
+    const i = a.issues.find((x) => x.path === 'accounts.credit')!;
+    expect(i.hint).toContain('customType');
+    expect(i.hint).toContain('typedColumns');
+  });
+
+  it('does not send a Gel temporal column to open an issue that is already answered', async () => {
+    const a = await analyzeSource('issue-path-gel', GEL);
+    const unknown = a.issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN');
+    // The six from the arm in `mapColumnType`: cal::local_datetime, cal::local_date,
+    // cal::local_time, and the three duration types.
+    expect(unknown.map((i) => i.path).sort()).toEqual([
+      't.d',
+      't.dd',
+      't.ld',
+      't.lt',
+      't.rd',
+      't.ts',
+    ]);
+    for (const i of unknown) {
+      expect(i.hint, `${i.path} still carries the generic hint`).not.toContain('Open an issue');
+      expect(i.hint).toMatch(/gel/i);
+    }
+  });
+
+  it('leaves a genuinely unmodelled column on the generic hint', async () => {
+    // A column class nothing here has an arm for. `unknown` here means "nobody has modelled it",
+    // which is the case the generic hint is right for, so the Gel arm must not swallow it.
+    const a = await analyzeSource(
+      'issue-path-alien',
+      `
+      class AlienColumn { getSQLType() { return 'alien'; } }
+      const col = new AlienColumn();
+      col.notNull = true;
+      export const t = {
+        [Symbol.for('drizzle:Name')]: 't',
+        [Symbol.for('drizzle:Columns')]: { weird: col },
+      };
+    `
+    );
+    const i = a.issues.find((x) => x.code === 'DRZL_ANL_UNKNOWN_COLUMN');
+    expect(i, JSON.stringify(a.issues)).toBeTruthy();
+    expect(i!.path).toBe('t.weird');
+    expect(i!.hint).toContain('Open an issue');
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,6 +17,7 @@ import {
   filterTables,
   loadConfig,
 } from './config.js';
+import { buildDoctorReport, renderDoctorReport } from './doctor.js';
 import { diffSnapshots, restoreSnapshot, snapshotAll } from './drift.js';
 import { GeneratorNotInstalledError, loadGenerator } from './generator-loader.js';
 import { maybeShowSponsorMessage } from './sponsor.js';
@@ -88,6 +89,68 @@ program
       else
         console.error(
           chalk.red('Analyze failed (DRZL_CLI_ANALYZE):'),
+          msg,
+          '\nTip: run with --json for structured output.'
+        );
+      process.exit(1);
+    }
+  });
+
+program
+  .command('doctor')
+  .description('Report what DRZL cannot type or enforce in your schema, and why')
+  .argument('[schema]', 'path to drizzle schema (TS); defaults to the schema in drzl.config')
+  .option('-c, --config <path>', 'path to drzl.config, read when no schema argument is given')
+  .option('--json', 'print the report as JSON instead of prose', false)
+  .option('--strict', 'exit 2 when anything is reported', false)
+  .action(async (schema: string | undefined, opts: any) => {
+    try {
+      // A schema path argument, like `analyze`, or the one already named in the config, since a
+      // user who has a config should not have to retype the path they put in it.
+      let target = schema;
+      if (!target) {
+        const cfg = await loadConfig(opts.config);
+        target = cfg?.schema;
+      }
+      if (!target) {
+        const msg = 'No schema given. Pass a path, or run from a directory with a drzl.config.';
+        if (opts.json)
+          console.log(JSON.stringify({ event: 'error', code: 'DRZL_CLI_DOCTOR', message: msg }));
+        else console.error(chalk.red('Doctor failed (DRZL_CLI_DOCTOR):'), msg);
+        process.exit(1);
+        return;
+      }
+
+      const analyzer = new SchemaAnalyzer(target);
+      // Both on, unconditionally. Doctor's job is to look at everything, and a warning that only
+      // appears when relations are read would be hidden by a flag turning them off.
+      const analysis = await analyzer.analyze({
+        includeRelations: true,
+        validateConstraints: true,
+      });
+      const report = buildDoctorReport(analysis, target);
+
+      if (opts.json) console.log(JSON.stringify(report, null, 2));
+      else console.log(renderDoctorReport(report));
+
+      // An error-level issue means the schema was never read: the file is missing, or importing it
+      // threw. There is no report to act on, so this exits like `analyze`'s failure path rather
+      // than pretending the empty analysis was a clean bill of health.
+      if (report.findings.some((f) => f.level === 'error')) {
+        process.exit(1);
+        return;
+      }
+      // Zero by default, and that is the whole point. A schema carrying a customType or a CHECK
+      // this parser will not guess at is normal and usable, and a doctor that failed every
+      // pipeline reading one would be switched off within a week. `--strict` is the opt-in.
+      process.exit(opts.strict && report.findings.length ? 2 : 0);
+    } catch (e: any) {
+      const msg = e?.message ?? String(e);
+      if (opts.json)
+        console.log(JSON.stringify({ event: 'error', code: 'DRZL_CLI_DOCTOR', message: msg }));
+      else
+        console.error(
+          chalk.red('Doctor failed (DRZL_CLI_DOCTOR):'),
           msg,
           '\nTip: run with --json for structured output.'
         );
@@ -892,6 +955,10 @@ function reportWideColumns(issues: Array<{ code?: string; message?: string; hint
   // One hint for the set, since they are almost always the same two.
   const hints = [...new Set(wide.map((i) => i.hint).filter(Boolean))];
   for (const h of hints) console.warn(chalk.gray(`  ${h}`));
+  // Untypeable columns are the only thing this line can see. A CHECK constraint the generators
+  // decline produces no output at all and so cannot be counted here without parsing every one of
+  // them on the generate path, which is what `doctor` is for.
+  console.warn(chalk.gray('  Run `drzl doctor` for the full report.'));
 }
 
 program.parseAsync(process.argv);

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -1,0 +1,415 @@
+/**
+ * The report behind `drzl doctor`: what DRZL will not check for you, and why.
+ *
+ * `drzl analyze` already prints the whole `Analysis` as JSON. This is not that. The analysis is a
+ * description of the schema and the reader has to know which fields mean trouble; this is the list
+ * of things that will silently not work, each with the sentence that says what to do about it.
+ *
+ * The point of the command is the *silent* half. A generator that cannot type a column emits a
+ * validator accepting any value, and a CHECK the parser declines is simply absent from the output:
+ * both produce a file that looks finished. `drzl generate` prints a one-line count for the first
+ * and says nothing at all about the second.
+ *
+ * Two of the sections here read something the analyzer does not know:
+ *
+ * - **CHECK constraints.** `parseCheck` lives in `@drzl/validation-core` and every validation
+ *   generator calls it; the analyzer never does. It carries the raw expression through and has no
+ *   opinion on whether anything can be made of it. So the only way to say "this constraint is in
+ *   your schema and nothing DRZL emits enforces it" is to run the generators' own parser, which is
+ *   what this file does.
+ * - **Primary keys.** The service generator keys `getById`, `update` and `delete` on
+ *   `table.primaryKey?.columns[0] ?? 'id'`, and the router templates take an `id` input to match.
+ *   A table with no primary key therefore gets a service referencing a column that may not exist,
+ *   and a composite key gets one keyed on half of it. The analysis states the key correctly; the
+ *   consequence is the generator's.
+ *
+ * Deliberately *not* reported, and each for a measured reason:
+ *
+ * - A CHECK that DRZL does translate. `age >= 18` folds into `.gte(18)` and `start < end` becomes
+ *   an object-level refinement; listing them as findings would drown the ones that matter.
+ * - `length(col)` and `cardinality(col)` landing on a column that cannot take them. Two of the four
+ *   validation generators drop those and two emit something for them, so no single sentence here is
+ *   true of all four. It is also unreachable from a working schema: Postgres has no
+ *   `length(anyarray)` and no `cardinality(integer)`, so the DDL is refused before DRZL sees it.
+ */
+import type { Analysis, Column, Issue, Table } from '@drzl/analyzer';
+import { parseCheck } from '@drzl/validation-core';
+import chalk from 'chalk';
+
+export type DoctorFindingKind =
+  /** A column whose validator will accept any value. */
+  | 'unknown-column'
+  /** A CHECK the shared parser refused to translate. */
+  | 'check-declined'
+  /** A CHECK naming a column the table does not have. */
+  | 'check-unknown-column'
+  /** A CHECK comparing an array or structured column against a scalar literal. */
+  | 'check-not-scalar'
+  /** A table the generators cannot key. */
+  | 'no-primary-key'
+  /** A table keyed on more columns than the generators use. */
+  | 'partial-primary-key'
+  /** Anything else the analyzer said, passed through rather than dropped. */
+  | 'analyzer';
+
+export interface DoctorFinding {
+  kind: DoctorFindingKind;
+  level: 'warn' | 'error';
+  /** Table this is about, as the analysis names it. Absent for a finding about the whole schema. */
+  table?: string;
+  column?: string;
+  /** Constraint name, where the finding is about a CHECK. */
+  constraint?: string;
+  message: string;
+  hint?: string;
+}
+
+export interface DoctorReport {
+  /** The schema path as the user spelled it, so the report names the file they asked about. */
+  schema: string;
+  dialect: string;
+  /** True only when there is nothing at all to say. */
+  ok: boolean;
+  counts: { tables: number; columns: number; checks: number; findings: number };
+  findings: DoctorFinding[];
+}
+
+/** Issue codes with a section of their own, so the catch-all does not print them twice. */
+const HANDLED_CODES = new Set(['DRZL_ANL_UNKNOWN_COLUMN']);
+
+/**
+ * Split an issue `path` into its table and column halves.
+ *
+ * The analyzer writes `table.column` for a column issue and a bare table name otherwise. Table
+ * names are JavaScript identifiers, so the last dot is the separator and there is no ambiguity.
+ */
+function splitPath(path: string | undefined): { table?: string; column?: string } {
+  if (!path) return {};
+  const dot = path.lastIndexOf('.');
+  if (dot <= 0) return { table: path };
+  return { table: path.slice(0, dot), column: path.slice(dot + 1) };
+}
+
+/** Every column name a parsed CHECK talks about, paired with the kind of constraint it came from. */
+function namedColumns(parsed: Extract<ReturnType<typeof parseCheck>, { ok: true }>) {
+  const out: Array<{ column: string; scalar: boolean }> = [];
+  // A comparison against a literal and an `IN` list are both statements about a scalar value, so
+  // neither describes an array or a structured column. The other three kinds are not: a length or
+  // a cardinality is a statement about a count, and a row check is a comparison of two columns.
+  for (const c of parsed.checks) out.push({ column: c.column, scalar: true });
+  for (const s of parsed.sets ?? []) out.push({ column: s.column, scalar: true });
+  for (const l of parsed.lengths ?? []) out.push({ column: l.column, scalar: false });
+  for (const c of parsed.cardinalities ?? []) out.push({ column: c.column, scalar: false });
+  for (const r of parsed.rows ?? []) {
+    out.push({ column: r.left, scalar: false });
+    out.push({ column: r.right, scalar: false });
+  }
+  return out;
+}
+
+/**
+ * What a column is, for a sentence about a constraint that does not fit it.
+ *
+ * Every `ColumnShape` kind has an arm, so a shape added later reads as "a structured column" rather
+ * than as a wrong noun. `arrayDimensions` is checked first because an array carries its element's
+ * shape and it is the array the constraint failed to describe.
+ */
+function describeShape(c: Column): string {
+  if (c.arrayDimensions) return 'an array';
+  switch (c.shape?.kind) {
+    case 'json':
+      return 'a JSON';
+    case 'buffer':
+      return 'a binary';
+    case 'tuple':
+    case 'numberObject':
+      return 'a structured';
+    case 'numberVector':
+      return 'a vector';
+    case 'bitstring':
+      return 'a bit-string';
+    case 'byteString':
+      return 'a byte-string';
+    case 'custom':
+      return 'a customType';
+    default:
+      return 'a structured';
+  }
+}
+
+function checkFindings(table: Table): DoctorFinding[] {
+  const out: DoctorFinding[] = [];
+  const byName = new Map(table.columns.map((c) => [c.name, c]));
+  for (const k of table.checks ?? []) {
+    const label = k.name ? `"${k.name}"` : 'an unnamed constraint';
+    const raw = k.expression ?? '';
+    // A constraint whose expression the analyzer could not render at all is the one case where
+    // printing the expression verbatim says nothing, and a line ending in "Expression:" reads
+    // like the report itself is broken.
+    const expr = raw.trim() ? raw : '(empty)';
+    const parsed = parseCheck(raw, k.name);
+    if (!parsed.ok) {
+      out.push({
+        kind: 'check-declined',
+        level: 'warn',
+        table: table.tsName,
+        constraint: k.name,
+        message: `CHECK ${label} on "${table.tsName}" is not translated: ${parsed.reason}. Expression: ${expr}`,
+        hint:
+          'Only constraints whose meaning is unambiguous are translated, because a validator ' +
+          'enforcing a guess rejects rows the database accepts. Your database still enforces ' +
+          'this one; nothing DRZL emits does.',
+      });
+      continue;
+    }
+
+    // Reported once per column rather than once per clause, so `a >= 1 AND a <= 9` on a missing
+    // column is one line and not two.
+    const seen = new Set<string>();
+    for (const { column, scalar } of namedColumns(parsed)) {
+      if (seen.has(column)) continue;
+      seen.add(column);
+      const col = byName.get(column);
+      if (!col) {
+        out.push({
+          kind: 'check-unknown-column',
+          level: 'warn',
+          table: table.tsName,
+          column,
+          constraint: k.name,
+          message: `CHECK ${label} on "${table.tsName}" names "${column}", which is not a column of that table, so nothing enforces it. Expression: ${expr}`,
+          hint:
+            'A constraint is attached to the field it names. Check the spelling, or move a ' +
+            'constraint spanning two tables out of the schema.',
+        });
+        continue;
+      }
+      if (scalar && (col.arrayDimensions || col.shape)) {
+        out.push({
+          kind: 'check-not-scalar',
+          level: 'warn',
+          table: table.tsName,
+          column,
+          constraint: k.name,
+          message: `CHECK ${label} on "${table.tsName}" compares ${describeShape(col)} column "${column}" against a scalar literal, which does not describe it, so it is not translated. Expression: ${expr}`,
+          hint:
+            'On an array column only cardinality(col) is read, since it is the one comparison ' +
+            'that is about the array rather than about an element.',
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function primaryKeyFindings(table: Table): DoctorFinding[] {
+  // A read-only relation takes no writes and gets no keyed route, so it needs no key.
+  if (table.readOnly) return [];
+  const pk = table.primaryKey?.columns ?? [];
+  if (!pk.length) {
+    const hasId = table.columns.some((c) => c.name === 'id');
+    return [
+      {
+        kind: 'no-primary-key',
+        level: 'warn',
+        table: table.tsName,
+        message: hasId
+          ? `Table "${table.tsName}" declares no primary key. The service and router generators fall back to a column named "id", which this table happens to have, so they work by coincidence.`
+          : `Table "${table.tsName}" declares no primary key. The service and router generators fall back to a column named "id", which this table does not have, so the generated service will not compile.`,
+        hint: 'Declare a primary key, or leave this table out with the config table filter.',
+      },
+    ];
+  }
+  if (pk.length > 1) {
+    return [
+      {
+        kind: 'partial-primary-key',
+        level: 'warn',
+        table: table.tsName,
+        message: `Table "${table.tsName}" has a composite primary key (${pk.join(', ')}). The service and router generators key getById, update and delete on "${pk[0]}" alone, so those operations match on part of the key.`,
+        hint: 'Treat the generated service as a starting point for this table and widen the key by hand.',
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Everything worth saying about one analysis, in the order it should be read.
+ *
+ * Ordered worst-first, and within that silent-first. A schema that could not be analyzed comes
+ * first because nothing after it is trustworthy. Untypeable columns and dropped constraints come
+ * next because they are invisible: the generated file exists, compiles and validates nothing. The
+ * primary-key findings come after because one half of that pair announces itself as a compile
+ * error. The catch-all is last.
+ */
+export function buildDoctorReport(analysis: Analysis, schemaPath: string): DoctorReport {
+  const findings: DoctorFinding[] = [];
+
+  const errors = analysis.issues.filter((i: Issue) => i.level === 'error');
+  for (const i of errors) {
+    findings.push({
+      kind: 'analyzer',
+      level: 'error',
+      ...splitPath(i.path),
+      message: i.message,
+      hint: i.hint,
+    });
+  }
+
+  for (const i of analysis.issues) {
+    if (i.code !== 'DRZL_ANL_UNKNOWN_COLUMN') continue;
+    findings.push({
+      kind: 'unknown-column',
+      level: 'warn',
+      ...splitPath(i.path),
+      message: i.message,
+      hint: i.hint,
+    });
+  }
+
+  for (const t of analysis.tables) findings.push(...checkFindings(t));
+  for (const t of analysis.tables) findings.push(...primaryKeyFindings(t));
+
+  for (const i of analysis.issues) {
+    if (i.level === 'error' || HANDLED_CODES.has(i.code)) continue;
+    findings.push({
+      kind: 'analyzer',
+      level: 'warn',
+      ...splitPath(i.path),
+      message: i.message,
+      hint: i.hint,
+    });
+  }
+
+  const columns = analysis.tables.reduce((n, t) => n + t.columns.length, 0);
+  const checks = analysis.tables.reduce((n, t) => n + (t.checks?.length ?? 0), 0);
+  return {
+    schema: schemaPath,
+    dialect: analysis.dialect,
+    ok: findings.length === 0,
+    counts: { tables: analysis.tables.length, columns, checks, findings: findings.length },
+    findings,
+  };
+}
+
+/** Sections, in report order, each with the sentence that says why its contents matter. */
+const SECTIONS: Array<{ kinds: DoctorFindingKind[]; title: string; why: string }> = [
+  {
+    kinds: ['unknown-column'],
+    title: 'Columns DRZL cannot type',
+    why: 'These get a validator that accepts any value.',
+  },
+  {
+    kinds: ['check-declined', 'check-unknown-column', 'check-not-scalar'],
+    title: 'CHECK constraints DRZL does not enforce',
+    why: 'Your database still enforces these. Nothing DRZL generates does.',
+  },
+  {
+    kinds: ['no-primary-key', 'partial-primary-key'],
+    title: 'Primary keys the generators cannot use',
+    why: 'The generated getById, update and delete are keyed on one column.',
+  },
+  {
+    kinds: ['analyzer'],
+    title: 'Other findings',
+    why: 'Reported by the analyzer while reading the schema.',
+  },
+];
+
+/**
+ * Wrap a sentence under a fixed indent, so it does not run off a narrow terminal.
+ *
+ * `first` is the prefix the opening line carries instead of the indent, which is what gives a
+ * finding its bullet and its continuation lines a hanging indent under the text rather than under
+ * the bullet.
+ */
+function wrap(text: string, indent: string, first = indent, width = 96): string {
+  const lines: string[] = [];
+  let line = '';
+  for (const word of text.split(/\s+/)) {
+    if (line && `${line} ${word}`.length + indent.length > width) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = line ? `${line} ${word}` : word;
+    }
+  }
+  if (line) lines.push(line);
+  return lines.map((l, i) => (i === 0 ? first : indent) + l).join('\n');
+}
+
+/**
+ * The human-readable report.
+ *
+ * A clean schema prints what was looked at rather than nothing, because an empty page cannot be
+ * told apart from a command that failed to run.
+ */
+export function renderDoctorReport(report: DoctorReport): string {
+  const out: string[] = [];
+  const plural = (n: number, one: string) => `${n} ${one}${n === 1 ? '' : 's'}`;
+
+  out.push(chalk.bold(`DRZL doctor  ${report.schema}`));
+  out.push(
+    chalk.dim(
+      `${report.dialect}, ${plural(report.counts.tables, 'table')}, ` +
+        `${plural(report.counts.columns, 'column')}, ${plural(report.counts.checks, 'CHECK constraint')}`
+    )
+  );
+  out.push('');
+
+  if (report.ok) {
+    out.push(chalk.green('Nothing to report.'));
+    out.push(chalk.dim('  Every column has a type DRZL can describe.'));
+    out.push(chalk.dim('  Every CHECK constraint is translated into the generated validators.'));
+    out.push(chalk.dim('  Every table has a primary key the generators can use.'));
+    return out.join('\n');
+  }
+
+  // Ahead of the sections rather than inside one. An error means the schema was never read, so
+  // every count above is zero and every section below is empty, and printing that under "Other
+  // findings" at the foot of the page buries the only sentence that matters.
+  const fatal = report.findings.filter((f) => f.level === 'error');
+  if (fatal.length) {
+    out.push(chalk.red('DRZL could not read this schema'));
+    out.push(chalk.dim('  Nothing else could be checked.'));
+    out.push('');
+    for (const f of fatal) {
+      out.push(wrap(f.message, '    ', `  ${chalk.dim('-')} `));
+      if (f.hint) out.push(chalk.dim(wrap(f.hint, '    ')));
+    }
+    out.push('');
+  }
+
+  for (const section of SECTIONS) {
+    const mine = report.findings.filter(
+      (f) => f.level !== 'error' && section.kinds.includes(f.kind)
+    );
+    if (!mine.length) continue;
+    out.push(chalk.yellow(`${section.title}  (${mine.length})`));
+    out.push(chalk.dim(`  ${section.why}`));
+    out.push('');
+    // One hint per distinct sentence, under the findings that share it: the same advice repeated
+    // under twenty columns is the thing that makes a report unreadable.
+    const groups = new Map<string, DoctorFinding[]>();
+    for (const f of mine) {
+      const key = f.hint ?? '';
+      groups.set(key, [...(groups.get(key) ?? []), f]);
+    }
+    for (const [hint, items] of groups) {
+      for (const f of items) out.push(wrap(f.message, '    ', `  ${chalk.dim('-')} `));
+      if (hint) out.push(chalk.dim(wrap(hint, '    ')));
+      out.push('');
+    }
+  }
+
+  out.push(
+    chalk.bold(`${plural(report.counts.findings, 'finding')} in ${report.schema}.`) +
+      chalk.dim(
+        fatal.length
+          ? ' Fix the error above and run this again.'
+          : ' None of these stop DRZL generating; they are what it will not check for you.'
+      )
+  );
+  return out.join('\n');
+}

--- a/packages/cli/test/doctor.e2e.spec.ts
+++ b/packages/cli/test/doctor.e2e.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * `drzl doctor` spawned as a real process, which is the only thing that proves the command exists.
+ *
+ * The unit file beside this one exercises the report builder. Nothing there would notice a command
+ * that was never registered, a `--json` branch that prints the human report, or an exit code that
+ * fails a user's CI on a schema whose only sin is a `customType`. Those are the failures this file
+ * is for.
+ *
+ * Requires a build, like the other end-to-end files here: CI builds before testing.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promises as fs, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const CLI = path.resolve(__dirname, '..', 'dist', 'cli.js');
+const ROOT = path.join(__dirname, '.tmp-doctor-e2e');
+
+const PROBLEM = `
+import { sql } from 'drizzle-orm';
+import { check, customType, integer, pgTable, serial, text } from 'drizzle-orm/pg-core';
+const money = customType({ dataType: () => 'numeric(12,2)' });
+export const accounts = pgTable(
+  'accounts',
+  {
+    id: serial('id').primaryKey(),
+    balance: money('balance').notNull(),
+    age: integer('age'),
+    email: text('email').notNull(),
+  },
+  (t) => [
+    check('age_adult', sql\`\${t.age} >= 18\`),
+    check('age_or', sql\`\${t.age} >= 18 OR \${t.age} <= 65\`),
+    check('email_re', sql\`\${t.email} ~ '^[a-z]+$'\`),
+  ]
+);
+`;
+
+const CLEAN = `
+import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+`;
+
+/**
+ * Run the CLI and return its code and streams instead of throwing.
+ *
+ * `execFile` rejects on a non-zero exit, and the exit code is half of what this file asserts, so
+ * a rejection has to be read rather than propagated.
+ */
+function cli(args: string[], cwd: string) {
+  return new Promise<{ code: number; stdout: string; stderr: string }>((resolve) => {
+    execFile(
+      process.execPath,
+      [CLI, ...args],
+      { cwd, maxBuffer: 20 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        resolve({ code: (err as { code?: number } | null)?.code ?? 0, stdout, stderr });
+      }
+    );
+  });
+}
+
+async function project(name: string, schema: string) {
+  const dir = path.join(ROOT, name);
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(path.join(dir, 'src', 'db'), { recursive: true });
+  await fs.writeFile(path.join(dir, 'src', 'db', 'schema.ts'), schema, 'utf8');
+  return dir;
+}
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.mkdir(ROOT, { recursive: true });
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe('drzl doctor', () => {
+  it('reports the untypeable column and both declined checks, and exits 0', async () => {
+    const dir = await project('problem', PROBLEM);
+    const r = await cli(['doctor', 'src/db/schema.ts'], dir);
+
+    // Zero on purpose. A schema carrying a customType is normal and usable, and a doctor that
+    // failed every pipeline reading it would be turned off within a week.
+    expect(r.code, r.stdout + r.stderr).toBe(0);
+    expect(r.stdout).toContain('balance');
+    expect(r.stdout).toContain('numeric(12,2)');
+    expect(r.stdout).toContain('age_or');
+    expect(r.stdout).toContain('email_re');
+    // The one check DRZL really enforces is not listed as a problem.
+    expect(r.stdout).not.toContain('age_adult');
+  }, 120_000);
+
+  it('exits 2 under --strict, so a pipeline can gate on it by choice', async () => {
+    const dir = await project('strict', PROBLEM);
+    const r = await cli(['doctor', 'src/db/schema.ts', '--strict'], dir);
+    expect(r.code).toBe(2);
+  }, 120_000);
+
+  it('says so, and exits 0, on a schema with nothing wrong', async () => {
+    const dir = await project('clean', CLEAN);
+    const r = await cli(['doctor', 'src/db/schema.ts'], dir);
+    expect(r.code, r.stdout + r.stderr).toBe(0);
+    expect(r.stdout).toContain('Nothing to report');
+
+    const strict = await cli(['doctor', 'src/db/schema.ts', '--strict'], dir);
+    expect(strict.code, 'a clean schema passes --strict').toBe(0);
+  }, 120_000);
+
+  it('emits the report as JSON under --json, and nothing else on stdout', async () => {
+    const dir = await project('json', PROBLEM);
+    const r = await cli(['doctor', 'src/db/schema.ts', '--json'], dir);
+    expect(r.code).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.dialect).toBe('postgres');
+    expect(parsed.counts.findings).toBe(parsed.findings.length);
+    expect(parsed.findings.map((f: { kind: string }) => f.kind)).toContain('check-declined');
+  }, 120_000);
+
+  it('exits 1 when the schema file is not there, rather than reporting a clean schema', async () => {
+    const dir = await project('missing', CLEAN);
+    const r = await cli(['doctor', 'src/db/nope.ts'], dir);
+    expect(r.code).toBe(1);
+    expect(r.stdout + r.stderr).not.toContain('Nothing to report');
+    // Naming the path it could not read. Without this the test also passes when the command does
+    // not exist at all, since commander exits 1 for an unknown command too.
+    expect(r.stdout + r.stderr).toContain('nope.ts');
+  }, 120_000);
+
+  it('reads the schema path from drzl.config.ts when no argument is given', async () => {
+    const dir = await project('config', PROBLEM);
+    await fs.writeFile(
+      path.join(dir, 'drzl.config.ts'),
+      `export default {
+         schema: './src/db/schema.ts',
+         outDir: './out',
+         generators: [{ kind: 'zod', path: './zod' }],
+       };`,
+      'utf8'
+    );
+    const r = await cli(['doctor'], dir);
+    expect(r.code, r.stdout + r.stderr).toBe(0);
+    expect(r.stdout).toContain('age_or');
+    // The schema named in the config, not a guess at one.
+    expect(r.stdout).toContain('src/db/schema.ts');
+  }, 120_000);
+
+  it('says what is wrong with the config rather than reporting a clean schema', async () => {
+    const dir = await project('bad-config', PROBLEM);
+    await fs.writeFile(
+      path.join(dir, 'drzl.config.ts'),
+      `export default { schema: './src/db/schema.ts', outDir: './out', generators: [] };`,
+      'utf8'
+    );
+    const r = await cli(['doctor'], dir);
+    expect(r.code).toBe(1);
+    expect(r.stdout + r.stderr).toContain('generators');
+    expect(r.stdout + r.stderr).not.toContain('Nothing to report');
+  }, 120_000);
+
+  it('says which flag to pass when there is neither an argument nor a config', async () => {
+    const dir = await project('nothing', CLEAN);
+    const r = await cli(['doctor'], dir);
+    expect(r.code).toBe(1);
+    expect(r.stdout + r.stderr).toMatch(/schema/i);
+  }, 120_000);
+});

--- a/packages/cli/test/doctor.spec.ts
+++ b/packages/cli/test/doctor.spec.ts
@@ -1,0 +1,334 @@
+/**
+ * What `drzl doctor` finds, measured through the real analyzer over a real Drizzle schema.
+ *
+ * A doctor that under-reports is worse than no doctor: it tells you the schema is fine when it is
+ * not. So nothing here builds a `Column[]` by hand. Every fixture is written to disk and read back
+ * through `SchemaAnalyzer`, exactly as the command does it, because a hand-written column object
+ * carries whatever the author believed and this repository has already been burnt by that: thirteen
+ * generator defects traced to fixtures that omitted ordinary field types.
+ *
+ * The two claims worth stating separately:
+ *
+ * 1. Every `DRZL_ANL_UNKNOWN_COLUMN` the analyzer raises appears in the report. Anything less and
+ *    the report is a subset of a warning the CLI already prints.
+ * 2. Every CHECK the shared parser declines appears too, with the parser's own reason. The
+ *    analyzer never calls that parser, so this is the half of the report only the generators knew.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer, type Analysis } from '@drzl/analyzer';
+import { buildDoctorReport, renderDoctorReport } from '../src/doctor';
+
+const DIR = path.join(__dirname, '.tmp-doctor');
+
+/**
+ * Every construct DRZL is known to handle imperfectly, in one Postgres table.
+ *
+ * Built with `pgTable`, `customType`, `check` and `sql` rather than with literals, so the columns
+ * and the rendered CHECK expressions are the ones drizzle really produces.
+ */
+const PROBLEM_SCHEMA = `
+import { sql } from 'drizzle-orm';
+import { check, customType, integer, jsonb, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+
+const money = customType({ dataType: () => 'numeric(12,2)' });
+
+export const accounts = pgTable(
+  'accounts',
+  {
+    id: serial('id').primaryKey(),
+    balance: money('balance').notNull(),
+    credit: money('credit'),
+    prefs: jsonb('prefs'),
+    tags: text('tags').array(),
+    age: integer('age'),
+    score: integer('score'),
+    email: text('email').notNull(),
+    blob: text('blob').notNull(),
+    startDate: timestamp('start_date'),
+    endDate: timestamp('end_date'),
+  },
+  (t) => [
+    check('age_adult', sql\`\${t.age} >= 18\`),
+    check('score_range', sql\`\${t.score} BETWEEN 0 AND 100\`),
+    check('date_order', sql\`\${t.startDate} < \${t.endDate}\`),
+    check('age_or', sql\`\${t.age} >= 18 OR \${t.age} <= 65\`),
+    check('age_not', sql\`NOT (\${t.age} >= 18)\`),
+    check('email_re', sql\`\${t.email} ~ '^[a-z]+$'\`),
+    check('blob_bytes', sql\`octet_length(\${t.blob}) <= 5\`),
+    check('mixed_and', sql\`\${t.age} >= 18 AND lower(\${t.email}) = 'x'\`),
+    check('empty_one', sql\`\`),
+    check('tags_scalar', sql\`\${t.tags} = '{}'\`),
+    check('prefs_shape', sql\`\${t.prefs} = '{}'\`),
+    check('balance_pos', sql\`\${t.balance} > 0\`),
+    check('ghost_col', sql\`nonexistent_column >= 3\`),
+    check('row_ghost', sql\`\${t.age} < missing_col\`),
+  ]
+);
+
+export const nopk = pgTable('nopk', { sku: text('sku').notNull(), qty: integer('qty').notNull() });
+`;
+
+/** Nothing wrong with it: every column typed, every CHECK translated, every table keyed. */
+const CLEAN_SCHEMA = `
+import { sql } from 'drizzle-orm';
+import { check, integer, pgTable, serial, text } from 'drizzle-orm/pg-core';
+
+export const users = pgTable(
+  'users',
+  {
+    id: serial('id').primaryKey(),
+    email: text('email').notNull(),
+    age: integer('age'),
+  },
+  (t) => [check('age_adult', sql\`\${t.age} >= 18\`)]
+);
+`;
+
+/**
+ * A composite key, and a materialized view.
+ *
+ * The view is here to pin the exclusion rather than the inclusion: it takes no writes and gets no
+ * keyed route, so reporting "no primary key" for one would be noise, and a doctor that cries wolf
+ * is turned off.
+ */
+const KEYS_SCHEMA = `
+import { integer, pgMaterializedView, pgTable, primaryKey, serial, text } from 'drizzle-orm/pg-core';
+
+export const composite = pgTable(
+  'composite',
+  { a: integer('a').notNull(), b: integer('b').notNull(), v: text('v') },
+  (t) => [primaryKey({ columns: [t.a, t.b] })]
+);
+export const users = pgTable('users', { id: serial('id').primaryKey(), name: text('name') });
+export const mv = pgMaterializedView('mv').as((qb) => qb.select({ n: users.name }).from(users));
+`;
+
+/** The six Gel temporal columns the analyzer deliberately leaves `unknown`. */
+const GEL_SCHEMA = `
+import { gelTable, boolean, localDate, localTime, dateDuration, relDuration, duration, timestamp } from 'drizzle-orm/gel-core';
+export const t = gelTable('t', {
+  flag: boolean('flag').notNull(),
+  ts: timestamp('ts').notNull(),
+  ld: localDate('ld').notNull(),
+  lt: localTime('lt').notNull(),
+  dd: dateDuration('dd').notNull(),
+  rd: relDuration('rd').notNull(),
+  d: duration('d').notNull(),
+});
+`;
+
+async function analyzed(name: string, source: string): Promise<Analysis> {
+  await fs.mkdir(DIR, { recursive: true });
+  const file = path.join(DIR, `${name}.ts`);
+  await fs.writeFile(file, source, 'utf8');
+  return new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({
+    includeRelations: true,
+    validateConstraints: true,
+  });
+}
+
+let problem: Analysis;
+let clean: Analysis;
+let gel: Analysis;
+let keys: Analysis;
+
+beforeAll(async () => {
+  problem = await analyzed('problem', PROBLEM_SCHEMA);
+  clean = await analyzed('clean', CLEAN_SCHEMA);
+  gel = await analyzed('gel', GEL_SCHEMA);
+  keys = await analyzed('keys', KEYS_SCHEMA);
+}, 60_000);
+
+const kinds = (a: Analysis, kind: string) =>
+  buildDoctorReport(a, 'x.ts').findings.filter((f) => f.kind === kind);
+
+describe('columns DRZL cannot type', () => {
+  it('reports every DRZL_ANL_UNKNOWN_COLUMN the analyzer raised, and no more', () => {
+    const raised = problem.issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN');
+    // Two customType columns, one notNull and one nullable. Both are genuinely unnameable.
+    expect(raised.length).toBe(2);
+    const reported = kinds(problem, 'unknown-column');
+    expect(reported.length).toBe(raised.length);
+    expect(reported.map((f) => `${f.table}.${f.column}`).sort()).toEqual([
+      'accounts.balance',
+      'accounts.credit',
+    ]);
+  });
+
+  it('names the SQL type and carries the analyzer hint, so the user knows what to do', () => {
+    const f = kinds(problem, 'unknown-column').find((x) => x.column === 'credit')!;
+    expect(f.message).toContain('numeric(12,2)');
+    expect(f.hint).toContain('customType');
+  });
+
+  it('finds all six Gel temporal columns', () => {
+    const reported = kinds(gel, 'unknown-column');
+    expect(reported.map((f) => f.column).sort()).toEqual(['d', 'dd', 'ld', 'lt', 'rd', 'ts']);
+  });
+
+  it('explains a Gel temporal as deliberate rather than telling the user to file an issue', () => {
+    const f = kinds(gel, 'unknown-column').find((x) => x.column === 'ld')!;
+    // The generic hint sends the user to open an issue naming the column type. These six are
+    // already named and deliberately left `unknown`, so that hint sends them to a closed issue.
+    expect(f.hint).not.toContain('Open an issue');
+    expect(f.hint).toMatch(/gel/i);
+  });
+
+  it('says nothing about a schema whose every column is typed', () => {
+    expect(kinds(clean, 'unknown-column')).toHaveLength(0);
+  });
+});
+
+describe('CHECK constraints DRZL will not enforce', () => {
+  it('reports every check the shared parser declines, with its reason', () => {
+    const declined = kinds(problem, 'check-declined');
+    expect(declined.map((f) => f.constraint).sort()).toEqual([
+      'age_not',
+      'age_or',
+      'blob_bytes',
+      'email_re',
+      'empty_one',
+      'mixed_and',
+    ]);
+    const byName = new Map(declined.map((f) => [f.constraint, f]));
+    expect(byName.get('age_or')!.message).toContain('contains OR');
+    expect(byName.get('age_not')!.message).toContain('contains NOT');
+    expect(byName.get('mixed_and')!.message).toContain('part of an AND');
+  });
+
+  it('quotes the expression, since the constraint name alone does not say what was written', () => {
+    const f = kinds(problem, 'check-declined').find((x) => x.constraint === 'email_re')!;
+    expect(f.message).toContain("email ~ '^[a-z]+$'");
+  });
+
+  it('reports a check naming a column the table does not have', () => {
+    const ghosts = kinds(problem, 'check-unknown-column');
+    expect(ghosts.map((f) => f.constraint).sort()).toEqual(['ghost_col', 'row_ghost']);
+    expect(ghosts.find((f) => f.constraint === 'ghost_col')!.message).toContain(
+      'nonexistent_column'
+    );
+    expect(ghosts.find((f) => f.constraint === 'row_ghost')!.message).toContain('missing_col');
+  });
+
+  it('reports a scalar comparison against an array or structured column', () => {
+    const wrong = kinds(problem, 'check-not-scalar');
+    expect(wrong.map((f) => f.constraint).sort()).toEqual([
+      'balance_pos',
+      'prefs_shape',
+      'tags_scalar',
+    ]);
+    expect(wrong.find((f) => f.constraint === 'tags_scalar')!.column).toBe('tags');
+    // Named for what it is, rather than as a generic "structured column". A customType is the one
+    // shape whose author chose it, so telling them which one it is costs nothing and helps.
+    expect(wrong.find((f) => f.constraint === 'balance_pos')!.message).toContain('customType');
+  });
+
+  it('reports a column that is both untypeable and carrying a dropped constraint', () => {
+    // Two findings about one column, from two sections. Deduplicating them would hide the
+    // constraint behind the type, and they have different fixes.
+    const about = buildDoctorReport(problem, 'x.ts').findings.filter((f) => f.column === 'balance');
+    expect(about.map((f) => f.kind).sort()).toEqual(['check-not-scalar', 'unknown-column']);
+  });
+
+  it('leaves the three checks DRZL really enforces out of the report', () => {
+    const named = buildDoctorReport(problem, 'x.ts')
+      .findings.map((f) => f.constraint)
+      .filter(Boolean);
+    // Measured through the emitted zod: `age_adult` folds into `.gte(18)`, `score_range` into
+    // `.gte(0).lte(100)`, and `date_order` becomes an object-level refinement.
+    expect(named).not.toContain('age_adult');
+    expect(named).not.toContain('score_range');
+    expect(named).not.toContain('date_order');
+  });
+
+  it('says nothing about a schema whose every check is translated', () => {
+    const report = buildDoctorReport(clean, 'x.ts');
+    expect(report.findings.filter((f) => f.kind.startsWith('check-'))).toHaveLength(0);
+  });
+});
+
+describe('primary keys the generators cannot use', () => {
+  it('reports a table with no primary key', () => {
+    const f = kinds(problem, 'no-primary-key');
+    expect(f).toHaveLength(1);
+    expect(f[0]!.table).toBe('nopk');
+  });
+
+  it('says nothing about a table that has one', () => {
+    expect(kinds(clean, 'no-primary-key')).toHaveLength(0);
+  });
+
+  it('reports a composite key, which the generators use only the first column of', () => {
+    const f = kinds(keys, 'partial-primary-key');
+    expect(f).toHaveLength(1);
+    expect(f[0]!.table).toBe('composite');
+    // Both columns named, and which one is actually used, since that is the difference between
+    // "this returns the wrong row" and "this is fine".
+    expect(f[0]!.message).toContain('(a, b)');
+    expect(f[0]!.message).toContain('"a" alone');
+  });
+
+  it('leaves a read-only relation alone, since it takes no writes and gets no keyed route', () => {
+    const mv = keys.tables.find((t) => t.tsName === 'mv');
+    expect(mv?.readOnly, 'the fixture no longer produces a read-only relation').toBe(true);
+    expect(kinds(keys, 'no-primary-key').map((f) => f.table)).not.toContain('mv');
+  });
+});
+
+describe('the report as a whole', () => {
+  it('counts what it looked at, so a clean run is distinguishable from a run that did nothing', () => {
+    const r = buildDoctorReport(problem, 'schema.ts');
+    expect(r.counts.tables).toBe(2);
+    expect(r.counts.checks).toBe(14);
+    expect(r.counts.columns).toBe(13);
+    expect(r.counts.findings).toBe(r.findings.length);
+    expect(r.dialect).toBe('postgres');
+    expect(r.schema).toBe('schema.ts');
+  });
+
+  it('is ok only when there is nothing at all to say', () => {
+    expect(buildDoctorReport(clean, 'x.ts').ok).toBe(true);
+    expect(buildDoctorReport(problem, 'x.ts').ok).toBe(false);
+  });
+
+  it('renders a clean schema as a statement rather than as an empty page', () => {
+    const out = renderDoctorReport(buildDoctorReport(clean, 'schema.ts'));
+    expect(out).toContain('Nothing to report');
+    // What was checked, so "clean" cannot be confused with "doctor did not run".
+    expect(out).toMatch(/every column/i);
+    expect(out).toMatch(/CHECK/);
+  });
+
+  it('renders every finding it holds, so nothing is counted but unprinted', () => {
+    const report = buildDoctorReport(problem, 'schema.ts');
+    const out = renderDoctorReport(report);
+    for (const f of report.findings) {
+      const token = f.constraint ?? f.column ?? f.table!;
+      expect(out, `${f.kind} ${token} is counted but not printed`).toContain(token);
+    }
+  });
+});
+
+describe('an analysis that failed outright', () => {
+  it('carries the analyzer error through as an error-level finding', async () => {
+    const a = await new SchemaAnalyzer('does/not/exist.ts').analyze({});
+    const r = buildDoctorReport(a, 'does/not/exist.ts');
+    expect(r.findings.some((f) => f.level === 'error')).toBe(true);
+    expect(r.ok).toBe(false);
+  });
+
+  it('leads with the error rather than filing it under "Other findings"', async () => {
+    const a = await new SchemaAnalyzer('does/not/exist.ts').analyze({});
+    const out = renderDoctorReport(buildDoctorReport(a, 'does/not/exist.ts'));
+    // Every count is zero and every section is empty when the schema was never read, so the only
+    // sentence that matters must not be at the foot of the page under a generic heading.
+    expect(out).toContain('could not read this schema');
+    expect(out).not.toContain('Other findings');
+    const lines = out.split('\n');
+    expect(lines.findIndex((l) => l.includes('could not read'))).toBeLessThan(
+      lines.findIndex((l) => l.includes('does/not/exist.ts.'))
+    );
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -458,6 +458,119 @@ fi
 echo "==> running the README's headline command"
 npx drzl generate >/dev/null
 
+# ---------------------------------------------------------------------------------------------
+# `drzl doctor`, against the analyzer it is reporting on.
+#
+# A doctor that under-reports is worse than none, because it tells the reader their schema is
+# fine when it is not, and nothing about a green run would say otherwise. So the assertion is not
+# that doctor prints something; it is that the set of columns doctor calls untypeable is exactly
+# the set the analyzer raised `DRZL_ANL_UNKNOWN_COLUMN` for. A filter that drifts on either side
+# fails here rather than in a user's schema.
+#
+# Both directions matter and neither is the obvious one. Doctor missing a column the analyzer
+# flagged is silence about a real defect. Doctor naming a column the analyzer did not is a report
+# that sends someone to fix nothing, which is how a tool stops being read.
+echo "==> doctor names exactly the columns the analyzer cannot type"
+# Its own fixture, because the app schema has nothing wrong with it. Run against that, both sets
+# are empty, the equality holds trivially and the stage reports success having compared nothing.
+# That is the failure this file has been bitten by more than any other, so the assertion below
+# refuses an empty set as well as a mismatched one.
+#
+# A `customType` is the honest case to build it from: it has no runtime shape any analyzer can
+# read, on either drizzle major, so it is untypeable by construction rather than by omission and
+# no future arm will quietly fix it and make this vacuous again.
+cat > src/db/doctor-fixture.ts <<'DOCTOR_FIXTURE'
+import { pgTable, integer, text, customType, check } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+
+const money = customType<{ data: string; driverData: string }>({
+  dataType: () => 'numeric(12,2)',
+});
+
+export const invoices = pgTable(
+  'invoices',
+  {
+    id: integer().primaryKey(),
+    reference: text().notNull(),
+    balance: money().notNull(),
+  },
+  (t) => [check('ref_or_id', sql`${t.reference} <> '' OR ${t.id} > 0`)]
+);
+DOCTOR_FIXTURE
+
+npx drzl analyze src/db/doctor-fixture.ts --json > "$WORK/analyze.json"
+npx drzl doctor src/db/doctor-fixture.ts --json > "$WORK/doctor.json"
+
+node --input-type=module -e "
+import { readFile } from 'node:fs/promises';
+const analysis = JSON.parse(await readFile('$WORK/analyze.json', 'utf8'));
+const report = JSON.parse(await readFile('$WORK/doctor.json', 'utf8'));
+
+const fromAnalyzer = new Set(
+  (analysis.issues ?? []).filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN').map((i) => i.path)
+);
+// Doctor splits the analyzer's dotted path into a table field and a column field, which is the
+// better shape for a consumer and means the two sides are not directly comparable. Rejoining here
+// rather than asking doctor to carry both: a report with two spellings of one fact is a report
+// where they can disagree.
+//
+// No backticks anywhere in this script block. It reaches node inside a double-quoted -e argument,
+// so bash reads a backtick as command substitution: a comment mentioning them ran the real
+// /usr/bin/column, which blocked reading stdin and hung the whole run with no output and no error.
+const fromDoctor = new Set(
+  (report.findings ?? [])
+    .filter((f) => f.kind === 'unknown-column')
+    .map((f) => [f.table, f.column].filter(Boolean).join('.'))
+);
+
+const missing = [...fromAnalyzer].filter((x) => !fromDoctor.has(x));
+const invented = [...fromDoctor].filter((x) => !fromAnalyzer.has(x));
+if (missing.length || invented.length) {
+  if (missing.length) console.error('    FAIL: the analyzer cannot type these and doctor is silent about them:');
+  for (const m of missing) console.error('      ' + m);
+  if (invented.length) console.error('    FAIL: doctor reports these and the analyzer typed them fine:');
+  for (const i of invented) console.error('      ' + i);
+  process.exit(1);
+}
+// Both empty compares equal, so the equality alone is satisfied by a fixture with nothing wrong
+// and by a doctor that reports nothing whatever it is given. The fixture above guarantees one
+// untypeable column; this is what notices if it ever stops doing so.
+if (fromAnalyzer.size === 0) {
+  console.error('    FAIL: the fixture produced no untypeable column, so the comparison above');
+  console.error('          compared two empty sets and proved nothing.');
+  process.exit(1);
+}
+const declined = (report.findings ?? []).filter((f) => f.kind === 'check-declined');
+if (declined.length === 0) {
+  console.error('    FAIL: the fixture CHECK uses OR, which no generator translates, and doctor');
+  console.error('          did not report it. Silence about an unenforced constraint is the');
+  console.error('          failure this command exists to prevent.');
+  process.exit(1);
+}
+console.log(
+  '    ' + fromDoctor.size + ' untypeable column(s) named identically by both, and ' +
+    declined.length + ' unenforced CHECK(s) reported'
+);
+" || { echo "FAIL: doctor and the analyzer disagree about which columns cannot be typed." >&2; exit 1; }
+
+# The exit codes are the contract a CI job depends on, and nothing else here reads one from the
+# packed artifact. `doctor` reports without failing a pipeline, `--strict` turns findings into a
+# failure, and an unreadable schema is a different answer from either.
+doctor_code() { npx drzl doctor "$@" >/dev/null 2>&1; echo $?; }
+got_plain=$(doctor_code src/db/doctor-fixture.ts)
+got_missing=$(doctor_code no-such-schema.ts)
+if [ "$got_plain" != 0 ]; then
+  echo "FAIL: drzl doctor exited $got_plain on a readable schema. A doctor that fails a build" >&2
+  echo "      for reporting is a doctor nobody leaves switched on." >&2
+  exit 1
+fi
+if [ "$got_missing" != 1 ]; then
+  echo "FAIL: drzl doctor exited $got_missing on a schema that does not exist, expected 1." >&2
+  exit 1
+fi
+echo "    exit codes: 0 on a readable schema, 1 on one it cannot read"
+rm -f src/db/doctor-fixture.ts
+
 BARREL="src/generated/zod/index.ts"
 [ -f "$BARREL" ] || { echo "FAIL: no barrel emitted at $BARREL" >&2; exit 1; }
 for f in src/generated/zod/users.zod.ts src/generated/zod/posts.zod.ts; do


### PR DESCRIPTION
Plan item 30. Every column DRZL cannot type, every CHECK it declined to parse, and why.

Not `analyze`, which dumps the whole `Analysis` as JSON. This is the human-readable "what will not work and what to do about it" report.

## An existing hint was wrong

Checking the hints rather than assuming they were adequate found one that was actively harmful. Gel's six temporal columns are **deliberately** left `unknown`, because the value is an instance of a class DRZL cannot import in generated code. The generic hint told their author to:

> open an issue naming the column type so it can be modelled

That is worse than no hint: it sends someone to file a report the code already answers on purpose. There is an `unnameable: 'gel-temporal'` marker on that arm now and a third hint giving the real reason. Genuinely unmodelled columns keep the generic wording, pinned by a test using a column class with no arm.

## Doctor reports things the analysis structurally cannot

`parseCheck` lives in `@drzl/validation-core`. Every validation generator calls it; **the analyzer never does**, and carries the raw expression through with no opinion. So `Analysis.issues` cannot say "this constraint is in your schema and nothing DRZL emits enforces it". Doctor calls the generators' own parser.

Same for primary keys: the analysis states the key correctly, and the consequence lives in the service generator's `primaryKey?.columns[0] ?? 'id'`.

## Report order, worst-first and silent-first

1. **Cannot read this schema.** Leads, because every count below is zero and nothing else is trustworthy. It originally fell into the catch-all and rendered at the *foot* of the page under "Other findings"; fixed and pinned by a test.
2. **Columns DRZL cannot type**
3. **CHECK constraints DRZL does not enforce**
4. **Primary keys the generators cannot use**
5. Other findings

2 and 3 come before 4 because they are **invisible**: the generated file exists, compiles, and validates nothing. Half of 4 announces itself as a compile error.

## Measurement, and the third column is the point

The test schema is built with the real `pgTable`/`customType`/`check` builders, because hand-written column objects have hidden defects in this repo twice. The third column is **not** a grep for the constraint name, which would miss a bound that folds into `.gte(18)`. It is the emitted zod schema *run* against a row the constraint forbids.

| construct | doctor says | emitted schema, given a forbidden row |
|---|---|---|
| `age >= 18` | silent | **rejects** (folds to `.gte(18)`) |
| `score BETWEEN 0 AND 100` | silent | **rejects** |
| `startDate < endDate` | silent | **rejects** (object refinement) |
| `age >= 18 OR age <= 65` | `check-declined`: contains OR | accepts |
| `NOT (age >= 18)` | `check-declined`: contains NOT | accepts |
| `email ~ '^[a-z]+$'` | `check-declined` | accepts |
| `octet_length(blob) <= 5` | `check-declined` | accepts |
| `tags = '{}'` on `text[]` | `check-not-scalar` (array) | accepts |
| `prefs = '{}'` on `jsonb` | `check-not-scalar` (JSON) | accepts |
| `nonexistent_column >= 3` | `check-unknown-column` | accepts |
| `customType` notNull and nullable | `unknown-column` with SQL type | `z.unknown()` |
| 6 Gel temporal columns | `unknown-column`, Gel-specific hint | `unknown` |
| table with no PK | `no-primary-key`, "will not compile" | **3x TS2339** under `tsc --strict` |
| composite PK | `partial-primary-key`, keyed on the first alone | matches on part of the key |
| materialized view | silent | correctly excluded |

No over-reporting: the three enforced CHECKs are silent. No under-reporting: all ten unenforced ones are named, and the `unknown-column` set is asserted equal to the analyzer's.

## Exit codes

`0` even with findings, because a schema with a `customType` is normal and usable, and **a doctor that fails a pipeline gets switched off**. `1` when the schema cannot be read. `2` under `--strict`.

This differs from `analyze`, where `2` means "the JSON you asked for is not there". Documented, and a maintainer may reasonably prefer `1` for `--strict` and no third code.

## The gate stage, and how it was wrong twice first

It asserts **set-equality in both directions** between doctor's `unknown-column` findings and the analyzer's `DRZL_ANL_UNKNOWN_COLUMN` paths, plus exit codes read from the packed artifact, which nothing in the repo previously checked.

**Version one passed while comparing two empty sets.** The app fixture has nothing wrong with it, so the equality held trivially and a doctor that reported nothing whatever it was given would have passed identically. It has its own fixture now, a `customType` and a CHECK using `OR`, both untypeable and untranslatable **by construction** rather than by omission, and the stage fails if either set is empty.

**Version two compared the wrong field.** Doctor splits the analyzer's dotted `path` into structured `table` and `column`; my assertion read `f.path` and got `undefined`. Fixed on the gate side rather than asking doctor to carry both spellings, since a report with two spellings of one fact is a report where they can disagree.

**Version three hung the entire run for three hours.** The stage reaches node through a double-quoted `-e` argument, so backticks in it are command substitution: a comment mentioning `` `table` `` and `` `column` `` ran the real `/usr/bin/column`, which blocked reading stdin. No output, no error, no timeout. The reason is written into the script so it is not reintroduced.

Final: `1 untypeable column(s) named identically by both, and 1 unenforced CHECK(s) reported`.

## A defect found and deliberately not reported by doctor

The four generators **disagree** about `length(col)` on an array or JSON column. zod and valibot guard with `if (c.arrayDimensions || c.shape)`; arktype and typebox emit `[...o['tags']].length > 1` against a `string[]`, and `[...o['prefs']]` against a JSON value, **which throws on a non-iterable**. `cardinality()` is the mirror image: only zod and valibot emit it.

Left out of doctor because no single sentence is true of all four, and unreachable from a working schema, since Postgres has no `length(anyarray)`. Filed as addendum BE rather than folded in here.

## Tests

Written first: analyzer spec 4/4 failed, doctor e2e 7/7 failed, doctor unit spec failed at collection. One e2e test initially passed **vacuously** (commander exits 1 for an unknown command too) and was tightened to assert the error names the path, after which it failed properly.

Final: 30 doctor tests, 4 analyzer tests, **1638 repo-wide**. `verify:packed`, `build`, `-r test`, `typecheck`, `lint`, `docs build` all green. Documented configs 12 to 13.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
