### PR TITLE
feat(zod): carry the analyzer's facts as schema metadata

### DIFF
--- a/.changeset/zod-schema-metadata.md
+++ b/.changeset/zod-schema-metadata.md
@@ -1,0 +1,76 @@
+---
+'@drzl/analyzer': minor
+'@drzl/validation-core': minor
+'@drzl/generator-zod': minor
+'@drzl/cli': minor
+---
+
+Emitted zod schemas can now carry the facts they cannot state about themselves.
+
+`{ kind: 'zod', path: 'src/validators/zod', meta: true }` attaches zod's own `.meta()` to every
+field and every table schema: the declared SQL type, the primary key, the unique constraints, the
+dialect, whether the database generates or defaults the value, the declared width, and the CHECK
+constraints, including the ones DRZL does not enforce.
+
+```ts
+bio: z.string().nullable().meta({ sqlType: 'text' }),
+```
+
+```ts
+SelectusersSchema.shape.bio.meta(); // { sqlType: 'text' }
+SelectusersSchema.meta().primaryKey; // ['id']
+```
+
+`z.toJSONSchema` copies the keys through, so the same option is what gets a declared width into an
+OpenAPI document: DRZL enforces `varchar(254)` as a `.refine()`, and `toJSONSchema` drops every
+refinement **in silence**, so without this the document says the column is an unbounded string and
+nothing in it says otherwise. `maxLength` is the JSON Schema keyword, so a validator acts on it.
+
+Off by default. On a ten-column table it costs about 48 bytes per field and 156 per schema, and
+roughly doubles the emitted module; generated code ships in your bundle.
+
+**Where it attaches is the whole design problem, and it is measured rather than reasoned about.**
+`.meta()` returns a clone carrying the entry, so an operation that clones keeps it and one that
+wraps does not. On zod 4.4.3, `.refine()`, `.min()`, `.describe()` and `.brand()` all preserve it,
+while `.nullable()`, `.optional()`, `.default()`, `z.array()` and `.pipe()` each build a new schema
+whose own `.meta()` answers `undefined`, reachable only at `.def.innerType`. DRZL wraps every
+nullable column, every array, every optional-on-insert column and every field of an update schema,
+so attaching to the base type would lose the metadata for most of the output. It is therefore
+attached last, after every wrapper, which is also the position `z.toJSONSchema` reads as the
+property's own keywords rather than as one arm of its `anyOf`.
+
+Every key had to say something the schema does not already say. `nullable` is deliberately absent
+for that reason: `.nullable()` is in the chain and `anyOf: [..., { "type": "null" }]` is in the
+JSON Schema, so it would be a second copy of an answer the consumer already has. `hasDefault` is
+present because a defaulted column and a nullable one are both `.optional()` on insert and the
+wrapper cannot tell them apart. `unenforcedChecks` is present because nothing else in the emitted
+module mentions a CHECK that DRZL declined; `drzl doctor` was the only place it appeared.
+
+`{ meta: { description: true } }` additionally writes a `description`, which `toJSONSchema` maps to
+the JSON Schema keyword of that name and which is the only key here any OpenAPI viewer renders
+without being taught. It is separate because it is prose repeating the machine-readable keys beside
+it, and prose is the most expensive thing in the output.
+
+**There are no column comments to carry, and this was measured before the feature was scoped.**
+`drizzle-orm` exposes none at all on either major: no comment-ish own key or prototype method on a
+built column, and `pg.text('a', { comment: 'hello' })` is refused by TypeScript as an excess
+property and, when passed through a variable, dropped at runtime with the string unreachable from
+the built column by any path. Every key above is therefore a fact the analyzer derived, never text
+the user wrote. The zod generator's documentation states this outright, because expecting it to
+work is reasonable.
+
+zod only, deliberately. The other four validation generators are not passed the option rather than
+being passed it and ignoring it: each has a metadata facility of its own, and where the metadata
+has to attach is exactly what had to be measured here. TypeBox is the obvious next one, because a
+TypeBox schema is a JSON Schema and there is no placement question at all. The `json-schema`
+generator does not read this either: it builds from the same analysis rather than from a zod schema,
+so there is nothing to read.
+
+`@drzl/analyzer` gains `Column.sqlType`, the column's type as the database declares it, from
+Drizzle's own `getSQLType()`: `varchar(255)`, `numeric(10, 2)`, `timestamp with time zone`,
+`text[]`, or an enum's type name. `dbType` could not answer this and was never meant to; it is a
+label with exactly one consumer, `isIntegerColumn`, and it calls `varchar`, `char` and `text` all
+`TEXT`. The two Drizzle majors disagree about an array and are reconciled: 0.4x wraps the column in
+a `PgArray` whose own answer is already `text[]`, while v1 leaves the class alone and raises
+`dimensions`, so the suffix is added from `arrayDimensions` when the type does not carry one. The
+field is absent, never guessed, where a builder cannot answer.

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -613,6 +613,195 @@ round trip.
 
 Off by default: generated code ships in your bundle.
 
+## `meta`: what the schema cannot say about itself
+
+A validator says what a value must look like. It does not say where the value came from, and a
+consumer holding only the schema cannot recover it: `z.string()` is a `text`, a `varchar(40)`, a
+`citext` and a `char(3)` alike, nothing on it says whether the database fills the column in, and
+nothing names the key.
+
+`meta: true` attaches those facts with zod's own `.meta()`, on every field and on every table
+schema.
+
+```ts
+export default {
+  schema: './src/db/schema.ts',
+  outDir: './src/api',
+  generators: [{ kind: 'zod', path: './src/validators/zod', meta: true }],
+};
+```
+
+emits:
+
+```ts
+export const SelectusersSchema = z
+  .object({
+    id: z.number().int().gte(-2147483648).lte(2147483647).meta({
+      sqlType: 'serial',
+      hasDefault: true,
+    }),
+    email: z
+      .string()
+      .refine((v) => [...v].length <= 254, { message: 'at most 254 characters' })
+      .meta({ sqlType: 'varchar(254)', maxLength: 254 }),
+    bio: z.string().nullable().meta({ sqlType: 'text' }),
+    age: z
+      .number()
+      .int()
+      .gte(18)
+      .lte(2147483647)
+      .nullable()
+      .meta({ sqlType: 'integer', checks: ['adult: age >= 18'] }),
+  })
+  .meta({
+    table: 'user_accounts',
+    dialect: 'postgres',
+    mode: 'select',
+    primaryKey: ['id'],
+    unique: [['email'], ['handle', 'role']],
+    unenforcedChecks: ["email_shape: email LIKE '%@%'"],
+  });
+```
+
+and reads back off the schema object:
+
+```ts
+SelectusersSchema.shape.bio.meta(); // { sqlType: 'text' }
+SelectusersSchema.meta().primaryKey; // ['id']
+```
+
+Off by default. Every byte lands in your bundle, and on a narrow table this roughly doubles the
+emitted size: measured on a ten-column table, about 48 bytes per field and 156 per schema.
+
+### Why it is attached last in the chain
+
+This is the one design decision worth knowing about, because it looks wrong until you measure it.
+
+`.meta()` returns a **clone** carrying the entry, so an operation that clones keeps it and an
+operation that _wraps_ does not. Measured on zod 4.4.3:
+
+| chained after `.meta({ x: 1 })`                                    | `.meta()` on the result |
+| ------------------------------------------------------------------ | ----------------------- |
+| `.refine()`, `.min()`, `.describe()`, `.brand()`                   | `{ x: 1 }`              |
+| `.nullable()`, `.optional()`, `.default()`, `z.array()`, `.pipe()` | `undefined`             |
+
+DRZL wraps every nullable column, every field of an update schema, every array column and every
+optional-on-insert column. So attaching the metadata to the base type loses it for most of the
+output: it survives only at `schema.def.innerType`, an internal you should not be walking.
+
+Attaching after every wrapper is also the position `z.toJSONSchema` reads as the property's own
+keywords rather than as one arm of its `anyOf`:
+
+```jsonc
+// attached last, which is what DRZL emits
+"bio": { "anyOf": [{ "type": "string" }, { "type": "null" }], "sqlType": "text" }
+
+// attached to the base type, which an OpenAPI reader would never find
+"bio": { "anyOf": [{ "type": "string", "sqlType": "text" }, { "type": "null" }] }
+```
+
+### What each key is, and why it earns its bytes
+
+A key is here only if it says something the schema does not already say. `nullable` is the
+counter-example and is deliberately absent: `.nullable()` is right there in the chain and
+`anyOf: [..., { "type": "null" }]` is right there in the JSON Schema.
+
+On each field:
+
+| key          | what it adds                                                                                                                                                                                                                                                                                                                     |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sqlType`    | The type as the database declares it, from Drizzle's own `getSQLType()`. Nothing in the schema distinguishes a `text` from a `varchar(40)`.                                                                                                                                                                                      |
+| `maxLength`  | The declared character limit. DRZL enforces it as a `.refine()`, and `z.toJSONSchema` **drops every refinement in silence**, so without this the JSON Schema says the column is an unbounded string. `maxLength` is also the JSON Schema keyword, so this puts the constraint back where a validator acts on it.                 |
+| `maxBytes`   | The declared byte limit, which MySQL's TEXT and BLOB families carry instead of a character one.                                                                                                                                                                                                                                  |
+| `hasDefault` | The database supplies a value when the write omits one. Not recoverable: a defaulted column and a nullable one are **both** `.optional()` on insert.                                                                                                                                                                             |
+| `generated`  | The database computes the value and refuses to be given one.                                                                                                                                                                                                                                                                     |
+| `checks`     | The CHECK constraints this field enforces, named as the failure messages name them. Not a restatement of the bound beside it: DRZL folds a CHECK into the column's own range, so `minimum: 18` is indistinguishable from a type bound, and this carries the provenance and the constraint name a database error will quote back. |
+
+On each table schema:
+
+| key                | what it adds                                                                                                                                                                                                                                                            |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `table`            | The SQL table name, which is not the Drizzle export name the schema is named after.                                                                                                                                                                                     |
+| `dialect`          | The same declaration means different things across databases.                                                                                                                                                                                                           |
+| `mode`             | `insert`, `update` or `select`. The export name says it; the schema object does not.                                                                                                                                                                                    |
+| `primaryKey`       | The key columns, in order. A per-field flag cannot carry the order or the grouping.                                                                                                                                                                                     |
+| `unique`           | The unique constraints. The one thing a per-row validator structurally cannot check, which is why [`duplicateFinder`](#duplicatefinder) exists.                                                                                                                         |
+| `readOnly`         | The relation refuses writes, which today means a materialized view.                                                                                                                                                                                                     |
+| `checks`           | Row-level CHECKs, enforced as object refinements and invisible for the same reason.                                                                                                                                                                                     |
+| `unenforcedChecks` | CHECK constraints the database enforces and this schema does not, whether the parser declined the expression or the column's shape has no way to state it. Nothing else in the emitted module mentions these at all; `drzl doctor` is the only other place they appear. |
+
+On an array column the metadata describes the column, and `maxLength` describes the element,
+because that is where the emitted schema applies it.
+
+### `description`
+
+`{ meta: { description: true } }` additionally writes a `description`, which `z.toJSONSchema` maps
+to the JSON Schema keyword of that name. That is what a Swagger or Redoc viewer renders to a human,
+and it is the only key here that any OpenAPI tool understands without being taught.
+
+```ts
+{ kind: 'zod', path: 'src/validators/zod', meta: { description: true } }
+```
+
+```jsonc
+"email":  { "type": "string", "description": "at most 254 characters" },
+"age":    { "anyOf": [...], "description": "CHECK adult: age >= 18" }
+```
+
+It is separate from `meta: true` because it is prose that repeats what the machine-readable keys
+beside it already say, and prose costs the most bytes of anything here.
+
+It is built only from what the schema enforces and cannot show, plus the constraints it does not
+enforce. It is never a restatement of the type, and it is never a user comment.
+
+### Two things to know before pointing `z.toJSONSchema` at an emitted schema
+
+**It throws on a column it cannot represent**, with or without this option. A `Date` column
+answers `Date cannot be represented in JSON Schema` and a `bytea`, a `customType` or a
+`typedColumns` narrowing answers `Custom types cannot be represented in JSON Schema`. Pass
+`{ unrepresentable: 'any' }` to get a document instead of an exception:
+
+```ts
+z.toJSONSchema(SelectusersSchema, { unrepresentable: 'any' });
+```
+
+**OpenAPI 3.0 refuses the keys.** The Schema Object in 3.0 is closed, so a key it does not know is
+an error rather than something a reader ignores. Measured against the official 3.0 schema through
+`@seriousme/openapi-schema-validator`: a document carrying `sqlType` on a property and `table` on a
+schema is invalid, the same document with `x-sqlType` and `x-table` is valid, and `maxLength`,
+`description` and `readOnly` are real 3.0 keywords and pass either way. OpenAPI 3.1 and JSON Schema
+2020-12 both ignore unknown keywords, so nothing here needs renaming for them. If you target 3.0,
+rename the DRZL keys onto `x-` as you build the document, and leave the three real keywords alone.
+
+### There are no column comments to carry, measured
+
+The obvious thing to want here is the comment you wrote on the column. It does not exist.
+`drizzle-orm` exposes no column comments at all, on either major:
+
+```
+comment-ish own keys on a built column     none
+comment-ish methods on its prototype       none
+pg.text('a', { comment: 'hello' })         TypeScript refuses the literal; at runtime the key is
+                                           dropped and the string is not reachable from the built
+                                           column by any path
+```
+
+Column options objects are not strict at runtime, so a `comment` key passed through a variable is
+accepted and silently discarded. There is no source for DRZL to read, which is why every key above
+is a fact the analyzer derived rather than text you wrote.
+
+### zod only, for now
+
+The other four validation generators do not take this option, and are not passed it. Each has a
+metadata facility of its own, and _where the metadata has to attach_ is the entire difficulty here:
+the answer for zod came out of measuring its clone-versus-wrap behaviour, and it does not transfer.
+TypeBox is the obvious next one, because a TypeBox schema **is** a JSON Schema and there is no
+placement question at all.
+
+The `json-schema` generator does not read this either. It builds its documents from the same
+analysis rather than from a zod schema, so there is nothing to read; it already states what JSON
+Schema cannot express as a `description` of its own.
+
 ## Nested relation schemas
 
 `nestedSchemas: true` also emits `NestedInsert<Table>` and `NestedSelect<Table>`, the table plus one

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -51,7 +51,35 @@ export interface Relation {
 export interface Column {
   name: string;
   tsType: string;
+  /**
+   * A coarse label for the column's kind, not its type.
+   *
+   * `varchar`, `char` and `text` are all `TEXT` here, deliberately: exactly one consumer reads
+   * this, `isIntegerColumn`, and it only asks whether a number is whole. Use `sqlType` for the
+   * question this name suggests it answers.
+   */
   dbType: string;
+  /**
+   * The column's type as the database declares it, from Drizzle's own `getSQLType()`:
+   * `varchar(255)`, `numeric(10, 2)`, `timestamp with time zone`, `text[]`, or an enum's type
+   * name.
+   *
+   * The one fact about a column that no validator schema can carry, and the one every other fact
+   * here is a consequence of. A generator that emits metadata beside its schemas has nothing else
+   * to put in it: `dbType` is a label rather than a type, and the declared width lives in
+   * `maxLength`, the precision in `min`/`max`, and neither of those says which type produced it.
+   *
+   * The two Drizzle majors disagree about an array and are reconciled here, measured rather than
+   * assumed: 0.4x wraps the column in a `PgArray` whose own answer is already `text[]`, while v1
+   * leaves the class alone and raises `dimensions`, so its answer is the bare `text`. The suffix
+   * is added from `arrayDimensions` when the type does not already carry one, so a consumer
+   * cannot tell which major produced its metadata.
+   *
+   * Absent where the builder has no `getSQLType` or it throws. Nothing is guessed from the class
+   * name: an invented type string reads exactly like a real one, and there is no way for a
+   * consumer to tell them apart.
+   */
+  sqlType?: string;
   nullable: boolean;
   hasDefault: boolean;
   isGenerated: boolean;
@@ -2354,10 +2382,29 @@ export class SchemaAnalyzer {
         });
       }
 
+      // The type as declared, read from the outer column so a 0.4x `PgArray` answers for the
+      // array rather than for its element. See `Column.sqlType` for the major-to-major
+      // reconciliation and for why nothing is invented when the builder cannot answer.
+      const dims = arrayDims || v1?.arrayDimensions || 0;
+      const declaredSqlType = ((): string | undefined => {
+        let raw: unknown;
+        try {
+          raw =
+            typeof (outerCol as any)?.getSQLType === 'function'
+              ? (outerCol as any).getSQLType()
+              : undefined;
+        } catch {
+          return undefined;
+        }
+        if (typeof raw !== 'string' || !raw) return undefined;
+        return raw.endsWith(']') ? raw : raw + '[]'.repeat(dims);
+      })();
+
       columns.push({
         name: colName,
         tsType,
         dbType,
+        ...(declaredSqlType ? { sqlType: declaredSqlType } : {}),
         nullable,
         hasDefault,
         isGenerated,

--- a/packages/analyzer/test/sql-type.spec.ts
+++ b/packages/analyzer/test/sql-type.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * `Column.sqlType`: the type as the database declares it.
+ *
+ * `dbType` is deliberately a label. The analyzer normalises `varchar`, `char` and `text` to the
+ * single word `TEXT` because exactly one consumer reads it, `isIntegerColumn`, and that consumer
+ * only asks whether a number is whole. So `dbType` cannot answer "what is this column", and a
+ * `varchar(255)` and a `text` are the same string there.
+ *
+ * Drizzle already knows the real answer and every column carries it: `getSQLType()` is what the
+ * migration would write. It is the one fact about a column that no validator schema can carry,
+ * and it is what every other fact here is a consequence of, so it is the first thing a consumer
+ * reading generated metadata wants.
+ *
+ * The one place the two Drizzle majors disagree is an array, measured here rather than assumed:
+ * 0.4x wraps the column in a `PgArray` whose `getSQLType()` already says `text[]`, while v1 leaves
+ * the class alone and raises `dimensions`, so its own answer is the bare `text`. The analyzer
+ * spells both the same way, because a consumer should not be able to tell which major produced
+ * its metadata.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function columnsOf(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const a = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+  return Object.fromEntries((a.tables[0]?.columns ?? []).map((c) => [c.name, c]));
+}
+
+describe('the declared SQL type', () => {
+  it('carries the width that dbType throws away', async () => {
+    const cols = await columnsOf(
+      'sqltype-pg',
+      `
+      import { pgTable, varchar, char, text, numeric, timestamp, serial } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', {
+        id: serial('id').primaryKey(),
+        name: varchar('name', { length: 255 }),
+        code: char('code', { length: 4 }),
+        body: text('body'),
+        price: numeric('price', { precision: 10, scale: 2 }),
+        at: timestamp('at', { withTimezone: true }),
+      });
+      `
+    );
+    expect(cols.id.sqlType).toBe('serial');
+    expect(cols.name.sqlType).toBe('varchar(255)');
+    expect(cols.code.sqlType).toBe('char(4)');
+    expect(cols.body.sqlType).toBe('text');
+    expect(cols.price.sqlType).toBe('numeric(10, 2)');
+    expect(cols.at.sqlType).toBe('timestamp with time zone');
+
+    // The point of the field: all three string columns are the same `dbType`.
+    expect([cols.name.dbType, cols.code.dbType, cols.body.dbType]).toEqual([
+      'TEXT',
+      'TEXT',
+      'TEXT',
+    ]);
+  });
+
+  it('names a pg enum by its type name', async () => {
+    const cols = await columnsOf(
+      'sqltype-enum',
+      `
+      import { pgTable, pgEnum } from 'drizzle-orm/pg-core';
+      export const mood = pgEnum('mood', ['ok', 'sad']);
+      export const t = pgTable('t', { m: mood('m') });
+      `
+    );
+    expect(cols.m.sqlType).toBe('mood');
+  });
+
+  it('spells an array the same way on either drizzle major', async () => {
+    // 0.4x answers `text[]` from the wrapping PgArray. v1 answers `text` and raises `dimensions`,
+    // so the suffix is added from `arrayDimensions` when the type does not already carry one.
+    const cols = await columnsOf(
+      'sqltype-array',
+      `
+      import { pgTable, text } from 'drizzle-orm/pg-core';
+      export const t = pgTable('t', {
+        tags: text('tags').array(),
+        grid: text('grid').array().array(),
+        plain: text('plain'),
+      });
+      `
+    );
+    expect(cols.tags.sqlType).toBe('text[]');
+    expect(cols.grid.sqlType).toBe('text' + '[]'.repeat(cols.grid.arrayDimensions ?? 0));
+    expect(cols.plain.sqlType).toBe('text');
+  });
+
+  it('adds the array suffix v1 does not spell for itself', async () => {
+    // The other half of the reconciliation, and the half the 0.4x path above cannot exercise:
+    // v1 leaves the column class alone and raises `dimensions`, so `getSQLType()` answers the
+    // bare element type and the suffix has to come from `arrayDimensions`. Without this the two
+    // majors describe the same column differently, which is what the cross-major stage in
+    // `scripts/verify-packed.sh` fails on.
+    const cols = await columnsOf(
+      'sqltype-array-v1',
+      `
+      import { pgTable, text, integer } from 'drizzle-orm-v1/pg-core';
+      export const t = pgTable('t', {
+        tags: text('tags').array(),
+        nums: integer('nums').array(),
+        plain: text('plain'),
+      });
+      `
+    );
+    expect(cols.tags.arrayDimensions, 'v1 raises dimensions rather than wrapping').toBe(1);
+    expect(cols.tags.sqlType).toBe('text[]');
+    expect(cols.nums.sqlType).toBe('integer[]');
+    expect(cols.plain.sqlType).toBe('text');
+  });
+
+  it('carries the declared width on mysql too', async () => {
+    const cols = await columnsOf(
+      'sqltype-mysql',
+      `
+      import { mysqlTable, varchar, tinytext, decimal, binary } from 'drizzle-orm/mysql-core';
+      export const t = mysqlTable('t', {
+        a: varchar('a', { length: 10 }),
+        b: tinytext('b'),
+        c: decimal('c', { precision: 8, scale: 3 }),
+        d: binary('d', { length: 4 }),
+      });
+      `
+    );
+    expect(cols.a.sqlType).toBe('varchar(10)');
+    expect(cols.b.sqlType).toBe('tinytext');
+    expect(cols.c.sqlType).toBe('decimal(8,3)');
+    expect(cols.d.sqlType).toBe('binary(4)');
+  });
+
+  it('is absent rather than guessed when the column cannot say', async () => {
+    // Nothing in the analysis invents this: a column whose builder has no `getSQLType` leaves the
+    // field off entirely, so "absent" and "unknown" are the same answer and neither is a string a
+    // consumer could act on by mistake.
+    const cols = await columnsOf(
+      'sqltype-sqlite',
+      `
+      import { sqliteTable, text, integer, blob } from 'drizzle-orm/sqlite-core';
+      export const t = sqliteTable('t', {
+        a: text('a'),
+        b: integer('b', { mode: 'timestamp' }),
+        c: blob('c'),
+      });
+      `
+    );
+    expect(cols.a.sqlType).toBe('text');
+    expect(cols.b.sqlType).toBe('integer');
+    expect(cols.c.sqlType).toBe('blob');
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -291,8 +291,10 @@ program
             );
             const gen = new ZodGenerator(analysis);
             const target = g.path ?? 'src/validators/zod';
+            // `meta` is zod-only; see `GeneratorCapabilities.meta` for why it is not passed to the
+            // other four rather than being passed and ignored.
             const files = await gen.generate(
-              validationOptions(g, cfg, target, { schemaTypes: true }) as never
+              validationOptions(g, cfg, target, { schemaTypes: true, meta: true }) as never
             );
             progress.stop();
             ora().succeed(chalk.green(`Generated (zod): ${files.length} files`));
@@ -736,13 +738,15 @@ program
               );
               const gen = new ZodGenerator(analysis);
               const target = g.path ?? 'src/validators/zod';
+              // `meta` is zod-only; see `GeneratorCapabilities.meta` for why it is not passed to
+              // the other four rather than being passed and ignored.
               // The same builder `generate` uses. Assembled by hand here until now, and every
               // option added since the builder existed was therefore absent from a watch rebuild:
               // `coerceDates`, `applyDefaults`, `typedJson`, `typedColumns` and `duplicateFinder`
               // were all dropped, so the first save after starting `drzl watch` silently replaced
               // correct output with output generated from defaults.
               const files = await gen.generate(
-                validationOptions(g, cfg, target, { schemaTypes: true }) as never
+                validationOptions(g, cfg, target, { schemaTypes: true, meta: true }) as never
               );
               opts.json
                 ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -118,6 +118,25 @@ export const GeneratorSchema = z.object({
    */
   duplicateFinder: z.boolean().optional(),
   /**
+   * zod only. Attach the facts the analyzer knows and a zod schema cannot state, as `.meta()` on
+   * every field and every table schema: the declared SQL type, the primary key, the unique
+   * constraints, whether the database generates or defaults the value, and the CHECK constraints,
+   * including the ones DRZL declined to enforce.
+   *
+   * `z.toJSONSchema` copies these through, so they are also how an OpenAPI document built from the
+   * emitted schemas gets the declared width back: DRZL enforces one as a `.refine()`, and
+   * `toJSONSchema` drops every refinement in silence.
+   *
+   * `true` is the shorthand for `{ enabled: true }`. `{ description: true }` additionally writes a
+   * `description`, which is what an OpenAPI viewer renders to a human.
+   */
+  meta: z
+    .union([
+      z.boolean(),
+      z.object({ enabled: z.boolean().optional(), description: z.boolean().optional() }).strict(),
+    ])
+    .optional(),
+  /**
    * TypeBox only. Give every emitted schema a `~standard` key, so it can be handed to a tRPC or
    * oRPC route.
    *

--- a/packages/cli/src/validation-options.ts
+++ b/packages/cli/src/validation-options.ts
@@ -33,6 +33,7 @@ export type ValidationGeneratorConfig = {
   nestedSchemas?: unknown;
   nestedDepth?: unknown;
   standardSchema?: unknown;
+  meta?: unknown;
 };
 
 export interface GeneratorCapabilities {
@@ -53,6 +54,16 @@ export interface GeneratorCapabilities {
    * it would read as a promise that something changed.
    */
   standardSchema?: boolean;
+  /**
+   * Whether the generator can attach metadata to what it emits.
+   *
+   * zod is the only one so far, and deliberately: it is the one validator here whose metadata has
+   * a destination outside itself, since `z.toJSONSchema` copies arbitrary keys through into the
+   * document an OpenAPI consumer reads. The other four each have a facility of their own and each
+   * needs its own measurement of where the metadata has to attach, which is the whole difficulty;
+   * building four on the strength of one measurement is how three of them come to be subtly wrong.
+   */
+  meta?: boolean;
 }
 
 export function validationOptions(
@@ -85,5 +96,6 @@ export function validationOptions(
         }
       : {}),
     ...(caps.standardSchema ? { standardSchema: g.standardSchema } : {}),
+    ...(caps.meta ? { meta: g.meta } : {}),
   };
 }

--- a/packages/cli/test/config.spec.ts
+++ b/packages/cli/test/config.spec.ts
@@ -39,6 +39,25 @@ describe('@drzl/cli config', () => {
   });
 });
 
+describe('@drzl/cli config meta', () => {
+  const base = (generators: any[]) => ({ schema: 'src/db/schema.ts', generators });
+
+  it('keeps the boolean shorthand and the object form through parse', () => {
+    const shorthand: any = ConfigSchema.parse(base([{ kind: 'zod', meta: true }]));
+    expect(shorthand.generators[0].meta).toBe(true);
+    const full: any = ConfigSchema.parse(base([{ kind: 'zod', meta: { description: true } }]));
+    expect(full.generators[0].meta).toEqual({ description: true });
+  });
+
+  it('refuses a key it does not know, rather than dropping it in silence', () => {
+    // The failure this guards is the one the repository has already had twice: a documented option
+    // parses, is stripped, and the feature does nothing while nothing says so.
+    expect(() =>
+      ConfigSchema.parse(base([{ kind: 'zod', meta: { descriptions: true } }]))
+    ).toThrow();
+  });
+});
+
 describe('@drzl/cli config affix', () => {
   const base = (generators: any[]) => ({ schema: 'src/db/schema.ts', generators });
 

--- a/packages/cli/test/validation-options.spec.ts
+++ b/packages/cli/test/validation-options.spec.ts
@@ -28,6 +28,7 @@ const generator = {
   duplicateFinder: true,
   nestedSchemas: true,
   nestedDepth: 2,
+  meta: { description: true },
 };
 const config = { schema: 'src/db/schema.ts' };
 
@@ -53,6 +54,18 @@ describe('the shared options', () => {
       nestedSchemas: true,
       nestedDepth: 2,
     });
+  });
+
+  it('withholds metadata from the four generators that have no measured place to put it', () => {
+    // zod is the only one that takes `meta` today. The other four each have a facility of their
+    // own, and where the metadata has to attach in each is the whole difficulty; passing the
+    // option to a generator that ignores it reads as a promise that something happened.
+    expect(validationOptions(generator, config, 'out', { schemaTypes: true })).not.toHaveProperty(
+      'meta'
+    );
+    expect(
+      validationOptions(generator, config, 'out', { schemaTypes: true, meta: true })
+    ).toMatchObject({ meta: { description: true } });
   });
 
   it('withholds the schema-import options from a generator that cannot use them', () => {

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -13,11 +13,13 @@ import type {
 } from '@drzl/validation-core';
 import type { NestedNode, NestedMode } from '@drzl/validation-core';
 import {
+  columnMetaFacts,
   formatCode,
   parseCheck,
   renderDuplicateFinder,
   resolveConfiguredImport,
   buildNestedPlan,
+  tableMetaFacts,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
   insertColumns,
@@ -38,6 +40,38 @@ import {
 } from '@drzl/validation-core';
 
 type Mode = 'insert' | 'update' | 'select';
+
+/**
+ * What `meta` is asking for, once the boolean shorthand is expanded.
+ *
+ * `undefined` means off, which is the default: every byte here ships in the consumer's bundle and
+ * most consumers never read it.
+ */
+interface MetaPlan {
+  /** Also write prose, which is what an OpenAPI viewer renders. Its own flag; see the option. */
+  description: boolean;
+  /** A fact about the analysis rather than about any one table, so it travels with the plan. */
+  dialect?: string;
+}
+
+/**
+ * `.meta({ ... })`, or nothing when the facts are empty and the call would say nothing.
+ *
+ * `JSON.stringify` rather than a hand-rolled object literal: every value here comes from a schema
+ * the user wrote, so a table named `it's` or a CHECK holding a quote has to survive into valid
+ * TypeScript. The formatter unquotes the keys that do not need quoting.
+ */
+function metaCall(facts: object): string {
+  if (!Object.keys(facts).length) return '';
+  return `.meta(${JSON.stringify(facts)})`;
+}
+
+function resolveMeta(opt: ZodGenerateOptions['meta'], dialect?: string): MetaPlan | undefined {
+  if (!opt) return undefined;
+  if (opt === true) return { description: false, dialect };
+  if (opt.enabled === false) return undefined;
+  return { description: !!opt.description, dialect };
+}
 
 /**
  * Suffix appended to the Drizzle export name for every emitted file. The barrel derives
@@ -394,7 +428,9 @@ function zodField(
    * type worth checking. This one is appended, so the checks stay and only the static type
    * narrows.
    */
-  narrowRef?: string
+  narrowRef?: string,
+  /** The column's metadata, already rendered. Appended last; see the call below for why. */
+  metaSuffix = ''
 ): string {
   let expr = zodExprForColumn(c, mode, coerceDates, typedJsonRef, sets, checks);
   // `.array()` does not give the column its own class in Drizzle, so everything above describes
@@ -431,7 +467,14 @@ function zodField(
   // parsed result and the inferred type, checked against zod rather than assumed, so the runtime
   // schema is untouched and only the static type narrows.
   if (narrowRef) expr = `${expr}.pipe(z.custom<${narrowRef}>())`;
-  return expr;
+  // After everything, including the pipe. `.meta()` returns a clone carrying the entry, so a
+  // *clone* operation keeps it and a *wrapping* one does not: measured on zod 4.4.3, `.refine()`,
+  // `.min()` and `.describe()` all preserve it, while `.nullable()`, `.optional()`, `.default()`,
+  // `z.array()` and `.pipe()` each build a new schema whose own `.meta()` answers undefined. So
+  // anywhere but last loses the metadata for every nullable column, every field of an update
+  // schema, and every array. It is also the position `z.toJSONSchema` reads as the property's own
+  // keywords rather than as one arm of its `anyOf`.
+  return expr + metaSuffix;
 }
 
 function renderObjectShape(
@@ -443,7 +486,8 @@ function renderObjectShape(
   sets: ColumnSet[] = [],
   applyDefaults = false,
   lengths: LengthCheck[] = [],
-  cardinalities: CardinalityCheck[] = []
+  cardinalities: CardinalityCheck[] = [],
+  meta?: { plan: MetaPlan; table: Table }
 ) {
   return cols
     .map((c) => {
@@ -455,7 +499,10 @@ function renderObjectShape(
       const replaces = c.tsType === 'any' || c.shape?.kind === 'custom';
       const ref = typedJson && replaces ? refFor(typedJson) : undefined;
       const narrow = typedJson?.allColumns && !replaces ? refFor(typedJson) : undefined;
-      return `  ${JSON.stringify(c.name)}: ${zodField(c, mode, coerceDates, checks, ref, sets, applyDefaults, lengths, cardinalities, narrow)},`;
+      const metaSuffix = meta
+        ? metaCall(columnMetaFacts(c, meta.table, { description: meta.plan.description }))
+        : '';
+      return `  ${JSON.stringify(c.name)}: ${zodField(c, mode, coerceDates, checks, ref, sets, applyDefaults, lengths, cardinalities, narrow, metaSuffix)},`;
     })
     .join('\n');
 }
@@ -536,7 +583,8 @@ function renderNestedObject(
   mode: NestedMode,
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   typedJson: { allColumns?: boolean } | undefined,
-  applyDefaults: boolean
+  applyDefaults: boolean,
+  meta?: MetaPlan
 ): string {
   const all = mode === 'insert' ? insertColumns(node.table) : selectColumns(node.table);
   const cols = nestedNodeColumns(all, node);
@@ -553,14 +601,15 @@ function renderNestedObject(
     sets,
     applyDefaults,
     lengths,
-    cardinalities
+    cardinalities,
+    meta ? { plan: meta, table: node.table } : undefined
   );
 
   const arms = node.arms.map((arm) => {
     const notes = nestedArmNotes(arm)
       .map((n) => `  // ${n}\n`)
       .join('');
-    const child = renderNestedObject(arm.child, mode, coerceDates, typedJson, applyDefaults);
+    const child = renderNestedObject(arm.child, mode, coerceDates, typedJson, applyDefaults, meta);
     // A to-one may come back null: a relational query returns null where there is no matching
     // row, and accepting it never turns away something the query produced. Optional throughout,
     // because which relations a payload carries is the caller's choice on a write and the `with`
@@ -572,7 +621,19 @@ function renderNestedObject(
   });
 
   const body = [fields, ...arms].filter(Boolean).join('\n');
-  return `z.object({\n${body}\n})${rowRefinements(rows, cols)}`;
+  // After the row refinements, for the same reason a field's metadata goes after its wrappers: on
+  // an object `.refine()` is a clone rather than a wrap, so this order is not forced, but keeping
+  // one rule for both positions means there is nothing to get wrong when either side changes.
+  const tableMeta = meta
+    ? metaCall(
+        tableMetaFacts(node.table, {
+          mode,
+          dialect: meta.dialect,
+          description: meta.description,
+        })
+      )
+    : '';
+  return `z.object({\n${body}\n})${rowRefinements(rows, cols)}${tableMeta}`;
 }
 
 /** The nested exports for one table, or nothing when it has no relations to describe. */
@@ -582,7 +643,8 @@ function renderNestedSchemas(
   coerceDates: NonNullable<ValidationGenerateOptions['coerceDates']>,
   typedJson: { allColumns?: boolean } | undefined,
   applyDefaults: boolean,
-  plans: Partial<Record<NestedMode, NestedNode>>
+  plans: Partial<Record<NestedMode, NestedNode>>,
+  meta?: MetaPlan
 ): string {
   const out: string[] = [];
   for (const mode of ['insert', 'select'] as const) {
@@ -590,7 +652,7 @@ function renderNestedSchemas(
     if (!plan) continue;
     const name = nestedSchemaName(mode, table.tsName, affix);
     const tname = nestedTypeName(mode, table.tsName, affix);
-    const expr = renderNestedObject(plan, mode, coerceDates, typedJson, applyDefaults);
+    const expr = renderNestedObject(plan, mode, coerceDates, typedJson, applyDefaults, meta);
     const infer = mode === 'insert' ? 'input' : 'output';
     out.push(
       `export const ${name} = ${expr};\n\nexport type ${tname} = z.${infer}<typeof ${name}>;`
@@ -613,7 +675,8 @@ function renderTableSchemas(
   typedJson?: { schemaSpecifier: string; allColumns?: boolean },
   applyDefaults = false,
   wantsDuplicateFinder = false,
-  nested: Partial<Record<NestedMode, NestedNode>> = {}
+  nested: Partial<Record<NestedMode, NestedNode>> = {},
+  meta?: MetaPlan
 ) {
   const T = table.tsName;
   const insertSchema = schemaName('insert', T, affix);
@@ -641,6 +704,7 @@ function renderTableSchemas(
   const tjInsert = typedJson
     ? { table: table.tsName, mode: 'insert' as const, allColumns: typedJson.allColumns }
     : undefined;
+  const forMeta = meta ? { plan: meta, table } : undefined;
   const bodyInsert = renderObjectShape(
     insertCols,
     'insert',
@@ -650,7 +714,8 @@ function renderTableSchemas(
     sets,
     applyDefaults,
     lengths,
-    cardinalities
+    cardinalities,
+    forMeta
   );
   const bodyUpdate = renderObjectShape(
     updateCols,
@@ -661,7 +726,8 @@ function renderTableSchemas(
     sets,
     applyDefaults,
     lengths,
-    cardinalities
+    cardinalities,
+    forMeta
   );
   const bodySelect = renderObjectShape(
     selectCols,
@@ -672,8 +738,16 @@ function renderTableSchemas(
     sets,
     applyDefaults,
     lengths,
-    cardinalities
+    cardinalities,
+    forMeta
   );
+  // One per mode, because the mode is the only thing that differs and it is one of the facts.
+  const tableMetaFor = (mode: Mode) =>
+    meta
+      ? metaCall(
+          tableMetaFacts(table, { mode, dialect: meta.dialect, description: meta.description })
+        )
+      : '';
   // A type-only import: it disappears at build time, so this adds no runtime dependency on the
   // schema module and cannot create an import cycle at runtime.
   //
@@ -693,11 +767,11 @@ function renderTableSchemas(
     ? ''
     : `export const ${insertSchema} = z.object({
 ${bodyInsert}
-})${rowRefinements(rows, insertCols)};
+})${rowRefinements(rows, insertCols)}${tableMetaFor('insert')};
 
 export const ${updateSchema} = z.object({
 ${bodyUpdate}
-})${rowRefinements(rows, updateCols)};
+})${rowRefinements(rows, updateCols)}${tableMetaFor('update')};
 
 `;
   const writeTypes = table.readOnly
@@ -719,14 +793,15 @@ export type ${updateType} = z.input<typeof ${updateSchema}>;
     coerceDates,
     typedJson,
     applyDefaults,
-    nested
+    nested,
+    meta
   );
 
   return `import { z } from 'zod';
 ${schemaImport}
 ${writes}export const ${selectSchema} = z.object({
 ${bodySelect}
-})${rowRefinements(rows, selectCols)};
+})${rowRefinements(rows, selectCols)}${tableMetaFor('select')};
 
 ${writeTypes}export type ${selectType} = z.output<typeof ${selectSchema}>;
 ${nestedCode}${duplicates}`;
@@ -743,6 +818,28 @@ export interface ZodGenerateOptions extends ValidationGenerateOptions {
    * generated code ships in the consumer's bundle.
    */
   duplicateFinder?: boolean;
+  /**
+   * Attach the facts the analyzer knows and a zod schema cannot state, as `.meta()` on every
+   * field and on every table schema.
+   *
+   * A validator says what a value must look like. It does not say where the value came from, and
+   * nothing on `z.string()` distinguishes a `text` from a `varchar(40)`, says whether the database
+   * fills it in, or names the key columns. This carries those, plus the two things the schema does
+   * enforce and cannot show: a declared width and every CHECK constraint, both of which are
+   * `.refine()` calls that `z.toJSONSchema` drops in silence.
+   *
+   * Off by default. Every byte lands in the consumer's bundle, and most consumers never read it.
+   *
+   * `{ description: true }` additionally writes a `description`, which `toJSONSchema` maps to the
+   * JSON Schema keyword of that name and is what an OpenAPI viewer renders to a human. It is prose
+   * and it repeats what the machine-readable keys beside it already say, so it is asked for
+   * separately.
+   *
+   * zod only, deliberately. It is the one validator DRZL emits whose metadata has a defined
+   * destination outside itself, and the placement question this answers had to be measured against
+   * zod's own clone-versus-wrap behaviour rather than reasoned about. See the docs page.
+   */
+  meta?: boolean | { enabled?: boolean; description?: boolean };
 }
 
 /**
@@ -805,6 +902,9 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
     const nestedDepth = opts.nestedSchemas
       ? resolveNestedDepth(opts.nestedDepth, (m) => console.warn(m))
       : 0;
+    // The dialect is a fact about the analysis rather than about any one table, and the same
+    // declaration means different things across dialects, so it travels with the plan.
+    const metaPlan = resolveMeta(opts.meta, this.analysis.dialect);
     // File names deliberately stay on the raw Drizzle export name: affixes and tableCase
     // rename identifiers, never modules, so the barrel and importPath keep resolving.
     for (const table of this.analysis.tables) {
@@ -816,7 +916,8 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
         typedJson,
         !!opts.applyDefaults,
         !!opts?.duplicateFinder,
-        opts.nestedSchemas ? nestedPlansFor(table, this.analysis, nestedDepth) : {}
+        opts.nestedSchemas ? nestedPlansFor(table, this.analysis, nestedDepth) : {},
+        metaPlan
       );
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
@@ -847,7 +948,9 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
       opts?.coerceDates ?? 'input',
       undefined,
       !!opts?.applyDefaults,
-      !!opts?.duplicateFinder
+      !!opts?.duplicateFinder,
+      {},
+      resolveMeta(opts?.meta, this.analysis.dialect)
     );
   }
 

--- a/packages/generator-zod/test/meta.spec.ts
+++ b/packages/generator-zod/test/meta.spec.ts
@@ -1,0 +1,303 @@
+/**
+ * `meta`: the facts the analyzer knows and a zod schema cannot state.
+ *
+ * Two things are being proved here, and both are read off a real emitted module rather than out of
+ * its source text.
+ *
+ * **The metadata survives the wrappers.** This is the whole design problem. `.meta()` returns a
+ * clone that carries the entry, so `.refine()`, `.min()` and `.describe()` keep it; but
+ * `.nullable()`, `.optional()`, `.default()`, `z.array()` and `.pipe()` build a *new* schema
+ * around the old one, and the new one has no entry at all. Measured on zod 4.4.3:
+ * `z.string().meta({ x: 1 }).nullable().meta()` is `undefined`, and the value is only reachable
+ * through `.def.innerType`, which is an internal a consumer has no business walking. DRZL wraps
+ * every nullable column and every field of an update schema, so attaching before the wrapper
+ * loses the metadata for most of the output. The generator therefore attaches last, after every
+ * wrapper, which is also the position that puts it beside `anyOf` in the JSON Schema rather than
+ * inside one arm of it.
+ *
+ * **It reaches JSON Schema.** `z.toJSONSchema` copies arbitrary meta keys through, and it drops
+ * every `.refine()` in silence. So a declared width, which DRZL enforces as a refinement, is
+ * absent from the JSON Schema of an emitted module and nothing says so. `maxLength` in the
+ * metadata is the same word JSON Schema uses, so it puts that constraint back where a validator
+ * will act on it.
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type { Analysis, Column, Relation, Table } from '@drzl/analyzer';
+import { ZodGenerator } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (name: string, cols: Column[], over: Partial<Table> = {}): Table =>
+  ({ name, tsName: name, columns: cols, unique: [], indexes: [], checks: [], ...over }) as Table;
+
+const users = table(
+  'user_accounts',
+  [
+    col('id', {
+      tsType: 'number',
+      dbType: 'INTEGER',
+      sqlType: 'serial',
+      integer: true,
+      isGenerated: true,
+      hasDefault: true,
+    }),
+    col('name', { sqlType: 'varchar(40)', maxLength: 40 }),
+    col('bio', { sqlType: 'text', nullable: true }),
+    col('country', { sqlType: 'char(2)', maxLength: 2, hasDefault: true, defaultValue: 'GB' }),
+    col('tags', { sqlType: 'text[]', arrayDimensions: 1 }),
+    col('age', { tsType: 'number', dbType: 'INTEGER', sqlType: 'integer', nullable: true }),
+  ],
+  {
+    primaryKey: { columns: ['id'] },
+    unique: [{ columns: ['name'] }],
+    checks: [
+      { name: 'adult', expression: 'age >= 18' },
+      { name: 'weird', expression: 'my_fn(name) > now()' },
+    ],
+  }
+);
+
+const posts = table(
+  'posts',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', sqlType: 'serial', isGenerated: true }),
+    col('userId', { tsType: 'number', dbType: 'INTEGER', sqlType: 'integer' }),
+    col('title', { sqlType: 'varchar(80)', maxLength: 80 }),
+  ],
+  {
+    primaryKey: { columns: ['id'] },
+    foreignKeys: [{ columns: ['userId'], foreignTable: 'user_accounts', foreignColumns: ['id'] }],
+  }
+);
+
+const RELATIONS: Relation[] = [
+  { kind: 'many', from: 'user_accounts', to: 'posts' },
+  { kind: 'one', from: 'posts', to: 'user_accounts' },
+];
+
+const analysis = (): Analysis => ({
+  dialect: 'postgres',
+  tables: [users, posts],
+  enums: [],
+  relations: RELATIONS,
+  issues: [],
+});
+
+let seq = 0;
+
+async function emit(opts: Record<string, unknown>, which = 'user_accounts') {
+  const dir = path.join(__dirname, '.tmp-meta', `run-${process.pid}-${seq++}`);
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis()).generate({ outDir: dir, ...opts } as never);
+  const file = path.join(dir, `${which}.zod.ts`);
+  return { mod: await import(file), text: await fs.readFile(file, 'utf8') };
+}
+
+describe('off by default', () => {
+  it('emits no metadata at all and no extra bytes', async () => {
+    const plain = await emit({});
+    expect(plain.text).not.toContain('.meta(');
+    const off = await emit({ meta: false });
+    expect(off.text).toBe(plain.text);
+  });
+});
+
+describe('a field', () => {
+  it('carries the SQL type, which nothing in the schema states', async () => {
+    const { mod } = await emit({ meta: true });
+    expect(mod.Selectuser_accountsSchema.shape.name.meta()).toMatchObject({
+      sqlType: 'varchar(40)',
+    });
+  });
+
+  it('is readable through .nullable(), which is where the naive attachment loses it', async () => {
+    const { mod } = await emit({ meta: true });
+    const bio = mod.Selectuser_accountsSchema.shape.bio;
+    // Precisely the position that returns undefined when `.meta()` is applied before the wrapper.
+    expect(bio.meta()).toMatchObject({ sqlType: 'text' });
+    // And the wrapper still does its job.
+    expect(bio.safeParse(null).success).toBe(true);
+  });
+
+  it('is readable through .optional() on an insert schema', async () => {
+    const { mod } = await emit({ meta: true });
+    const country = mod.Insertuser_accountsSchema.shape.country;
+    expect(country.meta()).toMatchObject({ sqlType: 'char(2)', hasDefault: true, maxLength: 2 });
+    expect(mod.Insertuser_accountsSchema.safeParse({ name: 'a', tags: [] }).success).toBe(true);
+  });
+
+  it('is readable through .optional() on every field of an update schema', async () => {
+    const { mod } = await emit({ meta: true });
+    for (const key of ['name', 'bio', 'country']) {
+      expect(mod.Updateuser_accountsSchema.shape[key].meta(), key).toBeTruthy();
+    }
+  });
+
+  it('is readable through .default(), which applyDefaults adds outside everything', async () => {
+    const { mod } = await emit({ meta: true, applyDefaults: true });
+    const country = mod.Insertuser_accountsSchema.shape.country;
+    expect(country.meta()).toMatchObject({ sqlType: 'char(2)' });
+    expect(country.parse(undefined)).toBe('GB');
+  });
+
+  it('is readable on an array column, where it describes the column and not the element', async () => {
+    const { mod } = await emit({ meta: true });
+    expect(mod.Selectuser_accountsSchema.shape.tags.meta()).toMatchObject({ sqlType: 'text[]' });
+  });
+
+  it('separates a database default from a nullable column', async () => {
+    const { mod } = await emit({ meta: true });
+    const shape = mod.Selectuser_accountsSchema.shape;
+    expect(shape.country.meta().hasDefault).toBe(true);
+    // Both are `.optional()` on insert; only one has a default.
+    expect(shape.bio.meta().hasDefault).toBeUndefined();
+  });
+
+  it('marks the generated column, which the write schemas simply omit', async () => {
+    const { mod } = await emit({ meta: true });
+    expect(mod.Selectuser_accountsSchema.shape.id.meta()).toMatchObject({ generated: true });
+    expect(Object.keys(mod.Insertuser_accountsSchema.shape)).not.toContain('id');
+  });
+
+  it('names the CHECK it enforces, in the spelling the failure message uses', async () => {
+    const { mod } = await emit({ meta: true });
+    expect(mod.Selectuser_accountsSchema.shape.age.meta().checks).toEqual(['adult: age >= 18']);
+  });
+
+  it('says nothing about nullability, which the schema already says', async () => {
+    const { mod } = await emit({ meta: true });
+    expect(Object.keys(mod.Selectuser_accountsSchema.shape.bio.meta())).not.toContain('nullable');
+  });
+});
+
+describe('the table schema', () => {
+  it('carries the SQL name, the dialect, the mode and the key', async () => {
+    const { mod } = await emit({ meta: true });
+    expect(mod.Selectuser_accountsSchema.meta()).toMatchObject({
+      table: 'user_accounts',
+      dialect: 'postgres',
+      mode: 'select',
+      primaryKey: ['id'],
+      unique: [['name']],
+    });
+    expect(mod.Insertuser_accountsSchema.meta().mode).toBe('insert');
+    expect(mod.Updateuser_accountsSchema.meta().mode).toBe('update');
+  });
+
+  it('names the CHECK it declined, which appears nowhere else in the module', async () => {
+    const { mod, text } = await emit({ meta: true });
+    expect(mod.Selectuser_accountsSchema.meta().unenforcedChecks).toEqual([
+      'weird: my_fn(name) > now()',
+    ]);
+    // The point: without this the constraint is in the database and in no part of the output.
+    const withoutMeta = (await emit({})).text;
+    expect(withoutMeta).not.toContain('my_fn');
+    expect(text).toContain('my_fn');
+  });
+
+  it('survives the row refinement that a row-level CHECK adds after the object', async () => {
+    const rows = table(
+      'spans',
+      [
+        col('lo', { tsType: 'number', sqlType: 'integer' }),
+        col('hi', { tsType: 'number', sqlType: 'integer' }),
+      ],
+      { checks: [{ name: 'order', expression: 'lo < hi' }] }
+    );
+    const dir = path.join(__dirname, '.tmp-meta', `rows-${process.pid}-${seq++}`);
+    await fs.mkdir(dir, { recursive: true });
+    await new ZodGenerator({
+      dialect: 'postgres',
+      tables: [rows],
+      enums: [],
+      relations: [],
+      issues: [],
+    } as Analysis).generate({ outDir: dir, meta: true } as never);
+    const mod = await import(path.join(dir, 'spans.zod.ts'));
+    expect(mod.SelectspansSchema.meta()).toMatchObject({ checks: ['order: lo < hi'] });
+    // The refinement is still enforced, so the metadata is not sitting on a schema that lost it.
+    expect(mod.SelectspansSchema.safeParse({ lo: 2, hi: 1 }).success).toBe(false);
+  });
+});
+
+describe('a nested schema', () => {
+  it('is readable on the object inside the relation array', async () => {
+    const { mod } = await emit({ meta: true, nestedSchemas: true });
+    const posts = mod.NestedSelectuser_accountsSchema.shape.posts;
+    // `z.array(child).optional()`: two wrappers between the caller and the child object.
+    const child = posts.def.innerType.element;
+    expect(child.meta()).toMatchObject({ table: 'posts', mode: 'select' });
+    expect(child.shape.title.meta()).toMatchObject({ sqlType: 'varchar(80)' });
+  });
+});
+
+describe('the JSON Schema it produces', () => {
+  it('puts the metadata of a nullable column beside anyOf, not inside one arm', async () => {
+    const { mod } = await emit({ meta: true });
+    const doc: any = z.toJSONSchema(mod.Selectuser_accountsSchema);
+    expect(doc.properties.bio.sqlType).toBe('text');
+    expect(doc.properties.bio.anyOf.some((a: any) => 'sqlType' in a)).toBe(false);
+  });
+
+  it('carries the table facts at the document root', async () => {
+    const { mod } = await emit({ meta: true });
+    const doc: any = z.toJSONSchema(mod.Selectuser_accountsSchema);
+    expect(doc).toMatchObject({ table: 'user_accounts', primaryKey: ['id'] });
+  });
+
+  it('restores the width that toJSONSchema drops with the refinement carrying it', async () => {
+    const withMeta: any = z.toJSONSchema(
+      (await emit({ meta: true })).mod.Selectuser_accountsSchema
+    );
+    const without: any = z.toJSONSchema((await emit({})).mod.Selectuser_accountsSchema);
+    // The refinement enforcing `varchar(40)` is dropped in silence, so the plain document says the
+    // column is an unbounded string.
+    expect(without.properties.name.maxLength).toBeUndefined();
+    expect(withMeta.properties.name.maxLength).toBe(40);
+  });
+});
+
+describe('the description', () => {
+  it('is absent unless asked for', async () => {
+    const { mod } = await emit({ meta: true });
+    expect(mod.Selectuser_accountsSchema.shape.name.meta().description).toBeUndefined();
+    expect(mod.Selectuser_accountsSchema.meta().description).toBeUndefined();
+  });
+
+  it('states what the schema enforces and cannot show, where an OpenAPI reader looks', async () => {
+    const { mod } = await emit({ meta: { description: true } });
+    const doc: any = z.toJSONSchema(mod.Selectuser_accountsSchema);
+    expect(doc.properties.name.description).toBe('at most 40 characters');
+    expect(doc.properties.age.description).toBe('CHECK adult: age >= 18');
+    expect(doc.description).toContain('not enforced by this schema');
+  });
+});
+
+describe('the schemas themselves', () => {
+  it('parse identically with the metadata on and off', async () => {
+    const on = (await emit({ meta: true })).mod.Selectuser_accountsSchema;
+    const off = (await emit({})).mod.Selectuser_accountsSchema;
+    const rows = [
+      { id: 1, name: 'ada', bio: null, country: 'GB', tags: ['a'], age: 30 },
+      { id: 1, name: 'ada', bio: 'hi', country: 'GB', tags: [], age: null },
+      { id: 1, name: 'x'.repeat(41), bio: null, country: 'GB', tags: [], age: 30 },
+      { id: 1, name: 'ada', bio: null, country: 'GB', tags: [], age: 5 },
+      { id: 1, name: 'ada', bio: null, country: 'GB', tags: 'nope', age: 30 },
+    ];
+    for (const row of rows) {
+      expect(on.safeParse(row).success, JSON.stringify(row)).toBe(off.safeParse(row).success);
+    }
+  });
+});

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -9,6 +9,7 @@ import type { AffixOptions } from './naming.js';
 
 export * from './checks.js';
 export * from './files.js';
+export * from './meta.js';
 export * from './naming.js';
 export * from './nested.js';
 

--- a/packages/validation-core/src/meta.ts
+++ b/packages/validation-core/src/meta.ts
@@ -1,0 +1,271 @@
+/**
+ * The facts a generated schema can carry beside itself.
+ *
+ * A validator says what a value must look like. It does not say where the value came from, and a
+ * consumer holding only the schema cannot recover that: `z.string()` is a `text`, a `varchar(40)`,
+ * a `citext` and a `char(3)` alike, and nothing on it says which, nor whether the database fills
+ * it in, nor which columns key the row.
+ *
+ * Every key here had to pass one test: **it says something the emitted schema does not already
+ * say.** Two ways to pass it.
+ *
+ *   the schema never knew it     the SQL type, the primary key, the unique constraints, the
+ *                                dialect, whether the database generates or defaults the value.
+ *
+ *   the schema enforces it and   a declared width and every CHECK are `.refine()` calls, and
+ *   cannot show it               `z.toJSONSchema` drops a refinement in silence. Measured on zod
+ *                                4.4.3: `z.object({ s: z.string().refine(...) })` produces
+ *                                `{ s: { type: 'string' } }` with no warning and no trace. So a
+ *                                JSON Schema built from an emitted module is wrong by omission,
+ *                                and nothing in the document says so.
+ *
+ * Nullability is the counter-example, and its absence is the rule working: `.nullable()` is in the
+ * schema and `anyOf: [..., { type: 'null' }]` is in its JSON Schema, so a `nullable` key would be a
+ * second copy of an answer the consumer already has. Same for the enum values, the integer-ness of
+ * a number and every numeric bound.
+ *
+ * Nothing here is a user comment, because there are none to carry. Measured against drizzle-orm on
+ * both majors: no column, table or builder exposes one, and a `comment` key passed to a column's
+ * options object is dropped before the column is built. See the zod generator's documentation.
+ */
+import type { Column, Table } from '@drzl/analyzer';
+import {
+  parseCheck,
+  type CardinalityCheck,
+  type ColumnCheck,
+  type ColumnSet,
+  type LengthCheck,
+  type RowCheck,
+} from './checks.js';
+
+/** What a column adds beside its schema. Every key is optional; an empty object is a real answer. */
+export interface ColumnMetaFacts {
+  /** The type as the database declares it: `varchar(255)`, `numeric(10, 2)`, `text[]`. */
+  sqlType?: string;
+  /**
+   * The declared character limit.
+   *
+   * Also the JSON Schema keyword of the same name, which is why it is spelled this way: the
+   * emitted schema enforces the limit inside a `.refine()` closure, `toJSONSchema` drops that, and
+   * this key puts the constraint back in the one spelling every JSON Schema validator enforces.
+   *
+   * On an array column the limit is the *element's*, since that is where the emitted schema
+   * applies it.
+   */
+  maxLength?: number;
+  /** The declared byte limit, which only MySQL's TEXT and BLOB families carry. */
+  maxBytes?: number;
+  /**
+   * The database supplies a value when the write omits one.
+   *
+   * Not recoverable from the schema: a defaulted column and a nullable one are both `.optional()`
+   * on insert, so the wrapper cannot tell them apart, and on select neither leaves a trace.
+   */
+  hasDefault?: true;
+  /** The database computes the value and refuses to be given one. Absent from the write schemas. */
+  generated?: true;
+  /**
+   * The CHECK constraints this field enforces, named as the failure messages name them.
+   *
+   * Not a restatement of the bound beside it. DRZL deliberately folds a CHECK into the column's
+   * own range, so `minimum: 18` in the JSON Schema is indistinguishable from a type bound, and a
+   * set constraint renders as an enum indistinguishable from a declared one. The provenance is
+   * what this carries, along with the constraint name a database error will quote back.
+   */
+  checks?: string[];
+  /** Prose for a reader, from the constraints the schema enforces and cannot show. Opt-in. */
+  description?: string;
+}
+
+/** What a table's schema adds beside itself. */
+export interface TableMetaFacts {
+  /** The SQL table name, which is not the Drizzle export name the schema is named after. */
+  table: string;
+  /** Which database this was analysed from. The same declaration means different things across them. */
+  dialect?: string;
+  /** Which of the three schemas this is. The export name says it; the schema object does not. */
+  mode: string;
+  /** The primary key columns, in order. A per-field flag cannot carry the order or the grouping. */
+  primaryKey?: string[];
+  /**
+   * The unique constraints.
+   *
+   * The one constraint a per-row validator structurally cannot check, which is why
+   * `duplicateFinder` exists at all. Carrying it lets a consumer see what the schema is silent
+   * about rather than assume it is silent because there is nothing to say.
+   */
+  unique?: string[][];
+  /** The relation refuses writes, which today means a materialized view. */
+  readOnly?: true;
+  /** Row-level CHECKs, enforced as object refinements and so invisible for the same reason. */
+  checks?: string[];
+  /**
+   * CHECK constraints the database enforces and this schema does not.
+   *
+   * Either the parser declined the expression, or it understood it and the column's shape has no
+   * way to state it. Both mean the same thing to a caller: the database can reject a row this
+   * schema accepted. Nothing else in the emitted module mentions these at all.
+   */
+  unenforcedChecks?: string[];
+  /** Prose for a reader. Opt-in. */
+  description?: string;
+}
+
+export interface MetaFactOptions {
+  /** Also write a `description`, which is what an OpenAPI reader renders. Off by default. */
+  description?: boolean;
+}
+
+export interface TableMetaOptions extends MetaFactOptions {
+  mode: string;
+  dialect?: string;
+}
+
+/** `name: expr`, matching how every emitted failure message labels the constraint it came from. */
+function labelled(name: string | undefined, text: string): string {
+  return name ? `${name}: ${text}` : text;
+}
+
+/** A literal as it reads inside the expression it came from, quoted exactly when it was quoted. */
+function literalText(value: string, kind: 'number' | 'string'): string {
+  return kind === 'string' ? `'${value}'` : value;
+}
+
+function columnCheckText(k: ColumnCheck): string {
+  return labelled(k.name, `${k.column} ${k.operator} ${literalText(k.value, k.kind)}`);
+}
+function setText(k: ColumnSet): string {
+  return labelled(
+    k.name,
+    `${k.column} IN (${k.values.map((v) => literalText(v, k.kind)).join(', ')})`
+  );
+}
+function lengthText(k: LengthCheck): string {
+  return labelled(k.name, `length(${k.column}) ${k.operator} ${k.value}`);
+}
+function cardinalityText(k: CardinalityCheck): string {
+  return labelled(k.name, `cardinality(${k.column}) ${k.operator} ${k.value}`);
+}
+function rowText(k: RowCheck): string {
+  return labelled(k.name, `${k.left} ${k.operator} ${k.right}`);
+}
+
+/**
+ * Whether a field-level constraint reaches this column at all.
+ *
+ * The same three guards every validation generator applies. A comparison against a scalar says
+ * nothing usable about an array or a tuple, and a character count says nothing about either; a
+ * cardinality is the mirror image and only means something on an array. A constraint that fails
+ * its guard is enforced nowhere, so it is reported on the table as unenforced rather than
+ * silently attributed to a field that does not check it.
+ */
+function takesScalarChecks(c: Column): boolean {
+  return !c.arrayDimensions && !c.shape;
+}
+
+/** Every CHECK on the table, split by where it lands. */
+function classifyChecks(table: Table) {
+  const perColumn = new Map<string, string[]>();
+  const rows: string[] = [];
+  const unenforced: string[] = [];
+  const byName = new Map(table.columns.map((c) => [c.name, c]));
+
+  const add = (column: string, text: string, guard: (c: Column) => boolean) => {
+    const c = byName.get(column);
+    // A constraint naming a column that is not on this table cannot be attributed to anything,
+    // and one whose column refuses the constraint is not checked by any field. Both are the
+    // caller's problem rather than a fact to hide.
+    if (!c || !guard(c)) {
+      unenforced.push(text);
+      return;
+    }
+    const list = perColumn.get(column) ?? [];
+    list.push(text);
+    perColumn.set(column, list);
+  };
+
+  for (const k of table.checks ?? []) {
+    const parsed = parseCheck(k.expression, k.name);
+    if (!parsed.ok) {
+      unenforced.push(labelled(k.name, (k.expression ?? '').trim()));
+      continue;
+    }
+    for (const c of parsed.checks) add(c.column, columnCheckText(c), takesScalarChecks);
+    for (const s of parsed.sets ?? []) add(s.column, setText(s), takesScalarChecks);
+    for (const l of parsed.lengths ?? []) add(l.column, lengthText(l), takesScalarChecks);
+    for (const a of parsed.cardinalities ?? [])
+      add(a.column, cardinalityText(a), (c) => !!c.arrayDimensions);
+    for (const r of parsed.rows ?? []) {
+      // A row check needs both columns present in the mode being rendered. That is decided by the
+      // generator, which knows the mode; here it is a fact about the table.
+      if (byName.has(r.left) && byName.has(r.right)) rows.push(rowText(r));
+      else unenforced.push(rowText(r));
+    }
+  }
+  return { perColumn, rows, unenforced };
+}
+
+/** The prose form of what a field enforces and cannot show, or nothing. */
+function columnDescription(facts: ColumnMetaFacts): string | undefined {
+  const parts: string[] = [];
+  if (facts.maxLength !== undefined) parts.push(`at most ${facts.maxLength} characters`);
+  if (facts.maxBytes !== undefined) parts.push(`at most ${facts.maxBytes} bytes`);
+  for (const c of facts.checks ?? []) parts.push(`CHECK ${c}`);
+  return parts.length ? parts.join('. ') : undefined;
+}
+
+function tableDescription(facts: TableMetaFacts): string | undefined {
+  const parts: string[] = [];
+  for (const c of facts.checks ?? []) parts.push(`CHECK ${c}`);
+  if (facts.unenforcedChecks?.length) {
+    parts.push(
+      `not enforced by this schema, the database also checks: ${facts.unenforcedChecks.join('; ')}`
+    );
+  }
+  return parts.length ? parts.join('. ') : undefined;
+}
+
+/**
+ * The metadata for one column.
+ *
+ * `table` is needed because a CHECK is declared on the table and only then attributed to a column,
+ * and because whether a constraint is enforced at all depends on the other columns it names.
+ */
+export function columnMetaFacts(
+  column: Column,
+  table: Table,
+  opts: MetaFactOptions = {}
+): ColumnMetaFacts {
+  const checks = classifyChecks(table).perColumn.get(column.name);
+  const facts: ColumnMetaFacts = {
+    ...(column.sqlType ? { sqlType: column.sqlType } : {}),
+    ...(column.maxLength !== undefined ? { maxLength: column.maxLength } : {}),
+    ...(column.maxBytes !== undefined ? { maxBytes: column.maxBytes } : {}),
+    ...(column.hasDefault ? { hasDefault: true as const } : {}),
+    ...(column.isGenerated ? { generated: true as const } : {}),
+    ...(checks?.length ? { checks } : {}),
+  };
+  if (!opts.description) return facts;
+  const description = columnDescription(facts);
+  return description ? { ...facts, description } : facts;
+}
+
+/** The metadata for one table's schema, in one mode. */
+export function tableMetaFacts(table: Table, opts: TableMetaOptions): TableMetaFacts {
+  const { rows, unenforced } = classifyChecks(table);
+  const pk = table.primaryKey?.columns ?? [];
+  const unique = (table.unique ?? []).map((k) => k.columns).filter((c) => c.length > 0);
+  const facts: TableMetaFacts = {
+    table: table.name,
+    ...(opts.dialect ? { dialect: opts.dialect } : {}),
+    mode: opts.mode,
+    ...(pk.length ? { primaryKey: pk } : {}),
+    ...(unique.length ? { unique } : {}),
+    ...(table.readOnly ? { readOnly: true as const } : {}),
+    ...(rows.length ? { checks: rows } : {}),
+    ...(unenforced.length ? { unenforcedChecks: unenforced } : {}),
+  };
+  if (!opts.description) return facts;
+  const description = tableDescription(facts);
+  return description ? { ...facts, description } : facts;
+}

--- a/packages/validation-core/test/meta.spec.ts
+++ b/packages/validation-core/test/meta.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * The facts a generated schema can carry beside itself.
+ *
+ * The rule every key here is chosen by: a key earns its bytes only if it says something the
+ * emitted schema does not already say. Two ways it can qualify.
+ *
+ *   the schema never knew it    the SQL type, the primary key, the unique constraints, the
+ *                               dialect, whether the database generates or defaults the value.
+ *   the schema enforces it and  a `varchar(255)` limit and every CHECK are `.refine()` calls in
+ *   cannot show it              zod, and `z.toJSONSchema` drops a refinement silently. So a
+ *                               JSON Schema built from the emitted module is wrong by omission
+ *                               and nothing in it says so.
+ *
+ * Nullability is the counter-example and is deliberately absent: `.nullable()` is in the schema
+ * and `anyOf: [..., { type: 'null' }]` is in its JSON Schema, so a `nullable` key would be a
+ * second copy of an answer the consumer already has.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Column, Table } from '@drzl/analyzer';
+import { columnMetaFacts, tableMetaFacts } from '../src/meta';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (over: Partial<Table> = {}): Table =>
+  ({
+    name: 't',
+    tsName: 't',
+    columns: [],
+    unique: [],
+    indexes: [],
+    checks: [],
+    ...over,
+  }) as Table;
+
+describe('a column', () => {
+  it('carries the declared SQL type, which no schema can state', () => {
+    expect(columnMetaFacts(col('a', { sqlType: 'varchar(255)' }), table(), {})).toEqual({
+      sqlType: 'varchar(255)',
+    });
+  });
+
+  it('says nothing about nullability, which the schema already says', () => {
+    const facts = columnMetaFacts(col('a', { sqlType: 'text', nullable: true }), table(), {});
+    expect(Object.keys(facts)).toEqual(['sqlType']);
+  });
+
+  it('carries a width that lives inside a closure in the emitted schema', () => {
+    // `.refine((v) => [...v].length <= 255)` is the emitted form, and both the number and the
+    // fact that there is a limit are invisible to every reader of the schema object.
+    expect(
+      columnMetaFacts(col('a', { sqlType: 'varchar(255)', maxLength: 255 }), table(), {})
+    ).toEqual({ sqlType: 'varchar(255)', maxLength: 255 });
+    expect(columnMetaFacts(col('a', { sqlType: 'tinytext', maxBytes: 255 }), table(), {})).toEqual({
+      sqlType: 'tinytext',
+      maxBytes: 255,
+    });
+  });
+
+  it('separates a database default from a nullable column, which .optional() cannot', () => {
+    // Both are `.optional()` on insert, so the wrapper alone cannot say which one it is.
+    const withDefault = columnMetaFacts(col('a', { hasDefault: true }), table(), {});
+    const nullable = columnMetaFacts(col('a', { nullable: true }), table(), {});
+    expect(withDefault).toEqual({ hasDefault: true });
+    expect(nullable).toEqual({});
+  });
+
+  it('marks a generated column, which is simply absent from the write schemas', () => {
+    expect(columnMetaFacts(col('a', { isGenerated: true, hasDefault: true }), table(), {})).toEqual(
+      {
+        hasDefault: true,
+        generated: true,
+      }
+    );
+  });
+
+  it('names the CHECK constraints that apply to it', () => {
+    const age = col('age', { tsType: 'number' });
+    const t = table({ columns: [age], checks: [{ name: 'adult', expression: 'age >= 18' }] });
+    expect(columnMetaFacts(age, t, {})).toEqual({ checks: ['adult: age >= 18'] });
+  });
+
+  it('names a length and a set constraint too, in the same spelling the messages use', () => {
+    const a = col('a');
+    const t = table({
+      columns: [a],
+      checks: [{ name: 'short', expression: 'length(a) <= 5' }, { expression: "a IN ('x', 'y')" }],
+    });
+    expect(columnMetaFacts(a, t, {}).checks).toEqual(['short: length(a) <= 5', "a IN ('x', 'y')"]);
+  });
+
+  it('reports a constraint its own shape refuses as enforced nowhere', () => {
+    // `CHECK (tags = '{}')` compares an array to a scalar. Every generator skips it, because
+    // `.refine((v) => v === '{}')` against a `string[]` rejects every row. Silently attributing it
+    // to the field would say the schema checks something no value can pass.
+    const tags = col('tags', { arrayDimensions: 1 });
+    const t = table({ columns: [tags], checks: [{ name: 'empty', expression: "tags = '{}'" }] });
+    expect(columnMetaFacts(tags, t, {}).checks).toBeUndefined();
+    expect(tableMetaFacts(t, { mode: 'select' }).unenforcedChecks).toEqual(["empty: tags = '{}'"]);
+  });
+
+  it('leaves a constraint about another column alone', () => {
+    const age = col('age', { tsType: 'number' });
+    const name = col('name');
+    const t = table({
+      columns: [age, name],
+      checks: [{ name: 'adult', expression: 'age >= 18' }],
+    });
+    expect(columnMetaFacts(name, t, {})).toEqual({});
+  });
+
+  it('writes a description only when asked, and only from what the schema cannot show', () => {
+    const c = col('age', { tsType: 'number', sqlType: 'integer' });
+    const t = table({ columns: [c], checks: [{ name: 'adult', expression: 'age >= 18' }] });
+    expect(columnMetaFacts(c, t, {}).description).toBeUndefined();
+    expect(columnMetaFacts(c, t, { description: true }).description).toBe('CHECK adult: age >= 18');
+  });
+
+  it('has no description when there is nothing the schema failed to show', () => {
+    const facts = columnMetaFacts(col('a', { sqlType: 'text' }), table(), { description: true });
+    expect(facts.description).toBeUndefined();
+  });
+});
+
+describe('a table', () => {
+  it('carries the SQL name, the dialect and the mode', () => {
+    const facts = tableMetaFacts(table({ name: 'user_accounts', tsName: 'userAccounts' }), {
+      mode: 'select',
+      dialect: 'postgres',
+    });
+    expect(facts).toMatchObject({ table: 'user_accounts', dialect: 'postgres', mode: 'select' });
+  });
+
+  it('carries the primary key in order, which a per-field flag cannot', () => {
+    const facts = tableMetaFacts(table({ primaryKey: { columns: ['tenant', 'id'] } }), {
+      mode: 'select',
+    });
+    expect(facts.primaryKey).toEqual(['tenant', 'id']);
+  });
+
+  it('carries the unique constraints, the one thing a per-row schema structurally cannot see', () => {
+    const facts = tableMetaFacts(
+      table({ unique: [{ columns: ['email'] }, { name: 'org_slug', columns: ['org', 'slug'] }] }),
+      { mode: 'insert' }
+    );
+    expect(facts.unique).toEqual([['email'], ['org', 'slug']]);
+  });
+
+  it('marks a relation that refuses writes', () => {
+    expect(tableMetaFacts(table({ readOnly: true }), { mode: 'select' }).readOnly).toBe(true);
+    expect(tableMetaFacts(table(), { mode: 'select' }).readOnly).toBeUndefined();
+  });
+
+  it('carries the row-level CHECKs, which are object refinements and so invisible', () => {
+    const facts = tableMetaFacts(
+      table({
+        columns: [col('start_date'), col('end_date')],
+        checks: [{ name: 'order', expression: 'start_date < end_date' }],
+      }),
+      { mode: 'select' }
+    );
+    expect(facts.checks).toEqual(['order: start_date < end_date']);
+  });
+
+  it('names the CHECKs it declined to translate, which appear nowhere else at all', () => {
+    // A parsed check becomes a `.refine()` a reader can at least find. A declined one is dropped
+    // in silence, and `drzl doctor` is the only thing that mentions it.
+    const facts = tableMetaFacts(
+      table({ checks: [{ name: 'weird', expression: 'my_fn(a) > now()' }] }),
+      { mode: 'select' }
+    );
+    expect(facts.unenforcedChecks).toEqual(['weird: my_fn(a) > now()']);
+    expect(facts.checks).toBeUndefined();
+  });
+
+  it('writes a description only when asked', () => {
+    const t = table({
+      columns: [col('lo'), col('hi')],
+      checks: [
+        { name: 'order', expression: 'lo < hi' },
+        { name: 'weird', expression: 'my_fn(a) > now()' },
+      ],
+    });
+    expect(tableMetaFacts(t, { mode: 'select' }).description).toBeUndefined();
+    const d = tableMetaFacts(t, { mode: 'select', description: true }).description;
+    expect(d).toContain('CHECK order: lo < hi');
+    expect(d).toContain('not enforced');
+    expect(d).toContain('my_fn(a) > now()');
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -6565,6 +6565,12 @@ const ALLOWED: Record<string, string> = {
   // this exact column: drizzle-zod 0.8.3 on 0.45.2 accepts [['a']] and rejects ['a'], and
   // drizzle-orm/zod on 1.0.0-rc.4 does the opposite. v1 also infers `string[]`, not `string[][]`.
   'rows.grid.arrayDimensions': "v1 spells 2D `.array('[][]')`; chaining `.array()` stays at 1",
+  // `sqlType` follows `arrayDimensions` for the same reason and on the same column: 0.4x's PgArray
+  // answers `text[][]` for a chained `.array().array()`, while v1 stays one dimension deep and
+  // answers the bare `text`, which the analyzer suffixes to `text[]`. Each is the type of the
+  // schema that major actually produces, so this is the divergence already recorded above showing
+  // up in a second field rather than a new one.
+  'rows.grid.sqlType': "v1 spells 2D `.array('[][]')`; chaining `.array()` stays at 1",
 };
 
 /**


### PR DESCRIPTION
Plan item 33, and the answer to item 34, which cannot be built.

## Item 34 is dead, measured

`drizzle-orm` exposes no column comments, on either major:

```
comment-ish own keys on a built column   none
comment-ish prototype methods            none
pg.text('a', { comment: 'hello' })       tsc: TS2353 excess property (inline literal)
                                         runtime: dropped; a reachability walk of the built
                                         column (own keys + symbols, depth 6) finds no 'hello'
```

Passed through a variable it compiles and is silently discarded. Both forms are documented, because a user will reasonably expect the option to work.

That removes the premise of item 33 as written. What zod's metadata can usefully carry is what the **analyzer** knows and a consumer cannot recover from a zod schema.

## The hard part was not what it looked like

Metadata is not "lost by wrappers". zod **clones** for some operations and **wraps** for others:

| chained op | `.meta()` on the result |
|---|---|
| `.refine()`, `.min()`, `.describe()`, `.brand()` | survives (clone) |
| `.nullable()`, `.optional()`, `.default()`, `z.array()`, `.pipe()` | `undefined` (wrap) |

Under a wrapper the entry survives only at `.def.innerType`, an internal. **So the attachment goes last, after every wrapper.**

That placement is measured, not assumed:

- optionality still works: `.optional().meta(M)` still omits from `required`, `.default('x').meta(M)` still fills in, `optional().pipe().meta(M)` still parses `{}`
- `toJSONSchema` places it at **property** level beside `anyOf`, not inside `anyOf[0]` — which is where an OpenAPI consumer reads. The naive attachment puts it in the wrong arm.
- Moving the attachment to the base expression **fails 10 of the 21 zod tests**.

## What the metadata contains, and the rule

A key earns its bytes only if the schema does not already say it. Two qualifying grounds: the schema never knew it, or the schema enforces it and cannot show it.

```
per field   sqlType, maxLength, maxBytes, hasDefault, generated, checks
per schema  table, dialect, mode, primaryKey, unique, readOnly, checks, unenforcedChecks
```

- **`nullable` is deliberately absent.** `.nullable()` and `anyOf[..., null]` already say it.
- **`hasDefault` earns its place** because a defaulted column and a nullable one are *both* `.optional()` on insert, and nothing else distinguishes them.
- **`maxLength` does double duty**: `z.toJSONSchema` drops every `.refine()` **in silence**, so restating the cap puts back a constraint the document had lost.
- `primaryKey`/`unique` are table-level, costing one key per schema instead of one per column.
- **Foreign keys are excluded**: they grow without bound with schema size and, unlike everything else here, no consumer of a parsed row can act on one without a database.

`description` is a separate opt-in (`meta: { description: true }`), built only from what the schema enforces and cannot show. Justification: `toJSONSchema` silently drops refinements, so the document is wrong by omission, and `description` is the only key an OpenAPI viewer renders without being taught. Separate because prose duplicating machine keys is the most expensive output there is.

## `Column.sqlType` is new

`dbType` could not answer this: it calls `varchar`, `char` and `text` all `TEXT`. Sourced from Drizzle's `getSQLType()`.

Worth noting for its own sake: across the 117 columns of the gate fixture, **`dbType` diverges between the two drizzle majors on 17 columns; `sqlType` diverges on one.**

## Real output, real read-back

```ts
age: z.number().int().gte(18).lte(2147483647).nullable()
      .meta({ sqlType: "integer", checks: ["adult: age >= 18"] }),
})
.meta({ table: "user_accounts", dialect: "postgres", mode: "select", primaryKey: ["id"],
        unique: [["email"], ["handle", "role"]],
        unenforcedChecks: ["email_shape: email LIKE '%@%'"] });
```

Read back off the imported module:

```
bio (nullable)                -> {"sqlType":"text"}      .safeParse(null) === true
role (optional on insert)     -> {"sqlType":"role","hasDefault":true}
posts[].title (in an array)   -> {"sqlType":"varchar(120)","maxLength":120}
naive placement, for contrast -> undefined
```

## Size

**Off: byte-for-byte identical to master**, proved by generating the same schema from a master worktree build and diffing, on both drizzle majors. On: ~48 bytes per field, ~156 per table schema; +81% on a 13-column two-table schema, +109% with descriptions. Hence opt-in.

## Scope

**zod only**, gated on a new `GeneratorCapabilities.meta` rather than passed to the others to ignore, following the `standardSchema` precedent. The placement answer came out of zod's own clone-versus-wrap behaviour and does not transfer. TypeBox is the obvious next one, and has no placement question since its schema *is* a JSON Schema.

**The `json-schema` generator does not read it.** It builds from the same `Analysis`, so there is nothing to read, and reading a zod schema would add a zod dependency to a package that deliberately has none.

## One caveat, documented rather than worked around

**OpenAPI 3.0 rejects these keys.** Measured against the official 3.0 schema: a document carrying `sqlType`/`table` is invalid; the same with `x-` prefixes is valid; `maxLength`/`description`/`readOnly` are real 3.0 keywords and pass either way. 3.1 and 2020-12 ignore unknown keywords. Also documented: `z.toJSONSchema` throws on Date, bytea and custom columns unless given `{ unrepresentable: 'any' }`.

## Gate

One line needed, and it is an old fact in a new field: `rows.grid.sqlType` diverges between majors for exactly the reason the entry directly above it records for `arrayDimensions` on the same column. v1 spells 2D as `.array('[][]')` while chaining `.array()` stays one deep, so each answer is correct for the schema that major produces. Placed beneath its cause.

Still wanted, not done here: a `report_size` over a `meta: true` tree with its own budget, and a `meta: true` arm in the moduleResolution stage. I checked all three resolutions by hand; nothing in CI does.

`build`, `-r test` (**1851 passed**, +50), `typecheck`, `lint`, `docs build`, `verify:packed` all green. Tests written first: 5, 18 and 21 failing respectively.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
