### PR TITLE
feat(cli): omit and pick columns per table

### DIFF
--- a/.changeset/omit-pick-columns.md
+++ b/.changeset/omit-pick-columns.md
@@ -1,0 +1,76 @@
+---
+'@drzl/cli': minor
+---
+
+Generate for a subset of a table's columns, without post-processing the output.
+
+`include`/`exclude` is all or nothing per table, and the column that should not appear in a
+generated schema is usually sitting in a table you do want: a `passwordHash` on `users`, an internal
+note beside the public fields, a `tenantId` the server sets from the session. The only previous
+answer was to edit the emitted file, which the next `drzl generate` overwrites.
+
+```ts
+columns: {
+  users: { omit: ['passwordHash'] },
+  'app_*': { omit: ['deleted_at'] },
+  audit_log: { pick: ['id', 'action', 'created_at'] },
+},
+```
+
+The key is a table pattern in the same language `include`/`exclude` already uses, sharing the same
+implementation rather than a second copy of it: the database table name, anchored, with `*` as the
+only metacharacter. Column patterns are that language again. Every matching entry applies in the
+order written, and within one entry `pick` narrows before `omit` removes, so `omit` wins, which is
+the precedence `exclude` already has over `include`.
+
+Four decisions worth knowing:
+
+- **It narrows the analysis, once, before any generator is constructed**, at the same seam
+  `filterTables` already uses. Not in `@drzl/analyzer`, which reads a schema module and has no
+  config: `drzl analyze` has to keep printing what is really there. And not in each generator, of
+  which there are nine plus two template packages: the one that forgot would emit a schema silently
+  wider than the config asked for. Narrowing the analysis is also what keeps the validators, the
+  OpenAPI document, the emitted `.meta()` facts and the service layer describing the same columns,
+  since all of them read that one object.
+
+- **A pattern that matches nothing is an error, not a no-op.** `omit: ['passwrodHash']` treated as a
+  no-op leaves the column exactly where it was while reading like a fix, and nothing downstream can
+  tell that apart from a column that was never there. A table pattern matching no table and a
+  column pattern matching no column both stop the run before anything is written, with every such
+  problem in one message. A column pattern has to match in at least one of the tables its entry
+  matched, not in all of them, which is what makes a wildcard table key usable.
+
+- **Omitting a primary key column is refused.** The generated `getById`, `update` and `delete`
+  address rows by that key and every generator reads it differently, so the consequence would
+  depend on which generators happened to be configured: the tRPC generator resolves the key against
+  the columns and silently drops those three procedures, the oRPC generator never reads the key and
+  keeps emitting them typed `{ id: number }`, the service generator falls back to a column literally
+  named `id` and emits `eq(users.id, id)`, and the OpenAPI document drops its `/{id}` paths. One
+  config, four outcomes, none announced. Refusing is also the reversible direction: an error can be
+  relaxed to a warning later without breaking a config that works.
+
+- **Omitting a NOT NULL column with no default is a warning, and generates.** It really does produce
+  an insert schema that cannot describe a whole row, and it is also the normal multi-tenant shape: an
+  insert schema describes a request body, not a row, and the server fills in the rest. The warning
+  says who has to supply the column. A CHECK naming an omitted column warns too, since nothing DRZL
+  emits can enforce it any more, though the database still does.
+
+There is deliberately no per-mode form: a column cannot be kept in `select` and dropped from
+`insert`. The service generator's `Update<Table>` is `Partial<Omit<typeof users.$inferInsert, 'id'>>`
+taken from Drizzle's own types rather than from the analysis, so a per-mode narrowing would be
+invisible in half the generated tree.
+
+The narrowing covers more than the column list, because a table names its columns again in
+`primaryKey`, `unique`, `indexes`, `foreignKeys` and `checks`. `unique` reaches emitted TypeScript
+verbatim through `findDuplicate<Table>`, so a stale name there is a generated file that does not
+compile; `unique`, `indexes` and `foreignKeys` are narrowed with the columns. `checks` deliberately
+is not: the generators already skip a row check naming a column the mode does not carry, and leaving
+it lets `meta` keep listing the constraint as unenforced, which is the true answer.
+
+Measured, because a schema that stops describing a column and a schema that stops carrying its value
+are different claims. Pushing a row that still holds the omitted column through the emitted select,
+insert and update schemas: zod 4.4.3, valibot 1.4.2 and Effect 3.22.1 strip the key; TypeBox 0.34.52
+strips it under `Value.Parse` and `Value.Clean` while `Value.Check` alone still returns `true`;
+arktype 2.2.3 leaves it in place; and the JSON Schema output emits `additionalProperties: false`, so
+a validator rejects the payload instead of trimming it. Those are the validators' own policies about
+undeclared keys, not something DRZL sets.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -108,6 +108,119 @@ model names are all overridable through `options.user.modelName`, so a built-in 
 renamed tables, and worse, would silently skip an ordinary table called `user`, which in most
 applications is the primary entity you *do* want generated.
 
+## Choosing which columns to generate for
+
+`include` and `exclude` are all or nothing per table, and the column you do not want in a generated
+schema is usually sitting in a table you *do* want: a `passwordHash` on `users`, an internal note
+beside the public fields, a `tenantId` your server sets from the session. `columns` narrows a table
+without dropping it:
+
+```ts
+columns: {
+  users: { omit: ['passwordHash'] },
+  // Table keys are patterns too, so one entry reaches every table that has the column.
+  'app_*': { omit: ['deleted_at'] },
+  // Or say what to keep instead.
+  audit_log: { pick: ['id', 'action', 'created_at'] },
+},
+```
+
+The key is a **table** pattern in the same language `include`/`exclude` uses: the database table
+name, anchored, with `*` as the only metacharacter. Column patterns are that language again, so
+`omit: ['*At']` drops `createdAt` and `updatedAt` and `omit: ['bio']` does not also drop `bios`.
+
+Every matching entry applies, in the order it is written. Within one entry `pick` runs first and
+`omit` then removes, so `omit` wins where both name the same column. That is the same precedence
+`exclude` already has over `include` one level up, for the same reason: the direction that takes
+something away is the safe one for the thing this option exists to remove.
+
+### A name that matches nothing is an error
+
+```
+drzl config: the "columns" option cannot be honoured.
+  - columns["users"].omit names "passwrodHash", which matches no column of users.
+    Available: id, email, passwordHash, bio.
+```
+
+`omit: ['passwrodHash']` treated as a no-op would leave the column exactly where it was while
+reading like a fix, and nothing downstream could tell that apart from a column that was never there.
+So a table pattern matching no table and a column pattern matching no column both stop the run,
+before anything is written, with every such problem in one message. A column pattern has to match in
+at least one of the tables its entry matched, not in all of them, which is what makes a wildcard
+table key usable.
+
+### It applies to every mode and every generator
+
+`columns` narrows the analysis once, before any generator runs, so the insert, update and select
+schemas, the OpenAPI document, the emitted metadata and the service layer all describe the same
+columns. There is deliberately no per-mode form: a column cannot be kept in `select` and dropped
+from `insert`. Half the output could not honour it if there were. The service generator's
+`Update<Table>` is `Partial<Omit<typeof users.$inferInsert, 'id'>>`, taken from Drizzle's own types
+rather than from the analysis, so a per-mode narrowing would be invisible there, and an option whose
+effect disappears in half the generated tree is worse than one that is not offered.
+
+### What it does not do
+
+The schema stops *describing* the column. Whether a value carrying it survives a `parse` is then the
+validator's own policy about undeclared keys, and they do not agree. Measured:
+
+| Generator | A row carrying the omitted column |
+| --- | --- |
+| zod 4.4.3 | key stripped from the parsed result |
+| valibot 1.4.2 | key stripped |
+| TypeBox 0.34.52 | `Value.Parse` and `Value.Clean` strip it; `Value.Check` alone returns `true` |
+| Effect 3.22.1 | key stripped by `decodeUnknownSync` |
+| arktype 2.2.3 | key left in place |
+| json-schema | `additionalProperties: false`, so a validator rejects the payload |
+
+If you are relying on a parse to strip a secret rather than on never selecting it, check which of
+those you are using.
+
+### Two cases DRZL will not simply do
+
+**Omitting a primary key column is refused.** The generated `getById`, `update` and `delete` address
+rows by that key, and every generator reads it differently: the tRPC generator resolves it against
+the columns and silently drops those three procedures, the oRPC generator keeps emitting them typed
+`{ id: number }`, the service generator falls back to a column literally named `id`, and the OpenAPI
+document drops its `/{id}` paths. One config, four outcomes, none of them announced. Use `exclude`
+on the whole table instead.
+
+**Omitting a NOT NULL column with no default is a warning**, and generation continues:
+
+```
+drzl config: the "columns" option drops "tenantId" from table "users", and the database
+requires it: NOT NULL with no default. The emitted insert schema therefore describes a
+payload that is not a complete row, so whatever calls db.insert has to supply "tenantId"
+itself.
+```
+
+That is a real hazard and also the normal multi-tenant shape: an insert schema describes a *request
+body*, not a row, and the server fills in the rest. Refusing it would remove one of the two things
+this option is for. A CHECK constraint naming a column you omitted also warns, because nothing DRZL
+emits can enforce it any more, though your database still does.
+
+### A complete config
+
+Against a schema declaring `users(id, email, nickname)` and `posts(id, slug, authorId)`:
+
+```ts
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  schema: 'src/db/schema.ts',
+  columns: {
+    users: { omit: ['nickname'] },
+    posts: { pick: ['id', 'slug'] },
+  },
+  generators: [{ kind: 'zod', path: 'src/validators/zod' }],
+});
+```
+
+`InsertusersSchema`, `UpdateusersSchema` and `SelectusersSchema` are emitted without `nickname`;
+`posts` keeps its key and its `slug` and loses `authorId`, along with the foreign key over it, so
+the relation lookup procedures the router generators would have derived from it are not emitted
+either.
+
 ## Naming generated identifiers
 
 By default the validation generators name their exports `Insert<Table>Schema`,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,6 +17,7 @@ import {
   filterTables,
   loadConfig,
 } from './config.js';
+import { filterColumns } from './column-filter.js';
 import { buildDoctorReport, renderDoctorReport } from './doctor.js';
 import { diffSnapshots, restoreSnapshot, snapshotAll } from './drift.js';
 import { GeneratorNotInstalledError, loadGenerator } from './generator-loader.js';
@@ -184,10 +185,19 @@ program
         validateConstraints: cfg.analyzer.validateConstraints,
         includeHeuristicRelations: cfg.analyzer.includeHeuristicRelations,
       });
-      // Applied before any generator sees the analysis, so every one of them honours it without
-      // needing to know the option exists.
-      analysis.tables = filterTables(analysis.tables, cfg);
+      // After the spinner rather than before it, because `filterColumns` throws on a config it
+      // cannot honour and a thrown error under a live ora spinner prints into a line the spinner
+      // then overwrites.
       spinner.succeed(`Analysis complete in ${Date.now() - t0}ms`);
+      // Both filters are applied before any generator sees the analysis, so every one of them
+      // honours them without needing to know the options exist.
+      //
+      // Columns first. Both orders leave the same tables, since one narrows columns and the other
+      // drops whole tables, but only this one lets a `columns` entry name a table that `exclude`
+      // also removes without that reading as a typo, and a typo is refused.
+      const narrowed = filterColumns(analysis.tables, cfg.columns);
+      analysis.tables = filterTables(narrowed.tables, cfg);
+      for (const w of narrowed.warnings) console.warn(chalk.yellow(w));
       reportWideColumns(analysis.issues);
       // Under --check the existing output is captured before anything overwrites it, so the
       // regenerated result can be compared against it and the tree put back either way.
@@ -621,7 +631,12 @@ program
           validateConstraints: cfg.analyzer.validateConstraints,
           includeHeuristicRelations: cfg.analyzer.includeHeuristicRelations,
         });
-        analysis.tables = filterTables(analysis.tables, cfg);
+        // Same order and the same reasons as `generate`. A config edited mid-watch that names a
+        // column that does not exist throws here, and `run`'s own catch reports it and keeps
+        // watching, so the next save can fix it.
+        const narrowed = filterColumns(analysis.tables, cfg.columns);
+        analysis.tables = filterTables(narrowed.tables, cfg);
+        if (!opts.json) for (const w of narrowed.warnings) console.warn(chalk.yellow(w));
         if (!opts.json) reportWideColumns(analysis.issues);
 
         if (opts.pipeline === 'analyze') {

--- a/packages/cli/src/column-filter.ts
+++ b/packages/cli/src/column-filter.ts
@@ -1,0 +1,239 @@
+/**
+ * Choosing which *columns* DRZL generates for.
+ *
+ * `include`/`exclude` answers "which tables". This answers "which columns of them", which the
+ * config had no way to say at all. A schema DRZL must read in full still holds columns that should
+ * not reach a generated file: a `passwordHash` no client should ever be handed, an internal note
+ * column, a `tenantId` the server sets from the session and a request body must not carry. The
+ * only previous answer was to edit the emitted file, which the next `drzl generate` overwrites.
+ *
+ * ## Where this runs
+ *
+ * On the `Analysis`, once, before any generator is constructed, at the same seam `filterTables`
+ * already uses. Not inside `@drzl/analyzer`, which reads a schema module and has no config: `drzl
+ * analyze` must keep printing what is really there, and a user asking "what does DRZL see" has to
+ * get the truth rather than their own config read back to them. And not inside each generator:
+ * there are nine of them plus two template packages, each with its own idea of a mode, and the one
+ * that forgot would emit a schema silently wider than the config asked for. Narrowing the analysis
+ * is also what keeps the validators, the OpenAPI document, the emitted `.meta()` facts and the
+ * service layer describing the same columns, since all of them read this one object.
+ *
+ * ## Why the narrowing is more than `columns`
+ *
+ * A table states its columns twice: once as `columns`, and again by name in `primaryKey`,
+ * `unique`, `indexes`, `foreignKeys` and `checks`. Dropping a column from the first list and
+ * leaving the others is not a smaller schema, it is an inconsistent one, and each stale name has a
+ * different consequence:
+ *
+ * - `unique` reaches emitted TypeScript verbatim. `findDuplicate<Table>` declares
+ *   `columns: ["email"]` against the insert row type, so a unique key naming a column that type no
+ *   longer has is a generated file that does not compile. Narrowed.
+ * - `foreignKeys` drives the relation lookup procedures in the tRPC and oRPC generators, both of
+ *   which already resolve the column against `columns` and skip when it is gone. Narrowed, which
+ *   changes no output and stops the analysis asserting a key over a column it does not have.
+ * - `indexes` is read by nothing today. Narrowed anyway, on the same grounds.
+ * - `checks` is deliberately *not* narrowed. Every generator already drops a row check naming a
+ *   column the mode does not carry, so nothing breaks, and the constraint really does still exist
+ *   in the database: leaving it lets `meta` keep listing it as unenforced, which is the honest
+ *   answer. A warning says so.
+ * - `primaryKey` cannot be narrowed, because omitting a key column is refused outright. See below.
+ */
+import type { Table } from '@drzl/analyzer';
+import { parseCheck } from '@drzl/validation-core';
+import { namedColumns } from './doctor.js';
+import { matchesAny } from './patterns.js';
+
+/** What to do with one table's columns. Both are patterns, in the language `patterns.ts` defines. */
+export interface ColumnRules {
+  /** Drop these. Applied after `pick`, so it wins where both name the same column. */
+  omit?: string[];
+  /** Keep only these. */
+  pick?: string[];
+}
+
+/** Keyed by table pattern, matched against the database table name exactly as `include` is. */
+export type ColumnFilter = Record<string, ColumnRules>;
+
+export interface ColumnFilterResult {
+  tables: Table[];
+  /** Printed by the caller. Nothing here stops generation. */
+  warnings: string[];
+}
+
+/** Every column name a CHECK talks about, whatever kind of constraint it turned out to be. */
+function checkedColumns(expression: string | undefined, name: string | undefined): string[] {
+  const parsed = parseCheck(expression, name);
+  if (!parsed.ok) return [];
+  return [...new Set(namedColumns(parsed).map((n) => n.column))];
+}
+
+/**
+ * Narrow every table's columns to what the config asked for.
+ *
+ * Throws on anything that cannot be honoured, with every such problem in one message: a config is
+ * edited once and rerun, and reporting the first of four typos three times is three wasted runs.
+ * Returns warnings for what *is* honoured but changes what the output can do.
+ *
+ * Call this **before** `filterTables`. Both orders produce the same tables, since one narrows
+ * columns and the other drops whole tables, but only this order lets a `columns` entry name a
+ * table that `exclude` also removes without that reading as a typo.
+ */
+export function filterColumns(tables: Table[], spec: ColumnFilter | undefined): ColumnFilterResult {
+  const entries = Object.entries(spec ?? {});
+  if (!entries.length) return { tables, warnings: [] };
+
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  /**
+   * Every pattern has to name something that exists.
+   *
+   * This is the loud half, and it is the reason the option is safe to reach for. `omit:
+   * ['passwrodHash']` that silently does nothing is not a no-op: it is the leak the option was
+   * reached for, wearing the shape of a fix, and nothing downstream can tell the difference
+   * between a column that was never there and one that was already dropped.
+   *
+   * A column pattern is required to match in *at least one* of the tables its entry matched, not
+   * in all of them. Requiring all would make a wildcard table key useless, and dropping
+   * `deleted_at` from every `app_*` table that has one is the main thing a wildcard key is for.
+   */
+  for (const [tablePattern, rules] of entries) {
+    const matched = tables.filter((t) => matchesAny([tablePattern], t.name));
+    if (!matched.length) {
+      errors.push(
+        `columns[${JSON.stringify(tablePattern)}] matches no table. ` +
+          `The schema declares: ${tables.map((t) => t.name).join(', ') || '(no tables)'}.`
+      );
+      continue;
+    }
+    const available = [...new Set(matched.flatMap((t) => t.columns.map((c) => c.name)))];
+    for (const which of ['pick', 'omit'] as const) {
+      for (const pattern of rules[which] ?? []) {
+        if (available.some((name) => matchesAny([pattern], name))) continue;
+        errors.push(
+          `columns[${JSON.stringify(tablePattern)}].${which} names ${JSON.stringify(pattern)}, ` +
+            `which matches no column of ${matched.map((t) => t.name).join(', ')}. ` +
+            `Available: ${available.join(', ')}.`
+        );
+      }
+    }
+  }
+
+  const out = tables.map((table) => {
+    const mine = entries.filter(([pattern]) => matchesAny([pattern], table.name));
+    if (!mine.length) return table;
+
+    // Applied in the order the entries are written, so a reader works down the config the way they
+    // read it. Within one entry `pick` narrows and then `omit` removes, which is the same
+    // precedence `exclude` already has over `include`: the direction that takes something away
+    // wins, because that is the safe direction for the thing this option exists to remove.
+    let keep = table.columns;
+    for (const [, rules] of mine) {
+      if (rules.pick?.length) keep = keep.filter((c) => matchesAny(rules.pick!, c.name));
+      if (rules.omit?.length) keep = keep.filter((c) => !matchesAny(rules.omit!, c.name));
+    }
+    if (keep.length === table.columns.length) return table;
+
+    const kept = new Set(keep.map((c) => c.name));
+    const dropped = table.columns.filter((c) => !kept.has(c.name));
+
+    if (!keep.length) {
+      errors.push(
+        `columns leaves table "${table.name}" with no columns at all. An empty schema describes ` +
+          `no row, so this is never a narrower API. Exclude the table instead, with the top-level ` +
+          `"exclude" option.`
+      );
+      return table;
+    }
+
+    /**
+     * A primary key column is refused rather than narrowed, and it is the one hard no here.
+     *
+     * The key is what addresses a row, and every generator that addresses one reads it
+     * differently, so the consequence of dropping it depends on which generators happen to be
+     * configured: the tRPC generator resolves the key against `columns` and silently drops byId,
+     * update and delete; the oRPC generator never reads the key at all and keeps emitting
+     * procedures typed `{ id: number }`; the service generator falls back to a column literally
+     * named `id` and emits `eq(users.id, id)`, which does not compile when the key was called
+     * something else; the OpenAPI document drops its `/{id}` paths; and zod's `meta` would publish
+     * a primary key whose column the schema no longer describes. One config, five outcomes, none
+     * of them announced.
+     *
+     * Refusing is also the reversible direction. An error can be relaxed to a warning later
+     * without breaking a config that works; a warning cannot be tightened into an error without
+     * breaking one.
+     */
+    const lostKey = (table.primaryKey?.columns ?? []).filter((n) => !kept.has(n));
+    if (lostKey.length) {
+      errors.push(
+        `columns drops ${lostKey.map((n) => JSON.stringify(n)).join(', ')} from table ` +
+          `"${table.name}", which is part of its primary key ` +
+          `(${table.primaryKey?.columns.join(', ')}). The generated getById, update and delete ` +
+          `address rows by that key, so the emitted schemas would describe a row nothing can ` +
+          `address. Keep the key, or leave the whole table out with the top-level "exclude" option.`
+      );
+      return table;
+    }
+
+    /**
+     * A NOT NULL column with no default is warned about and then dropped, which is the other half
+     * of the same judgement.
+     *
+     * It really does produce an insert schema that cannot describe a whole row. It is also the
+     * multi-tenant pattern: a NOT NULL `tenantId` the server takes from the session is exactly a
+     * column a request body must not carry, and refusing it would remove one of the two things
+     * this option is for. An insert schema describes a request, not a row, so the narrower
+     * statement is true; what is not obvious is who then supplies the rest, and that is what the
+     * warning says. If a generated service in `drizzle` mode is handed the narrowed body, its
+     * `create` parameter is Drizzle's own `$inferInsert` and the missing column is a compile error
+     * in the generated project, which is loud on its own.
+     */
+    for (const c of dropped) {
+      if (c.nullable || c.hasDefault || c.isGenerated || table.readOnly) continue;
+      warnings.push(
+        `drzl config: the "columns" option drops "${c.name}" from table "${table.name}", and the ` +
+          `database requires it: NOT NULL with no default. The emitted insert schema therefore ` +
+          `describes a payload that is not a complete row, so whatever calls db.insert has to ` +
+          `supply "${c.name}" itself.`
+      );
+    }
+
+    // A CHECK naming a dropped column stops being enforced by anything DRZL emits. The generators
+    // already skip it rather than emitting a comparison against a field that is not there, so this
+    // is a warning and not an error, but it is exactly the silent kind of loss `drzl doctor` was
+    // written for.
+    for (const k of table.checks ?? []) {
+      // Only names this filter really took away. A CHECK naming a column the table never had is a
+      // different finding with a section of its own in `drzl doctor`, and claiming it here would
+      // blame the config for something that was already wrong.
+      const lost = checkedColumns(k.expression, k.name).filter(
+        (n) => !kept.has(n) && table.columns.some((c) => c.name === n)
+      );
+      if (!lost.length) continue;
+      warnings.push(
+        `drzl config: CHECK ${k.name ? `"${k.name}"` : '(unnamed)'} on table "${table.name}" ` +
+          `names ${lost.map((n) => JSON.stringify(n)).join(', ')}, which the "columns" option ` +
+          `drops, so nothing DRZL emits enforces it. Your database still does.`
+      );
+    }
+
+    return {
+      ...table,
+      columns: keep,
+      unique: (table.unique ?? []).filter((k) => k.columns.every((n) => kept.has(n))),
+      indexes: (table.indexes ?? []).filter((i) => i.columns.every((n) => kept.has(n))),
+      ...(table.foreignKeys
+        ? { foreignKeys: table.foreignKeys.filter((f) => f.columns.every((n) => kept.has(n))) }
+        : {}),
+    };
+  });
+
+  if (errors.length) {
+    throw new Error(
+      `drzl config: the "columns" option cannot be honoured.\n` +
+        errors.map((e) => `  - ${e}`).join('\n')
+    );
+  }
+
+  return { tables: out, warnings };
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -12,6 +12,7 @@ import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { z } from 'zod';
+import { matchesAny } from './patterns.js';
 
 export const NamingSchema = z
   .object({
@@ -277,6 +278,20 @@ export const GeneratorSchema = z.object({
   templateOptions: z.record(z.string(), z.any()).optional(),
 });
 
+/**
+ * One table's column rules. Strict, so `ommit` is refused by the parser rather than dropped.
+ *
+ * The whole option exists to remove a column, and a key zod strips in silence is a config that
+ * looks like it removed one and did not. `GeneratorSchema` is deliberately not strict and has
+ * already cost this repo two options that parsed and then did nothing.
+ */
+export const ColumnRulesSchema = z
+  .object({
+    omit: z.array(z.string()).optional(),
+    pick: z.array(z.string()).optional(),
+  })
+  .strict();
+
 export const AnalyzerSchema = z.object({
   includeRelations: z.boolean().default(true),
   validateConstraints: z.boolean().default(true),
@@ -305,6 +320,37 @@ export const ConfigSchema = z
      */
     include: z.array(z.string()).optional(),
     exclude: z.array(z.string()).optional(),
+    /**
+     * Which columns of those tables to generate for, keyed by table.
+     *
+     * `include`/`exclude` is all or nothing per table, and the column that should not be in a
+     * generated schema is usually sitting in a table you do want: `passwordHash` on `users`, an
+     * internal note beside the public fields, a `tenantId` the server sets from the session and a
+     * request body must not carry. Editing the emitted file is not an answer, because the next
+     * `drzl generate` overwrites it.
+     *
+     * ```ts
+     * columns: {
+     *   users: { omit: ['passwordHash'] },
+     *   'app_*': { omit: ['deleted_at'] },
+     * }
+     * ```
+     *
+     * The key is a table pattern in the same language `include`/`exclude` uses: the database table
+     * name, anchored, with `*` as the only metacharacter. Column patterns are the same language
+     * again. Every matching entry applies, in the order written; within one entry `pick` narrows
+     * first and `omit` then removes, so `omit` wins, exactly as `exclude` wins over `include`.
+     *
+     * Applies to every mode and every generator at once, because it narrows the analysis rather
+     * than any one generator's output. A column cannot be kept in `select` and dropped from
+     * `insert`: see the docs for why that form was not taken on.
+     *
+     * A pattern that matches nothing is an error rather than a no-op, because a typo in `omit`
+     * that silently does nothing leaves the column exactly where it was while reading like a fix.
+     * Dropping a primary key column is an error too; dropping a NOT NULL column with no default is
+     * a warning.
+     */
+    columns: z.record(z.string(), ColumnRulesSchema).optional(),
     /**
      * How every relative specifier drzl invents spells its extension, for every generator.
      * A generator may override it. Defaults to `js`, which is the only form that resolves
@@ -634,22 +680,9 @@ export function filterTables<T extends { name: string }>(
   tables: T[],
   opts: { include?: string[]; exclude?: string[] }
 ): T[] {
-  const toRegExp = (pattern: string) =>
-    new RegExp(
-      '^' +
-        pattern
-          .split('*')
-          .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-          .join('.*') +
-        '$'
-    );
-
-  const matches = (patterns: string[], name: string) =>
-    patterns.some((p) => toRegExp(p).test(name));
-
   let out = tables;
-  if (opts.include?.length) out = out.filter((t) => matches(opts.include!, t.name));
-  if (opts.exclude?.length) out = out.filter((t) => !matches(opts.exclude!, t.name));
+  if (opts.include?.length) out = out.filter((t) => matchesAny(opts.include!, t.name));
+  if (opts.exclude?.length) out = out.filter((t) => !matchesAny(opts.exclude!, t.name));
   return out;
 }
 

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -90,8 +90,13 @@ function splitPath(path: string | undefined): { table?: string; column?: string 
   return { table: path.slice(0, dot), column: path.slice(dot + 1) };
 }
 
-/** Every column name a parsed CHECK talks about, paired with the kind of constraint it came from. */
-function namedColumns(parsed: Extract<ReturnType<typeof parseCheck>, { ok: true }>) {
+/**
+ * Every column name a parsed CHECK talks about, paired with the kind of constraint it came from.
+ *
+ * Exported because the column filter needs the same answer: a constraint stops being enforced when
+ * any column it names is dropped, and "which columns does this name" has to mean one thing.
+ */
+export function namedColumns(parsed: Extract<ReturnType<typeof parseCheck>, { ok: true }>) {
   const out: Array<{ column: string; scalar: boolean }> = [];
   // A comparison against a literal and an `IN` list are both statements about a scalar value, so
   // neither describes an array or a structured column. The other three kinds are not: a length or

--- a/packages/cli/src/patterns.ts
+++ b/packages/cli/src/patterns.ts
@@ -1,0 +1,27 @@
+/**
+ * The one name-matching language every filter in a DRZL config speaks.
+ *
+ * Anchored, with `*` as the only metacharacter. Anchored is the whole point: `user` must not also
+ * match `users`, and a substring match would, which for the table filter means silently dropping
+ * the application's main entity while trying to drop an auth table.
+ *
+ * Shared rather than reimplemented. `include`/`exclude` and the per-table `columns` filter both
+ * take patterns, and a reader who has learned one has learned the other only while there is one
+ * implementation of "learned". Two copies of an anchored glob agree on the easy cases and drift on
+ * exactly the corners that made this explicit in the first place.
+ */
+export function patternToRegExp(pattern: string): RegExp {
+  return new RegExp(
+    '^' +
+      pattern
+        .split('*')
+        .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        .join('.*') +
+      '$'
+  );
+}
+
+/** Whether any of `patterns` matches `name` outright. */
+export function matchesAny(patterns: string[], name: string): boolean {
+  return patterns.some((p) => patternToRegExp(p).test(name));
+}

--- a/packages/cli/test/column-filter.e2e.spec.ts
+++ b/packages/cli/test/column-filter.e2e.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * An omitted column, checked against what the emitted schemas actually *do*.
+ *
+ * The unit tests assert on the narrowed `Analysis`, and the emitted text can be grepped, but
+ * neither answers the question that matters: after `omit`, is the column genuinely gone from what
+ * a parse hands back, or merely missing from a source file while the value still flows through?
+ * Those are different, and which one you get is the validator's own policy about undeclared keys,
+ * not DRZL's. So this runs the real analyzer over a real Drizzle schema, applies the real filter,
+ * emits with the real generators, imports what was written, and parses a row that still carries
+ * the omitted column.
+ *
+ * Two directories because two things have to resolve. The schema imports `drizzle-orm`, which
+ * resolves from `packages/cli`; the emitted modules import `zod`, `valibot` and `arktype`, and the
+ * one place all three resolve from is `packages/generator-trpc`. Both are `test/.tmp-*`, which is
+ * gitignored for every package.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import type { Analysis } from '@drzl/analyzer';
+import { ZodGenerator } from '@drzl/generator-zod';
+import { ValibotGenerator } from '@drzl/generator-valibot';
+import { ArkTypeGenerator } from '@drzl/generator-arktype';
+import { filterColumns } from '../src/column-filter';
+
+const SCHEMA_DIR = path.join(__dirname, '.tmp-column-filter-e2e');
+const EMIT_DIR = path.join(
+  __dirname,
+  '..',
+  '..',
+  'generator-trpc',
+  'test',
+  `.tmp-column-filter-e2e-${process.pid}`
+);
+
+const SCHEMA = `
+import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey(),
+  email: text('email').notNull(),
+  passwordHash: text('password_hash').notNull(),
+  bio: text('bio'),
+});
+`;
+
+/** A row as the database really hands it back: the omitted column is still in it. */
+const ROW = { id: 1, email: 'ann@example.com', passwordHash: 'argon2:xxx', bio: null };
+
+let warnings: string[] = [];
+let zod: Record<string, any>;
+let valibot: Record<string, any>;
+let arktype: Record<string, any>;
+let v: { parse: (schema: unknown, value: unknown) => unknown };
+let emittedZodSource: string;
+let emittedArkTypeSource: string;
+
+beforeAll(async () => {
+  await fs.rm(SCHEMA_DIR, { recursive: true, force: true });
+  await fs.rm(EMIT_DIR, { recursive: true, force: true });
+  await fs.mkdir(SCHEMA_DIR, { recursive: true });
+  await fs.mkdir(EMIT_DIR, { recursive: true });
+
+  const schemaFile = path.join(SCHEMA_DIR, 'schema.mjs');
+  await fs.writeFile(schemaFile, SCHEMA, 'utf8');
+
+  const analysis: Analysis = await new SchemaAnalyzer(
+    path.relative(process.cwd(), schemaFile)
+  ).analyze({});
+
+  const narrowed = filterColumns(analysis.tables, { users: { omit: ['passwordHash'] } });
+  warnings = narrowed.warnings;
+  analysis.tables = narrowed.tables;
+
+  await new ZodGenerator(analysis).generate({ outDir: EMIT_DIR } as never);
+  await new ValibotGenerator(analysis).generate({ outDir: EMIT_DIR } as never);
+  await new ArkTypeGenerator(analysis).generate({ outDir: EMIT_DIR } as never);
+
+  // valibot is reached through a file in the emitted directory rather than imported here: this
+  // package does not depend on it, and the emitted module resolves it from exactly this location.
+  await fs.writeFile(path.join(EMIT_DIR, 'valibot-runtime.mjs'), `export * from 'valibot';\n`);
+
+  emittedZodSource = await fs.readFile(path.join(EMIT_DIR, 'users.zod.ts'), 'utf8');
+  emittedArkTypeSource = await fs.readFile(path.join(EMIT_DIR, 'users.arktype.ts'), 'utf8');
+  zod = await import(path.join(EMIT_DIR, 'users.zod.ts'));
+  valibot = await import(path.join(EMIT_DIR, 'users.valibot.ts'));
+  arktype = await import(path.join(EMIT_DIR, 'users.arktype.ts'));
+  v = (await import(path.join(EMIT_DIR, 'valibot-runtime.mjs'))) as never;
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(SCHEMA_DIR, { recursive: true, force: true });
+  await fs.rm(EMIT_DIR, { recursive: true, force: true });
+});
+
+describe('the analysis the generators were handed', () => {
+  it('warns that the database requires the column that was dropped', () => {
+    expect(warnings.join('\n')).toMatch(/passwordHash/);
+    expect(warnings.join('\n')).toMatch(/NOT NULL/);
+  });
+});
+
+describe('the emitted zod module', () => {
+  it('does not mention the column at all', () => {
+    expect(emittedZodSource).not.toMatch(/passwordHash/);
+    // The columns that were kept are still there, so this is a narrowing and not an empty file.
+    expect(emittedZodSource).toMatch(/email/);
+    expect(emittedZodSource).toMatch(/bio/);
+  });
+
+  it('drops the key from a parsed select row, rather than passing it through', () => {
+    const out = zod.SelectusersSchema.parse(ROW);
+    expect(Object.keys(out).sort()).toEqual(['bio', 'email', 'id']);
+    expect('passwordHash' in out).toBe(false);
+  });
+
+  it('drops it from a parsed insert payload', () => {
+    const out = zod.InsertusersSchema.parse({ id: 1, email: 'a@b.c', passwordHash: 'x' });
+    expect('passwordHash' in out).toBe(false);
+    expect(out.email).toBe('a@b.c');
+  });
+
+  it('drops it from a parsed update payload', () => {
+    const out = zod.UpdateusersSchema.parse({ email: 'a@b.c', passwordHash: 'x' });
+    expect('passwordHash' in out).toBe(false);
+    expect(out.email).toBe('a@b.c');
+  });
+
+  it('still accepts a row that does not carry it', () => {
+    expect(zod.SelectusersSchema.safeParse({ id: 1, email: 'a@b.c', bio: null }).success).toBe(
+      true
+    );
+  });
+});
+
+describe('the emitted valibot module', () => {
+  it('drops the key from a parsed select row', () => {
+    const out = v.parse(valibot.SelectusersSchema, ROW) as Record<string, unknown>;
+    expect(Object.keys(out).sort()).toEqual(['bio', 'email', 'id']);
+  });
+
+  it('drops it from a parsed insert payload', () => {
+    const out = v.parse(valibot.InsertusersSchema, {
+      id: 1,
+      email: 'a@b.c',
+      passwordHash: 'x',
+    }) as Record<string, unknown>;
+    expect('passwordHash' in out).toBe(false);
+  });
+
+  it('drops it from a parsed update payload', () => {
+    const out = v.parse(valibot.UpdateusersSchema, {
+      email: 'a@b.c',
+      passwordHash: 'x',
+    }) as Record<string, unknown>;
+    expect('passwordHash' in out).toBe(false);
+  });
+});
+
+describe('the emitted arktype module', () => {
+  /**
+   * Measured rather than asserted from the docs, and recorded because it is the one answer that
+   * differs. arktype's default for an undeclared key is to leave it where it is: the schema no
+   * longer *describes* the column, and a value carrying it still validates and comes back
+   * carrying it. That is arktype's policy about undeclared keys and not something DRZL sets, so
+   * the honest thing is to state which half of the guarantee holds.
+   */
+  it('no longer describes the column', () => {
+    expect(emittedArkTypeSource).not.toMatch(/passwordHash/);
+    expect(emittedArkTypeSource).toMatch(/email/);
+  });
+
+  it('says whether the value survives a parse', () => {
+    const out = arktype.SelectusersSchema(ROW) as Record<string, unknown>;
+    // Whichever it is, it is written down. A change here is a change in arktype's behaviour and
+    // should be read as one rather than silently absorbed.
+    expect('passwordHash' in out).toBe(true);
+  });
+});

--- a/packages/cli/test/column-filter.spec.ts
+++ b/packages/cli/test/column-filter.spec.ts
@@ -1,0 +1,311 @@
+/**
+ * Choosing which *columns* DRZL generates for.
+ *
+ * The table filter answers "which tables"; there was no way to answer "which columns of them".
+ * A schema that DRZL must read in full still has columns that should not appear in a generated
+ * schema: a `passwordHash` a client must never be handed, an internal note column, a `tenantId`
+ * the server sets from the session and a request body must not carry. Today the only way to get
+ * one out is to edit the generated file, which the next `drzl generate` overwrites.
+ *
+ * The filter narrows the `Analysis` once, before any generator sees it, exactly as `filterTables`
+ * does, so all nine generators, the OpenAPI document and the emitted metadata describe the same
+ * columns without any of them knowing the option exists.
+ *
+ * Two failure modes drive the loud parts of this. A typo in `omit` that silently does nothing is
+ * the leak the option was reached for, dressed as a fix. And a narrowing that leaves `unique`,
+ * `foreignKeys` or `primaryKey` naming a column the table no longer has produces emitted code that
+ * either does not compile or quietly loses procedures.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Column, Table } from '@drzl/analyzer';
+import { filterColumns } from '../src/column-filter';
+
+function col(name: string, over: Partial<Column> = {}): Column {
+  return {
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  };
+}
+
+function table(name: string, columns: Column[], over: Partial<Table> = {}): Table {
+  return { name, tsName: name, columns, unique: [], indexes: [], ...over };
+}
+
+const names = (t: Table[]) => t.map((x) => x.columns.map((c) => c.name));
+
+const users = () =>
+  table(
+    'users',
+    [
+      col('id', { tsType: 'number', nullable: false }),
+      col('email', { nullable: false }),
+      col('passwordHash', { nullable: false }),
+      col('bio'),
+    ],
+    { primaryKey: { columns: ['id'] } }
+  );
+
+describe('with no columns option', () => {
+  it('leaves every table exactly as the analyzer stated it', () => {
+    const before = [users(), table('posts', [col('id'), col('title')])];
+    const { tables, warnings } = filterColumns(before, undefined);
+    expect(names(tables)).toEqual([
+      ['id', 'email', 'passwordHash', 'bio'],
+      ['id', 'title'],
+    ]);
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('omit', () => {
+  it('drops the named columns', () => {
+    const { tables } = filterColumns([users()], { users: { omit: ['passwordHash', 'bio'] } });
+    expect(names(tables)).toEqual([['id', 'email']]);
+  });
+
+  it('supports a wildcard, like the table filter', () => {
+    const t = table('users', [col('id'), col('createdAt'), col('updatedAt'), col('name')]);
+    const { tables } = filterColumns([t], { users: { omit: ['*At'] } });
+    expect(names(tables)).toEqual([['id', 'name']]);
+  });
+
+  it('is anchored, so `bio` does not also drop `bios`', () => {
+    const t = table('users', [col('bio'), col('bios')]);
+    const { tables } = filterColumns([t], { users: { omit: ['bio'] } });
+    expect(names(tables)).toEqual([['bios']]);
+  });
+});
+
+describe('pick', () => {
+  it('keeps only what matches', () => {
+    const { tables } = filterColumns([users()], { users: { pick: ['id', 'email'] } });
+    expect(names(tables)).toEqual([['id', 'email']]);
+  });
+
+  it('keeps the analyzer column order, not the order they were listed in', () => {
+    const { tables } = filterColumns([users()], { users: { pick: ['bio', 'id'] } });
+    expect(names(tables)).toEqual([['id', 'bio']]);
+  });
+
+  it('supports a wildcard', () => {
+    const t = table('users', [col('id'), col('publicName'), col('publicBio'), col('secret')]);
+    const { tables } = filterColumns([t], { users: { pick: ['id', 'public*'] } });
+    expect(names(tables)).toEqual([['id', 'publicName', 'publicBio']]);
+  });
+});
+
+describe('omit and pick on the same table', () => {
+  it('applies pick first and lets omit win, exactly as exclude wins over include one level up', () => {
+    const t = table('users', [col('id'), col('publicName'), col('publicSecret'), col('other')]);
+    const { tables } = filterColumns([t], {
+      users: { pick: ['id', 'public*'], omit: ['publicSecret'] },
+    });
+    expect(names(tables)).toEqual([['id', 'publicName']]);
+  });
+});
+
+describe('naming a table', () => {
+  it('matches the database name with a wildcard, like the table filter', () => {
+    const before = [
+      table('app_users', [col('id'), col('deleted_at')]),
+      table('app_posts', [col('id'), col('deleted_at')]),
+      table('other', [col('id')]),
+    ];
+    const { tables } = filterColumns(before, { 'app_*': { omit: ['deleted_at'] } });
+    expect(names(tables)).toEqual([['id'], ['id'], ['id']]);
+  });
+
+  it('applies every matching entry, in the order they are written', () => {
+    const t = table('users', [col('id'), col('a'), col('b'), col('c')]);
+    const { tables } = filterColumns([t], {
+      '*': { omit: ['a'] },
+      users: { omit: ['b'] },
+    });
+    expect(names(tables)).toEqual([['id', 'c']]);
+  });
+
+  it('matches the database name and not the TypeScript export name', () => {
+    // `filterTables` matches `t.name`, so this one has to as well, or one config key would mean
+    // two different things depending on which option it appeared in.
+    const t = table('app_user', [col('id'), col('secret')], { tsName: 'appUsers' });
+    const { tables } = filterColumns([t], { app_user: { omit: ['secret'] } });
+    expect(names(tables)).toEqual([['id']]);
+  });
+});
+
+describe('a name that matches nothing', () => {
+  it('refuses a table pattern that matches no table, naming what there was', () => {
+    const before = [users(), table('posts', [col('id')])];
+    expect(() => filterColumns(before, { userz: { omit: ['bio'] } })).toThrow(/"userz"/);
+    expect(() => filterColumns(before, { userz: { omit: ['bio'] } })).toThrow(/users, posts/);
+  });
+
+  it('refuses an omit pattern that matches no column, which is the typo that silently leaks', () => {
+    expect(() => filterColumns([users()], { users: { omit: ['passwrodHash'] } })).toThrow(
+      /passwrodHash/
+    );
+  });
+
+  it('refuses a pick pattern that matches no column', () => {
+    expect(() => filterColumns([users()], { users: { pick: ['id', 'emial'] } })).toThrow(/emial/);
+  });
+
+  it('reports every bad name at once, so one run fixes them all', () => {
+    let message = '';
+    try {
+      filterColumns([users()], { users: { omit: ['nope', 'alsoNope'] } });
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toMatch(/nope/);
+    expect(message).toMatch(/alsoNope/);
+  });
+
+  it('accepts a column that exists on only some of the tables a wildcard matched', () => {
+    // The whole point of a wildcard table key. `deleted_at` is on one of these and not the other,
+    // and requiring it on both would make the form unusable.
+    const before = [
+      table('app_users', [col('id'), col('deleted_at')]),
+      table('app_posts', [col('id')]),
+    ];
+    const { tables } = filterColumns(before, { 'app_*': { omit: ['deleted_at'] } });
+    expect(names(tables)).toEqual([['id'], ['id']]);
+  });
+});
+
+describe('the dangerous cases', () => {
+  it('refuses to omit a primary key column', () => {
+    expect(() => filterColumns([users()], { users: { omit: ['id'] } })).toThrow(/primary key/i);
+  });
+
+  it('refuses to omit part of a composite primary key', () => {
+    const t = table('memberships', [col('orgId'), col('userId'), col('role')], {
+      primaryKey: { columns: ['orgId', 'userId'] },
+    });
+    expect(() => filterColumns([t], { memberships: { omit: ['userId'] } })).toThrow(/primary key/i);
+  });
+
+  it('refuses a pick that leaves the primary key out', () => {
+    expect(() => filterColumns([users()], { users: { pick: ['email'] } })).toThrow(/primary key/i);
+  });
+
+  it('refuses to leave a table with no columns at all', () => {
+    const t = table('flags', [col('name')]);
+    expect(() => filterColumns([t], { flags: { omit: ['*'] } })).toThrow(/no columns/i);
+  });
+
+  it('warns when it drops a column the database requires, and still generates', () => {
+    const t = table(
+      'posts',
+      [
+        col('id', { nullable: false }),
+        col('tenantId', { nullable: false }),
+        col('title', { nullable: false }),
+      ],
+      { primaryKey: { columns: ['id'] } }
+    );
+    const { tables, warnings } = filterColumns([t], { posts: { omit: ['tenantId'] } });
+    expect(names(tables)).toEqual([['id', 'title']]);
+    expect(warnings.join('\n')).toMatch(/tenantId/);
+    expect(warnings.join('\n')).toMatch(/NOT NULL/);
+  });
+
+  it('does not warn for a nullable column, or one the database defaults', () => {
+    const t = table(
+      'posts',
+      [
+        col('id', { nullable: false }),
+        col('bio'),
+        col('createdAt', { nullable: false, hasDefault: true }),
+        col('slug', { nullable: false, isGenerated: true }),
+      ],
+      { primaryKey: { columns: ['id'] } }
+    );
+    const { warnings } = filterColumns([t], { posts: { omit: ['bio', 'createdAt', 'slug'] } });
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns that a CHECK naming an omitted column is no longer enforced', () => {
+    const t = table('events', [col('id', { nullable: false }), col('startsAt'), col('endsAt')], {
+      primaryKey: { columns: ['id'] },
+      checks: [{ name: 'ordered', expression: 'startsAt < endsAt' }],
+    });
+    const { warnings } = filterColumns([t], { events: { omit: ['endsAt'] } });
+    expect(warnings.join('\n')).toMatch(/ordered/);
+  });
+
+  it('leaves the CHECK on the table, so the emitted metadata still calls it unenforced', () => {
+    const t = table('events', [col('id', { nullable: false }), col('startsAt'), col('endsAt')], {
+      primaryKey: { columns: ['id'] },
+      checks: [{ name: 'ordered', expression: 'startsAt < endsAt' }],
+    });
+    const { tables } = filterColumns([t], { events: { omit: ['endsAt'] } });
+    expect(tables[0].checks).toHaveLength(1);
+  });
+});
+
+describe('keeping the rest of the analysis honest', () => {
+  it('drops a unique constraint naming an omitted column', () => {
+    // `findDuplicate<Table>` writes those names into emitted TypeScript typed against the insert
+    // row, so a stale one is a generated file that does not compile.
+    const t = table('users', [col('id', { nullable: false }), col('email'), col('name')], {
+      primaryKey: { columns: ['id'] },
+      unique: [{ name: 'users_email_unique', columns: ['email'] }, { columns: ['name'] }],
+    });
+    const { tables } = filterColumns([t], { users: { omit: ['email'] } });
+    expect(tables[0].unique.map((k) => k.columns)).toEqual([['name']]);
+  });
+
+  it('drops a composite unique constraint when any one of its columns goes', () => {
+    const t = table('users', [col('id', { nullable: false }), col('a'), col('b')], {
+      primaryKey: { columns: ['id'] },
+      unique: [{ columns: ['a', 'b'] }],
+    });
+    const { tables } = filterColumns([t], { users: { omit: ['b'] } });
+    expect(tables[0].unique).toEqual([]);
+  });
+
+  it('drops an index naming an omitted column', () => {
+    const t = table('users', [col('id', { nullable: false }), col('email')], {
+      primaryKey: { columns: ['id'] },
+      indexes: [{ name: 'by_email', columns: ['email'] }],
+    });
+    const { tables } = filterColumns([t], { users: { omit: ['email'] } });
+    expect(tables[0].indexes).toEqual([]);
+  });
+
+  it('drops a foreign key whose local column is omitted', () => {
+    const t = table('posts', [col('id', { nullable: false }), col('authorId')], {
+      primaryKey: { columns: ['id'] },
+      foreignKeys: [{ columns: ['authorId'], foreignTable: 'users', foreignColumns: ['id'] }],
+    });
+    const { tables } = filterColumns([t], { posts: { omit: ['authorId'] } });
+    expect(tables[0].foreignKeys).toEqual([]);
+  });
+
+  it('keeps a foreign key whose local column survives', () => {
+    const t = table('posts', [col('id', { nullable: false }), col('authorId'), col('draft')], {
+      primaryKey: { columns: ['id'] },
+      foreignKeys: [{ columns: ['authorId'], foreignTable: 'users', foreignColumns: ['id'] }],
+    });
+    const { tables } = filterColumns([t], { posts: { omit: ['draft'] } });
+    expect(tables[0].foreignKeys).toHaveLength(1);
+  });
+
+  it('does not mutate the analysis it was given', () => {
+    const before = users();
+    filterColumns([before], { users: { omit: ['passwordHash'] } });
+    expect(before.columns.map((c) => c.name)).toEqual(['id', 'email', 'passwordHash', 'bio']);
+  });
+
+  it('leaves a table no entry matched untouched, by identity', () => {
+    const posts = table('posts', [col('id')]);
+    const { tables } = filterColumns([users(), posts], { users: { omit: ['bio'] } });
+    expect(tables[1]).toBe(posts);
+  });
+});


### PR DESCRIPTION
Plan item 35. A subset of columns without post-processing.

```ts
columns: {
  users:     { omit: ['passwordHash'] },
  'app_*':   { omit: ['deleted_at'] },
  audit_log: { pick: ['id', 'action', 'created_at'] },
},
```

## Where the filter lives

**On the `Analysis`, once**, at the seam `filterTables` already uses, before any generator is constructed.

Not in `@drzl/analyzer`: it has no config, and `drzl analyze` must keep printing what is really there. Not in each generator: there are nine plus two template packages, and the one that forgot would emit a schema **silently wider than asked**. Narrowing once is also what keeps `doctor`, the JSON Schema document, the service generator and both routers agreeing, since they all read the same object.

Verified rather than assumed: with `passwordHash` omitted, `components.ts`, `openapi.ts` and `users.schema.ts` contain zero occurrences of it.

Table matching **shares** the `include`/`exclude` matcher rather than duplicating its semantics: the anchored glob moved into its own module and both call it.

## `omit` wins over `pick`

Defined precedence, not an error, mirroring `exclude` over `include` and for the same reason: the direction that takes something away is the safe one. `pick: ['public*'], omit: ['public_secret']` is the "this family except that one" shape people actually want, and erroring would break it to catch a confusion that costs nothing.

## A name that matches nothing aborts the run

Every such problem is collected into one message and the run exits non-zero with nothing written.

**A silent no-op there is not nothing.** `omit: ['passwrodHash']` is the leak the option was reached for, wearing the shape of a fix. Deliberately stricter than `exclude`, which remains a silent no-op: an absent *table* is visible in the output tree, an absent *column* vanishes into a field list nobody rereads. `ColumnRulesSchema` is `.strict()`, unlike `GeneratorSchema`, which has already cost this repo two options that parsed and did nothing.

## The dangerous cases

**Omitting a primary key: refused.** One config produced five outcomes depending on which generators were configured, none of them announced:

```
generator-trpc     silently drops byId / update / delete
generator-orpc     never reads table.primaryKey, keeps emitting { id: number }
generator-service  falls back to a column named id; does not compile if the key was named otherwise
openapi            drops its /{id} paths
zod meta           publishes a key whose column the schema no longer describes
```

An error can be relaxed to a warning later without breaking a working config; the reverse cannot.

**Omitting a NOT NULL column with no default: warns, generates.** It is the normal multi-tenant shape, and an insert schema describes a **request body**, not a row. Refusing would remove one of the two things the option is for. Handed to a `dataAccess: 'drizzle'` service, the missing column is a compile error in the generated project, which is loud on its own.

**A third case the task did not name, which would have shipped broken.** `validation-core/src/duplicates.ts` writes `table.unique` names verbatim into emitted TypeScript typed against the insert row, so omitting a unique column emitted a `findDuplicate<Table>` that **does not compile**. The narrowing therefore covers `unique`, `indexes` and `foreignKeys` as well. `checks` is deliberately left alone: every generator already skips a row check naming an absent column, and leaving it lets `meta` keep reporting the constraint as unenforced, which is true. It warns.

## Per table, not per mode

Per mode cannot be expressed by narrowing the analysis, so it would move the feature into all nine generators. And half the output could not honour it: the service generator's `Insert<T>` and `Update<T>` come from Drizzle's types, not from the analysis, so a column dropped from `insert` alone would still sit in its parameter type. An option whose effect disappears in half the tree is worse than one not offered. The config shape stays forward-compatible.

## Measured by parsing, not by reading emitted text

A real schema, real analyzer, real emitted modules, imported and handed a row that still carries the omitted column:

| generator | result |
|---|---|
| zod 4.4.3 | key stripped, all three modes |
| valibot 1.4.2 | key stripped |
| Effect 3.22.1 | key stripped by `decodeUnknownSync` |
| TypeBox 0.34.52 | stripped by `Value.Parse`/`Value.Clean`; **`Value.Check` alone returns `true`** |
| json-schema | `additionalProperties: false`, so a validator rejects rather than trims |
| **arktype 2.2.3** | **key left in place** |

arktype is a real finding, pinned by an assertion so a change reads as a change. It is arktype's undeclared-key policy rather than anything DRZL sets; making it strip needs `onUndeclaredKey: 'delete'`, a behaviour change for every existing user. Documented, not built.

"Absent from the emitted text" and "absent from the parsed value" are different claims, and the docs now make the second.

## Gate

`verify:packed` green, `scripts/verify-packed.sh` untouched. It covers one thing here: the documented `columns` config parses off the **published** `dist/config.d.ts`, generates against the packed tarballs, and typechecks under bundler/node16/nodenext.

Three additions I would want, each with the reason it is not already covered:

1. **Assert the column is actually gone** in the doc-config stage: two greps. Today the stage checks only the exit code and `tsc`, so if `columns` were silently dropped by the config parser it would still pass — the exact defect class this file's own comments record twice (`coerceDates`, `databaseInjection`).
2. **One refusal probe**: an `omit` naming a nonexistent column must exit non-zero and write nothing. The strictness *is* the feature, and a regression turning it back into a no-op leaves every other check green.
3. **A parse-level probe** pushing a row carrying the omitted column through the packed generators, recording which libraries strip the key. It differs by library and can drift under a validator bump.

## Not built

- **arktype leaving the key in place**: fixable only as a behaviour change for existing users.
- **`doctor` ignores both config filters** — it honours no narrowing today, not even `include`/`exclude`. Fixing that means deciding whether `doctor --strict` should pass because you excluded the offending table, which is a security-relevant change to a CI gate and its own work.
- Entry ordering relies on JS object key order; deterministic for ordinary names, noted rather than hidden.

## Tests

Written first: with the module absent, 0 of 31 ran; reduced to a pass-through, **35 failed / 7 passed of 42**. Green at 42 (31 unit + 11 e2e). Real CLI runs of both failure paths confirmed: two typos produce both errors in one message and exit 1.

`build`, `-r test`, `typecheck`, `lint`, `docs build`, `verify:packed` all green.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
