### PR TITLE
feat(analyzer): address a table by its schema, and stop two names colliding

### DIFF
--- a/.changeset/multi-schema.md
+++ b/.changeset/multi-schema.md
@@ -1,0 +1,87 @@
+---
+'@drzl/analyzer': minor
+'@drzl/validation-core': minor
+'@drzl/generator-json-schema': minor
+'@drzl/generator-orpc': patch
+'@drzl/cli': minor
+---
+
+Multi-schema support: two tables of the same name in different Postgres schemas, addressed and
+generated end to end.
+
+`pgSchema('reporting').table('users', ...)` and `pgTable('users', ...)` are two different relations
+that share one database name. The analyzer already recorded which schema each was declared in, and
+nothing downstream read it, so every surface that addresses a table by name treated the two as one.
+
+What was measured, rather than assumed, before any of this was written:
+
+- **File names, export names, the barrel, the service and router files never collided.** All of them
+  are derived from the Drizzle _export_ name, which is unique within a module by construction, so
+  `users.zod.ts` and `reportingUsers.zod.ts` sat side by side and the barrel was already valid. That
+  is now pinned by a test rather than left to hold by accident.
+- **The OpenAPI document refused to build at all.** Both tables wanted `/users`, and the path guard
+  threw rather than let one silently overwrite the other. It was right to.
+- **The config filters over-matched in silence.** `exclude: ['users']` took both, and
+  `columns: { users: { ... } }` narrowed both.
+- **Foreign keys could not say which schema they pointed into.** A key to `reporting.users` and a
+  key to `public.users` both recorded `foreignTable: 'users'`, so anything resolving one back to a
+  table object got whichever it happened to see first.
+
+### Addressing one schema from a config
+
+`include`, `exclude` and the `columns` keys now match a schema-qualified name as well as the bare
+one:
+
+```ts
+export default defineConfig({
+  schema: 'src/db/schema.ts',
+  exclude: ['reporting.*'],
+  columns: {
+    'public.users': { omit: ['passwordHash'] },
+  },
+  generators: [{ kind: 'zod' }, { kind: 'json-schema', document: true }],
+});
+```
+
+- **A bare pattern still matches in every schema.** `exclude: ['users']` written before a
+  `reporting` schema existed means "the users tables", and narrowing it to one of them would start
+  generating an endpoint the config had already turned off. When a bare pattern really does reach
+  two schemas, DRZL now says so and names the qualified spellings. A warning and not an error,
+  because it has to keep parsing a config that works, and because the direction `exclude` takes is
+  the safe one anyway. It matters most for `columns`, where a column pattern only has to match in
+  one of the tables its entry matched: `columns: { users: { pick: ['id', 'email'] } }` narrows both
+  tables and the one with no `email` silently keeps only `id`, with no typo for the existing check
+  to report.
+- **`public.` is the spelling for the default schema.** Not an arbitrary choice: Drizzle refuses
+  `pgSchema('public')` outright, so a plain `pgTable` is the only way to declare a table there and
+  an absent schema _is_ `public`. `public.users` therefore names exactly one table, and no analysis
+  can ever contradict it by carrying `schema: 'public'`.
+- **`*` works on either side of the dot**, so `reporting.*` is a schema and `*.users` is every
+  `users`.
+
+### What else follows the schema now
+
+- `Table.schema` is documented as the fact everything reads, and `qualifiedTableName` is exported
+  so one function decides what a qualified name looks like.
+- `ForeignKey.foreignSchema` and `Column.references.schema` are new, so a key states which schema it
+  points into. `Relation.from`, `.to` and `.via` are qualified names, and the nested-schema planner
+  and the oRPC relation procedures resolve them qualified. On a schema that calls no `pgSchema` a
+  qualified name is the bare name, so every one of these is byte for byte what it was.
+- The OpenAPI document gives a schema-qualified table its own path, `/reporting/users`, and its own
+  tag. A table in the default schema keeps the bare `/users`. The duplicate-path guard stays: it
+  still catches two exports of one table name in one schema, which Drizzle allows.
+- The `.meta()` facts carry `schema` beside `table`, added rather than folded in, so existing
+  emitted metadata is unchanged and a consumer can still tell `reporting.users` from `public.users`.
+
+### Fixed along the way
+
+Relations declared with `defineRelations` named their target by its **key in the schema object**
+rather than by its table name, while the other end of the same relation was a table name. Every
+consumer resolves those strings against `Table.name`, so for any export whose name differs from its
+table's, `export const reportingUsers = reporting.table('users', ...)` being the obvious case, the
+relation was dropped in silence and no nested schema or relation procedure was emitted for it. Both
+ends are now read off the table object Drizzle already provides.
+
+Verified end to end: a project generated from a schema holding `public.users`, `reporting.users` and
+a child in each is compiled with `tsc --strict` under `nodenext`, with a probe that imports both
+`users` schemas through the barrel at once and reads a field only one of them has.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -34,7 +34,7 @@ export default defineConfig({
 });
 ```
 
-Two things are deliberately *not* written twice here.
+Two things are deliberately _not_ written twice here.
 
 `servicesDir` is derived from the `service` generator's `path`, so naming it on the router as well
 is how the two drift apart.
@@ -92,6 +92,61 @@ Matching is on the **database table name**, anchored, with `*` as the only metac
 Anchored matters: `exclude: ['user']` does not also drop `users`. `exclude` is applied after
 `include`, so it wins when both name the same table.
 
+### Tables in a Postgres schema
+
+Postgres puts every table in a schema, and `pgSchema('reporting').table('users', ...)` gives you a
+second table called `users`. A pattern therefore matches on two names, and you pick which one you
+mean:
+
+```ts
+import { pgTable, pgSchema, integer, text } from 'drizzle-orm/pg-core';
+
+export const reporting = pgSchema('reporting');
+
+export const users = pgTable('users', {
+  id: integer('id').primaryKey(),
+  email: text('email').notNull(),
+});
+
+export const reportingUsers = reporting.table('users', {
+  id: integer('id').primaryKey(),
+  label: text('label').notNull(),
+});
+```
+
+```ts
+export default defineConfig({
+  schema: 'src/db/schema.ts',
+  // Every schema's `users`, which is what a bare name has always meant.
+  exclude: ['users'],
+  // Just the one in `reporting`.
+  // exclude: ['reporting.users'],
+  // The whole `reporting` schema.
+  // exclude: ['reporting.*'],
+  // Just the default schema's, which is what `pgTable` declares.
+  // exclude: ['public.users'],
+  generators: [{ kind: 'orpc' }],
+});
+```
+
+- **A bare pattern matches in every schema.** `exclude: ['users']` written before `reporting`
+  existed means "the users tables", and quietly narrowing it to one of them would start generating
+  an endpoint the config had already turned off. When a bare pattern really does reach two schemas,
+  DRZL says so on stderr and names the qualified spellings, because that is nearly always a pattern
+  written before the second schema existed.
+- **`public.` is how you name the default schema.** Drizzle refuses `pgSchema('public')` outright,
+  with "Postgres is using public schema by default", so a table declared with plain `pgTable` is the
+  only spelling of a table in `public` and `public.users` is how a config addresses it.
+- **`*` works on either side of the dot**, so `reporting.*` is a whole schema and `*.users` is every
+  `users` there is.
+
+Everything else follows the schema too. Emitted file names and exported schema names come from the
+Drizzle **export** name, which is unique per module, so `users` and `reportingUsers` never collided
+and still do not. The OpenAPI document gives a qualified table its own path, `/reporting/users`,
+while a table in the default schema keeps the bare `/users` it has always had. Relations, including
+the foreign keys behind nested schemas, follow the key into its own schema rather than into a
+same-named table in another one.
+
 ### Auth tables in particular
 
 If you use an auth library that writes into the same schema file, exclude its credential tables.
@@ -106,12 +161,12 @@ exclude: ['session', 'account', 'verification'],
 DRZL deliberately does not detect auth libraries and skip their tables for you. Better Auth's
 model names are all overridable through `options.user.modelName`, so a built-in list would miss
 renamed tables, and worse, would silently skip an ordinary table called `user`, which in most
-applications is the primary entity you *do* want generated.
+applications is the primary entity you _do_ want generated.
 
 ## Choosing which columns to generate for
 
 `include` and `exclude` are all or nothing per table, and the column you do not want in a generated
-schema is usually sitting in a table you *do* want: a `passwordHash` on `users`, an internal note
+schema is usually sitting in a table you _do_ want: a `passwordHash` on `users`, an internal note
 beside the public fields, a `tenantId` your server sets from the session. `columns` narrows a table
 without dropping it:
 
@@ -126,8 +181,24 @@ columns: {
 ```
 
 The key is a **table** pattern in the same language `include`/`exclude` uses: the database table
-name, anchored, with `*` as the only metacharacter. Column patterns are that language again, so
-`omit: ['*At']` drops `createdAt` and `updatedAt` and `omit: ['bio']` does not also drop `bios`.
+name, anchored, with `*` as the only metacharacter, and the schema-qualified name too. Column
+patterns are that language again, so `omit: ['*At']` drops `createdAt` and `updatedAt` and
+`omit: ['bio']` does not also drop `bios`.
+
+```ts
+columns: {
+  // Only the users table in the default schema.
+  'public.users': { omit: ['passwordHash'] },
+  // Every table in the reporting schema.
+  'reporting.*': { omit: ['internal_note'] },
+},
+```
+
+A bare key reaches every schema, exactly as `include` and `exclude` do, and DRZL warns when one
+really does. That warning is worth reading here in particular: a column pattern only has to match
+in **one** of the tables its entry matched, so `columns: { users: { pick: ['id', 'email'] } }`
+against two same-named tables narrows both and the one without an `email` silently loses every
+column but `id`, with no typo to report.
 
 Every matching entry applies, in the order it is written. Within one entry `pick` runs first and
 `omit` then removes, so `omit` wins where both name the same column. That is the same precedence
@@ -161,17 +232,17 @@ effect disappears in half the generated tree is worse than one that is not offer
 
 ### What it does not do
 
-The schema stops *describing* the column. Whether a value carrying it survives a `parse` is then the
+The schema stops _describing_ the column. Whether a value carrying it survives a `parse` is then the
 validator's own policy about undeclared keys, and they do not agree. Measured:
 
-| Generator | A row carrying the omitted column |
-| --- | --- |
-| zod 4.4.3 | key stripped from the parsed result |
-| valibot 1.4.2 | key stripped |
+| Generator       | A row carrying the omitted column                                            |
+| --------------- | ---------------------------------------------------------------------------- |
+| zod 4.4.3       | key stripped from the parsed result                                          |
+| valibot 1.4.2   | key stripped                                                                 |
 | TypeBox 0.34.52 | `Value.Parse` and `Value.Clean` strip it; `Value.Check` alone returns `true` |
-| Effect 3.22.1 | key stripped by `decodeUnknownSync` |
-| arktype 2.2.3 | key left in place |
-| json-schema | `additionalProperties: false`, so a validator rejects the payload |
+| Effect 3.22.1   | key stripped by `decodeUnknownSync`                                          |
+| arktype 2.2.3   | key left in place                                                            |
+| json-schema     | `additionalProperties: false`, so a validator rejects the payload            |
 
 If you are relying on a parse to strip a secret rather than on never selecting it, check which of
 those you are using.
@@ -194,8 +265,8 @@ payload that is not a complete row, so whatever calls db.insert has to supply "t
 itself.
 ```
 
-That is a real hazard and also the normal multi-tenant shape: an insert schema describes a *request
-body*, not a row, and the server fills in the rest. Refusing it would remove one of the two things
+That is a real hazard and also the normal multi-tenant shape: an insert schema describes a _request
+body_, not a row, and the server fills in the rest. Refusing it would remove one of the two things
 this option is for. A CHECK constraint naming a column you omitted also warns, because nothing DRZL
 emits can enforce it any more, though your database still does.
 
@@ -260,15 +331,9 @@ it out keeps the names above unchanged.
 That config emits:
 
 ```ts
-export const InsertUserProfilesSchema = z.object({
-  /* ... */
-});
-export const UpdateUserProfilesSchema = z.object({
-  /* ... */
-});
-export const SelectUserProfilesSchema = z.object({
-  /* ... */
-});
+export const InsertUserProfilesSchema = z.object({/* ... */});
+export const UpdateUserProfilesSchema = z.object({/* ... */});
+export const SelectUserProfilesSchema = z.object({/* ... */});
 
 export type CreateUserProfilesInput = z.input<typeof InsertUserProfilesSchema>;
 export type EditUserProfilesInput = z.input<typeof UpdateUserProfilesSchema>;

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -41,11 +41,22 @@ export interface ColumnRef {
   column: string;
 }
 
+/**
+ * A link between two tables, each end named by `qualifiedTableName`.
+ *
+ * Qualified rather than bare, because a bare database name identifies a table only while no two
+ * SQL schemas hold it: `to: 'users'` cannot say whether it means `public.users` or
+ * `reporting.users`, and every consumer resolves these strings back to a table object. A table in
+ * the default schema has no prefix, so nothing about a single-schema analysis changes.
+ */
 export interface Relation {
   kind: 'one' | 'many' | 'manyToMany';
-  from: string; // table name
-  to: string; // table name
-  via?: string; // join table name for m2m
+  /** Qualified table name: `users`, or `reporting.users`. */
+  from: string;
+  /** Qualified table name: `users`, or `reporting.users`. */
+  to: string;
+  /** Qualified name of the join table, for m2m. */
+  via?: string;
 }
 
 export interface Column {
@@ -84,7 +95,14 @@ export interface Column {
   hasDefault: boolean;
   isGenerated: boolean;
   defaultExpression?: string;
-  references?: { table: string; column: string; onDelete?: string; onUpdate?: string };
+  references?: {
+    table: string;
+    /** SQL schema of the referenced table, absent for the default one. See `ForeignKey`. */
+    schema?: string;
+    column: string;
+    onDelete?: string;
+    onUpdate?: string;
+  };
   enumValues?: string[];
 
   /**
@@ -313,6 +331,17 @@ export interface ForeignKey {
   name?: string;
   columns: string[];
   foreignTable: string;
+  /**
+   * The SQL schema the referenced table lives in, absent for the default one, exactly as
+   * `Table.schema` is.
+   *
+   * `foreignTable` is a bare database name and Postgres lets two schemas hold the same one, so a
+   * key pointing at `reporting.users` recorded the identical string a key pointing at
+   * `public.users` records. Every consumer that resolves a key back to a table object did so by
+   * that string, and therefore resolved to whichever of the two it saw first. Use
+   * `qualifiedForeignTable` rather than reading the two fields apart.
+   */
+  foreignSchema?: string;
   foreignColumns: string[];
   onDelete?: string;
   onUpdate?: string;
@@ -321,6 +350,15 @@ export interface ForeignKey {
 export interface Table {
   name: string;
   tsName: string;
+  /**
+   * The SQL schema the table was declared in, from `pgSchema('reporting').table(...)` and the
+   * MySQL and SingleStore equivalents. Absent for a table declared with plain `pgTable`, which is
+   * the only spelling of the default schema there is: Drizzle refuses `pgSchema('public')`
+   * outright, with "Postgres is using public schema by default".
+   *
+   * `name` stays bare, so two tables in two schemas share one. `qualifiedTableName` is what tells
+   * them apart, and is what every name-addressed surface in DRZL matches against.
+   */
   schema?: string;
   columns: Column[];
   primaryKey?: Key;
@@ -340,6 +378,31 @@ export interface Table {
 export interface Enum {
   name: string;
   values: string[];
+}
+
+/**
+ * The one name that identifies a table across every SQL schema in an analysis.
+ *
+ * `reporting.users` where the table names a schema, and the bare `users` where it does not. The
+ * bare form for the default schema is deliberate and is what makes this safe to reach for
+ * everywhere: on a schema module that never calls `pgSchema`, and that is nearly all of them, this
+ * returns exactly `table.name`, so every file name, every export, every config pattern and every
+ * emitted path is byte for byte what it was.
+ *
+ * `public.users` is not produced here. Drizzle refuses `pgSchema('public')`, so no analysis can
+ * ever carry `schema: 'public'`, and a table with no schema *is* the public one. `public.` exists
+ * only as a spelling a config may use, resolved by `@drzl/cli`.
+ */
+export function qualifiedTableName(table: { name: string; schema?: string }): string {
+  return table.schema ? `${table.schema}.${table.name}` : table.name;
+}
+
+/** The same name, for the far end of a foreign key. */
+export function qualifiedForeignTable(fk: {
+  foreignTable: string;
+  foreignSchema?: string;
+}): string {
+  return fk.foreignSchema ? `${fk.foreignSchema}.${fk.foreignTable}` : fk.foreignTable;
 }
 
 export interface Analysis {
@@ -1269,6 +1332,20 @@ export function isRelationsV2(val: any): boolean {
 }
 
 /**
+ * The qualified name of a Drizzle table object, or `undefined` when it is not one.
+ *
+ * Both halves come off the same object, which is the only place they agree: reading
+ * `drizzle:Name` alone gives a bare name that two SQL schemas can both answer to, and a relation
+ * built from it names a table rather than *the* table.
+ */
+function qualifiedNameOfDrizzleTable(tbl: unknown): string | undefined {
+  const name = getSymbolOf(tbl, 'drizzle:Name');
+  if (typeof name !== 'string' || !name) return undefined;
+  const schema = getSymbolOf(tbl, 'drizzle:Schema');
+  return typeof schema === 'string' && schema ? `${schema}.${name}` : name;
+}
+
+/**
  * Read the relations declared by `defineRelations`.
  *
  * Simpler than the v1 reader, which has to invoke a callback with a stand-in builder to find
@@ -1280,9 +1357,16 @@ export function isRelationsV2(val: any): boolean {
 export function readRelationsV2(val: any, issues: Issue[] = []): Relation[] {
   const out: Relation[] = [];
   for (const [tableKey, entry] of Object.entries<any>(val)) {
-    const from = (getSymbolOf(entry.table, 'drizzle:Name') as string) ?? entry.name ?? tableKey;
+    const from = qualifiedNameOfDrizzleTable(entry.table) ?? entry.name ?? tableKey;
     for (const [fieldName, r] of Object.entries<any>(entry.relations ?? {})) {
-      const to = r?.targetTableName;
+      // `targetTable` before `targetTableName`, because the two do not hold the same thing.
+      // Measured against drizzle-orm 1.0.0-rc.4: `targetTableName` is the *key* the table has in
+      // the object handed to `defineRelations`, so for `export const rUsers =
+      // reporting.table('users', ...)` it is `rUsers`, while the other end of this relation is a
+      // database name. Every consumer resolves `to` against `Table.name`, so the two never met
+      // and the arm was dropped in silence for any export whose name differs from its table's.
+      // The object states the database name and the schema, which is what is wanted at both ends.
+      const to = qualifiedNameOfDrizzleTable(r?.targetTable) ?? r?.targetTableName;
       if (typeof to !== 'string' || !to) {
         issues.push({
           code: 'DRZL_ANL_REL_V2',
@@ -1294,8 +1378,8 @@ export function readRelationsV2(val: any, issues: Issue[] = []): Relation[] {
       }
       // `through` is the join table of a many-to-many, which v1 leaves to a heuristic.
       const via =
-        (getSymbolOf(r.throughTable, 'drizzle:Name') as string) ??
-        (getSymbolOf(r.through?.sourceTable, 'drizzle:Name') as string) ??
+        qualifiedNameOfDrizzleTable(r.throughTable) ??
+        qualifiedNameOfDrizzleTable(r.through?.sourceTable) ??
         undefined;
       if (via) out.push({ kind: 'manyToMany', from, to, via });
       else out.push({ kind: r.relationType === 'many' ? 'many' : 'one', from, to });
@@ -1443,9 +1527,14 @@ export class SchemaAnalyzer {
     const foreignColumnsObj = this.getSymbol(ref.foreignTable, 'drizzle:Columns') ?? {};
     const toForeignTs = this.dbToTsNames(foreignColumnsObj);
 
+    // Read off the referenced table itself, the same way the referencing table reads its own.
+    // Without it the key states a bare name, which two schemas can both answer to.
+    const foreignSchema = this.getSymbol(ref.foreignTable, 'drizzle:Schema') as string | undefined;
+
     return {
       columns: (ref.columns ?? []).map((c: any) => toTs(c?.name)),
       foreignTable: (this.getSymbol(ref.foreignTable, 'drizzle:Name') as string) ?? 'unknown',
+      ...(foreignSchema ? { foreignSchema } : {}),
       foreignColumns: (ref.foreignColumns ?? []).map((c: any) => toForeignTs(c?.name)),
       onDelete: action(fk?.onDelete, fk?._onDelete),
       onUpdate: action(fk?.onUpdate, fk?._onUpdate),
@@ -1512,7 +1601,7 @@ export class SchemaAnalyzer {
    * on each returned value, so the stand-in results must carry that method or the call throws.
    */
   private readRelationsObject(val: any, exportName: string, issues: Issue[]): Relation[] {
-    const from = (this.getSymbol(val.table, 'drizzle:Name') as string) ?? exportName;
+    const from = qualifiedNameOfDrizzleTable(val.table) ?? exportName;
     const make = (kind: 'one' | 'many') => (table: any, cfg: any) => ({
       kind,
       referencedTable: table,
@@ -1527,7 +1616,7 @@ export class SchemaAnalyzer {
       const built = val.config({ one: make('one'), many: make('many') });
       const out: Relation[] = [];
       for (const rel of Object.values(built ?? {}) as any[]) {
-        const to = this.getSymbol(rel?.referencedTable, 'drizzle:Name') as string | undefined;
+        const to = qualifiedNameOfDrizzleTable(rel?.referencedTable);
         if (to) out.push({ kind: rel.kind, from, to });
       }
       return out;
@@ -1558,10 +1647,11 @@ export class SchemaAnalyzer {
       if (fks.length < 2) continue;
       const fkCols = new Set(fks.flatMap((f) => f.columns));
       if (!t.columns.every((c) => fkCols.has(c.name))) continue;
-      const targets = [...new Set(fks.map((f) => f.foreignTable))];
+      const targets = [...new Set(fks.map(qualifiedForeignTable))];
       if (targets.length !== 2) continue;
-      out.push({ kind: 'manyToMany', from: targets[0], to: targets[1], via: t.name });
-      out.push({ kind: 'manyToMany', from: targets[1], to: targets[0], via: t.name });
+      const via = qualifiedTableName(t);
+      out.push({ kind: 'manyToMany', from: targets[0], to: targets[1], via });
+      out.push({ kind: 'manyToMany', from: targets[1], to: targets[0], via });
     }
     return out;
   }
@@ -2508,6 +2598,7 @@ export class SchemaAnalyzer {
       if (!col) continue;
       col.references = {
         table: fk.foreignTable,
+        ...(fk.foreignSchema ? { schema: fk.foreignSchema } : {}),
         column: fk.foreignColumns[0],
         onDelete: fk.onDelete,
         onUpdate: fk.onUpdate,
@@ -2611,10 +2702,18 @@ export class SchemaAnalyzer {
 
           // A foreign key is a relation in both directions: the child has one parent, and
           // the parent has many children. Generators need both to emit nested endpoints.
+          //
+          // Both ends are named by `qualifiedTableName`, not by the bare database name. Two
+          // tables in two schemas share a bare name, so `to: 'users'` from a key that really
+          // points at `reporting.users` is a relation a consumer resolves against whichever of
+          // the two it finds first. On a schema that calls no `pgSchema`, which is nearly all of
+          // them, the qualified name *is* the bare name and nothing about this changes.
           if (opts.includeRelations) {
+            const self = qualifiedTableName(table);
             for (const fk of table.foreignKeys ?? []) {
-              relations.push({ kind: 'one', from: table.name, to: fk.foreignTable });
-              relations.push({ kind: 'many', from: fk.foreignTable, to: table.name });
+              const target = qualifiedForeignTable(fk);
+              relations.push({ kind: 'one', from: self, to: target });
+              relations.push({ kind: 'many', from: target, to: self });
             }
           }
         } else if (this.isRelationsObject(val)) {
@@ -2737,11 +2836,26 @@ export class SchemaAnalyzer {
     // Name-based guessing, off by default. It only fires for columns that carry no real
     // foreign key, so a schema with proper constraints is never second-guessed by a heuristic.
     if (opts.includeRelations && opts.includeHeuristicRelations) {
-      const tableNames = new Set(tables.map((t) => t.name));
-      const findTarget = (base: string): string | undefined => {
-        if (tableNames.has(base)) return base;
-        if (tableNames.has(base + 's')) return base + 's';
-        if (tableNames.has(base + 'es')) return base + 'es';
+      // Every table that answers to a given bare name. More than one means two SQL schemas hold
+      // it, and `authorId` says nothing about which was meant, so the guess is declined rather
+      // than made: a heuristic that picks the wrong schema is worse than one that stays quiet,
+      // and this whole block is already opt-in.
+      const byBareName = new Map<string, Table[]>();
+      for (const t of tables) {
+        const list = byBareName.get(t.name);
+        if (list) list.push(t);
+        else byBareName.set(t.name, [t]);
+      }
+      const findTarget = (base: string, from: Table): string | undefined => {
+        for (const candidate of [base, base + 's', base + 'es']) {
+          const hits = byBareName.get(candidate);
+          if (!hits?.length) continue;
+          // A table in the referencing table's own schema is the reading a person would take.
+          const sameSchema = hits.filter((t) => t.schema === from.schema);
+          if (sameSchema.length === 1) return qualifiedTableName(sameSchema[0]);
+          if (hits.length === 1) return qualifiedTableName(hits[0]);
+          return undefined;
+        }
         return undefined;
       };
       for (const t of tables) {
@@ -2749,8 +2863,8 @@ export class SchemaAnalyzer {
           if (c.references) continue;
           if (c.name.endsWith('Id')) {
             const base = c.name.slice(0, -2);
-            const target = findTarget(base);
-            if (target) relations.push({ kind: 'one', from: t.name, to: target });
+            const target = findTarget(base, t);
+            if (target) relations.push({ kind: 'one', from: qualifiedTableName(t), to: target });
           }
         }
       }

--- a/packages/analyzer/test/multi-schema.spec.ts
+++ b/packages/analyzer/test/multi-schema.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * Postgres puts a table in a schema, and two schemas may hold a table of the same name.
+ *
+ * `pgSchema('reporting').table('users', ...)` and `pgTable('users', ...)` are two different
+ * relations that share one `drizzle:Name`. The analyzer already read `drizzle:Schema` onto
+ * `Table.schema`, so the fact was recorded; nothing downstream read it, and every surface keyed on
+ * the bare name therefore treated the two as one. This pins the facts the rest of the repo now
+ * builds on.
+ *
+ * The foreign key half is the part that was genuinely lost rather than merely unread: a key
+ * pointing at `reporting.users` recorded `foreignTable: 'users'`, which is the same string a key
+ * pointing at `public.users` records, so a consumer resolving the target by name picked whichever
+ * table it happened to see first.
+ *
+ * Measured against real drizzle-orm, not a hand-built object: `pgSchema('public')` is what
+ * establishes that a bare `pgTable` is the only spelling of the default schema, and only the real
+ * builder throws on it.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer, qualifiedTableName } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function analyzeSource(name: string, source: string) {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  return new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({ includeRelations: true });
+}
+
+const SAME_NAME = `
+import { pgTable, pgSchema, integer, text } from 'drizzle-orm/pg-core';
+
+export const reporting = pgSchema('reporting');
+
+export const users = pgTable('users', {
+  id: integer('id').primaryKey(),
+  email: text('email').notNull(),
+});
+
+export const reportingUsers = reporting.table('users', {
+  id: integer('id').primaryKey(),
+  label: text('label').notNull(),
+});
+`;
+
+const CROSS_SCHEMA_FK = `
+import { pgTable, pgSchema, integer, text } from 'drizzle-orm/pg-core';
+
+export const reporting = pgSchema('reporting');
+
+export const users = pgTable('users', {
+  id: integer('id').primaryKey(),
+  email: text('email').notNull(),
+});
+
+export const reportingUsers = reporting.table('users', {
+  id: integer('id').primaryKey(),
+  label: text('label').notNull(),
+});
+
+export const reportingNotes = reporting.table('notes', {
+  id: integer('id').primaryKey(),
+  userId: integer('user_id').references(() => reportingUsers.id),
+});
+
+export const publicNotes = pgTable('notes_pub', {
+  id: integer('id').primaryKey(),
+  userId: integer('user_id').references(() => users.id),
+});
+`;
+
+describe('the schema a table lives in', () => {
+  it('is recorded, and is absent for a bare pgTable', async () => {
+    const a = await analyzeSource('multi-schema-same-name', SAME_NAME);
+    const byTs = Object.fromEntries(a.tables.map((t) => [t.tsName, t]));
+    expect(byTs.users.schema).toBeUndefined();
+    expect(byTs.reportingUsers.schema).toBe('reporting');
+  });
+
+  it('leaves the database name bare, so the two tables share one', async () => {
+    const a = await analyzeSource('multi-schema-same-name', SAME_NAME);
+    expect(a.tables.map((t) => t.name).sort()).toEqual(['users', 'users']);
+  });
+
+  it('is what distinguishes them, through the qualified name', async () => {
+    const a = await analyzeSource('multi-schema-same-name', SAME_NAME);
+    expect(a.tables.map(qualifiedTableName).sort()).toEqual(['reporting.users', 'users']);
+  });
+
+  it('reaches a view as well as a table', async () => {
+    const a = await analyzeSource(
+      'multi-schema-view',
+      SAME_NAME +
+        `\nexport const summary = reporting.view('user_summary').as((qb) => qb.select().from(reportingUsers));\n`
+    );
+    const view = a.tables.find((t) => t.tsName === 'summary');
+    expect(view?.schema).toBe('reporting');
+  });
+});
+
+/**
+ * The one question the config design turned on, and Drizzle answers it rather than DRZL.
+ *
+ * `pgSchema('public')` does not construct: Drizzle refuses the name outright. So there is exactly
+ * one spelling of a table in the default schema, `pgTable`, and `Table.schema` being absent *is*
+ * `public`. That is why the config's `public.` prefix is an alias DRZL defines rather than
+ * something read back off the schema module.
+ */
+describe('the default schema', () => {
+  it('cannot be named explicitly, so an absent schema is unambiguously public', async () => {
+    const a = await analyzeSource(
+      'multi-schema-explicit-public',
+      `
+import { pgSchema, integer } from 'drizzle-orm/pg-core';
+export const pub = pgSchema('public');
+export const widgets = pub.table('widgets', { id: integer('id').primaryKey() });
+`
+    );
+    expect(a.issues.map((i) => i.code)).toContain('DRZL_ANL_IMPORT');
+    expect(a.issues[0].message).toMatch(/public/);
+  });
+});
+
+describe('a foreign key across schemas', () => {
+  it('records the schema of the table it points at', async () => {
+    const a = await analyzeSource('multi-schema-fk', CROSS_SCHEMA_FK);
+    const byTs = Object.fromEntries(a.tables.map((t) => [t.tsName, t]));
+    expect(byTs.reportingNotes.foreignKeys?.[0]).toMatchObject({
+      foreignTable: 'users',
+      foreignSchema: 'reporting',
+    });
+    expect(byTs.publicNotes.foreignKeys?.[0]).toMatchObject({ foreignTable: 'users' });
+    expect(byTs.publicNotes.foreignKeys?.[0].foreignSchema).toBeUndefined();
+  });
+
+  it('mirrors it onto the column too', async () => {
+    const a = await analyzeSource('multi-schema-fk', CROSS_SCHEMA_FK);
+    const byTs = Object.fromEntries(a.tables.map((t) => [t.tsName, t]));
+    const col = byTs.reportingNotes.columns.find((c) => c.name === 'userId');
+    expect(col?.references).toMatchObject({ table: 'users', schema: 'reporting', column: 'id' });
+  });
+
+  it('names both ends of the derived relation by their qualified name', async () => {
+    const a = await analyzeSource('multi-schema-fk', CROSS_SCHEMA_FK);
+    const one = a.relations.filter((r) => r.kind === 'one');
+    expect(one).toContainEqual({ kind: 'one', from: 'reporting.notes', to: 'reporting.users' });
+    expect(one).toContainEqual({ kind: 'one', from: 'notes_pub', to: 'users' });
+    // The wrong pairing is the one that existed before: reporting.notes -> public.users.
+    expect(one).not.toContainEqual({ kind: 'one', from: 'reporting.notes', to: 'users' });
+  });
+});
+
+/**
+ * Relations v2 named its target by the wrong thing entirely, and a schema-qualified export is
+ * where that becomes visible.
+ *
+ * `targetTableName` is the *key* the table has in the object handed to `defineRelations`, measured
+ * against drizzle-orm 1.0.0-rc.4: for `export const reportingUsers = reporting.table('users', ...)`
+ * it is `reportingUsers`, while the `from` end of the same relation was a database name. Every
+ * consumer resolves both against `Table.name`, so the arm was dropped in silence for any export
+ * whose name differs from its table's. The descriptor also carries `targetTable`, which is the
+ * table object and states the name and the schema.
+ */
+describe('relations declared with defineRelations', () => {
+  it('names its target by table and schema, not by the export key', async () => {
+    const a = await analyzeSource(
+      'multi-schema-v2',
+      `
+import { pgTable, pgSchema, integer } from 'drizzle-orm-v1/pg-core';
+import { defineRelations } from 'drizzle-orm-v1';
+
+const reporting = pgSchema('reporting');
+export const users = pgTable('users', { id: integer('id').primaryKey() });
+export const reportingUsers = reporting.table('users', { id: integer('id').primaryKey() });
+export const reportingNotes = reporting.table('notes', {
+  id: integer('id').primaryKey(),
+  userId: integer('user_id'),
+});
+
+export const relations = defineRelations(
+  { users, reportingUsers, reportingNotes },
+  (r) => ({
+    reportingNotes: {
+      author: r.one.reportingUsers({ from: r.reportingNotes.userId, to: r.reportingUsers.id }),
+    },
+    reportingUsers: { notes: r.many.reportingNotes() },
+  })
+);
+`
+    );
+    expect(a.issues.filter((i) => i.level === 'error')).toEqual([]);
+    expect(a.relations).toContainEqual({
+      kind: 'one',
+      from: 'reporting.notes',
+      to: 'reporting.users',
+    });
+    expect(a.relations).toContainEqual({
+      kind: 'many',
+      from: 'reporting.users',
+      to: 'reporting.notes',
+    });
+    // The export key, which is what it used to say and what nothing could resolve.
+    expect(a.relations.map((r) => r.to)).not.toContain('reportingUsers');
+  });
+});
+
+describe('qualifiedTableName', () => {
+  it('leaves a table with no schema exactly as it was', () => {
+    expect(qualifiedTableName({ name: 'users' })).toBe('users');
+  });
+
+  it('prefixes a schema with a dot', () => {
+    expect(qualifiedTableName({ name: 'users', schema: 'reporting' })).toBe('reporting.users');
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,6 +16,7 @@ import {
   DrzlConfig,
   filterTables,
   loadConfig,
+  tableFilterWarnings,
 } from './config.js';
 import { filterColumns } from './column-filter.js';
 import { buildDoctorReport, renderDoctorReport } from './doctor.js';
@@ -196,8 +197,11 @@ program
       // drops whole tables, but only this one lets a `columns` entry name a table that `exclude`
       // also removes without that reading as a typo, and a typo is refused.
       const narrowed = filterColumns(analysis.tables, cfg.columns);
+      // Before the filter runs, so the tables it reports on are the ones the pattern really
+      // reached rather than what survived it.
+      const filterWarnings = tableFilterWarnings(narrowed.tables, cfg);
       analysis.tables = filterTables(narrowed.tables, cfg);
-      for (const w of narrowed.warnings) console.warn(chalk.yellow(w));
+      for (const w of [...narrowed.warnings, ...filterWarnings]) console.warn(chalk.yellow(w));
       reportWideColumns(analysis.issues);
       // Under --check the existing output is captured before anything overwrites it, so the
       // regenerated result can be compared against it and the tree put back either way.
@@ -635,8 +639,10 @@ program
         // column that does not exist throws here, and `run`'s own catch reports it and keeps
         // watching, so the next save can fix it.
         const narrowed = filterColumns(analysis.tables, cfg.columns);
+        const filterWarnings = tableFilterWarnings(narrowed.tables, cfg);
         analysis.tables = filterTables(narrowed.tables, cfg);
-        if (!opts.json) for (const w of narrowed.warnings) console.warn(chalk.yellow(w));
+        if (!opts.json)
+          for (const w of [...narrowed.warnings, ...filterWarnings]) console.warn(chalk.yellow(w));
         if (!opts.json) reportWideColumns(analysis.issues);
 
         if (opts.pipeline === 'analyze') {

--- a/packages/cli/src/column-filter.ts
+++ b/packages/cli/src/column-filter.ts
@@ -41,7 +41,14 @@
 import type { Table } from '@drzl/analyzer';
 import { parseCheck } from '@drzl/validation-core';
 import { namedColumns } from './doctor.js';
-import { matchesAny } from './patterns.js';
+import {
+  addressableName,
+  ambiguousPatternWarnings,
+  displayTableName,
+  hasNamedSchemas,
+  matchesAny,
+  matchesTable,
+} from './patterns.js';
 
 /** What to do with one table's columns. Both are patterns, in the language `patterns.ts` defines. */
 export interface ColumnRules {
@@ -51,7 +58,11 @@ export interface ColumnRules {
   pick?: string[];
 }
 
-/** Keyed by table pattern, matched against the database table name exactly as `include` is. */
+/**
+ * Keyed by table pattern, matched against the database table name exactly as `include` is, and
+ * against the schema-qualified name too: `reporting.users` names one of two same-named tables and
+ * `reporting.*` names a whole schema.
+ */
 export type ColumnFilter = Record<string, ColumnRules>;
 
 export interface ColumnFilterResult {
@@ -84,6 +95,9 @@ export function filterColumns(tables: Table[], spec: ColumnFilter | undefined): 
 
   const errors: string[] = [];
   const warnings: string[] = [];
+  // Only where the analysis really has more than one schema. A project with one has no `public.`
+  // to write, so offering it as the spelling to copy names something its schema file never says.
+  const nameForConfig = hasNamedSchemas(tables) ? addressableName : displayTableName;
 
   /**
    * Every pattern has to name something that exists.
@@ -98,11 +112,11 @@ export function filterColumns(tables: Table[], spec: ColumnFilter | undefined): 
    * `deleted_at` from every `app_*` table that has one is the main thing a wildcard key is for.
    */
   for (const [tablePattern, rules] of entries) {
-    const matched = tables.filter((t) => matchesAny([tablePattern], t.name));
+    const matched = tables.filter((t) => matchesTable([tablePattern], t));
     if (!matched.length) {
       errors.push(
         `columns[${JSON.stringify(tablePattern)}] matches no table. ` +
-          `The schema declares: ${tables.map((t) => t.name).join(', ') || '(no tables)'}.`
+          `The schema declares: ${tables.map(nameForConfig).join(', ') || '(no tables)'}.`
       );
       continue;
     }
@@ -112,15 +126,25 @@ export function filterColumns(tables: Table[], spec: ColumnFilter | undefined): 
         if (available.some((name) => matchesAny([pattern], name))) continue;
         errors.push(
           `columns[${JSON.stringify(tablePattern)}].${which} names ${JSON.stringify(pattern)}, ` +
-            `which matches no column of ${matched.map((t) => t.name).join(', ')}. ` +
+            `which matches no column of ${matched.map(nameForConfig).join(', ')}. ` +
             `Available: ${available.join(', ')}.`
         );
       }
     }
   }
 
+  // Said once per pattern, before anything is narrowed, because the consequence is that the rules
+  // below run over more tables than the writer had in mind and every one of them is a real table.
+  warnings.push(
+    ...ambiguousPatternWarnings(
+      entries.map(([p]) => p),
+      tables,
+      'columns'
+    )
+  );
+
   const out = tables.map((table) => {
-    const mine = entries.filter(([pattern]) => matchesAny([pattern], table.name));
+    const mine = entries.filter(([pattern]) => matchesTable([pattern], table));
     if (!mine.length) return table;
 
     // Applied in the order the entries are written, so a reader works down the config the way they
@@ -139,7 +163,7 @@ export function filterColumns(tables: Table[], spec: ColumnFilter | undefined): 
 
     if (!keep.length) {
       errors.push(
-        `columns leaves table "${table.name}" with no columns at all. An empty schema describes ` +
+        `columns leaves table "${displayTableName(table)}" with no columns at all. An empty schema describes ` +
           `no row, so this is never a narrower API. Exclude the table instead, with the top-level ` +
           `"exclude" option.`
       );
@@ -167,7 +191,7 @@ export function filterColumns(tables: Table[], spec: ColumnFilter | undefined): 
     if (lostKey.length) {
       errors.push(
         `columns drops ${lostKey.map((n) => JSON.stringify(n)).join(', ')} from table ` +
-          `"${table.name}", which is part of its primary key ` +
+          `"${displayTableName(table)}", which is part of its primary key ` +
           `(${table.primaryKey?.columns.join(', ')}). The generated getById, update and delete ` +
           `address rows by that key, so the emitted schemas would describe a row nothing can ` +
           `address. Keep the key, or leave the whole table out with the top-level "exclude" option.`
@@ -191,7 +215,7 @@ export function filterColumns(tables: Table[], spec: ColumnFilter | undefined): 
     for (const c of dropped) {
       if (c.nullable || c.hasDefault || c.isGenerated || table.readOnly) continue;
       warnings.push(
-        `drzl config: the "columns" option drops "${c.name}" from table "${table.name}", and the ` +
+        `drzl config: the "columns" option drops "${c.name}" from table "${displayTableName(table)}", and the ` +
           `database requires it: NOT NULL with no default. The emitted insert schema therefore ` +
           `describes a payload that is not a complete row, so whatever calls db.insert has to ` +
           `supply "${c.name}" itself.`
@@ -211,7 +235,7 @@ export function filterColumns(tables: Table[], spec: ColumnFilter | undefined): 
       );
       if (!lost.length) continue;
       warnings.push(
-        `drzl config: CHECK ${k.name ? `"${k.name}"` : '(unnamed)'} on table "${table.name}" ` +
+        `drzl config: CHECK ${k.name ? `"${k.name}"` : '(unnamed)'} on table "${displayTableName(table)}" ` +
           `names ${lost.map((n) => JSON.stringify(n)).join(', ')}, which the "columns" option ` +
           `drops, so nothing DRZL emits enforces it. Your database still does.`
       );

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -12,7 +12,7 @@ import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { z } from 'zod';
-import { matchesAny } from './patterns.js';
+import { ambiguousPatternWarnings, matchesTable } from './patterns.js';
 
 export const NamingSchema = z
   .object({
@@ -702,15 +702,34 @@ export function resolveTemplateDirsSync(cfg: DrzlConfig, cwd = process.cwd()): s
  * Matching is on the database table name, anchored, with `*` as the only metacharacter. Anchored
  * matters: `user` must not also drop `users`, and a substring match would. `exclude` is applied
  * after `include`, so the safer direction wins when both name the same table.
+ *
+ * A table also answers to its schema-qualified name, so `reporting.users` addresses one of two
+ * same-named tables and `reporting.*` addresses a whole schema. See `tableAliases`.
  */
-export function filterTables<T extends { name: string }>(
+export function filterTables<T extends { name: string; schema?: string }>(
   tables: T[],
   opts: { include?: string[]; exclude?: string[] }
 ): T[] {
   let out = tables;
-  if (opts.include?.length) out = out.filter((t) => matchesAny(opts.include!, t.name));
-  if (opts.exclude?.length) out = out.filter((t) => !matchesAny(opts.exclude!, t.name));
+  if (opts.include?.length) out = out.filter((t) => matchesTable(opts.include!, t));
+  if (opts.exclude?.length) out = out.filter((t) => !matchesTable(opts.exclude!, t));
   return out;
+}
+
+/**
+ * What to warn about the table filter, before it is applied.
+ *
+ * Separate from `filterTables` so that returns a plain array, as every caller and every test
+ * already expects it to.
+ */
+export function tableFilterWarnings(
+  tables: readonly { name: string; schema?: string }[],
+  opts: { include?: string[]; exclude?: string[] }
+): string[] {
+  return [
+    ...ambiguousPatternWarnings(opts.include ?? [], tables, 'include'),
+    ...ambiguousPatternWarnings(opts.exclude ?? [], tables, 'exclude'),
+  ];
 }
 
 export function computeWatchTargets(cfg: DrzlConfig, cwd = process.cwd()): string[] {

--- a/packages/cli/src/patterns.ts
+++ b/packages/cli/src/patterns.ts
@@ -25,3 +25,105 @@ export function patternToRegExp(pattern: string): RegExp {
 export function matchesAny(patterns: string[], name: string): boolean {
   return patterns.some((p) => patternToRegExp(p).test(name));
 }
+
+/** The least a filter needs to know about a table. */
+export interface NamedTable {
+  name: string;
+  schema?: string;
+}
+
+/** How the default SQL schema is spelled in a config, since a table in it carries no name for it. */
+export const DEFAULT_SCHEMA_ALIAS = 'public';
+
+/**
+ * Every name a table answers to in a config pattern.
+ *
+ * A table states one name and lives in one schema, and Postgres lets two schemas hold the same
+ * name, so `users` alone stopped identifying a table the moment `pgSchema` entered the picture.
+ * Each table therefore answers to two:
+ *
+ *  - its bare database name, unchanged and listed first, so every pattern that matched before
+ *    matches now. That is not a compatibility gesture: `exclude: ['users']` written before a
+ *    `reporting` schema existed means "the users tables", and quietly narrowing it to one of them
+ *    would start generating an endpoint the config had already turned off.
+ *  - its qualified name, `reporting.users`, which is what addresses exactly one of them.
+ *
+ * A table with no schema answers to `public.users` rather than to a bare-schema form, because
+ * Drizzle refuses `pgSchema('public')` outright: there is no other way to write a table in the
+ * default schema, so there is no other name for it to have. That makes `public.` an alias this
+ * file defines rather than something read back off the analysis, which is why it is only ever
+ * offered to a table that names no schema.
+ *
+ * Order is the order they are tried, and the bare name being first is what keeps a table whose own
+ * name contains a dot reachable by a pattern that spells it.
+ */
+export function tableAliases(table: NamedTable): string[] {
+  return [table.name, `${table.schema ?? DEFAULT_SCHEMA_ALIAS}.${table.name}`];
+}
+
+/** Whether any of `patterns` matches the table under any of the names it answers to. */
+export function matchesTable(patterns: string[], table: NamedTable): boolean {
+  return tableAliases(table).some((alias) => matchesAny(patterns, alias));
+}
+
+/**
+ * How a message names one table.
+ *
+ * Qualified only where the table names a schema, so every message in a project that uses none is
+ * word for word what it was, and a project that uses several never has two of them reading alike.
+ */
+export function displayTableName(table: NamedTable): string {
+  return table.schema ? `${table.schema}.${table.name}` : table.name;
+}
+
+/**
+ * The spelling that addresses exactly this table and no other, `public.users` included.
+ *
+ * For a message whose job is to hand the reader something to paste into a config. Elsewhere
+ * `displayTableName` is the one to use: spelling `public.` at someone who has only ever had one
+ * schema names a concept their schema file does not contain.
+ */
+export function addressableName(table: NamedTable): string {
+  return `${table.schema ?? DEFAULT_SCHEMA_ALIAS}.${table.name}`;
+}
+
+/** Whether an analysis has any table outside the default schema at all. */
+export function hasNamedSchemas(tables: readonly NamedTable[]): boolean {
+  return tables.some((t) => t.schema);
+}
+
+/**
+ * Patterns that reach more than one SQL schema, which is nearly always a pattern written before
+ * the second schema existed.
+ *
+ * Reported rather than refused. Matching every schema is what an unqualified pattern has always
+ * done and is the reading that keeps an existing `exclude` doing its job, so it cannot be an
+ * error. It is still worth a sentence, because the two tables are different tables: `columns: {
+ * users: { pick: ['id', 'email'] } }` narrows both, and the table that has no `email` silently
+ * loses every column that is not `id`, while the typo check stays quiet because the pattern did
+ * match a column somewhere.
+ *
+ * Silent on a schema that uses no `pgSchema`, which is the shape of nearly every one: with one
+ * schema in play no pattern can span two.
+ */
+export function ambiguousPatternWarnings(
+  patterns: string[],
+  tables: readonly NamedTable[],
+  option: string
+): string[] {
+  const out: string[] = [];
+  for (const pattern of patterns) {
+    // A pattern that already names a schema said which one it meant.
+    if (pattern.includes('.')) continue;
+    const matched = tables.filter((t) => matchesTable([pattern], t));
+    const schemas = new Set(matched.map((t) => t.schema ?? DEFAULT_SCHEMA_ALIAS));
+    if (schemas.size < 2) continue;
+    out.push(
+      `drzl config: ${option} pattern ${JSON.stringify(pattern)} matches tables in more than one ` +
+        `schema, and every one of them is affected: ` +
+        `${matched.map(addressableName).sort().join(', ')}. ` +
+        `Write the schema to mean one of them, for example ${JSON.stringify(addressableName(matched[0]))}.`
+    );
+  }
+  return out;
+}

--- a/packages/cli/test/multi-schema-filter.spec.ts
+++ b/packages/cli/test/multi-schema-filter.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Addressing one of two same-named tables from the config.
+ *
+ * `include`, `exclude` and `columns` all match the database table name, and Postgres lets two
+ * schemas hold that name at once. So `exclude: ['users']` in a schema that has both
+ * `public.users` and `reporting.users` takes away both, and `columns: { users: { pick: [...] } }`
+ * narrows both, which is silent and is not what anybody writing it meant.
+ *
+ * A table now answers to more than one name: its bare name, exactly as before, and its qualified
+ * name. `public.` is an alias for a table with no schema, because `pgSchema('public')` does not
+ * construct at all, so an absent schema is the only spelling of the default one.
+ */
+import { describe, it, expect } from 'vitest';
+import { filterTables } from '../src/config';
+import { filterColumns } from '../src/column-filter';
+import { matchesTable, tableAliases, ambiguousPatternWarnings } from '../src/patterns';
+import type { Table } from '@drzl/analyzer';
+
+const t = (name: string, schema?: string, columns: string[] = ['id']): Table =>
+  ({
+    name,
+    tsName: schema ? `${schema}_${name}` : name,
+    ...(schema ? { schema } : {}),
+    columns: columns.map((c) => ({
+      name: c,
+      tsType: 'string',
+      dbType: 'TEXT',
+      nullable: true,
+      hasDefault: false,
+      isGenerated: false,
+    })),
+    primaryKey: { columns: ['id'] },
+    unique: [],
+    indexes: [],
+    checks: [],
+  }) as never;
+
+const qualified = (ts: Table[]) => ts.map((x) => (x.schema ? `${x.schema}.${x.name}` : x.name));
+
+describe('the names a table answers to', () => {
+  it('is just its own, when it has no schema, plus the public alias', () => {
+    expect(tableAliases(t('users'))).toEqual(['users', 'public.users']);
+  });
+
+  it('is its own and its qualified one, when it has a schema', () => {
+    expect(tableAliases(t('users', 'reporting'))).toEqual(['users', 'reporting.users']);
+  });
+
+  it('never claims public for a table that names a schema', () => {
+    expect(tableAliases(t('users', 'reporting'))).not.toContain('public.users');
+  });
+});
+
+describe('matchesTable', () => {
+  it('matches a bare pattern against every schema, as it always did', () => {
+    expect(matchesTable(['users'], t('users'))).toBe(true);
+    expect(matchesTable(['users'], t('users', 'reporting'))).toBe(true);
+  });
+
+  it('matches a qualified pattern against only that schema', () => {
+    expect(matchesTable(['reporting.users'], t('users', 'reporting'))).toBe(true);
+    expect(matchesTable(['reporting.users'], t('users'))).toBe(false);
+  });
+
+  it('spells the default schema as public', () => {
+    expect(matchesTable(['public.users'], t('users'))).toBe(true);
+    expect(matchesTable(['public.users'], t('users', 'reporting'))).toBe(false);
+  });
+
+  it('takes a wildcard on either side of the dot', () => {
+    expect(matchesTable(['reporting.*'], t('notes', 'reporting'))).toBe(true);
+    expect(matchesTable(['reporting.*'], t('notes'))).toBe(false);
+    expect(matchesTable(['*.users'], t('users', 'reporting'))).toBe(true);
+    expect(matchesTable(['*.users'], t('users'))).toBe(true);
+  });
+
+  it('still matches a table whose own name contains a dot', () => {
+    // The bare arm is tried first and unconditionally, so a dotted pattern cannot stop
+    // reaching a literally dotted table name.
+    expect(matchesTable(['odd.name'], t('odd.name'))).toBe(true);
+  });
+});
+
+describe('include and exclude', () => {
+  const tables = [t('users'), t('users', 'reporting'), t('notes', 'reporting')];
+
+  it('takes both schemas for a bare pattern, which is what it did before', () => {
+    expect(qualified(filterTables(tables, { include: ['users'] }))).toEqual([
+      'users',
+      'reporting.users',
+    ]);
+  });
+
+  it('takes one schema for a qualified pattern', () => {
+    expect(qualified(filterTables(tables, { include: ['reporting.users'] }))).toEqual([
+      'reporting.users',
+    ]);
+  });
+
+  it('excludes a whole schema with a wildcard', () => {
+    expect(qualified(filterTables(tables, { exclude: ['reporting.*'] }))).toEqual(['users']);
+  });
+
+  it('keeps the default schema alone with public', () => {
+    expect(qualified(filterTables(tables, { include: ['public.*'] }))).toEqual(['users']);
+  });
+});
+
+describe('the columns option', () => {
+  const tables = [
+    t('users', undefined, ['id', 'email', 'passwordHash']),
+    t('users', 'reporting', ['id', 'label']),
+  ];
+
+  it('narrows one schema when the key is qualified', () => {
+    const r = filterColumns(tables, { 'public.users': { omit: ['passwordHash'] } });
+    expect(r.tables.map((x) => x.columns.map((c) => c.name))).toEqual([
+      ['id', 'email'],
+      ['id', 'label'],
+    ]);
+  });
+
+  it('names the qualified table when a pattern matches nothing', () => {
+    expect(() => filterColumns(tables, { 'reporting.orders': { omit: ['x'] } })).toThrow(
+      /public\.users, reporting\.users/
+    );
+  });
+
+  /**
+   * The silent case this whole item turns on. `pick` on a bare key narrowed both tables, and the
+   * "matches at least one" rule made the typo check pass because `email` existed in the other
+   * one, so `reporting.users` quietly lost `label`.
+   */
+  it('warns when a bare key reaches more than one schema', () => {
+    const r = filterColumns(tables, { users: { pick: ['id', 'email'] } });
+    expect(r.warnings.join('\n')).toMatch(/"users" matches tables in more than one schema/);
+    expect(r.warnings.join('\n')).toMatch(/public\.users/);
+    expect(r.warnings.join('\n')).toMatch(/reporting\.users/);
+  });
+
+  it('says nothing when the key is qualified', () => {
+    const r = filterColumns(tables, { 'public.users': { pick: ['id', 'email'] } });
+    expect(r.warnings.join('\n')).not.toMatch(/more than one schema/);
+  });
+});
+
+describe('ambiguousPatternWarnings', () => {
+  const tables = [t('users'), t('users', 'reporting'), t('notes', 'reporting')];
+
+  it('reports a bare include pattern that spans schemas', () => {
+    const w = ambiguousPatternWarnings(['users'], tables, 'include');
+    expect(w).toHaveLength(1);
+    expect(w[0]).toMatch(/include/);
+    expect(w[0]).toMatch(/public\.users, reporting\.users/);
+  });
+
+  it('says nothing for a pattern confined to one schema', () => {
+    expect(ambiguousPatternWarnings(['notes'], tables, 'exclude')).toEqual([]);
+  });
+
+  it('says nothing for a qualified pattern', () => {
+    expect(ambiguousPatternWarnings(['reporting.users'], tables, 'include')).toEqual([]);
+  });
+
+  it('says nothing at all when no table names a schema', () => {
+    expect(ambiguousPatternWarnings(['*'], [t('users'), t('notes')], 'include')).toEqual([]);
+  });
+});

--- a/packages/cli/test/multi-schema.e2e.spec.ts
+++ b/packages/cli/test/multi-schema.e2e.spec.ts
@@ -1,0 +1,274 @@
+/**
+ * A whole project generated from a schema that holds two tables of the same name, and compiled.
+ *
+ * The unit tests each pin one surface. This one asks the question those cannot: with
+ * `public.users` and `reporting.users` both present, does a real run of the real analyzer and the
+ * real generators produce a tree that a consumer's `tsc` accepts? Every collision this item is
+ * about is a collision between two *files* or two *exports*, and only a compile of the emitted
+ * tree can say whether one silently replaced the other.
+ *
+ * The schema is built with real drizzle-orm rather than hand-written `Table` objects, because the
+ * one fact everything rests on, that `pgSchema('reporting').table('users', ...)` records `users`
+ * and not `reporting.users`, is a fact about Drizzle and not about DRZL.
+ *
+ * Two directories because two things have to resolve: the schema imports `drizzle-orm`, which
+ * resolves from `packages/cli`, and the emitted modules import `zod`, which resolves from
+ * `packages/generator-zod`. Both are `test/.tmp-*`, gitignored for every package.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer, qualifiedTableName } from '@drzl/analyzer';
+import type { Analysis } from '@drzl/analyzer';
+import { ZodGenerator } from '@drzl/generator-zod';
+import { ServiceGenerator } from '@drzl/generator-service';
+import { JsonSchemaGenerator } from '@drzl/generator-json-schema';
+import { filterColumns } from '../src/column-filter';
+import { filterTables, tableFilterWarnings } from '../src/config';
+
+const SCHEMA_DIR = path.join(__dirname, '.tmp-multi-schema-e2e');
+const EMIT_ROOT = path.join(
+  __dirname,
+  '..',
+  '..',
+  'generator-zod',
+  'test',
+  `.tmp-multi-schema-e2e-${process.pid}`
+);
+const tsc = path.resolve(__dirname, '..', '..', 'generator-zod', 'node_modules', '.bin', 'tsc');
+
+/**
+ * Two `users`, one child in each schema, and a name that exists in only one.
+ *
+ * `reportingUsers` deliberately carries a column `public.users` does not, and vice versa, so a
+ * schema built from the wrong table is a visible difference rather than a coincidence.
+ */
+const SCHEMA = `
+import { pgTable, pgSchema, integer, text, boolean } from 'drizzle-orm/pg-core';
+
+export const reporting = pgSchema('reporting');
+
+export const users = pgTable('users', {
+  id: integer('id').primaryKey(),
+  email: text('email').notNull(),
+  passwordHash: text('password_hash').notNull(),
+  active: boolean('active').notNull().default(true),
+});
+
+export const reportingUsers = reporting.table('users', {
+  id: integer('id').primaryKey(),
+  label: text('label').notNull(),
+});
+
+export const posts = pgTable('posts', {
+  id: integer('id').primaryKey(),
+  authorId: integer('author_id').references(() => users.id),
+  title: text('title').notNull(),
+});
+
+export const reportingNotes = reporting.table('notes', {
+  id: integer('id').primaryKey(),
+  userId: integer('user_id').references(() => reportingUsers.id),
+  body: text('body').notNull(),
+});
+`;
+
+let analysis: Analysis;
+let warnings: string[];
+let emitted: string[];
+let barrel: string;
+let openapi: any;
+
+beforeAll(async () => {
+  await fs.rm(SCHEMA_DIR, { recursive: true, force: true });
+  await fs.rm(EMIT_ROOT, { recursive: true, force: true });
+  await fs.mkdir(SCHEMA_DIR, { recursive: true });
+  await fs.mkdir(path.join(EMIT_ROOT, 'validators'), { recursive: true });
+
+  const schemaFile = path.join(SCHEMA_DIR, 'schema.mjs');
+  await fs.writeFile(schemaFile, SCHEMA, 'utf8');
+
+  analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schemaFile)).analyze({
+    includeRelations: true,
+  });
+
+  // A qualified key, which is the whole point: `passwordHash` is on `public.users` and the other
+  // `users` must not be touched.
+  const narrowed = filterColumns(analysis.tables, {
+    'public.users': { omit: ['passwordHash'] },
+  });
+  const cfg = { exclude: ['reporting.notes'] };
+  warnings = [...narrowed.warnings, ...tableFilterWarnings(narrowed.tables, cfg)];
+  analysis.tables = filterTables(narrowed.tables, cfg);
+
+  await new ZodGenerator(analysis).generate({
+    outDir: path.join(EMIT_ROOT, 'validators'),
+    nestedSchemas: true,
+  } as never);
+  await new ServiceGenerator(analysis).generate({
+    outDir: path.join(EMIT_ROOT, 'services'),
+  } as never);
+  await new JsonSchemaGenerator(analysis).generate({
+    outDir: path.join(EMIT_ROOT, 'openapi'),
+    document: { format: 'json' },
+    includeRelations: true,
+  } as never);
+
+  emitted = (await fs.readdir(path.join(EMIT_ROOT, 'validators'))).sort();
+  barrel = await fs.readFile(path.join(EMIT_ROOT, 'validators', 'index.ts'), 'utf8');
+  openapi = JSON.parse(await fs.readFile(path.join(EMIT_ROOT, 'openapi', 'openapi.json'), 'utf8'));
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(SCHEMA_DIR, { recursive: true, force: true });
+  await fs.rm(EMIT_ROOT, { recursive: true, force: true });
+});
+
+describe('the analysis', () => {
+  it('sees four tables and tells the two users apart', () => {
+    expect(analysis.tables.map(qualifiedTableName).sort()).toEqual([
+      'posts',
+      'reporting.users',
+      'users',
+    ]);
+  });
+
+  it('honoured the qualified columns key on one table only', () => {
+    const byQualified = Object.fromEntries(analysis.tables.map((t) => [qualifiedTableName(t), t]));
+    expect(byQualified['users'].columns.map((c) => c.name)).toEqual(['id', 'email', 'active']);
+    expect(byQualified['reporting.users'].columns.map((c) => c.name)).toEqual(['id', 'label']);
+  });
+
+  it('honoured a qualified exclude', () => {
+    expect(analysis.tables.map(qualifiedTableName)).not.toContain('reporting.notes');
+  });
+
+  it('said nothing about ambiguity, because every pattern named its schema', () => {
+    // The one warning that is here is the pre-existing NOT NULL note about `passwordHash`, which
+    // has nothing to do with schemas and is exactly right.
+    expect(warnings.filter((w) => w.includes('more than one schema'))).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/drops "passwordHash" from table "users"/);
+  });
+
+  it('would have warned had the key been bare', () => {
+    // `email` is on `public.users` only, so the "matches at least one" typo check stays quiet and
+    // the entry silently reaches a second, unrelated table. That is the case the warning is for.
+    const bare = filterColumns(analysis.tables, { users: { omit: ['email'] } });
+    expect(bare.warnings.join('\n')).toMatch(/matches tables in more than one schema/);
+    expect(bare.warnings.join('\n')).toMatch(/public\.users, reporting\.users/);
+  });
+});
+
+describe('the emitted files', () => {
+  it('gives each table its own module, named from the Drizzle export', () => {
+    expect(emitted).toEqual(['index.ts', 'posts.zod.ts', 'reportingUsers.zod.ts', 'users.zod.ts']);
+  });
+
+  it('exports every module from the barrel exactly once', () => {
+    const lines = barrel.split('\n').filter((l) => l.startsWith('export'));
+    expect(lines).toEqual([
+      "export * from './posts.zod.js';",
+      "export * from './reportingUsers.zod.js';",
+      "export * from './users.zod.js';",
+    ]);
+  });
+
+  it('keeps the two schemas describing different rows', async () => {
+    const pub = await fs.readFile(path.join(EMIT_ROOT, 'validators', 'users.zod.ts'), 'utf8');
+    const rep = await fs.readFile(
+      path.join(EMIT_ROOT, 'validators', 'reportingUsers.zod.ts'),
+      'utf8'
+    );
+    expect(pub).toContain('SelectusersSchema');
+    expect(pub).toContain('email');
+    expect(pub).not.toContain('passwordHash');
+    expect(rep).toContain('SelectreportingUsersSchema');
+    expect(rep).toContain('label');
+    expect(rep).not.toContain('email');
+  });
+
+  it('gives the services distinct names too', async () => {
+    const files = (await fs.readdir(path.join(EMIT_ROOT, 'services'))).sort();
+    expect(files).toContain('userService.ts');
+    expect(files).toContain('reportingUserService.ts');
+  });
+});
+
+describe('the OpenAPI document', () => {
+  it('emits a path for both tables rather than refusing', () => {
+    expect(Object.keys(openapi.paths)).toContain('/users');
+    expect(Object.keys(openapi.paths)).toContain('/reporting/users');
+  });
+
+  it('tags them apart', () => {
+    expect(openapi.tags.map((t: any) => t.name).sort()).toEqual([
+      'posts',
+      'reporting.users',
+      'users',
+    ]);
+  });
+
+  it('hangs the child under the parent in its own schema', () => {
+    // `posts.authorId` points at `public.users`, so `/users/{id}/posts` and nothing under
+    // `/reporting/users/{id}`.
+    expect(Object.keys(openapi.paths)).toContain('/users/{id}/posts');
+    expect(Object.keys(openapi.paths)).not.toContain('/reporting/users/{id}/posts');
+  });
+});
+
+describe('the generated project', () => {
+  it('has a tsc to run', () => {
+    expect(existsSync(tsc), `no tsc at ${tsc}; run pnpm install`).toBe(true);
+  });
+
+  it('compiles under strict nodenext', async () => {
+    const tsconfig = path.join(EMIT_ROOT, 'tsconfig.json');
+    await fs.writeFile(
+      tsconfig,
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          target: 'es2022',
+          module: 'nodenext',
+          moduleResolution: 'nodenext',
+          skipLibCheck: true,
+        },
+        include: ['validators/**/*.ts', 'services/**/*.ts'],
+      })
+    );
+    await fs.writeFile(
+      path.join(EMIT_ROOT, 'package.json'),
+      '{"name":"probe","type":"module","private":true}'
+    );
+
+    // A probe that imports both `users` schemas through the barrel at once. If the two modules
+    // had collided on a file name or an export name, this is where it stops compiling.
+    await fs.writeFile(
+      path.join(EMIT_ROOT, 'validators', 'probe.ts'),
+      [
+        "import { SelectusersSchema, SelectreportingUsersSchema } from './index.js';",
+        "import type { SelectusersOutput, SelectreportingUsersOutput } from './index.js';",
+        'export const a: SelectusersOutput = SelectusersSchema.parse({',
+        "  id: 1, email: 'a@b.c', active: true,",
+        '});',
+        'export const b: SelectreportingUsersOutput = SelectreportingUsersSchema.parse({',
+        "  id: 1, label: 'x',",
+        '});',
+        '// Each row has a field the other does not, so a module that answered for both fails here.',
+        'export const bothDiffer: [string, string] = [a.email, b.label];',
+      ].join('\n')
+    );
+
+    let out = '';
+    try {
+      execFileSync(tsc, ['-p', tsconfig], { cwd: EMIT_ROOT, stdio: 'pipe' });
+    } catch (e) {
+      const err = e as { stdout?: Buffer; stderr?: Buffer };
+      out = `${err.stdout?.toString() ?? ''}${err.stderr?.toString() ?? ''}`;
+    }
+    expect(out).toBe('');
+  }, 120_000);
+});

--- a/packages/generator-json-schema/src/openapi.ts
+++ b/packages/generator-json-schema/src/openapi.ts
@@ -17,6 +17,7 @@
  * compiler anywhere says so.
  */
 import type { Column, Table } from '@drzl/analyzer';
+import { qualifiedForeignTable, qualifiedTableName } from '@drzl/analyzer';
 import { tableSchemas, type JsonSchemaTarget, type Schema } from './schemas.js';
 
 /** What the document says about itself. DRZL knows the schema and nothing else, so this is input. */
@@ -101,19 +102,35 @@ const modesFor = (table: Table, key: Column[] | null): Mode[] => [
  * DRZL user addresses a table by: `include` and `exclude` in the config are matched against it, and
  * that was itself a deliberate decision recorded in the config schema. Percent-encoded, since a
  * table name is not constrained to characters that are safe in a path.
+ *
+ * A table that names a SQL schema takes a segment for it first, so `reporting.users` is
+ * `/reporting/users`. Two schemas can hold one table name and a path names one resource, so
+ * something had to give; the schema is what the database itself uses to tell them apart, and it
+ * reads as the resource hierarchy it is. A table in the default schema keeps the bare `/users` it
+ * has always had, which is not a compromise: Drizzle refuses `pgSchema('public')` outright, so
+ * there is no second spelling for such a table to disagree with.
+ *
+ * Each half is encoded on its own, so the separator survives a schema name that needs escaping.
  */
-const resourceSegment = (table: Table) => encodeURIComponent(table.name);
+const resourceSegment = (table: Table) =>
+  table.schema
+    ? `${encodeURIComponent(table.schema)}/${encodeURIComponent(table.name)}`
+    : encodeURIComponent(table.name);
 
 /** Every foreign key the table declares, including the ones only mirrored onto a column. */
-function foreignKeysOf(
-  table: Table
-): Array<{ columns: string[]; foreignTable: string; foreignColumns: string[] }> {
+function foreignKeysOf(table: Table): Array<{
+  columns: string[];
+  foreignTable: string;
+  foreignSchema?: string;
+  foreignColumns: string[];
+}> {
   if (table.foreignKeys?.length) return table.foreignKeys;
   return table.columns
     .filter((c) => c.references)
     .map((c) => ({
       columns: [c.name],
       foreignTable: c.references!.table,
+      ...(c.references!.schema ? { foreignSchema: c.references!.schema } : {}),
       foreignColumns: [c.references!.column],
     }));
 }
@@ -166,12 +183,15 @@ function build(
     if (clash !== undefined) {
       throw new Error(
         `@drzl/generator-json-schema: the operationId "${id}" would be emitted for both ` +
-          `"${clash}" and "${table.name}". An operationId is the method name a client generator ` +
+          `"${clash}" and "${qualifiedTableName(table)}". An operationId is the method name a ` +
+          `client generator ` +
           `derives, and the specification requires it to be unique across the document.`
       );
     }
-    operationIds.set(id, table.name);
-    return { operationId: id, tags: [table.name], ...rest };
+    operationIds.set(id, qualifiedTableName(table));
+    // Tagged by the qualified name, because a tag groups the operations of one resource and two
+    // tables sharing a bare name would otherwise be presented as a single one.
+    return { operationId: id, tags: [qualifiedTableName(table)], ...rest };
   };
 
   const built = tables.map((table) => ({
@@ -196,7 +216,10 @@ function build(
     if (table.readOnly) {
       notes.push('It refuses every write, so only reads are described.');
     }
-    tags.push({ name: table.name, description: [`Table "${table.name}".`, ...notes].join(' ') });
+    tags.push({
+      name: qualifiedTableName(table),
+      description: [`Table "${qualifiedTableName(table)}".`, ...notes].join(' '),
+    });
 
     const T = pascal(table.tsName);
     const select = ref(componentName(table, 'select'));
@@ -217,7 +240,7 @@ function build(
     });
 
     const collection = `/${segment}`;
-    claim(collection, table.tsName, table.name);
+    claim(collection, table.tsName, qualifiedTableName(table));
     const item: Record<string, unknown> = {
       get: operation(`list${T}`, table, {
         summary: `List every ${table.name} row.`,
@@ -248,7 +271,7 @@ function build(
     if (!key) continue;
 
     const itemPath = `${collection}/${key.map((c) => `{${c.name}}`).join('/')}`;
-    claim(itemPath, table.tsName, table.name);
+    claim(itemPath, table.tsName, qualifiedTableName(table));
     const parameters = key.map((c) => ({
       name: c.name,
       in: 'path',
@@ -320,7 +343,9 @@ function build(
       // schemas drop a child with more than one key back to its parent.
       const matching = foreignKeysOf(child.table).filter(
         (fk) =>
-          fk.foreignTable === table.name &&
+          // Qualified on both sides. On the bare name a key pointing at `reporting.users` also
+          // answered for `public.users`, so the child was hung under a parent in another schema.
+          qualifiedForeignTable(fk) === qualifiedTableName(table) &&
           fk.foreignColumns.length === key.length &&
           fk.foreignColumns.every((c, i) => c === key[i].name)
       );
@@ -329,7 +354,7 @@ function build(
       claim(
         subPath,
         `${table.tsName} -> ${child.table.tsName}`,
-        `${table.name} -> ${child.table.name}`
+        `${qualifiedTableName(table)} -> ${qualifiedTableName(child.table)}`
       );
       paths[subPath] = {
         parameters,

--- a/packages/generator-json-schema/test/multi-schema.spec.ts
+++ b/packages/generator-json-schema/test/multi-schema.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Two tables of the same name in different SQL schemas, addressed by one document.
+ *
+ * A path is the one place in this generator where the *database* name is load-bearing rather than
+ * decorative, and it was the one surface that already knew multi-schema was coming: `claim` threw
+ * on the duplicate rather than emitting a document where one table silently overwrote the other.
+ * Throwing was right while there was nothing better to spell. There is now.
+ *
+ * The default schema keeps `/users`, byte for byte, because that is what every existing document
+ * says and because Drizzle refuses `pgSchema('public')` outright, so a bare table has no other
+ * name it could take. A schema-qualified table takes `/reporting/users`.
+ */
+import { describe, expect, it } from 'vitest';
+import { openApiDocument } from '../src/index';
+import { col, serial, table, users } from './fixtures';
+
+const reportingUsers = () =>
+  table({
+    name: 'users',
+    tsName: 'reportingUsers',
+    schema: 'reporting',
+    columns: [serial('id'), col('label')],
+    primaryKey: { columns: ['id'] },
+  });
+
+const reportingNotes = () =>
+  table({
+    name: 'notes',
+    tsName: 'reportingNotes',
+    schema: 'reporting',
+    columns: [serial('id'), serial('userId')],
+    primaryKey: { columns: ['id'] },
+    foreignKeys: [
+      {
+        columns: ['userId'],
+        foreignTable: 'users',
+        foreignSchema: 'reporting',
+        foreignColumns: ['id'],
+      },
+    ],
+  });
+
+/** The same child, pointing at `public.users` instead. */
+const publicNotes = () =>
+  table({
+    name: 'notes_pub',
+    tsName: 'publicNotes',
+    columns: [serial('id'), serial('userId')],
+    primaryKey: { columns: ['id'] },
+    foreignKeys: [{ columns: ['userId'], foreignTable: 'users', foreignColumns: ['id'] }],
+  });
+
+const doc = (tables: unknown[], opts = {}) => openApiDocument(tables as never, opts) as any;
+
+describe('paths', () => {
+  it('emits both tables rather than refusing the document', () => {
+    const paths = Object.keys(doc([users(), reportingUsers()]).paths);
+    expect(paths).toContain('/users');
+    expect(paths).toContain('/reporting/users');
+  });
+
+  it('leaves a schema-less table exactly where it was', () => {
+    expect(Object.keys(doc([users()]).paths)).toEqual(['/users', '/users/{id}']);
+  });
+
+  it('gives the qualified table its own item path', () => {
+    const paths = Object.keys(doc([users(), reportingUsers()]).paths);
+    expect(paths).toContain('/users/{id}');
+    expect(paths).toContain('/reporting/users/{id}');
+  });
+
+  it('percent-encodes a schema name that is not path safe', () => {
+    const t = table({
+      name: 'users',
+      tsName: 'oddUsers',
+      schema: 'a b',
+      columns: [serial('id')],
+      primaryKey: { columns: ['id'] },
+    });
+    expect(Object.keys(doc([t]).paths)).toContain('/a%20b/users');
+  });
+});
+
+describe('tags', () => {
+  it('names each table by its qualified name, so the two do not merge', () => {
+    const d = doc([users(), reportingUsers()]);
+    expect(d.tags.map((t: any) => t.name)).toEqual(['users', 'reporting.users']);
+  });
+
+  it('tags every operation with the qualified name', () => {
+    const d = doc([users(), reportingUsers()]);
+    expect(d.paths['/reporting/users'].get.tags).toEqual(['reporting.users']);
+    expect(d.paths['/users'].get.tags).toEqual(['users']);
+  });
+});
+
+describe('a nested path from a foreign key', () => {
+  it('follows the key into its own schema and not the other one', () => {
+    const paths = Object.keys(
+      doc([users(), reportingUsers(), reportingNotes()], { includeRelations: true }).paths
+    );
+    expect(paths).toContain('/reporting/users/{id}/reporting/notes');
+    expect(paths).not.toContain('/users/{id}/reporting/notes');
+  });
+
+  it('follows a key into the default schema the same way', () => {
+    const paths = Object.keys(
+      doc([users(), reportingUsers(), publicNotes()], { includeRelations: true }).paths
+    );
+    expect(paths).toContain('/users/{id}/notes_pub');
+    expect(paths).not.toContain('/reporting/users/{id}/notes_pub');
+  });
+});
+
+describe('a genuine path clash', () => {
+  /**
+   * A table whose *own* name contains a slash cannot reach the two-segment path, because each
+   * half is encoded separately: `reporting/users` becomes the single segment
+   * `reporting%2Fusers`. So splitting on the schema did not open a new way for two tables to want
+   * one path, which was the thing worth checking before taking the guard's job away from it.
+   */
+  it('does not let a slash in a table name reach a schema path', () => {
+    const odd = table({
+      name: 'reporting/users',
+      tsName: 'odd',
+      columns: [serial('id')],
+      primaryKey: { columns: ['id'] },
+    });
+    const paths = Object.keys(doc([reportingUsers(), odd]).paths);
+    expect(paths).toContain('/reporting/users');
+    expect(paths).toContain('/reporting%2Fusers');
+  });
+
+  it('still refuses two exports of one table name in one schema', () => {
+    // Drizzle allows it, and one path names one resource, so the guard is still the only thing
+    // between that schema and a document where the second table silently replaces the first.
+    const twin = table({
+      name: 'users',
+      tsName: 'usersAgain',
+      columns: [serial('id')],
+      primaryKey: { columns: ['id'] },
+    });
+    expect(() => doc([users(), twin])).toThrow(/claimed twice/);
+  });
+});

--- a/packages/generator-orpc/src/index.ts
+++ b/packages/generator-orpc/src/index.ts
@@ -1,4 +1,5 @@
 import type { Analysis, Column, Table } from '@drzl/analyzer';
+import { qualifiedTableName } from '@drzl/analyzer';
 import type { AffixOptions, ImportExtension } from '@drzl/validation-core';
 import {
   formatCode,
@@ -453,15 +454,20 @@ export class ORPCGenerator {
     const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
     const T = cap(table.tsName);
     const specs: ProcedureSpec[] = [];
-    const byDbName = new Map(analysis.tables.map((t) => [t.name, t]));
+    // Keyed on the qualified name, which is what a `Relation` states at both ends. On the bare
+    // one, two tables of the same name in two SQL schemas built a single entry and the later
+    // silently replaced the earlier, so a relation naming either resolved to whichever the
+    // analyzer emitted last.
+    const byName = new Map(analysis.tables.map((t) => [qualifiedTableName(t), t]));
+    const self = qualifiedTableName(table);
 
     const wanted = (analysis.relations ?? []).filter(
-      (r) => r.from === table.name && (r.kind === 'many' || r.kind === 'manyToMany')
+      (r) => r.from === self && (r.kind === 'many' || r.kind === 'manyToMany')
     );
 
     for (const rel of wanted) {
-      const target = byDbName.get(rel.to);
-      if (!target || target.name === table.name) continue;
+      const target = byName.get(rel.to);
+      if (!target || qualifiedTableName(target) === self) continue;
 
       const name = `list${cap(target.tsName)}`;
       if (taken.has(name)) continue;

--- a/packages/validation-core/src/meta.ts
+++ b/packages/validation-core/src/meta.ts
@@ -81,6 +81,16 @@ export interface ColumnMetaFacts {
 export interface TableMetaFacts {
   /** The SQL table name, which is not the Drizzle export name the schema is named after. */
   table: string;
+  /**
+   * The SQL schema the table lives in, present only when it names one.
+   *
+   * Beside `table` rather than folded into it. `table` is the bare name in every emitted file
+   * that exists, and two tables in two schemas publish the same one, so without this a consumer
+   * reading the metadata of `reporting.users` cannot tell it from `public.users`. Absent for a
+   * table in the default schema, which is what `pgTable` declares and the only thing it can
+   * declare: Drizzle refuses `pgSchema('public')`.
+   */
+  schema?: string;
   /** Which database this was analysed from. The same declaration means different things across them. */
   dialect?: string;
   /** Which of the three schemas this is. The export name says it; the schema object does not. */
@@ -257,6 +267,7 @@ export function tableMetaFacts(table: Table, opts: TableMetaOptions): TableMetaF
   const unique = (table.unique ?? []).map((k) => k.columns).filter((c) => c.length > 0);
   const facts: TableMetaFacts = {
     table: table.name,
+    ...(table.schema ? { schema: table.schema } : {}),
     ...(opts.dialect ? { dialect: opts.dialect } : {}),
     mode: opts.mode,
     ...(pk.length ? { primaryKey: pk } : {}),

--- a/packages/validation-core/src/nested.ts
+++ b/packages/validation-core/src/nested.ts
@@ -19,6 +19,7 @@
  * which relations appear or which columns a child carries.
  */
 import type { Relation, Table } from '@drzl/analyzer';
+import { qualifiedForeignTable, qualifiedTableName } from '@drzl/analyzer';
 import { schemaName, typeName, type NameMode, type ResolvedAffix } from './naming.js';
 
 /**
@@ -159,14 +160,18 @@ const KIND_ORDER: Record<Relation['kind'], number> = { many: 0, manyToMany: 1, o
  * both foreign keys present exactly as the plain insert schema has them, and a comment saying why.
  */
 function omittedColumnsFor(parent: Table, child: Table): { omitted: string[]; note?: string } {
-  const back = (child.foreignKeys ?? []).filter((fk) => fk.foreignTable === parent.name);
+  // Qualified on both sides. Matched on the bare name, a key pointing at `reporting.users`
+  // answered for `public.users` as well, so the parent's payload omitted a column belonging to
+  // the other schema's child.
+  const parentName = qualifiedTableName(parent);
+  const back = (child.foreignKeys ?? []).filter((fk) => qualifiedForeignTable(fk) === parentName);
   if (back.length === 1) return { omitted: [...back[0].columns] };
   if (back.length === 0) return { omitted: [] };
   const named = back.map((fk) => fk.columns.join('+')).join(', ');
   return {
     omitted: [],
     note:
-      `${child.tsName} has ${back.length} foreign keys to ${parent.name} (${named}), so which one ` +
+      `${child.tsName} has ${back.length} foreign keys to ${parentName} (${named}), so which one ` +
       `this relation uses is not stated. None were omitted: supply them yourself.`,
   };
 }
@@ -210,20 +215,25 @@ function buildNode(
 ): NestedNode {
   if (depth <= 0) return { table, omitted, arms: [] };
 
-  const byDbName = new Map(tables.map((t) => [t.name, t]));
+  // Keyed on the qualified name, which is what a `Relation` states at both ends. Keyed on the
+  // bare one, two tables of the same name in two SQL schemas built one entry and the later table
+  // silently replaced the earlier, so every relation naming either of them resolved to whichever
+  // the analyzer happened to emit last.
+  const byName = new Map(tables.map((t) => [qualifiedTableName(t), t]));
   const allowed = KINDS_BY_MODE[mode];
   // A relation key sits in the same object as the columns, so a column of the same name would be
   // overwritten by it. The columns are the row and win.
   const columnNames = new Set(table.columns.map((c) => c.name));
   const taken = new Set<string>();
   const arms: NestedArm[] = [];
+  const self = qualifiedTableName(table);
 
   const candidates = relations
-    .filter((r) => r.from === table.name && allowed.has(r.kind))
+    .filter((r) => r.from === self && allowed.has(r.kind))
     .sort((a, b) => KIND_ORDER[a.kind] - KIND_ORDER[b.kind]);
 
   for (const rel of candidates) {
-    const child = byDbName.get(rel.to);
+    const child = byName.get(rel.to);
     if (!child) continue;
     const key = child.tsName;
     if (columnNames.has(key)) continue;

--- a/packages/validation-core/test/multi-schema-nested.spec.ts
+++ b/packages/validation-core/test/multi-schema-nested.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * The nested plan when two schemas hold a table of the same name.
+ *
+ * Two things here were keyed on the bare database name and cannot be: the map from a relation's
+ * `to` back to a table, which silently kept whichever of the two it saw last, and the search for
+ * the child's foreign keys back to the parent, which matched a key pointing at `reporting.users`
+ * against `public.users` and omitted a column from the wrong schema's payload.
+ *
+ * Nothing here changes for a schema that names no schema: a qualified name for a table with no
+ * schema is its own name, so every existing plan is byte for byte what it was.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Relation, Table } from '@drzl/analyzer';
+import { buildNestedPlan } from '../src/index';
+
+const col = (name: string) =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+  }) as never;
+
+const table = (name: string, tsName: string, cols: string[], over: Partial<Table> = {}): Table =>
+  ({
+    name,
+    tsName,
+    columns: cols.map((c) => col(c)),
+    unique: [],
+    indexes: [],
+    checks: [],
+    ...over,
+  }) as Table;
+
+const publicUsers = table('users', 'users', ['id', 'email']);
+const reportingUsers = table('users', 'reportingUsers', ['id', 'label'], {
+  schema: 'reporting',
+});
+
+/** A child of `reporting.users`, in the same schema. */
+const reportingNotes = table('notes', 'reportingNotes', ['id', 'userId', 'body'], {
+  schema: 'reporting',
+  foreignKeys: [
+    {
+      columns: ['userId'],
+      foreignTable: 'users',
+      foreignSchema: 'reporting',
+      foreignColumns: ['id'],
+    },
+  ],
+});
+
+/** A child of `public.users`. */
+const publicPosts = table('posts', 'posts', ['id', 'authorId', 'title'], {
+  foreignKeys: [{ columns: ['authorId'], foreignTable: 'users', foreignColumns: ['id'] }],
+});
+
+const TABLES = [publicUsers, reportingUsers, reportingNotes, publicPosts];
+
+/** Exactly what the analyzer now emits for those four, from their foreign keys alone. */
+const REL: Relation[] = [
+  { kind: 'one', from: 'reporting.notes', to: 'reporting.users' },
+  { kind: 'many', from: 'reporting.users', to: 'reporting.notes' },
+  { kind: 'one', from: 'posts', to: 'users' },
+  { kind: 'many', from: 'users', to: 'posts' },
+];
+
+describe('a table resolved from a relation', () => {
+  it('is the one in the relation two schemas apart, not whichever came last', () => {
+    const plan = buildNestedPlan(reportingUsers, TABLES, REL, 'insert', 1)!;
+    expect(plan.arms.map((a) => a.key)).toEqual(['reportingNotes']);
+  });
+
+  it('leaves the table in the default schema with its own child only', () => {
+    const plan = buildNestedPlan(publicUsers, TABLES, REL, 'insert', 1)!;
+    expect(plan.arms.map((a) => a.key)).toEqual(['posts']);
+  });
+});
+
+describe('the column a nested insert omits', () => {
+  it('comes from a foreign key that names the parent schema too', () => {
+    const plan = buildNestedPlan(reportingUsers, TABLES, REL, 'insert', 1)!;
+    expect(plan.arms[0].child.omitted).toEqual(['userId']);
+  });
+
+  it('is not taken from a key pointing at a same-named table in another schema', () => {
+    // `publicPosts.authorId` points at `public.users`. Asked for `reporting.users`'s payload, the
+    // old bare-name match would have claimed it.
+    const plan = buildNestedPlan(publicUsers, TABLES, REL, 'insert', 1)!;
+    expect(plan.arms[0].child.omitted).toEqual(['authorId']);
+  });
+});

--- a/packages/validation-core/test/no-bundled-formatter.spec.ts
+++ b/packages/validation-core/test/no-bundled-formatter.spec.ts
@@ -77,6 +77,13 @@ function build(pkg: string): Promise<string> {
 /**
  * The built validation-core, copied somewhere Node's resolver cannot reach this repo's
  * node_modules, so an optional peer is genuinely missing rather than mocked away.
+ *
+ * Everything the manifest declares as a `dependencies` entry is linked in, and nothing else.
+ * A consumer really does get those installed, so leaving them out would make this sandbox
+ * describe an install nobody has, and the first runtime import of one would fail here for a
+ * reason that has nothing to do with a formatter. Declared-and-only-declared is also the
+ * stricter statement: an import of a package the manifest does not list still fails, which is
+ * the missing-dependency defect worth catching.
  */
 const sandboxed = new Map<string, Promise<string>>();
 function sandbox(): Promise<string> {
@@ -90,6 +97,18 @@ function sandbox(): Promise<string> {
     }
     // Without this, `.js` in a directory with no manifest is read as CommonJS.
     await fs.writeFile(path.join(to, 'package.json'), '{"type":"module"}');
+
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(repoRoot, 'packages/validation-core/package.json'), 'utf8')
+    );
+    for (const dep of Object.keys(manifest.dependencies ?? {})) {
+      // Symlinked from the workspace rather than installed, so the sandbox sees the package as
+      // it is right now rather than whatever the registry last published.
+      const from = path.join(repoRoot, 'packages/validation-core/node_modules', dep);
+      const at = path.join(to, 'node_modules', dep);
+      await fs.mkdir(path.dirname(at), { recursive: true });
+      await fs.symlink(await fs.realpath(from), at, 'dir');
+    }
     return to;
   })();
   sandboxed.set('validation-core', run);


### PR DESCRIPTION
Plan item 38, and the verdict on item 37.

## Item 37 is already done. Nothing built.

Measured through the real analyzer and generator, then parsed against:

| PATCH body | result |
|---|---|
| `{}` | ACCEPT |
| `{nickname:null}` (nullable column) | ACCEPT |
| `{email:null}` (NOT NULL) | REJECT `invalid_type` |
| `{active:null}` (NOT NULL + default) | REJECT |
| `{id:5,email:"x"}` (PK present) | ACCEPT, `id` stripped |

Every candidate distinction is already handled, and in two cases handled *better* than a separate variant would be:

- **PK in the body**: stripped rather than rejected, so a client echoing the id alongside the path parameter succeeds instead of 400ing. A `Partial` that *included* the PK would be worse, not different.
- **Explicit `null` vs absent**: already correct **per column**, which is exactly JSON Merge Patch semantics against the database's own nullability. No second schema could improve on that.
- **Rejecting `{}` as a no-op**: the one real distinction, and it is a route policy rather than a shape. One `.refine()`, and a no-op PATCH returning the unchanged row is a defensible API.

`openapi.ts:277` already emits `byId.patch` against the update schema, and line 284 already carries the comment "The primary key is not in the update schema, so a patch cannot collide on it." The item was satisfied by the design it describes; building it would ship a byte-identical duplicate under a second name.

## Item 38: what was actually wrong

The analyzer **already** recorded `schema: 'reporting'` from the `drizzle:Schema` symbol. Grep for `table.schema` across `packages/*/src` returned **zero consumers**. So this was not about discovering the name, it was about every name-addressed surface ignoring it.

With `public.users` and `reporting.users` both present, measured:

| surface | keyed on | before |
|---|---|---|
| files, exports, barrel, service, both routers | `tsName` | no collision |
| OpenAPI paths | `table.name` | **threw**, `path "/users" claimed twice` |
| `include`/`exclude` | `table.name` | **silently took both** |
| `columns` matcher (item 35) | `table.name` | **silently narrowed both** |
| `nested.ts` table map | `table.name` | **silent overwrite**, last wins |
| `ForeignKey.foreignTable` | bare name | **ambiguous**, both recorded the same string |
| `meta.table` | bare name | identical metadata for two different tables |

The split is clean: `tsName`-addressed surfaces were fine, `name`-addressed ones were not, and only OpenAPI failed loudly.

## Design decisions

**Qualified spelling is `reporting.users`.** A table answers to its bare name (tried first, unchanged) and to `${schema}.${name}`. `qualifiedTableName` lives beside `Table` in the analyzer so one function decides.

**An unqualified pattern still matches every schema, and warns.** Not a compatibility gesture: `exclude: ['users']` written before `reporting` existed means "the users tables", and narrowing it to one would **start generating** an endpoint the config had already turned off. Erroring would break a working config the moment someone adds a `pgSchema`. It matters most for `columns`, where a column pattern need only match **one** of the matched tables, so a `pick` can silently keep a different set per table with no typo for the existing check to catch.

**`public` is explicit in config, absent from a schema file, and Drizzle settled it:**

```
pgSchema('public')  ->  You can't specify 'public' as schema name.
                        Postgres is using public schema by default
```

So no analysis can ever carry `schema: 'public'`, an absent schema *is* public, and `public.users` is an alias the CLI defines rather than something read back. Pinned by a test asserting that Drizzle error.

**OpenAPI**: a qualified table gets `/reporting/users`; a default-schema table keeps `/users` byte for byte. Each half is percent-encoded separately, so a table literally named `reporting/users` becomes `/reporting%2Fusers` and cannot reach the two-segment form. The claim guard stays.

## A real defect fixed along the way, unrelated to schemas

`defineRelations` (Relations v2) named its target by `targetTableName`, which measured against drizzle-orm 1.0.0-rc.4 is **the key in the schema object**, not the table name, while `from` was a table name. Everything resolves both against `Table.name`, so **for any export whose name differs from its table's, the relation was dropped in silence** and no nested schema or relation procedure was emitted. Both ends now read the table object Drizzle already provides.

## Verification

- Tests first: **35 failed / 8 passed** across four new spec files.
- **A real generated project with two same-named tables compiles** under `tsc --strict` / `nodenext`: real drizzle-orm schema, real analyzer, `columns: { 'public.users': { omit: ['passwordHash'] } }`, `exclude: ['reporting.notes']`, emitted with zod + service + json-schema, and a probe importing both `users` schemas through one barrel and reading a field only one of them has.
- `pnpm -r test` **1844 green**, plus `build`, `typecheck`, `lint`, `docs build`, `verify:packed` all green.

## What I would want added to the gate (not touched)

Its doc-config fixture is single-schema, so the packed run never sees a `pgSchema`:

1. **A `pgSchema('reporting')` table sharing a name with a `pgTable` one** in the doc-probe fixture. That alone would have caught the OpenAPI throw from the packed artifact, and makes every documented config exercise the qualified matcher.
2. **A `document: true` config in that stage**, so the path-claim guard runs against a packed build.
3. **A cross-schema foreign key in the parity fixture**, since `foreignSchema` is new and only unit-tested.

## Worth knowing

- `no-bundled-formatter`'s sandbox now symlinks exactly the manifest's declared `dependencies` rather than nothing. **Stricter, not weaker**: an import of a package the manifest does not list still fails, which is the defect worth catching, while the optional peer stays genuinely absent, which is what the test's own prose says it tests.
- **`Relation.from`/`.to`/`.via` are now qualified strings.** A shape change to an exported type, a no-op for any schema calling no `pgSchema`. All four in-repo consumers updated; the changeset marks `@drzl/analyzer` minor and says so.
- **MySQL/SingleStore schemas** work identically (same symbol), but `public.` as the default alias is a Postgres word and I did not verify what a MySQL user would expect. Everything functions; only the alias spelling is Postgres-flavoured.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
