### PR TITLE
feat(validation): a constraint ledger, and a map from an issue back to it

### DIFF
--- a/.changeset/constraint-data-and-error-maps.md
+++ b/.changeset/constraint-data-and-error-maps.md
@@ -1,0 +1,67 @@
+---
+'@drzl/validation-core': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-zod': minor
+'@drzl/cli': minor
+---
+
+Emit the table's constraints as data, and map a validation issue back to the constraint that caused
+it
+
+`constraints: true` on the zod or valibot generator writes one more file, `constraints.ts`: every
+CHECK, unique constraint, primary key and foreign key on each table as plain objects, plus
+`constraintForIssue`, which turns a failed parse back into the constraint that produced it.
+
+```ts
+{ kind: 'zod', path: 'src/validators/zod', constraints: true }
+```
+
+Off by default. With it off the emitted schemas are byte-for-byte what they were: this adds a file
+and changes nothing in the existing ones.
+
+**Why a schema is not enough.** A validator states what a value must look like and never says which
+constraint said so, so `Too small: expected number to be >=18` gives a form a message and no way to
+attribute it, no way to substitute its own wording for that rule, and no way to tell that failure
+apart from the column's own type bound. And two of a table's constraints are absent from a
+generated schema in every form: whether a value is already taken and whether the row it points at
+exists are facts about the table, not about the row.
+
+**What it maps, measured.** The same table and the same failing rows, on zod 4.4.3 and valibot
+1.4.2, both answering with the same constraint:
+
+| the row breaks          | zod reports                               | valibot reports                          |
+| ----------------------- | ----------------------------------------- | ---------------------------------------- |
+| `CHECK (age >= 18)`     | `too_small`, `minimum: 18`                | `min_value`, `requirement: 18`           |
+| `varchar(10)`           | `custom`, `at most 10 characters`         | `check`, `at most 10 characters`         |
+| `CHECK (length(...))`   | `custom`, `email_len: length(email) >= 3` | `check`, `email_len: length(email) >= 3` |
+| `CHECK (status IN ...)` | `invalid_value`                           | `picklist`                               |
+| `CHECK (starts < ends)` | `path: ['starts']`                        | `path: []`, naming no column             |
+
+The last row is why the map exists rather than being a one-line path lookup: valibot names no
+column for a row-level check, so the column comes out of the constraint data instead, and it is the
+same column zod chose.
+
+`CHECK (age >= 18)` is the other one. DRZL deliberately folds a numeric CHECK into the column's own
+range, which is worth keeping because it yields the library's machine-readable bound instead of a
+sentence DRZL wrote, and it costs the constraint name: the failure is worded entirely by the
+library. The map answers that by matching the bound, and answers a failure against the column's own
+`int4` ceiling with nothing rather than blaming the nearest CHECK.
+
+**Constraints nothing enforces are present and marked.** A CHECK the parser declines appears with
+`enforced: false` and the parser's own reason, because a form still wants to know the rule exists.
+It can never produce a validation issue, so it never comes back from `constraintForIssue`.
+
+**Not `meta` written to a second file.** `meta` describes a _field_, renders a CHECK as prose, has
+no foreign keys, drops the names of the unique constraints, and is reachable only by holding the
+schema object. This describes the table's _constraints_, carries their names, states each operand
+as data, and is a record keyed by table with no validator import. Both are built from one
+classification internally, so they cannot disagree about which CHECKs are enforced.
+
+**zod and valibot only, and the boundary is measured.** The data claims the schemas enforce each
+constraint and states the exact message they use. Measured on ArkType 2.2.3 against the same table,
+neither claim would hold: it folds `cardinality(tags) > 0` into its own DSL, moves a `length()`
+check onto the object, puts DRZL's wording in `expected` rather than `message`, and emits nothing
+at all for `name <> 'x'`.
+
+`{ errorMap: false }` emits the data without the matcher: for a table with twelve constraints, 1,855
+bytes minified against 2,831 with it, and 708 against 1,117 gzipped.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -69,6 +69,7 @@ export default {
           { text: 'OpenAPI Document', link: '/generators/openapi' },
           { text: 'Nested Relations', link: '/generators/nested-relations' },
           { text: 'Branded Keys', link: '/generators/branded-keys' },
+          { text: 'Constraint Data', link: '/generators/constraints' },
           { text: 'Adapters (Overview)', link: '/adapters/overview' },
           { text: 'Router Adapters', link: '/adapters/router' },
         ],

--- a/docs/generators/constraints.md
+++ b/docs/generators/constraints.md
@@ -1,0 +1,286 @@
+# Constraint Data and Form Error Maps
+
+Emit `constraints.ts` beside the schemas: every CHECK, unique constraint, primary key and foreign
+key on each table, as plain data, plus `constraintForIssue`, which turns a validation issue back
+into the constraint that caused it.
+
+```ts
+{ kind: 'zod', path: 'src/validators/zod', constraints: true }
+```
+
+Available on the zod and valibot generators, off by default. With it off the emitted output is
+byte-for-byte what it was before: this adds a file and changes nothing in the schemas.
+
+A whole config:
+
+```ts
+export default {
+  schema: 'src/db/schema.ts',
+  outDir: 'src/api',
+  generators: [
+    { kind: 'zod', path: 'src/validators/zod', constraints: true },
+    { kind: 'valibot', path: 'src/validators/valibot', constraints: { errorMap: false } },
+  ],
+};
+```
+
+## Why a schema is not enough
+
+A validator says what a value must look like. It never says **which constraint said so**, and two
+of a table's constraints are not in it at all.
+
+- A failed parse hands a form a message and no way to attribute it. Zod's wording for a broken
+  `age_adult` never mentions `age_adult`, so a form cannot look up its own phrasing for that rule,
+  cannot highlight the field the rule is really about, and cannot tell that failure apart from the
+  column's own type bound.
+- **Uniqueness and foreign keys are absent in every form.** Whether a value is already taken, and
+  whether the row it points at exists, are facts about the table rather than about the row, so no
+  per-row schema can carry them. A form that wants to check a handle's availability, or render a
+  picker for a foreign key, has nowhere to read them from.
+
+## What it emits
+
+For a table with a length cap, a few CHECKs, a unique constraint and a foreign key:
+
+```ts
+export const eventsConstraints: DrzlTableConstraints = {
+  table: 'events',
+  constraints: [
+    {
+      id: 'events_pkey',
+      name: 'events_pkey',
+      kind: 'primaryKey',
+      columns: ['id'],
+      rule: 'PRIMARY KEY (id)',
+      enforced: false,
+    },
+    {
+      id: 'events_name_key',
+      name: 'events_name_key',
+      kind: 'unique',
+      columns: ['name'],
+      rule: 'UNIQUE (name)',
+      enforced: false,
+    },
+    {
+      id: 'events_owner_fk',
+      name: 'events_owner_fk',
+      kind: 'foreignKey',
+      columns: ['ownerId'],
+      rule: 'FOREIGN KEY (ownerId) REFERENCES users (id) ON DELETE cascade',
+      enforced: false,
+      references: { table: 'users', columns: ['id'], onDelete: 'cascade' },
+    },
+    {
+      id: 'age_adult',
+      name: 'age_adult',
+      kind: 'check',
+      columns: ['age'],
+      rule: 'CHECK (age >= 18)',
+      enforced: true,
+      bounds: [{ column: 'age', operator: '>=', value: '18' }],
+    },
+    {
+      id: 'status_valid',
+      name: 'status_valid',
+      kind: 'check',
+      columns: ['status'],
+      rule: "CHECK (status IN ('draft', 'live'))",
+      enforced: true,
+      values: { column: 'status', values: ['draft', 'live'], kind: 'string' },
+    },
+    {
+      id: 'email_len',
+      name: 'email_len',
+      kind: 'check',
+      columns: ['email'],
+      rule: 'CHECK (length(email) >= 3)',
+      enforced: true,
+      messages: ['email_len: length(email) >= 3'],
+    },
+    {
+      id: 'events_name_maxlength',
+      kind: 'maxLength',
+      columns: ['name'],
+      rule: 'at most 10 characters',
+      enforced: true,
+      messages: ['at most 10 characters'],
+    },
+  ],
+};
+
+export const constraintsByTable: Record<string, DrzlTableConstraints> = {
+  events: eventsConstraints,
+};
+```
+
+Nothing in the file imports anything. It is data, so a form builder, a server route or a one-off
+script can read it without pulling a validator in.
+
+## Mapping an issue back to its constraint
+
+```ts
+import { SelecteventsSchema, constraintForIssue } from './validators/zod';
+
+const result = SelecteventsSchema.safeParse(row);
+if (!result.success) {
+  for (const issue of result.error.issues) {
+    const hit = constraintForIssue('events', issue);
+    if (hit) {
+      form.setError(hit.column, { message: myMessages[hit.constraint.id] ?? hit.constraint.rule });
+    }
+  }
+}
+```
+
+`hit.constraint.id` is the stable identifier: the SQL constraint name where the declaration has
+one, and a derived name (`events_name_maxlength`) where SQL leaves it anonymous. Keying your own
+messages on it is what turns "the row is bad" into "you have to be 18".
+
+The same call works on a valibot issue. The two libraries report a failure differently enough that
+the shapes have almost nothing in common, and the map reads both.
+
+## What each library reports, measured
+
+The same table, the same failing rows, on zod 4.4.3 and valibot 1.4.2. `mapped` is what
+`constraintForIssue` answers.
+
+| the row breaks                        | zod issue                                 | valibot issue                                     | mapped                                        |
+| ------------------------------------- | ----------------------------------------- | ------------------------------------------------- | --------------------------------------------- |
+| `CHECK (age >= 18)`                   | `too_small`, `minimum: 18`, zod's wording | `min_value`, `requirement: 18`, valibot's wording | `age_adult`, by the bound                     |
+| `varchar(10)`                         | `custom`, `at most 10 characters`         | `check`, `at most 10 characters`                  | `events_name_maxlength`, by the message       |
+| `CHECK (length(...))`                 | `custom`, `email_len: length(email) >= 3` | `check`, `email_len: length(email) >= 3`          | `email_len`, by the message                   |
+| `CHECK (status IN ...)`               | `invalid_value`, zod's wording            | `picklist`, valibot's wording                     | `status_valid`, by the column                 |
+| `CHECK (starts < ends)`               | `custom`, `path: ['starts']`              | `check`, **`path: []`**                           | `window_ok`, column recovered from the ledger |
+| the value is not a number             | `invalid_type`                            | `number`                                          | nothing, which is correct                     |
+| above the column's own `int4` ceiling | `too_big`, `maximum: 2147483647`          | `max_value`, `requirement: 2147483647`            | nothing, which is correct                     |
+
+Two rows there are the whole design.
+
+**The row check.** Valibot puts a check on the object and names no column at all, so a map keying
+only on the path would have a message and nowhere to put it. The column comes out of the ledger
+instead, and it is the same column zod chose.
+
+**The column's own bound.** `age >= 18` is deliberately folded into the column's range rather than
+emitted as a predicate, so DRZL writes no message for it and the constraint name is nowhere in the
+issue. That fold is worth keeping: it gives the library's own machine-readable bound instead of a
+sentence DRZL wrote. What it costs is exactly what the last row shows: a failure against the
+column's `int4` ceiling arrives on the same column with the same family of code. The map answers
+that one with nothing rather than blaming the nearest CHECK.
+
+## How the match is made
+
+Three tiers, in order, and the answer says which one hit.
+
+1. **`matchedBy: 'message'`.** An exact lookup on a string these schemas wrote. Every constraint
+   stated as a predicate carries one, and the ledger holds it verbatim, so this tier cannot be
+   wrong. It is also asserted per generator: every message in the ledger has to appear in the
+   emitted schema, byte for byte.
+2. **`matchedBy: 'bound'`.** For a folded numeric CHECK. Both libraries put the bound on the issue
+   as data, so the ledger's recorded bound is matched against it. A bound that belongs to the
+   column's type matches nothing and gets no answer.
+3. **`matchedBy: 'column'`.** For a folded set constraint, which becomes an enum and leaves neither
+   a message nor a bound. Safe only because a column carries at most one.
+
+The two folds are kept apart rather than pooled, and that is what stops the third tier
+over-claiming: a folded bound **always** reports its bound, so an issue on that column carrying no
+bound is not that constraint, it is the field failing to be a number at all.
+
+The column is read from the **last** key on the path, so an issue inside an array column names the
+column rather than the index. One case is not handled: an issue from a
+[nested relation schema](/generators/nested-relations) belongs to a child table, and
+`constraintForIssue` is told which table to look in by its caller. Pass the child's name for a
+child's issue, or the answer will be whatever the parent happens to have under that column name.
+
+## Constraints the database enforces and no schema does
+
+A CHECK DRZL declines to translate is in the ledger, marked, with the parser's own reason:
+
+```ts
+{
+  id: 'unparseable',
+  name: 'unparseable',
+  kind: 'check',
+  columns: [],
+  rule: 'CHECK (my_fn(name) > now())',
+  enforced: false,
+  unenforced: [
+    { part: 'unparseable: my_fn(name) > now()',
+      reason: 'not a single comparison this version understands' },
+  ],
+}
+```
+
+It is present rather than dropped because a form still wants to know the rule exists: the server
+can reject a row this form accepted, and a form that knows it can say so instead of promising
+otherwise. It can never produce a validation issue, so it never comes back from
+`constraintForIssue`.
+
+`drzl doctor` reports the same set as a checklist for a human. This is the machine-readable half of
+that report, sitting next to the schemas rather than in terminal output.
+
+## How this differs from `meta`
+
+Both exist, and they answer different questions.
+
+|              | `meta`                                         | `constraints`                              |
+| ------------ | ---------------------------------------------- | ------------------------------------------ |
+| describes    | a **field**                                    | a **table's constraints**                  |
+| shape        | prose: `'age_adult: age >= 18'`                | data: `{ operator: '>=', value: '18' }`    |
+| foreign keys | absent                                         | present, with the target and its actions   |
+| unique       | column groups, names dropped                   | named, which is what the error map keys on |
+| addressed by | holding the schema object, per field, per mode | a record keyed by table                    |
+| destination  | `z.toJSONSchema`, then an OpenAPI viewer       | your own code                              |
+
+Turn on `meta` when you want the emitted schemas to carry their provenance into a JSON Schema
+document. Turn on `constraints` when something in your application has to reason about the
+constraints themselves. They share one classification internally, so the two can never disagree
+about which CHECKs are enforced.
+
+`meta` remains the place to read a **column's** facts: its SQL type, whether the database defaults
+the value, its declared width. Those are not repeated here.
+
+## zod and valibot only, for now
+
+Not a shortfall of effort, and the boundary was measured. The ledger claims two things about each
+constraint: that the schemas enforce it, and the exact message they use when they reject a row.
+Both are true of zod and valibot, which enforce the same constraints in the same words.
+
+ArkType is why this is a per-generator capability rather than a global one. Measured on 2.2.3
+against the same table: it folds `cardinality(tags) > 0` into its own DSL, moves a `length()` check
+onto the object so the issue names no column, puts DRZL's wording in `expected` rather than in
+`message`, and emits nothing at all for `name <> 'x'`. A ledger claiming that last constraint is
+enforced would be wrong, and wrong in silence. TypeBox and Effect were not measured, so they are
+not claimed.
+
+## What it costs
+
+For a table with twelve constraints, one primary key, one unique constraint, one foreign key, seven
+CHECKs and a declared width:
+
+| what             | source   | minified | minified and gzipped |
+| ---------------- | -------- | -------- | -------------------- |
+| data and the map | 10,110 B | 2,831 B  | 1,117 B              |
+| data alone       | 5,291 B  | 1,855 B  | 708 B                |
+
+Most of the source is doc comments and type declarations, and both vanish at build time. Use
+`{ errorMap: false }` for the data without the matcher, which is the split between plan items 39
+and 40 expressed as a flag.
+
+The ledger is one module for the whole output directory, not one per table, so a consumer
+importing one table's constraints pulls the record for all of them. That is the trade for
+`constraintForIssue` being a single function that takes a table name.
+
+## Options
+
+```ts
+{ kind: 'zod', path: 'src/validators/zod', constraints: true }
+{ kind: 'zod', path: 'src/validators/zod', constraints: { enabled: true, errorMap: false } }
+```
+
+| option     | default | what it does                                        |
+| ---------- | ------- | --------------------------------------------------- |
+| `enabled`  | `false` | emit `constraints.ts` and export it from the barrel |
+| `errorMap` | `true`  | also emit `constraintForIssue` and its types        |
+
+`true` is the shorthand for `{ enabled: true }`.

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -259,6 +259,17 @@ round trip.
 
 Off by default: generated code ships in your bundle.
 
+## `constraints`: the table's constraints as data
+
+`constraints: true` also emits `constraints.ts`: every CHECK, unique constraint, primary key and
+foreign key on each table as plain data, plus `constraintForIssue`, which turns a failed parse back
+into the constraint that caused it.
+
+Valibot is the generator that decided the shape of that map. It reports a row-level check with an
+**empty path**, naming no column at all, so the column has to come out of the constraint data
+rather than out of the issue. See
+[Constraint Data and Form Error Maps](/generators/constraints).
+
 ## Nested relation schemas
 
 `nestedSchemas: true` also emits `NestedInsert<Table>` and `NestedSelect<Table>`, the table plus one

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -802,6 +802,19 @@ The `json-schema` generator does not read this either. It builds its documents f
 analysis rather than from a zod schema, so there is nothing to read; it already states what JSON
 Schema cannot express as a `description` of its own.
 
+## `constraints`: the table's constraints as data
+
+`constraints: true` also emits `constraints.ts`: every CHECK, unique constraint, primary key and
+foreign key on each table as plain data, plus `constraintForIssue`, which turns a failed parse back
+into the constraint that caused it.
+
+Not `meta` written to a second file. `meta` describes a **field** and travels with the schema into
+`z.toJSONSchema`; this describes the table's **constraints**, carries their names, states each
+operand as data rather than inside a sentence, and is read without holding a schema at all. It also
+carries the two constraints no per-row schema can hold in any form, uniqueness and foreign keys.
+
+See [Constraint Data and Form Error Maps](/generators/constraints).
+
 ## Nested relation schemas
 
 `nestedSchemas: true` also emits `NestedInsert<Table>` and `NestedSelect<Table>`, the table plus one

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -308,7 +308,11 @@ program
             // `meta` is zod-only; see `GeneratorCapabilities.meta` for why it is not passed to the
             // other four rather than being passed and ignored.
             const files = await gen.generate(
-              validationOptions(g, cfg, target, { schemaTypes: true, meta: true }) as never
+              validationOptions(g, cfg, target, {
+                schemaTypes: true,
+                meta: true,
+                constraints: true,
+              }) as never
             );
             progress.stop();
             ora().succeed(chalk.green(`Generated (zod): ${files.length} files`));
@@ -327,7 +331,7 @@ program
             const gen = new ValibotGenerator(analysis);
             const target = g.path ?? 'src/validators/valibot';
             const files = await gen.generate(
-              validationOptions(g, cfg, target, { schemaTypes: true }) as never
+              validationOptions(g, cfg, target, { schemaTypes: true, constraints: true }) as never
             );
             progress.stop();
             ora().succeed(chalk.green(`Generated (valibot): ${files.length} files`));
@@ -767,7 +771,11 @@ program
               // were all dropped, so the first save after starting `drzl watch` silently replaced
               // correct output with output generated from defaults.
               const files = await gen.generate(
-                validationOptions(g, cfg, target, { schemaTypes: true, meta: true }) as never
+                validationOptions(g, cfg, target, {
+                  schemaTypes: true,
+                  meta: true,
+                  constraints: true,
+                }) as never
               );
               opts.json
                 ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
@@ -794,7 +802,10 @@ program
               // were all dropped, so the first save after starting `drzl watch` silently replaced
               // correct output with output generated from defaults.
               const files = await gen.generate(
-                validationOptions(g, cfg, target, { schemaTypes: true }) as never
+                validationOptions(g, cfg, target, {
+                  schemaTypes: true,
+                  constraints: true,
+                }) as never
               );
               opts.json
                 ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -119,6 +119,29 @@ export const GeneratorSchema = z.object({
    */
   duplicateFinder: z.boolean().optional(),
   /**
+   * zod and valibot. Also emit `constraints.ts`: every CHECK, unique constraint, primary and
+   * foreign key on each table as plain data, plus `constraintForIssue`, which maps a validation
+   * issue back to the constraint that caused it.
+   *
+   * For building forms. A schema states what a value must look like and never says which
+   * constraint said so, so a failed parse hands a form a message and no way to attribute it; and
+   * uniqueness and foreign keys, the two constraints no per-row schema can check, are absent from
+   * the emitted schemas in every form.
+   *
+   * Not `meta` written to a second file. `meta` describes a *field* and travels with the schema
+   * into `z.toJSONSchema`; this describes the table's *constraints*, carries their names, states
+   * each operand as data rather than inside a sentence, and is read without holding a schema.
+   *
+   * `true` is the shorthand for `{ enabled: true }`. `{ errorMap: false }` emits the data alone,
+   * without the matcher.
+   */
+  constraints: z
+    .union([
+      z.boolean(),
+      z.object({ enabled: z.boolean().optional(), errorMap: z.boolean().optional() }).strict(),
+    ])
+    .optional(),
+  /**
    * zod only. Attach the facts the analyzer knows and a zod schema cannot state, as `.meta()` on
    * every field and every table schema: the declared SQL type, the primary key, the unique
    * constraints, whether the database generates or defaults the value, and the CHECK constraints,

--- a/packages/cli/src/validation-options.ts
+++ b/packages/cli/src/validation-options.ts
@@ -30,6 +30,7 @@ export type ValidationGeneratorConfig = {
   typedJson?: unknown;
   typedColumns?: unknown;
   duplicateFinder?: unknown;
+  constraints?: unknown;
   nestedSchemas?: unknown;
   nestedDepth?: unknown;
   branded?: unknown;
@@ -65,6 +66,20 @@ export interface GeneratorCapabilities {
    * building four on the strength of one measurement is how three of them come to be subtly wrong.
    */
   meta?: boolean;
+  /**
+   * Whether the generator emits the constraint ledger beside its schemas.
+   *
+   * zod and valibot so far, and the boundary is measured rather than conservative. The ledger
+   * carries the exact message the emitted schema attaches for each constraint, which is what the
+   * error map keys on, and those two enforce the same set of constraints in the same words.
+   *
+   * ArkType is the case that says why this is a flag. Measured on 2.2.3 against the same table:
+   * it folds `cardinality(tags) > 0` into its own DSL, moves a `length()` check onto the object
+   * so the issue names no column, reports DRZL's wording in `expected` rather than in `message`,
+   * and emits nothing at all for `name <> 'x'`. A ledger claiming that constraint is enforced
+   * would be wrong there, and it would be wrong silently.
+   */
+  constraints?: boolean;
 }
 
 export function validationOptions(
@@ -103,5 +118,6 @@ export function validationOptions(
       : {}),
     ...(caps.standardSchema ? { standardSchema: g.standardSchema } : {}),
     ...(caps.meta ? { meta: g.meta } : {}),
+    ...(caps.constraints ? { constraints: g.constraints } : {}),
   };
 }

--- a/packages/cli/test/config.spec.ts
+++ b/packages/cli/test/config.spec.ts
@@ -58,6 +58,25 @@ describe('@drzl/cli config meta', () => {
   });
 });
 
+describe('@drzl/cli config constraints', () => {
+  const base = (generators: any[]) => ({ schema: 'src/db/schema.ts', generators });
+
+  it('keeps the boolean shorthand and the object form through parse', () => {
+    const shorthand: any = ConfigSchema.parse(base([{ kind: 'zod', constraints: true }]));
+    expect(shorthand.generators[0].constraints).toBe(true);
+    const full: any = ConfigSchema.parse(
+      base([{ kind: 'valibot', constraints: { errorMap: false } }])
+    );
+    expect(full.generators[0].constraints).toEqual({ errorMap: false });
+  });
+
+  it('refuses a key it does not know, rather than dropping it in silence', () => {
+    expect(() =>
+      ConfigSchema.parse(base([{ kind: 'zod', constraints: { errorMaps: false } }]))
+    ).toThrow();
+  });
+});
+
 describe('@drzl/cli config affix', () => {
   const base = (generators: any[]) => ({ schema: 'src/db/schema.ts', generators });
 

--- a/packages/cli/test/validation-options.spec.ts
+++ b/packages/cli/test/validation-options.spec.ts
@@ -26,6 +26,7 @@ const generator = {
   typedJson: true,
   typedColumns: true,
   duplicateFinder: true,
+  constraints: { errorMap: false },
   nestedSchemas: true,
   nestedDepth: 2,
   branded: { foreignKeys: false },
@@ -67,6 +68,19 @@ describe('the shared options', () => {
         foreignKeys: false,
       });
     }
+  });
+
+  it('withholds the constraint ledger from the generators whose enforcement was not measured', () => {
+    // The ledger states which constraints the emitted schemas enforce and the exact message each
+    // uses. Measured on ArkType 2.2.3, neither claim holds there: it folds a cardinality check
+    // into its own DSL, puts DRZL's wording in `expected` rather than `message`, and emits nothing
+    // at all for a string `<>`. A flag is the honest record of where it was measured.
+    expect(validationOptions(generator, config, 'out', { schemaTypes: true })).not.toHaveProperty(
+      'constraints'
+    );
+    expect(
+      validationOptions(generator, config, 'out', { schemaTypes: true, constraints: true })
+    ).toMatchObject({ constraints: { errorMap: false } });
   });
 
   it('withholds metadata from the four generators that have no measured place to put it', () => {

--- a/packages/generator-valibot/README.md
+++ b/packages/generator-valibot/README.md
@@ -40,6 +40,10 @@ generators: [{ kind: 'valibot', path: 'src/validators/valibot' }];
 - `Insert<Table>Schema`, `Update<Table>Schema`, `Select<Table>Schema`
 - Optional `index` barrel
 - Shared vs inlined schemas supported
+- `constraints.ts` under `constraints: true`: every CHECK, unique constraint, primary key
+  and foreign key on each table as plain data, plus `constraintForIssue`, which maps a
+  validation issue back to the constraint that caused it. Off by default. See the
+  [Constraint Data](https://use-drzl.github.io/drzl/generators/constraints) page.
 
 ## Custom names
 

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -7,12 +7,14 @@ import type {
 } from '@drzl/validation-core';
 import type { CardinalityCheck, ColumnCheck, ColumnSet, LengthCheck } from '@drzl/validation-core';
 import type { NestedMode, NestedNode } from '@drzl/validation-core';
-import type { BrandPlan } from '@drzl/validation-core';
+import type { BrandPlan, ConstraintsOption } from '@drzl/validation-core';
 import {
   buildBrandPlan,
   buildNestedPlan,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
+  CONSTRAINTS_MODULE,
+  importSpecifier,
   insertColumns,
   isIntegerColumn,
   nestedArmNotes,
@@ -22,8 +24,10 @@ import {
   nonFiniteAccepted,
   parseCheck,
   parsesToADate,
+  renderConstraintsModule,
   renderDuplicateFinder,
   resolveConfiguredImport,
+  resolveConstraints,
   resolveNestedDepth,
   updateColumns,
   selectColumns,
@@ -829,6 +833,22 @@ export interface ValibotGenerateOptions extends ValidationGenerateOptions {
    * generated code ships in the consumer's bundle.
    */
   duplicateFinder?: boolean;
+  /**
+   * Also emit `constraints.ts`: every CHECK, unique constraint, primary and foreign key on each
+   * table, as plain data, plus `constraintForIssue` to map a validation issue back to the
+   * constraint that caused it.
+   *
+   * For a consumer building forms. A schema states what a value must look like and never says
+   * which constraint said so, so a failed parse gives a form a message and no way to attribute it;
+   * and the two constraints a per-row schema cannot check at all, uniqueness and a foreign key,
+   * are absent from the emitted module in every form.
+   *
+   * The emitted module is library-neutral data, and its matcher reads valibot's path items and
+   * zod's alike. Off by default, like every option that adds bytes to the consumer's bundle.
+   * `true` is the shorthand for `{ enabled: true }`; `{ errorMap: false }` emits the data without
+   * the matcher.
+   */
+  constraints?: ConstraintsOption;
 }
 
 export class ValibotGenerator implements ValidationRenderer<ValibotGenerateOptions> {
@@ -892,6 +912,22 @@ export class ValibotGenerator implements ValidationRenderer<ValibotGenerateOptio
       await fs.writeFile(filePath, formatted, 'utf8');
       files.push(filePath);
     }
+    // Before the barrel, which re-exports it. A file of plain data with no import of its own.
+    const constraints = resolveConstraints(opts.constraints);
+    if (constraints) {
+      const constraintsPath = path.join(out, CONSTRAINTS_MODULE);
+      await fs.writeFile(
+        constraintsPath,
+        await formatCode(
+          buildHeader(opts.outputHeader) +
+            renderConstraintsModule(this.analysis.tables, constraints),
+          constraintsPath,
+          opts.format
+        ),
+        'utf8'
+      );
+      files.push(constraintsPath);
+    }
     const indexPath = path.join(out, 'index.ts');
     const indexCode = this.defaultIndex(this.analysis, opts);
     const indexFormatted = await formatCode(
@@ -922,7 +958,12 @@ export class ValibotGenerator implements ValidationRenderer<ValibotGenerateOptio
     const exports = analysis.tables
       .map((t) => `export * from '${moduleSpecifier(t.tsName, fileSuffix, opts.importExtension)}';`)
       .join('\n');
-    return exports + '\n';
+    // The ledger is named rather than suffixed, so its specifier is built from the module name
+    // rather than from `fileSuffix`, and it is only exported when it was written.
+    const ledger = resolveConstraints(opts.constraints)
+      ? `export * from '${importSpecifier(`./${CONSTRAINTS_MODULE}`, opts.importExtension)}';\n`
+      : '';
+    return exports + '\n' + ledger;
   }
 }
 

--- a/packages/generator-valibot/test/constraints.spec.ts
+++ b/packages/generator-valibot/test/constraints.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * The constraint ledger and its error map, against valibot rather than zod.
+ *
+ * The map exists once and has to work for both, and the two libraries report a failure differently
+ * enough that a map built against either alone would be wrong for the other. Measured on valibot
+ * 1.4.2 and zod 4.4.3, for the same table and the same failing rows:
+ *
+ *   path shape        zod `['age']`, a bare string; valibot `[{ type: 'object', key: 'age' }]`
+ *   a row CHECK       zod reports `path: ['starts']`; valibot reports `path: []`, naming no column
+ *   a folded bound    zod puts `minimum: 18` on the issue; valibot puts `requirement: 18`
+ *   a folded set      zod raises `invalid_value`; valibot raises a `picklist` schema issue
+ *
+ * The row check is the one that decides the design: on valibot the library reports no column at
+ * all, so the column has to come out of the ledger rather than out of the issue.
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import * as v from 'valibot';
+import type { Analysis, Column, Table } from '@drzl/analyzer';
+import { ValibotGenerator } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (name: string, cols: Column[], over: Partial<Table> = {}): Table =>
+  ({ name, tsName: name, columns: cols, unique: [], indexes: [], checks: [], ...over }) as Table;
+
+const events = table(
+  'events',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', sqlType: 'serial', isGenerated: true }),
+    col('name', { sqlType: 'varchar(10)', maxLength: 10 }),
+    col('age', {
+      tsType: 'number',
+      dbType: 'INTEGER',
+      sqlType: 'integer',
+      integer: true,
+      min: '-2147483648',
+      max: '2147483647',
+    }),
+    col('email', { sqlType: 'text' }),
+    col('status', { sqlType: 'text' }),
+    col('starts', { tsType: 'number', dbType: 'INTEGER', sqlType: 'integer', integer: true }),
+    col('ends', { tsType: 'number', dbType: 'INTEGER', sqlType: 'integer', integer: true }),
+    col('tags', { sqlType: 'text[]', arrayDimensions: 1 }),
+  ],
+  {
+    primaryKey: { name: 'events_pkey', columns: ['id'] },
+    unique: [{ name: 'events_name_key', columns: ['name'] }],
+    checks: [
+      { name: 'age_adult', expression: 'age >= 18' },
+      { name: 'email_len', expression: 'length(email) >= 3' },
+      { name: 'status_valid', expression: "status IN ('draft', 'live')" },
+      { name: 'window_ok', expression: 'starts < ends' },
+      { name: 'has_tags', expression: 'cardinality(tags) > 0' },
+      { name: 'name_not_x', expression: "name <> 'x'" },
+    ],
+  }
+);
+
+const analysis = (): Analysis => ({
+  dialect: 'postgres',
+  tables: [events],
+  enums: [],
+  relations: [],
+  issues: [],
+});
+
+let seq = 0;
+
+async function emit(opts: Record<string, unknown>) {
+  const dir = path.join(__dirname, '.tmp-constraints', `run-${process.pid}-${seq++}`);
+  await fs.mkdir(dir, { recursive: true });
+  const files = await new ValibotGenerator(analysis()).generate({ outDir: dir, ...opts } as never);
+  const constraintsPath = path.join(dir, 'constraints.ts');
+  const exists = files.includes(constraintsPath);
+  return {
+    exists,
+    schema: await import(path.join(dir, 'events.valibot.ts')),
+    mod: exists ? await import(constraintsPath) : undefined,
+    schemaText: await fs.readFile(path.join(dir, 'events.valibot.ts'), 'utf8'),
+  };
+}
+
+const OK = {
+  id: 1,
+  name: 'ok',
+  age: 30,
+  email: 'abc',
+  status: 'live',
+  starts: 1,
+  ends: 2,
+  tags: ['a'],
+};
+
+describe('opt-in', () => {
+  it('emits nothing at all by default', async () => {
+    expect((await emit({})).exists).toBe(false);
+  });
+
+  it('leaves the schemas byte-for-byte unchanged', async () => {
+    expect((await emit({ constraints: true })).schemaText).toBe((await emit({})).schemaText);
+  });
+});
+
+describe('the messages', () => {
+  it('are byte-identical to the strings the emitted valibot schema carries', async () => {
+    const { mod, schemaText } = await emit({ constraints: true });
+    const messages = mod!.eventsConstraints.constraints.flatMap(
+      (c: { messages?: string[] }) => c.messages ?? []
+    );
+    expect(messages.length).toBeGreaterThan(0);
+    // The message text, not its JSON form: the formatter picks the quote character.
+    for (const m of messages) expect(schemaText, m).toContain(m);
+  });
+});
+
+describe('mapping a real valibot issue back to its constraint', () => {
+  const match = async (row: Record<string, unknown>) => {
+    const { mod, schema } = await emit({ constraints: true });
+    const r = v.safeParse(schema.SelecteventsSchema, row);
+    expect(r.success, JSON.stringify(row)).toBe(false);
+    return r.issues!.map((i: unknown) => mod!.constraintForIssue('events', i));
+  };
+
+  it('reads a column out of valibot path items, which are objects and not strings', async () => {
+    const [m] = await match({ ...OK, email: 'a' });
+    expect(m).toMatchObject({ column: 'email', matchedBy: 'message' });
+    expect(m.constraint.id).toBe('email_len');
+  });
+
+  it('maps a folded bound by the value valibot carries as `requirement`', async () => {
+    const [m] = await match({ ...OK, age: 5 });
+    expect(m).toMatchObject({ column: 'age', matchedBy: 'bound' });
+    expect(m.constraint.id).toBe('age_adult');
+  });
+
+  it('does not attribute the column type own bound to a constraint', async () => {
+    // Above the int32 ceiling. The CHECK narrowed the lower end, so the upper one is the column's
+    // own type and no constraint owns it, even though the issue looks the same from outside.
+    expect((await match({ ...OK, age: 3000000000 }))[0]).toBeUndefined();
+  });
+
+  it('maps a failed picklist, which valibot raises as a schema issue with no requirement', async () => {
+    const [m] = await match({ ...OK, status: 'nope' });
+    expect(m).toMatchObject({ column: 'status', matchedBy: 'column' });
+    expect(m.constraint.id).toBe('status_valid');
+  });
+
+  it('recovers the column of a row CHECK, which valibot reports with an empty path', async () => {
+    const { mod, schema } = await emit({ constraints: true });
+    const r = v.safeParse(schema.SelecteventsSchema, { ...OK, starts: 9, ends: 2 });
+    expect(r.success).toBe(false);
+    // The measurement this test exists for: valibot names no column here.
+    expect(r.issues![0]!.path ?? []).toEqual([]);
+    const m = mod!.constraintForIssue('events', r.issues![0]);
+    expect(m.constraint.id).toBe('window_ok');
+    expect(m.column).toBe('starts');
+  });
+
+  it('maps a failed cardinality CHECK on an array column', async () => {
+    expect((await match({ ...OK, tags: [] }))[0].constraint.id).toBe('has_tags');
+  });
+
+  it('returns nothing for a plain type failure', async () => {
+    expect((await match({ ...OK, age: 'not a number' }))[0]).toBeUndefined();
+  });
+});

--- a/packages/generator-zod/README.md
+++ b/packages/generator-zod/README.md
@@ -40,6 +40,10 @@ generators: [{ kind: 'zod', path: 'src/validators/zod' }];
 - `Insert<Table>Schema`, `Update<Table>Schema`, `Select<Table>Schema`
 - Optional `index` barrel
 - Shared vs inlined schemas supported
+- `constraints.ts` under `constraints: true`: every CHECK, unique constraint, primary key
+  and foreign key on each table as plain data, plus `constraintForIssue`, which maps a
+  validation issue back to the constraint that caused it. Off by default. See the
+  [Constraint Data](https://use-drzl.github.io/drzl/generators/constraints) page.
 
 ## Custom names
 

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -13,17 +13,22 @@ import type {
 } from '@drzl/validation-core';
 import type { NestedNode, NestedMode } from '@drzl/validation-core';
 import type { BrandPlan } from '@drzl/validation-core';
+import type { ConstraintsOption } from '@drzl/validation-core';
 import {
   buildBrandPlan,
   columnMetaFacts,
   formatCode,
   parseCheck,
+  renderConstraintsModule,
+  resolveConstraints,
+  CONSTRAINTS_MODULE,
   renderDuplicateFinder,
   resolveConfiguredImport,
   buildNestedPlan,
   tableMetaFacts,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
+  importSpecifier,
   insertColumns,
   isIntegerColumn,
   moduleFileName,
@@ -904,6 +909,25 @@ export interface ZodGenerateOptions extends ValidationGenerateOptions {
    * zod's own clone-versus-wrap behaviour rather than reasoned about. See the docs page.
    */
   meta?: boolean | { enabled?: boolean; description?: boolean };
+  /**
+   * Also emit `constraints.ts`: every CHECK, unique constraint, primary and foreign key on each
+   * table, as plain data, plus `constraintForIssue` to map a validation issue back to the
+   * constraint that caused it.
+   *
+   * For a consumer building forms. A schema states what a value must look like and never says
+   * which constraint said so, so a failed parse gives a form a message and no way to attribute it;
+   * and the two constraints a per-row schema cannot check at all, uniqueness and a foreign key,
+   * are absent from the emitted module in every form. This is the table's constraints addressed by
+   * name, with the operand of each as data rather than inside a sentence.
+   *
+   * Not `meta` written to a second file. `meta` describes a *field* and travels with the schema
+   * into `z.toJSONSchema`; this describes the *table's constraints*, carries their names, and is
+   * read without holding a schema at all. See `@drzl/validation-core`'s constraints module.
+   *
+   * Off by default, like every option that adds bytes to the consumer's bundle. `true` is the
+   * shorthand for `{ enabled: true }`; `{ errorMap: false }` emits the data without the matcher.
+   */
+  constraints?: ConstraintsOption;
 }
 
 /**
@@ -996,6 +1020,23 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
       await fs.writeFile(filePath, formatted, 'utf8');
       files.push(filePath);
     }
+    // Before the barrel, which re-exports it. A file of plain data with no import of its own, so
+    // it is written the same way whatever the schemas above ended up looking like.
+    const constraints = resolveConstraints(opts.constraints);
+    if (constraints) {
+      const constraintsPath = path.join(out, CONSTRAINTS_MODULE);
+      const constraintsCode = renderConstraintsModule(this.analysis.tables, constraints);
+      await fs.writeFile(
+        constraintsPath,
+        await formatCode(
+          buildHeader(opts.outputHeader) + constraintsCode,
+          constraintsPath,
+          opts.format
+        ),
+        'utf8'
+      );
+      files.push(constraintsPath);
+    }
     // Index barrel
     const indexPath = path.join(out, 'index.ts');
     const indexCode =
@@ -1031,7 +1072,12 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
     const exports = analysis.tables
       .map((t) => `export * from '${moduleSpecifier(t.tsName, fileSuffix, opts.importExtension)}';`)
       .join('\n');
-    return exports + '\n';
+    // The ledger is named rather than suffixed, so its specifier is built from the module name
+    // rather than from `fileSuffix`, and it is only exported when it was written.
+    const ledger = resolveConstraints(opts.constraints)
+      ? `export * from '${importSpecifier(`./${CONSTRAINTS_MODULE}`, opts.importExtension)}';\n`
+      : '';
+    return exports + '\n' + ledger;
   }
 }
 

--- a/packages/generator-zod/test/constraints.spec.ts
+++ b/packages/generator-zod/test/constraints.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * `constraints`: the table's CHECK, unique and foreign key constraints emitted as data, and the
+ * error map that turns a validation issue back into the constraint that caused it.
+ *
+ * The identity under test is the fragile one. A constraint the schema states as a predicate carries
+ * a message DRZL wrote, and the map is an exact lookup on that string; a constraint DRZL folds into
+ * zod's own vocabulary carries no message at all, because zod writes that one. Measured on zod
+ * 4.4.3, for the same table:
+ *
+ *   CHECK (length(email) >= 3)   code `custom`, message `email_len: length(email) >= 3`
+ *   CHECK (age >= 18)            code `too_small`, `minimum: 18`, message written by zod
+ *   CHECK (status IN (...))      code `invalid_value`, message written by zod
+ *
+ * So the constraint name survives in the first and is gone in the other two, and the map has to key
+ * on something else there. It keys on the bound, which zod puts on the issue as data.
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { Analysis, Column, Table } from '@drzl/analyzer';
+import { ZodGenerator } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (name: string, cols: Column[], over: Partial<Table> = {}): Table =>
+  ({ name, tsName: name, columns: cols, unique: [], indexes: [], checks: [], ...over }) as Table;
+
+const events = table(
+  'events',
+  [
+    col('id', { tsType: 'number', dbType: 'INTEGER', sqlType: 'serial', isGenerated: true }),
+    col('name', { sqlType: 'varchar(10)', maxLength: 10 }),
+    col('age', {
+      tsType: 'number',
+      dbType: 'INTEGER',
+      sqlType: 'integer',
+      integer: true,
+      min: '-2147483648',
+      max: '2147483647',
+    }),
+    col('email', { sqlType: 'text' }),
+    col('status', { sqlType: 'text' }),
+    col('starts', { tsType: 'number', dbType: 'INTEGER', sqlType: 'integer', integer: true }),
+    col('ends', { tsType: 'number', dbType: 'INTEGER', sqlType: 'integer', integer: true }),
+    col('tags', { sqlType: 'text[]', arrayDimensions: 1 }),
+    col('ownerId', { tsType: 'number', dbType: 'INTEGER', sqlType: 'integer' }),
+  ],
+  {
+    primaryKey: { name: 'events_pkey', columns: ['id'] },
+    unique: [{ name: 'events_name_key', columns: ['name'] }],
+    foreignKeys: [
+      {
+        name: 'events_owner_fk',
+        columns: ['ownerId'],
+        foreignTable: 'users',
+        foreignColumns: ['id'],
+        onDelete: 'cascade',
+      },
+    ],
+    checks: [
+      { name: 'age_adult', expression: 'age >= 18' },
+      { name: 'email_len', expression: 'length(email) >= 3' },
+      { name: 'status_valid', expression: "status IN ('draft', 'live')" },
+      { name: 'window_ok', expression: 'starts < ends' },
+      { name: 'has_tags', expression: 'cardinality(tags) > 0' },
+      { name: 'name_not_x', expression: "name <> 'x'" },
+      { name: 'unparseable', expression: 'my_fn(name) > now()' },
+    ],
+  }
+);
+
+const analysis = (): Analysis => ({
+  dialect: 'postgres',
+  tables: [events],
+  enums: [],
+  relations: [],
+  issues: [],
+});
+
+let seq = 0;
+
+async function emit(opts: Record<string, unknown>) {
+  const dir = path.join(__dirname, '.tmp-constraints', `run-${process.pid}-${seq++}`);
+  await fs.mkdir(dir, { recursive: true });
+  const files = await new ZodGenerator(analysis()).generate({ outDir: dir, ...opts } as never);
+  const constraintsPath = path.join(dir, 'constraints.ts');
+  const exists = files.includes(constraintsPath);
+  return {
+    dir,
+    files,
+    exists,
+    schema: await import(path.join(dir, 'events.zod.ts')),
+    mod: exists ? await import(constraintsPath) : undefined,
+    text: exists ? await fs.readFile(constraintsPath, 'utf8') : '',
+    schemaText: await fs.readFile(path.join(dir, 'events.zod.ts'), 'utf8'),
+  };
+}
+
+const OK = {
+  id: 1,
+  name: 'ok',
+  age: 30,
+  email: 'abc',
+  status: 'live',
+  starts: 1,
+  ends: 2,
+  tags: ['a'],
+  ownerId: 7,
+};
+
+describe('opt-in', () => {
+  it('emits nothing at all by default', async () => {
+    const off = await emit({});
+    expect(off.exists).toBe(false);
+  });
+
+  it('emits the module and exports it from the barrel when asked for', async () => {
+    const on = await emit({ constraints: true });
+    expect(on.exists).toBe(true);
+    const barrel = await fs.readFile(path.join(on.dir, 'index.ts'), 'utf8');
+    expect(barrel).toContain("./constraints.js'");
+  });
+
+  it('leaves the schemas byte-for-byte unchanged, since this adds a file rather than code', async () => {
+    const off = await emit({});
+    const on = await emit({ constraints: true });
+    expect(on.schemaText).toBe(off.schemaText);
+  });
+});
+
+describe('the messages, which are the whole of the error map', () => {
+  it('are byte-identical to the strings the emitted schema carries', async () => {
+    const { mod, schemaText } = await emit({ constraints: true });
+    const messages = mod!.eventsConstraints.constraints.flatMap(
+      (c: { messages?: string[] }) => c.messages ?? []
+    );
+    expect(messages.length).toBeGreaterThan(0);
+    // The message text, not its JSON form: the formatter picks the quote character, so
+    // `name_not_x: name <> 'x'` is emitted inside double quotes and the rest inside single ones.
+    // What has to be identical is what ends up in the issue, which is the text between them.
+    for (const m of messages) expect(schemaText, m).toContain(m);
+  });
+});
+
+describe('mapping a real issue back to the constraint that caused it', () => {
+  const match = async (row: Record<string, unknown>) => {
+    const { mod, schema } = await emit({ constraints: true });
+    const r = schema.SelecteventsSchema.safeParse(row);
+    expect(r.success, JSON.stringify(row)).toBe(false);
+    return r.error.issues.map((i: unknown) => mod!.constraintForIssue('events', i));
+  };
+
+  it('maps a failed length CHECK by the message zod carries verbatim', async () => {
+    const [m] = await match({ ...OK, email: 'a' });
+    expect(m).toMatchObject({ column: 'email', matchedBy: 'message' });
+    expect(m.constraint.id).toBe('email_len');
+    expect(m.constraint.rule).toBe('CHECK (length(email) >= 3)');
+  });
+
+  it('maps a failed length cap, whose message says nothing about which constraint', async () => {
+    const [m] = await match({ ...OK, name: 'wayyyyy too long' });
+    expect(m).toMatchObject({ column: 'name', matchedBy: 'message' });
+    expect(m.constraint.kind).toBe('maxLength');
+  });
+
+  it('maps a folded CHECK, where zod writes the message and the name is gone', async () => {
+    const [m] = await match({ ...OK, age: 5 });
+    expect(m).toMatchObject({ column: 'age', matchedBy: 'bound' });
+    expect(m.constraint.id).toBe('age_adult');
+  });
+
+  it('does not attribute the column type own bound to a constraint', async () => {
+    // Above the int32 ceiling. The CHECK narrowed the *lower* end, so the upper one is the
+    // column's own type, and the issue looks exactly like a folded CHECK failing: same column,
+    // same family of code, a bound on the issue. Keying on the column would have claimed
+    // `age_adult` here, for a rule the row did not break.
+    const [m] = await match({ ...OK, age: 3000000000 });
+    expect(m).toBeUndefined();
+  });
+
+  it('maps a failed set CHECK, which zod states as an enum', async () => {
+    const [m] = await match({ ...OK, status: 'nope' });
+    expect(m).toMatchObject({ column: 'status', matchedBy: 'column' });
+    expect(m.constraint.id).toBe('status_valid');
+    expect(m.constraint.values.values).toEqual(['draft', 'live']);
+  });
+
+  it('maps a failed row CHECK to the constraint naming both columns', async () => {
+    const [m] = await match({ ...OK, starts: 9, ends: 2 });
+    expect(m.constraint.id).toBe('window_ok');
+    expect(m.constraint.columns).toEqual(['starts', 'ends']);
+  });
+
+  it('maps a failed cardinality CHECK on an array column', async () => {
+    const [m] = await match({ ...OK, tags: [] });
+    expect(m.constraint.id).toBe('has_tags');
+  });
+
+  it('returns nothing for an issue no constraint caused', async () => {
+    const [m] = await match({ ...OK, age: 'not a number' });
+    expect(m).toBeUndefined();
+  });
+
+  it('returns nothing for a table it has no ledger for', async () => {
+    const { mod } = await emit({ constraints: true });
+    expect(mod!.constraintForIssue('nope', { path: ['age'], message: 'x' })).toBeUndefined();
+  });
+});
+
+describe('what a form builder reads before anything fails', () => {
+  it('finds the unique constraints, so it can check availability against the server', async () => {
+    const { mod } = await emit({ constraints: true });
+    const unique = mod!.eventsConstraints.constraints.filter(
+      (c: { kind: string }) => c.kind === 'unique'
+    );
+    expect(unique).toHaveLength(1);
+    expect(unique[0].columns).toEqual(['name']);
+  });
+
+  it('finds the foreign key and where it points, so it can render a picker', async () => {
+    const { mod } = await emit({ constraints: true });
+    const fk = mod!.eventsConstraints.constraints.find(
+      (c: { kind: string }) => c.kind === 'foreignKey'
+    );
+    expect(fk.references).toMatchObject({ table: 'users', columns: ['id'], onDelete: 'cascade' });
+  });
+
+  it('finds the CHECK the database enforces and no schema does, marked as such', async () => {
+    const { mod } = await emit({ constraints: true });
+    const c = mod!.eventsConstraints.constraints.find(
+      (x: { id: string }) => x.id === 'unparseable'
+    );
+    expect(c.enforced).toBe(false);
+    expect(c.unenforced[0].reason).toBeTruthy();
+  });
+});
+
+describe('the error map is separable from the data', () => {
+  it('is left out when only the ledger is wanted', async () => {
+    const { text } = await emit({ constraints: { errorMap: false } });
+    expect(text).not.toContain('constraintForIssue');
+    expect(text).toContain('eventsConstraints');
+  });
+});

--- a/packages/validation-core/README.md
+++ b/packages/validation-core/README.md
@@ -62,6 +62,20 @@ Shared interfaces and helpers used by validation generators.
   - `CODEPOINT_LENGTH` -> `[...v].length`, since `varchar(n)` counts characters and JavaScript's
     `.length` counts UTF-16 units. All four generators use it.
   - `isIntegerColumn(c)`
+- Constraints as data (shared by the generators that emit a ledger)
+  - `tableConstraints(table)` -> every CHECK, unique constraint, primary key and foreign key on a
+    table, each with a stable `id`, the columns it names, the rule as a sentence, whether a
+    generated schema enforces it, and, where it does, the exact message it attaches. A folded
+    numeric CHECK carries its `bounds` and a folded `IN` list its `values`, because those are what
+    is left to match on once the library writes the failure message itself.
+  - `classifyTableChecks(table)` -> the one reading of `parseCheck` plus the column-shape guards,
+    shared with `meta`, so "the database also checks this and no schema does" is one answer rather
+    than two.
+  - `renderConstraintsModule(tables, opts)` -> the source of `constraints.ts`: the data above plus,
+    unless `errorMap` is false, `constraintForIssue(table, issue)`. Plain objects with no import of
+    any kind, and the matcher reads zod's path items and valibot's alike.
+  - `resolveConstraints(option)` expands the `true` shorthand; `CONSTRAINTS_MODULE` is the file
+    name every generator writes it to.
 - Uniqueness
   - `renderDuplicateFinder(table, fnName, rowType)` -> the source of a function returning the rows
     in a batch that collide with an earlier row on a unique constraint. Plain TypeScript with no

--- a/packages/validation-core/src/constraints.ts
+++ b/packages/validation-core/src/constraints.ts
@@ -1,0 +1,692 @@
+/**
+ * Every constraint on a table, as data a consumer can read without holding a validator.
+ *
+ * `meta` already carries most of these facts, and this is deliberately not a second copy of it.
+ * Three differences, each of which is why both exist.
+ *
+ *   **shape**       `meta` renders a CHECK as prose: `"age_adult: age >= 18"`. That is the right
+ *                   form for its destination, which is `z.toJSONSchema` and then an OpenAPI
+ *                   viewer, and the wrong form for a form builder, which wants the bound as a
+ *                   number and would otherwise have to parse SQL back out of a sentence. Here the
+ *                   operand is data and the sentence is beside it.
+ *
+ *   **content**     `meta` has no foreign keys at all, and its `unique` is a list of column groups
+ *                   with the constraint names dropped. A form cannot render a picker without the
+ *                   first, and, more sharply, nothing can be mapped back to a constraint that has
+ *                   no name, which is what makes the second load bearing rather than cosmetic.
+ *
+ *   **addressing**  `meta` is reachable only by holding the emitted schema object and asking each
+ *                   field, per mode. This is a plain record keyed by table, so the answer to "what
+ *                   constrains this table" costs one property read and no validator import.
+ *
+ * What is *not* here is anything `meta` states about a column rather than a constraint: the SQL
+ * type, whether the database defaults the value, the numeric range of the column's own type. Those
+ * are facts about a field, `meta` carries them, and restating them here would be exactly the
+ * duplication the paragraph above is arguing against.
+ *
+ * Both halves are built from `classifyTableChecks` below, which `meta` also uses, so the two can
+ * disagree about what is enforced only by both being wrong at once.
+ */
+import type { Column, ForeignKey, Key, Table } from '@drzl/analyzer';
+import {
+  parseCheck,
+  type CardinalityCheck,
+  type ColumnCheck,
+  type ColumnSet,
+  type LengthCheck,
+  type RowCheck,
+} from './checks.js';
+
+/** `name: expr`, matching how every emitted failure message labels the constraint it came from. */
+function labelled(name: string | undefined, text: string): string {
+  return name ? `${name}: ${text}` : text;
+}
+
+/** A literal as it reads inside the expression it came from, quoted exactly when it was quoted. */
+function literalText(value: string, kind: 'number' | 'string'): string {
+  return kind === 'string' ? `'${value}'` : value;
+}
+
+function columnCheckText(k: ColumnCheck): string {
+  return labelled(k.name, `${k.column} ${k.operator} ${literalText(k.value, k.kind)}`);
+}
+function setText(k: ColumnSet): string {
+  return labelled(
+    k.name,
+    `${k.column} IN (${k.values.map((v) => literalText(v, k.kind)).join(', ')})`
+  );
+}
+function lengthText(k: LengthCheck): string {
+  return labelled(k.name, `length(${k.column}) ${k.operator} ${k.value}`);
+}
+function cardinalityText(k: CardinalityCheck): string {
+  return labelled(k.name, `cardinality(${k.column}) ${k.operator} ${k.value}`);
+}
+function rowText(k: RowCheck): string {
+  return labelled(k.name, `${k.left} ${k.operator} ${k.right}`);
+}
+
+/**
+ * Whether a field-level constraint reaches this column at all.
+ *
+ * The same three guards every validation generator applies. A comparison against a scalar says
+ * nothing usable about an array or a tuple, and a character count says nothing about either; a
+ * cardinality is the mirror image and only means something on an array. A constraint that fails
+ * its guard is enforced nowhere, so it is reported as unenforced rather than silently attributed
+ * to a field that does not check it.
+ */
+function takesScalarChecks(c: Column): boolean {
+  return !c.arrayDimensions && !c.shape;
+}
+
+/**
+ * Whether a numeric comparison is folded into the column's own range rather than stated as a
+ * predicate carrying a message.
+ *
+ * The condition the zod and valibot generators each apply, held once so this cannot drift from
+ * what they emit. It decides whether the constraint has a message to be matched on at all: a
+ * folded bound becomes `.gte(18)` / `v.minValue(18)`, and the failure is then worded by the
+ * library, with the constraint name nowhere in it.
+ */
+function foldsIntoBounds(c: Column, k: ColumnCheck): boolean {
+  if (c.arrayDimensions || c.shape) return false;
+  if (c.tsType !== 'number' && c.tsType !== 'bigint') return false;
+  return k.kind === 'number' && k.operator !== '=' && k.operator !== '<>';
+}
+
+/**
+ * Whether a string column's declared width reaches the emitted schema as a predicate.
+ *
+ * A column whose value space is stated some other way never gets one: a structured column, a
+ * column narrowed to a set of literals by a CHECK, a declared enum, and a `uuid` or `numeric`
+ * column, whose format supersedes any width. Mirrors the branch order in every generator's column
+ * expression, and is the difference between a message this ledger can be matched on and one the
+ * emitted module never writes.
+ */
+function statesCap(c: Column, hasSet: boolean): boolean {
+  if (c.shape || hasSet) return false;
+  if (c.enumValues && c.enumValues.length) return false;
+  if (c.tsType !== 'string') return false;
+  // `uuid` becomes `z.uuid()` and `numeric` a pattern; both replace the width rather than adding
+  // to it. Those are the only two the analyzer produces.
+  return !c.format;
+}
+
+/** Where one part of a parsed CHECK lands. */
+export type CheckPartPlace = 'column' | 'row' | 'none';
+
+/**
+ * One clause of one CHECK, classified by what the generated schemas do with it.
+ *
+ * A single `CHECK` declaration can split into several of these: `BETWEEN` is two bounds, and a
+ * conjunction is one part per operand. They are kept apart here because enforcement is decided
+ * per clause, and rejoined into one constraint by `tableConstraints`, because a database has one
+ * constraint there and quotes one name back.
+ */
+export interface CheckPart {
+  /** The clause as text. Also the message the emitted schema attaches, when it attaches one. */
+  text: string;
+  /** The columns the clause is about, in the order the expression names them. */
+  columns: string[];
+  place: CheckPartPlace;
+  /** Why nothing enforces it, when nothing does. */
+  reason?: string;
+  /** Present when the clause was folded into the column's range instead of a predicate. */
+  bound?: { column: string; operator: ColumnCheck['operator']; value: string };
+  /** Present when the clause was folded into a set of literals instead of a predicate. */
+  set?: { column: string; values: string[]; kind: 'number' | 'string' };
+}
+
+/** One declared CHECK, with each of its clauses placed. */
+export interface ClassifiedCheck {
+  name?: string;
+  /** The expression as declared, trimmed. */
+  expression: string;
+  parts: CheckPart[];
+}
+
+/**
+ * Every CHECK on a table, split into clauses and placed.
+ *
+ * The single reading of `parseCheck` plus the shape guards, shared by `meta` and by the constraint
+ * ledger so that "the database also checks this and we do not" is one answer rather than two.
+ */
+export function classifyTableChecks(table: Table): ClassifiedCheck[] {
+  const byName = new Map(table.columns.map((c) => [c.name, c]));
+  const out: ClassifiedCheck[] = [];
+
+  for (const k of table.checks ?? []) {
+    const expression = (k.expression ?? '').trim();
+    const parsed = parseCheck(k.expression, k.name);
+    if (!parsed.ok) {
+      out.push({
+        ...(k.name ? { name: k.name } : {}),
+        expression,
+        parts: [
+          {
+            text: labelled(k.name, expression),
+            columns: [],
+            place: 'none',
+            reason: parsed.reason,
+          },
+        ],
+      });
+      continue;
+    }
+
+    const parts: CheckPart[] = [];
+    const place = (
+      column: string,
+      text: string,
+      guard: (c: Column) => boolean,
+      guardReason: (c: Column) => string,
+      extra: Partial<CheckPart> = {}
+    ) => {
+      const c = byName.get(column);
+      if (!c) {
+        parts.push({
+          text,
+          columns: [column],
+          place: 'none',
+          reason: `"${column}" is not a column of that table`,
+        });
+        return;
+      }
+      if (!guard(c)) {
+        parts.push({ text, columns: [column], place: 'none', reason: guardReason(c) });
+        return;
+      }
+      parts.push({ text, columns: [column], place: 'column', ...extra });
+    };
+
+    const notScalar = (c: Column) =>
+      c.arrayDimensions
+        ? `"${c.name}" is an array, and the clause describes a scalar`
+        : `"${c.name}" is a structured column, and the clause describes a scalar`;
+
+    for (const c of parsed.checks) {
+      const col = byName.get(c.column);
+      place(c.column, columnCheckText(c), takesScalarChecks, notScalar, {
+        ...(col && foldsIntoBounds(col, c)
+          ? { bound: { column: c.column, operator: c.operator, value: c.value } }
+          : {}),
+      });
+    }
+    for (const s of parsed.sets ?? []) {
+      place(s.column, setText(s), takesScalarChecks, notScalar, {
+        set: { column: s.column, values: s.values, kind: s.kind },
+      });
+    }
+    for (const l of parsed.lengths ?? []) {
+      place(l.column, lengthText(l), takesScalarChecks, notScalar);
+    }
+    for (const a of parsed.cardinalities ?? []) {
+      place(
+        a.column,
+        cardinalityText(a),
+        (c) => !!c.arrayDimensions,
+        (c) => `"${c.name}" is not an array, so it has no elements to count`
+      );
+    }
+    for (const r of parsed.rows ?? []) {
+      const text = rowText(r);
+      const missing = [r.left, r.right].filter((n) => !byName.has(n));
+      parts.push(
+        missing.length
+          ? {
+              text,
+              columns: [r.left, r.right],
+              place: 'none',
+              reason: `${missing.map((n) => `"${n}"`).join(' and ')} ${
+                missing.length > 1 ? 'are not columns' : 'is not a column'
+              } of that table`,
+            }
+          : { text, columns: [r.left, r.right], place: 'row' }
+      );
+    }
+
+    out.push({ ...(k.name ? { name: k.name } : {}), expression, parts });
+  }
+  return out;
+}
+
+/** What a constraint is. */
+export type ConstraintKind =
+  'primaryKey' | 'unique' | 'foreignKey' | 'check' | 'maxLength' | 'maxBytes';
+
+/** One clause of a constraint that nothing in the generated schemas checks. */
+export interface UnenforcedPart {
+  part: string;
+  reason: string;
+}
+
+/** One constraint on one table. */
+export interface ConstraintFacts {
+  /**
+   * Stable identifier, unique within the table.
+   *
+   * The SQL constraint name where the declaration has one, and a derived name where it does not.
+   * This is what an error map keys on and what a caller stores against its own copy for a
+   * message, so it has to exist even for the constraints SQL leaves anonymous.
+   */
+  id: string;
+  /** The SQL constraint name, absent where the declaration did not give one. */
+  name?: string;
+  kind: ConstraintKind;
+  /** The columns the constraint is about, in declaration order. */
+  columns: string[];
+  /** The rule as a sentence, for a form with nothing better to show. */
+  rule: string;
+  /** Whether a generated schema can reject a row for this constraint. */
+  enforced: boolean;
+  /** The clauses nothing enforces, and why. Absent when there are none. */
+  unenforced?: UnenforcedPart[];
+  /**
+   * The exact messages a generated schema attaches for this constraint.
+   *
+   * Absent where the schema states the constraint in the validator's own vocabulary instead, which
+   * is where the constraint name is lost and the error map has to key on something else.
+   */
+  messages?: string[];
+  /** Bounds folded into a column's range. What a bound-carrying issue is matched against. */
+  bounds?: { column: string; operator: string; value: string }[];
+  /** A set of literals folded into an enum. */
+  values?: { column: string; values: string[]; kind: 'number' | 'string' };
+  /** Where a foreign key points. */
+  references?: {
+    table: string;
+    schema?: string;
+    columns: string[];
+    onDelete?: string;
+    onUpdate?: string;
+  };
+}
+
+/** Every constraint on one table. */
+export interface TableConstraints {
+  /** The SQL table name, which is not the Drizzle export name. */
+  table: string;
+  /** The SQL schema, present only when the table names one. */
+  schema?: string;
+  constraints: ConstraintFacts[];
+}
+
+/** `a, b` for a rule sentence. */
+const list = (cols: string[]) => cols.join(', ');
+
+function foreignKeyRule(fk: ForeignKey): string {
+  const target = fk.foreignSchema ? `${fk.foreignSchema}.${fk.foreignTable}` : fk.foreignTable;
+  return (
+    `FOREIGN KEY (${list(fk.columns)}) REFERENCES ${target} (${list(fk.foreignColumns)})` +
+    (fk.onDelete ? ` ON DELETE ${fk.onDelete}` : '') +
+    (fk.onUpdate ? ` ON UPDATE ${fk.onUpdate}` : '')
+  );
+}
+
+/**
+ * Make every id distinct within one table.
+ *
+ * Two constraints can arrive with the same derived id, and one database can even carry two CHECKs
+ * under the same name in two schemas. An id that repeats would make the error map answer with
+ * whichever entry it met first, silently, so a repeat gets a numeric suffix rather than a
+ * collision.
+ */
+function uniquifier() {
+  const seen = new Map<string, number>();
+  return (id: string) => {
+    const n = seen.get(id) ?? 0;
+    seen.set(id, n + 1);
+    return n === 0 ? id : `${id}_${n + 1}`;
+  };
+}
+
+/** Every constraint on a table, as data. */
+export function tableConstraints(table: Table): TableConstraints {
+  const out: ConstraintFacts[] = [];
+  const id = uniquifier();
+  const named = (key: Key | ForeignKey, fallback: string) =>
+    key.name ? { id: id(key.name), name: key.name } : { id: id(fallback) };
+
+  if (table.primaryKey?.columns.length) {
+    const pk = table.primaryKey;
+    out.push({
+      ...named(pk, `${table.name}_pkey`),
+      kind: 'primaryKey',
+      columns: [...pk.columns],
+      rule: `PRIMARY KEY (${list(pk.columns)})`,
+      // No per-row validator can check a key: whether a value is already taken is a fact about
+      // the table. `duplicateFinder` checks the half that needs no database, and even that only
+      // answers whether a batch collides with itself.
+      enforced: false,
+    });
+  }
+
+  for (const u of table.unique ?? []) {
+    if (!u.columns.length) continue;
+    out.push({
+      ...named(u, `${table.name}_${u.columns.join('_')}_key`),
+      kind: 'unique',
+      columns: [...u.columns],
+      rule: `UNIQUE (${list(u.columns)})`,
+      enforced: false,
+    });
+  }
+
+  for (const fk of table.foreignKeys ?? []) {
+    if (!fk.columns.length) continue;
+    out.push({
+      ...named(fk, `${table.name}_${fk.columns.join('_')}_fkey`),
+      kind: 'foreignKey',
+      columns: [...fk.columns],
+      rule: foreignKeyRule(fk),
+      // The referenced row either exists or it does not, and only the database knows.
+      enforced: false,
+      references: {
+        table: fk.foreignTable,
+        ...(fk.foreignSchema ? { schema: fk.foreignSchema } : {}),
+        columns: [...fk.foreignColumns],
+        ...(fk.onDelete ? { onDelete: fk.onDelete } : {}),
+        ...(fk.onUpdate ? { onUpdate: fk.onUpdate } : {}),
+      },
+    });
+  }
+
+  const classified = classifyTableChecks(table);
+  classified.forEach((k, i) => {
+    const columns: string[] = [];
+    for (const p of k.parts) for (const c of p.columns) if (!columns.includes(c)) columns.push(c);
+    const messages = k.parts
+      .filter((p) => p.place !== 'none' && !p.bound && !p.set)
+      .map((p) => p.text);
+    const bounds = k.parts.filter((p) => p.bound).map((p) => p.bound!);
+    const set = k.parts.find((p) => p.set)?.set;
+    const unenforced = k.parts
+      .filter((p) => p.place === 'none')
+      .map((p) => ({ part: p.text, reason: p.reason ?? 'not translated' }));
+    out.push({
+      ...(k.name ? { id: id(k.name), name: k.name } : { id: id(`${table.name}_check_${i + 1}`) }),
+      kind: 'check',
+      columns,
+      rule: `CHECK (${k.expression})`,
+      enforced: k.parts.some((p) => p.place !== 'none'),
+      ...(unenforced.length ? { unenforced } : {}),
+      ...(messages.length ? { messages } : {}),
+      ...(bounds.length ? { bounds } : {}),
+      ...(set ? { values: set } : {}),
+    });
+  });
+
+  // A column narrowed to a set of literals states its value space that way instead of by width,
+  // which is what the cap guard asks about. Read off the classification rather than re-parsed.
+  const setColumns = new Set(
+    classified.flatMap((k) => k.parts.filter((p) => p.set).map((p) => p.set!.column))
+  );
+
+  for (const c of table.columns) {
+    if (!statesCap(c, setColumns.has(c.name))) continue;
+    if (c.maxLength !== undefined) {
+      const message = `at most ${c.maxLength} characters`;
+      out.push({
+        id: id(`${table.name}_${c.name}_maxlength`),
+        kind: 'maxLength',
+        columns: [c.name],
+        rule: message,
+        enforced: true,
+        messages: [message],
+      });
+    }
+    if (c.maxBytes !== undefined) {
+      const message = `at most ${c.maxBytes} bytes`;
+      out.push({
+        id: id(`${table.name}_${c.name}_maxbytes`),
+        kind: 'maxBytes',
+        columns: [c.name],
+        rule: message,
+        enforced: true,
+        messages: [message],
+      });
+    }
+  }
+
+  return {
+    table: table.name,
+    ...(table.schema ? { schema: table.schema } : {}),
+    constraints: out,
+  };
+}
+
+export interface ConstraintsModuleOptions {
+  /** Also emit `constraintForIssue`, which is the half that maps a failure back. */
+  errorMap?: boolean;
+}
+
+/** What `constraints` is asking for, once the boolean shorthand is expanded. */
+export type ConstraintsOption = boolean | { enabled?: boolean; errorMap?: boolean };
+
+export function resolveConstraints(
+  opt: ConstraintsOption | undefined
+): ConstraintsModuleOptions | undefined {
+  if (!opt) return undefined;
+  if (opt === true) return { errorMap: true };
+  if (opt.enabled === false) return undefined;
+  return { errorMap: opt.errorMap !== false };
+}
+
+/** The file every generator writes the ledger to. Fixed, like the barrel's own name. */
+export const CONSTRAINTS_MODULE = 'constraints.ts';
+
+const TYPES = `/** What a constraint is. */
+export type DrzlConstraintKind =
+  | 'primaryKey'
+  | 'unique'
+  | 'foreignKey'
+  | 'check'
+  | 'maxLength'
+  | 'maxBytes';
+
+/** One constraint on one table. */
+export interface DrzlConstraint {
+  /** Stable within the table. The SQL constraint name where the declaration has one. */
+  id: string;
+  /** The SQL constraint name, absent where the declaration did not give one. */
+  name?: string;
+  kind: DrzlConstraintKind;
+  /** The columns the constraint is about, in declaration order. */
+  columns: string[];
+  /** The rule as a sentence, for a form with nothing better to show. */
+  rule: string;
+  /** Whether a generated schema can reject a row for this constraint. */
+  enforced: boolean;
+  /** The clauses nothing in these schemas checks, and why. */
+  unenforced?: { part: string; reason: string }[];
+  /** The exact messages the generated schemas attach for this constraint. */
+  messages?: string[];
+  /** Bounds folded into a column's range, which is where the constraint name is lost. */
+  bounds?: { column: string; operator: string; value: string }[];
+  /** A set of literals folded into an enum, which is the other place it is lost. */
+  values?: { column: string; values: string[]; kind: 'number' | 'string' };
+  /** Where a foreign key points. */
+  references?: {
+    table: string;
+    schema?: string;
+    columns: string[];
+    onDelete?: string;
+    onUpdate?: string;
+  };
+}
+
+/** Every constraint on one table. */
+export interface DrzlTableConstraints {
+  /** The SQL table name, which is not the Drizzle export name this is exported under. */
+  table: string;
+  /** The SQL schema, present only when the table names one. */
+  schema?: string;
+  constraints: DrzlConstraint[];
+}`;
+
+const MATCHER = `/** A validation issue traced back to the constraint that caused it. */
+export interface DrzlConstraintMatch {
+  constraint: DrzlConstraint;
+  /**
+   * The column to put the message on.
+   *
+   * Taken from the issue where the library named one, and from the constraint where it did not.
+   * Valibot reports a row-level check with an empty path, so without the fallback a form would
+   * have a message and nowhere to show it.
+   */
+  column?: string;
+  /**
+   * How the constraint was identified.
+   *
+   * \`message\` is an exact match on a string these schemas wrote, and is the only tier that is
+   * certain. \`bound\` matched the numeric bound the library put on the issue against a bound this
+   * constraint folded, which is what a folded CHECK leaves to match on once its name is gone.
+   * \`column\` is the last resort: the column has exactly one constraint stated in the validator's
+   * own vocabulary, so nothing else on the issue can be wrong about which.
+   */
+  matchedBy: 'message' | 'bound' | 'column';
+}
+
+/**
+ * The column an issue is about, across the path shapes these libraries use.
+ *
+ * zod and ArkType spell a path item as the key itself; valibot spells it as an object carrying
+ * one. The last key is taken rather than the first, so an issue inside an array or a nested
+ * payload names the field rather than the collection holding it.
+ */
+function drzlIssueColumn(issue: any): string | undefined {
+  const path = issue?.path;
+  if (!Array.isArray(path)) return undefined;
+  for (let i = path.length - 1; i >= 0; i--) {
+    const item: any = path[i];
+    if (typeof item === 'string') return item;
+    if (item && typeof item === 'object' && typeof item.key === 'string') return item.key;
+  }
+  return undefined;
+}
+
+/**
+ * The numeric bound an issue reports, as a decimal string, or nothing.
+ *
+ * Measured rather than guessed: zod 4.4.3 puts \`minimum\`/\`maximum\` on a \`too_small\`/\`too_big\`
+ * issue and valibot 1.4.2 puts \`requirement\` on a \`min_value\`/\`max_value\` one. A bigint bound
+ * is read too, since a 64 bit column's range is not representable as a number.
+ */
+function drzlIssueBound(issue: any): string | undefined {
+  for (const key of ['minimum', 'maximum', 'requirement']) {
+    const v = issue?.[key];
+    if (typeof v === 'number' || typeof v === 'bigint') return String(v);
+  }
+  return undefined;
+}
+
+/**
+ * The constraint a validation issue came from, or nothing.
+ *
+ * Three tiers, because a constraint does not always survive into the issue in the same form. Every
+ * constraint stated as a predicate carries a message these schemas wrote, and that is an exact
+ * lookup. A numeric CHECK is deliberately folded into the column's own range instead, so the
+ * failure is worded by the library and the constraint name is nowhere in it; the bound is, and it
+ * is matched on that. A set constraint becomes an enum and leaves neither, so it is resolved by
+ * the column alone, which is safe only because a column can carry one such constraint at most.
+ *
+ * The two folds are kept apart rather than pooled, and that is what stops the third tier
+ * over-claiming. A folded bound always reports its bound, in every library measured, so an issue
+ * on that column carrying **no** bound is not that constraint: it is the field failing to be a
+ * number at all. Pooling them answered \`invalid_type\` on a column with a numeric CHECK with the
+ * CHECK, which is a rule the row did not break.
+ *
+ * Returns nothing rather than a guess, for the same reason. A \`too_small\` reporting the column's
+ * own type bound has no matching constraint and gets no answer.
+ */
+export function constraintForIssue(
+  table: string,
+  issue: unknown
+): DrzlConstraintMatch | undefined {
+  const ledger = constraintsByTable[table];
+  if (!ledger) return undefined;
+  const raw: any = issue;
+  const column = drzlIssueColumn(raw);
+  const message = typeof raw?.message === 'string' ? raw.message : undefined;
+
+  if (message !== undefined) {
+    for (const constraint of ledger.constraints) {
+      if (!constraint.messages || constraint.messages.indexOf(message) < 0) continue;
+      if (column !== undefined && constraint.columns.indexOf(column) < 0) continue;
+      return {
+        constraint,
+        column: column ?? constraint.columns[0],
+        matchedBy: 'message',
+      };
+    }
+  }
+
+  if (column === undefined) return undefined;
+
+  const bound = drzlIssueBound(raw);
+  if (bound !== undefined) {
+    const hit = ledger.constraints.find(
+      (c) => c.bounds && c.bounds.some((b) => b.column === column && b.value === bound)
+    );
+    return hit ? { constraint: hit, column, matchedBy: 'bound' } : undefined;
+  }
+
+  const sets = ledger.constraints.filter((c) => c.values && c.values.column === column);
+  return sets.length === 1 ? { constraint: sets[0], column, matchedBy: 'column' } : undefined;
+}`;
+
+/**
+ * A JavaScript identifier that cannot collide with anything else in the module.
+ *
+ * A Drizzle export name reaches this verbatim, and it is a TypeScript identifier already, so the
+ * replacement below only has to survive the shapes a table name can take when it is not one.
+ */
+function constName(tsName: string): string {
+  const safe = tsName.replace(/[^A-Za-z0-9_$]/g, '_');
+  return `${/^[0-9]/.test(safe) ? `_${safe}` : safe}Constraints`;
+}
+
+/**
+ * The `constraints.ts` module, as source.
+ *
+ * Plain objects and, optionally, one function. Nothing here imports a validator or any part of
+ * DRZL, so a consumer can read the ledger from a script, a form builder or a server route without
+ * pulling a schema in. The matcher is a separate export for the same reason a separate option
+ * turns it off: a consumer who only renders forms should not carry the code that maps failures.
+ *
+ * `JSON.stringify` rather than a hand-rolled literal, because every string here comes from a
+ * schema the user wrote: a table named `it's` or a CHECK holding a quote has to survive into valid
+ * TypeScript. The formatter unquotes the keys that do not need quoting.
+ */
+export function renderConstraintsModule(
+  tables: Table[],
+  opts: ConstraintsModuleOptions = {}
+): string {
+  const entries = tables.map((t) => ({ tsName: t.tsName, facts: tableConstraints(t) }));
+  const consts = entries
+    .map(
+      (e) =>
+        `/** Every constraint on \`${e.facts.table}\`. */\n` +
+        `export const ${constName(e.tsName)}: DrzlTableConstraints = ${JSON.stringify(e.facts, null, 2)};`
+    )
+    .join('\n\n');
+  const record =
+    `/** Every table's constraints, keyed by the Drizzle export name its schemas are named after. */\n` +
+    `export const constraintsByTable: Record<string, DrzlTableConstraints> = {\n` +
+    entries.map((e) => `  ${JSON.stringify(e.tsName)}: ${constName(e.tsName)},`).join('\n') +
+    `\n};`;
+
+  return [
+    '/**',
+    ' * Every CHECK, unique constraint, primary and foreign key on each table, as data.',
+    ' *',
+    ' * Generated beside the schemas rather than derived from them: a validator states what a value',
+    ' * must look like and says nothing about which constraint said so, and the two constraints a',
+    ' * per-row schema cannot check at all, uniqueness and a foreign key, are not in it in any form.',
+    ' */',
+    TYPES,
+    consts,
+    record,
+    ...(opts.errorMap ? [MATCHER] : []),
+  ].join('\n\n');
+}

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -10,6 +10,7 @@ import type { AffixOptions } from './naming.js';
 
 export * from './branding.js';
 export * from './checks.js';
+export * from './constraints.js';
 export * from './files.js';
 export * from './meta.js';
 export * from './naming.js';

--- a/packages/validation-core/src/meta.ts
+++ b/packages/validation-core/src/meta.ts
@@ -29,14 +29,7 @@
  * options object is dropped before the column is built. See the zod generator's documentation.
  */
 import type { Column, Table } from '@drzl/analyzer';
-import {
-  parseCheck,
-  type CardinalityCheck,
-  type ColumnCheck,
-  type ColumnSet,
-  type LengthCheck,
-  type RowCheck,
-} from './checks.js';
+import { classifyTableChecks } from './constraints.js';
 
 /** What a column adds beside its schema. Every key is optional; an empty object is a real answer. */
 export interface ColumnMetaFacts {
@@ -131,85 +124,34 @@ export interface TableMetaOptions extends MetaFactOptions {
   dialect?: string;
 }
 
-/** `name: expr`, matching how every emitted failure message labels the constraint it came from. */
-function labelled(name: string | undefined, text: string): string {
-  return name ? `${name}: ${text}` : text;
-}
-
-/** A literal as it reads inside the expression it came from, quoted exactly when it was quoted. */
-function literalText(value: string, kind: 'number' | 'string'): string {
-  return kind === 'string' ? `'${value}'` : value;
-}
-
-function columnCheckText(k: ColumnCheck): string {
-  return labelled(k.name, `${k.column} ${k.operator} ${literalText(k.value, k.kind)}`);
-}
-function setText(k: ColumnSet): string {
-  return labelled(
-    k.name,
-    `${k.column} IN (${k.values.map((v) => literalText(v, k.kind)).join(', ')})`
-  );
-}
-function lengthText(k: LengthCheck): string {
-  return labelled(k.name, `length(${k.column}) ${k.operator} ${k.value}`);
-}
-function cardinalityText(k: CardinalityCheck): string {
-  return labelled(k.name, `cardinality(${k.column}) ${k.operator} ${k.value}`);
-}
-function rowText(k: RowCheck): string {
-  return labelled(k.name, `${k.left} ${k.operator} ${k.right}`);
-}
-
 /**
- * Whether a field-level constraint reaches this column at all.
+ * Every CHECK on the table, split by where it lands.
  *
- * The same three guards every validation generator applies. A comparison against a scalar says
- * nothing usable about an array or a tuple, and a character count says nothing about either; a
- * cardinality is the mirror image and only means something on an array. A constraint that fails
- * its guard is enforced nowhere, so it is reported on the table as unenforced rather than
- * silently attributed to a field that does not check it.
+ * A reading of `classifyTableChecks`, which is shared with the constraint ledger rather than
+ * repeated here. The two used to be one copy each of the same guards, and the failure that
+ * matters is not that they would drift on a spelling: it is that "the database also checks this
+ * and no schema does" would become two answers, and a caller reading one of them would have no
+ * way to know which.
  */
-function takesScalarChecks(c: Column): boolean {
-  return !c.arrayDimensions && !c.shape;
-}
-
-/** Every CHECK on the table, split by where it lands. */
 function classifyChecks(table: Table) {
   const perColumn = new Map<string, string[]>();
   const rows: string[] = [];
   const unenforced: string[] = [];
-  const byName = new Map(table.columns.map((c) => [c.name, c]));
 
-  const add = (column: string, text: string, guard: (c: Column) => boolean) => {
-    const c = byName.get(column);
-    // A constraint naming a column that is not on this table cannot be attributed to anything,
-    // and one whose column refuses the constraint is not checked by any field. Both are the
-    // caller's problem rather than a fact to hide.
-    if (!c || !guard(c)) {
-      unenforced.push(text);
-      return;
-    }
-    const list = perColumn.get(column) ?? [];
-    list.push(text);
-    perColumn.set(column, list);
-  };
-
-  for (const k of table.checks ?? []) {
-    const parsed = parseCheck(k.expression, k.name);
-    if (!parsed.ok) {
-      unenforced.push(labelled(k.name, (k.expression ?? '').trim()));
-      continue;
-    }
-    for (const c of parsed.checks) add(c.column, columnCheckText(c), takesScalarChecks);
-    for (const s of parsed.sets ?? []) add(s.column, setText(s), takesScalarChecks);
-    for (const l of parsed.lengths ?? []) add(l.column, lengthText(l), takesScalarChecks);
-    for (const a of parsed.cardinalities ?? [])
-      add(a.column, cardinalityText(a), (c) => !!c.arrayDimensions);
-    for (const r of parsed.rows ?? []) {
-      // A row check needs both columns present in the mode being rendered. That is decided by the
-      // generator, which knows the mode; here it is a fact about the table.
-      if (byName.has(r.left) && byName.has(r.right)) rows.push(rowText(r));
-      else unenforced.push(rowText(r));
+  for (const check of classifyTableChecks(table)) {
+    for (const part of check.parts) {
+      if (part.place === 'none') {
+        unenforced.push(part.text);
+        continue;
+      }
+      if (part.place === 'row') {
+        rows.push(part.text);
+        continue;
+      }
+      const column = part.columns[0]!;
+      const list = perColumn.get(column) ?? [];
+      list.push(part.text);
+      perColumn.set(column, list);
     }
   }
   return { perColumn, rows, unenforced };

--- a/packages/validation-core/test/constraints.spec.ts
+++ b/packages/validation-core/test/constraints.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * The constraint ledger: every CHECK, unique, primary and foreign key on a table, as data.
+ *
+ * Two things are under test. The **facts** are what a form builder reads, and the point of them is
+ * that they are structured where `meta` is prose: `meta` carries `"age_adult: age >= 18"`, and a
+ * consumer wanting the bound out of that has to parse SQL back out of a sentence.
+ *
+ * The **messages** are what makes an error map possible at all, and they are the fragile half: each
+ * one has to be byte-identical to the string the generators put in the emitted schema, or the map
+ * silently matches nothing. That identity is asserted here against the shared renderers and again
+ * in each generator's own suite against a real emitted module.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Column, Table } from '@drzl/analyzer';
+import { tableConstraints, renderConstraintsModule } from '../src/constraints';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (name: string, cols: Column[], over: Partial<Table> = {}): Table =>
+  ({ name, tsName: name, columns: cols, unique: [], indexes: [], checks: [], ...over }) as Table;
+
+const events = () =>
+  table(
+    'events',
+    [
+      col('id', { tsType: 'number', dbType: 'INTEGER', sqlType: 'serial', isGenerated: true }),
+      col('name', { sqlType: 'varchar(10)', maxLength: 10 }),
+      col('age', {
+        tsType: 'number',
+        dbType: 'INTEGER',
+        sqlType: 'integer',
+        integer: true,
+        min: '-2147483648',
+        max: '2147483647',
+      }),
+      col('email', { sqlType: 'text' }),
+      col('status', { sqlType: 'text' }),
+      col('starts', { tsType: 'number', dbType: 'INTEGER', sqlType: 'integer', integer: true }),
+      col('ends', { tsType: 'number', dbType: 'INTEGER', sqlType: 'integer', integer: true }),
+      col('tags', { sqlType: 'text[]', arrayDimensions: 1 }),
+      col('ownerId', { tsType: 'number', dbType: 'INTEGER', sqlType: 'integer' }),
+    ],
+    {
+      primaryKey: { name: 'events_pkey', columns: ['id'] },
+      unique: [{ name: 'events_name_key', columns: ['name'] }, { columns: ['starts', 'ends'] }],
+      foreignKeys: [
+        {
+          name: 'events_owner_fk',
+          columns: ['ownerId'],
+          foreignTable: 'users',
+          foreignColumns: ['id'],
+          onDelete: 'cascade',
+        },
+      ],
+      checks: [
+        { name: 'age_adult', expression: 'age >= 18' },
+        { name: 'email_len', expression: 'length(email) >= 3' },
+        { name: 'status_valid', expression: "status IN ('draft', 'live')" },
+        { name: 'window_ok', expression: 'starts < ends' },
+        { name: 'has_tags', expression: 'cardinality(tags) > 0' },
+        { name: 'name_not_x', expression: "name <> 'x'" },
+        { name: 'unparseable', expression: 'my_fn(name) > now()' },
+        { name: 'no_such_column', expression: 'nowhere > 1' },
+      ],
+    }
+  );
+
+const byId = (t: Table) => {
+  const out = new Map<string, ReturnType<typeof tableConstraints>['constraints'][number]>();
+  for (const c of tableConstraints(t).constraints) out.set(c.id, c);
+  return out;
+};
+
+describe('the keys, which meta carries without their names', () => {
+  it('names the primary key and lists its columns in order', () => {
+    const pk = byId(events()).get('events_pkey');
+    expect(pk).toMatchObject({ kind: 'primaryKey', columns: ['id'], name: 'events_pkey' });
+    expect(pk!.rule).toBe('PRIMARY KEY (id)');
+  });
+
+  it('carries the unique constraint name a database error quotes back', () => {
+    const u = byId(events()).get('events_name_key');
+    expect(u).toMatchObject({ kind: 'unique', columns: ['name'], name: 'events_name_key' });
+  });
+
+  it('derives a stable id for an unnamed constraint, and marks the name absent', () => {
+    const u = byId(events()).get('events_starts_ends_key');
+    expect(u).toMatchObject({ kind: 'unique', columns: ['starts', 'ends'] });
+    expect(u!.name).toBeUndefined();
+  });
+
+  it('carries the foreign key, which meta has no key for at all', () => {
+    const fk = byId(events()).get('events_owner_fk');
+    expect(fk).toMatchObject({
+      kind: 'foreignKey',
+      columns: ['ownerId'],
+      references: { table: 'users', columns: ['id'], onDelete: 'cascade' },
+    });
+    expect(fk!.rule).toBe('FOREIGN KEY (ownerId) REFERENCES users (id) ON DELETE cascade');
+  });
+
+  it('says a key produces no validation issue, since no per-row schema can check one', () => {
+    const m = byId(events());
+    for (const id of ['events_pkey', 'events_name_key', 'events_owner_fk']) {
+      expect(m.get(id)!.enforced, id).toBe(false);
+      expect(m.get(id)!.messages, id).toBeUndefined();
+    }
+  });
+});
+
+describe('a CHECK, structured rather than as prose', () => {
+  it('is one entry per declared constraint, whatever the parser splits it into', () => {
+    const t = table('t', [col('age', { tsType: 'number', dbType: 'INTEGER', integer: true })], {
+      checks: [{ name: 'age_range', expression: 'age BETWEEN 18 AND 65' }],
+    });
+    const checks = tableConstraints(t).constraints.filter((c) => c.kind === 'check');
+    expect(checks).toHaveLength(1);
+    expect(checks[0]!.bounds).toEqual([
+      { column: 'age', operator: '>=', value: '18' },
+      { column: 'age', operator: '<=', value: '65' },
+    ]);
+  });
+
+  it('carries the operand of a folded bound, which meta states only inside a sentence', () => {
+    const c = byId(events()).get('age_adult')!;
+    expect(c.bounds).toEqual([{ column: 'age', operator: '>=', value: '18' }]);
+    // Folded into the column's own range, so no generated schema writes a message for it.
+    expect(c.messages).toBeUndefined();
+  });
+
+  it('carries the allowed values of a set constraint, which meta states only inside a sentence', () => {
+    const c = byId(events()).get('status_valid')!;
+    expect(c.values).toEqual({ column: 'status', values: ['draft', 'live'], kind: 'string' });
+    expect(c.messages).toBeUndefined();
+  });
+
+  it('carries the exact message the schema attaches, for the ones stated as a predicate', () => {
+    const m = byId(events());
+    expect(m.get('email_len')!.messages).toEqual(['email_len: length(email) >= 3']);
+    expect(m.get('has_tags')!.messages).toEqual(['has_tags: cardinality(tags) > 0']);
+    expect(m.get('name_not_x')!.messages).toEqual(["name_not_x: name <> 'x'"]);
+    expect(m.get('window_ok')!.messages).toEqual(['window_ok: starts < ends']);
+  });
+
+  it('names both columns of a row check, in the order the expression names them', () => {
+    expect(byId(events()).get('window_ok')!.columns).toEqual(['starts', 'ends']);
+  });
+
+  it('keeps the expression as written, so a form can show the rule', () => {
+    expect(byId(events()).get('age_adult')!.rule).toBe('CHECK (age >= 18)');
+  });
+});
+
+describe('a CHECK the database enforces and no schema does', () => {
+  it('is present rather than dropped, since a form builder still wants to know it exists', () => {
+    expect(byId(events()).has('unparseable')).toBe(true);
+  });
+
+  it('is marked unenforced and says why, in the parser own words', () => {
+    const c = byId(events()).get('unparseable')!;
+    expect(c.enforced).toBe(false);
+    expect(c.unenforced?.[0]?.reason).toMatch(/not a single comparison/);
+    expect(c.messages).toBeUndefined();
+  });
+
+  it('is marked unenforced when it names a column the table does not have', () => {
+    const c = byId(events()).get('no_such_column')!;
+    expect(c.enforced).toBe(false);
+    expect(c.unenforced?.[0]?.reason).toMatch(/not a column of/);
+  });
+
+  it('agrees with what meta reports as unenforced, so the two cannot drift', async () => {
+    const { tableMetaFacts } = await import('../src/meta');
+    const facts = tableMetaFacts(events(), { mode: 'select' });
+    const declined = tableConstraints(events())
+      .constraints.filter((c) => c.kind === 'check' && !c.enforced)
+      .flatMap((c) => c.unenforced!.map((u) => u.part));
+    expect(new Set(declined)).toEqual(new Set(facts.unenforcedChecks));
+  });
+});
+
+describe('the declared width, which is a constraint that does produce an issue', () => {
+  it('is an entry of its own, carrying the message the schema attaches', () => {
+    const c = byId(events()).get('events_name_maxlength')!;
+    expect(c).toMatchObject({ kind: 'maxLength', columns: ['name'], enforced: true });
+    expect(c.messages).toEqual(['at most 10 characters']);
+    expect(c.rule).toBe('at most 10 characters');
+    expect(c.name).toBeUndefined();
+  });
+
+  it('carries a byte budget separately, which only MySQL TEXT columns declare', () => {
+    const t = table('t', [col('body', { sqlType: 'tinytext', maxBytes: 255 })]);
+    const c = tableConstraints(t).constraints.find((x) => x.kind === 'maxBytes')!;
+    expect(c.messages).toEqual(['at most 255 bytes']);
+  });
+});
+
+describe('the emitted module', () => {
+  const render = (opts: Record<string, unknown> = {}) =>
+    renderConstraintsModule([events()], { errorMap: true, ...opts });
+
+  it('imports nothing, so it is data a consumer can read without a validator', () => {
+    expect(render()).not.toMatch(/^import /m);
+  });
+
+  it('exports one const per table plus the lookup record', () => {
+    const code = render();
+    expect(code).toContain('export const eventsConstraints');
+    expect(code).toContain('export const constraintsByTable');
+  });
+
+  it('leaves the matcher out when the error map is not asked for', () => {
+    const code = render({ errorMap: false });
+    expect(code).not.toContain('constraintForIssue');
+    expect(render()).toContain('export function constraintForIssue');
+  });
+
+  it('survives a table name holding a quote, since every value is a user string', () => {
+    const t = table("it's", [col('a')], { checks: [{ name: "o'clock", expression: "a <> 'b'" }] });
+    const code = renderConstraintsModule([t], { errorMap: false });
+    expect(code).toContain(JSON.stringify("o'clock"));
+  });
+});


### PR DESCRIPTION
Plan items 39 and 40, built as one feature: **40 is impossible unless 39 carries stable names.**

## Is this a duplicate of `meta`? No, and the question was worth asking

Three differences, each load-bearing:

1. **Shape.** `meta` carries `"age_adult: age >= 18"`. A form builder wanting the bound parses SQL back out of a sentence. The ledger carries `{ operator: '>=', value: '18' }` with the sentence beside it.
2. **Content.** `meta` has **no foreign keys at all**, and its `unique` is `string[][]` with the constraint names dropped. Those names are exactly what item 40 needs.
3. **Addressing.** `meta` is reachable only by holding the schema object and asking each field, per mode. The ledger is a record keyed by table, with no validator import.

Deliberately **not** copied: `sqlType`, `hasDefault`, `generated`, the column's numeric range. Those are field facts `meta` already has. Consequence, stated in the docs: a form builder reading only `constraints.ts` cannot render `<input required min max>` and needs `meta` or the JSON Schema output for that half.

**Both are built on one classification.** `classifyTableChecks` moved into the new module and `meta.ts` derives from it (shrinking ~65 lines), so "the database checks this and no schema does" is one answer rather than two that can drift. A test asserts they agree.

## The identifier problem, measured by running failing rows

| the row breaks | zod 4.4.3 | valibot 1.4.2 | arktype 2.2.3 |
|---|---|---|---|
| `CHECK (age >= 18)` | `too_small`, `minimum: 18` | `min_value`, `requirement: 18` | `min` |
| `varchar(10)` | `custom`, DRZL's string | `check`, same string | `predicate`, string in `expected` |
| `CHECK (length(email) >= 3)` | `custom`, DRZL's string | `check`, same | `predicate`, `path: []` |
| `CHECK (status IN (...))` | `invalid_value` | `picklist` | `union` |
| `CHECK (starts < ends)` | `custom`, `path: ['starts']` | `check`, **`path: []`** | `predicate`, `path: []` |
| `CHECK (name <> 'x')` | `custom`, DRZL's message | `check`, DRZL's message | **nothing, not enforced** |

Paths differ too: zod `['age']`, valibot `[{ type: 'object', key: 'age' }]`.

**Two findings decided the design.** DRZL's own deliberate folds destroy the name: a numeric CHECK becomes `.gte(18)` and an `IN` list becomes an enum, and the failure is then worded entirely by the library. And valibot names **no column** for a row-level check, so a path-keyed map would hold a message with nowhere to put it.

## Three tiers, and it reports which one answered

- **`message`** — exact lookup on a string DRZL wrote. Certain by construction, and asserted byte-identical against the emitted schema per generator.
- **`bound`** — for a folded numeric CHECK, matched on the bound value both libraries put on the issue as data.
- **`column`** — for a folded set, which leaves neither. Safe only because a column carries at most one.

**The two folds are kept apart rather than pooled, and that is what stops tier 3 over-claiming.** Pooled, an `invalid_type` on a numeric column answered with that column's CHECK — a rule the row had not broken. A folded bound always reports its bound, so no bound means it is not that constraint. Both false positives are regression-tested.

## End to end, through the real CLI

```
zod      too_small     ["age"]                                    -> age_adult (check) by=bound
zod      custom        ["handle"]  "at most 10 characters"        -> users_handle_maxlength by=message
zod      invalid_value ["status"]                                 -> status_valid (check) by=column
zod      custom        ["starts"]  "window_ok: starts < ends"     -> window_ok column=starts by=message

valibot  min_value     ["age"]                                    -> age_adult (check) by=bound
valibot  check         []          "window_ok: starts < ends"     -> window_ok column=starts by=message
```

The valibot row check has an **empty path** and still resolves to `starts`, the same column zod chose. That probe fed valibot's issues through the **zod-emitted** ledger, demonstrating the module is library-neutral. The emitted tree typechecks under `strict` + `nodenext`.

## Decisions

- **Data plus one function in one module**, zero imports, following the `renderDuplicateFinder` precedent that emitted code never imports a DRZL runtime. `{ errorMap: false }` drops the matcher: that flag *is* items 39 and 40.
- **zod and valibot only.** ArkType is why this is a capability flag rather than a global option: it silently enforces nothing for a string `<>`, so `enforced: true` would be a lie. TypeBox and Effect were not measured, so they are not claimed.
- **Declined CHECKs are present** with `enforced: false` and the parser's own reason, because a form still wants to know the database can reject what it accepted. They can never produce an issue, so they never come back from the map.
- **One entry per declared CHECK**, not per parsed clause: `BETWEEN 18 AND 65` is one constraint with two bounds, because the database has one constraint there and quotes one name.
- **Opt-in**, and off means byte-identical (asserted).

## Size

12 constraints: **10,110 B source / 2,831 minified / 1,117 gzipped** with the map; **5,291 / 1,855 / 708** without. Most of the source is doc comments and types, both gone at build time.

## Tests

Written first: validation-core 22 uncollected, zod **15 failed / 2 passed**, valibot **8 failed / 2 passed**. Three of those failures were real: two wrong test premises (the fold *replaces* the type's lower bound, so that end is untrippable) and one genuine matcher defect (tier 3 over-claiming).

Final: **2095 passed, 0 failed** (52 new). `build`, `typecheck`, `lint`, `docs build`, `verify:packed` all green, 20 documented configs.

## What I would want added to the gate (not touched)

1. **Run the error map against the packed artefacts.** This is the one claim a compiler cannot check and a library upgrade can break in silence: if zod renames `minimum` or valibot stops setting `requirement`, every workspace test still passes (they pin the installed version) and the map quietly matches nothing in a consumer's tree.
2. **Message identity over the full dialect matrix**, since the identity spans two packages and the matrix covers constraint shapes I did not think of.
3. **Compare against Postgres's own constraint name.** The ground-truth stage already probes CHECK-constrained tables against a real Postgres, whose rejection carries `constraint: 'age_adult'`.
4. **A size line for the ledger**, which is a per-constraint cost and invisible to the bytes-per-column budget.

## Could not settle

- **A pre-existing discrepancy inherited on purpose**: `meta`'s guard marks an `IN` check on an **array** column unenforced, while zod applies it to the element. Sharing the classification means the ledger inherits the same conservative answer; fixing it changes `meta`'s bytes for existing users.
- **`binary(n)`/`varbinary(n)` caps are absent** — they come from `shape.kind === 'byteString'`, not `maxLength`. A miss, never a wrong answer.
- **Nested-relation payloads**: `constraintForIssue` takes the table from its caller, so a child object's issue is looked up in the parent's ledger. Documented.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
