### PR TITLE
feat(checks): parse OR over one column, IS NOT NULL, and IS DISTINCT FROM

### DIFF
--- a/.changeset/check-or-and-unary.md
+++ b/.changeset/check-or-and-unary.md
@@ -1,0 +1,89 @@
+---
+'@drzl/validation-core': minor
+'@drzl/generator-arktype': minor
+'@drzl/generator-effect': minor
+'@drzl/generator-json-schema': minor
+'@drzl/generator-typebox': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-zod': minor
+'@drzl/cli': minor
+---
+
+Read three more CHECK shapes: a disjunction that pins one column, `IS NOT NULL`, and the null
+guard in front of a predicate
+
+`parseCheck` refused every expression holding `OR` and every expression holding `NOT`, which took
+`col IS NOT NULL` with it. Three of those refusals are now readings, one is unchanged, and one that
+used to be a generic "not a comparison" now says what it found.
+
+```ts
+// check('status_valid', sql`${t.status} = 'draft' OR ${t.status} = 'live'`)
+status: z.enum(['draft', 'live'] as const).nullable(),
+
+// check('email_set', sql`${t.email} IS NOT NULL`)   // on a nullable column
+email: z.string(),
+
+// check('age_adult', sql`${t.age} IS NULL OR ${t.age} >= 18`)
+age: z.number().int().gte(18).lte(2147483647).nullable(),
+
+// check('tier_ok', sql`${t.tier} IS DISTINCT FROM 'banned'`)
+tier: z.string().refine((v) => v !== 'banned', { message: "tier_ok: tier <> 'banned'" }).nullable(),
+```
+
+All five validator generators and the JSON Schema generator, plus `drzl doctor` and the constraint
+ledger.
+
+**Why a disjunction was refused, and what changed.** A conjunction splits because every part is
+independently _necessary_. A disjunction is the opposite: `CHECK (a OR b)` is satisfied by a row
+that breaks `a`, so a schema enforcing `a` refuses rows the database takes. Nothing about that
+argument has weakened. What is read is the one shape where the _whole_ disjunction is a single
+statement: every branch pinning the same column to a literal, by `=` or by `IN`. `s = 'a' OR
+s = 'b'` and `s IN ('a','b')` are the same statement in SQL, NULL included, so they emit the same
+schema. Everything else is refused **whole**, never in part, and named:
+
+| Refused                     | Reason reported                                 |
+| --------------------------- | ----------------------------------------------- |
+| `n < 0 OR n > 100`          | a branch is a range rather than a set of values |
+| `a = 'x' OR b = 'y'`        | the branches constrain different columns (a, b) |
+| `s = 'a' OR s = 1`          | the branches mix a string and a number          |
+| `s = 'a' OR lower(s) = 'b'` | part of an OR was not understood                |
+
+**`IS NOT NULL` narrows the field rather than adding a predicate.** Every other CHECK is emitted
+_inside_ the nullable wrapper, precisely so `null` skips it, which is what makes them match SQL.
+This one is the statement that `null` is not allowed, so it is said by the field not being
+nullable. Applied once, in the three column selectors every generator already calls, so no
+generator learns a new kind of check and none of the six can disagree with the others. On insert
+the field becomes required, because a row omitting a nullable column with no default writes NULL;
+a column that defaults to a value stays optional. On a column already `.notNull()` it changes
+nothing and stops being reported as declined.
+
+**A null guard reduces away.** `col IS NULL OR P` states nothing beyond `P`, because a CHECK
+already passes on NULL and every operator here yields NULL when its column is NULL. Sound only when
+`P` names the guarded column and holds no null test of its own, so `a IS NULL OR b > 0` is still
+refused: with `a` null it accepts every `b`. `IS DISTINCT FROM <literal>` reduces the same way and
+emits byte for byte what the `<>` it means emits.
+
+**Arithmetic over two columns stays refused, and now says so.** `x + y < 100` used to report "not a
+single comparison this version understands". It now names the operator, and `drzl doctor` says what
+to do instead. The reason is measured rather than argued: Postgres computes `numeric` exactly and
+JavaScript computes in binary floating point.
+
+| Column type        | `CHECK (x + y <= 0.3)` with `(0.1, 0.2)` | JavaScript `0.1 + 0.2 <= 0.3` |
+| ------------------ | ---------------------------------------- | ----------------------------- |
+| `numeric(10,2)`    | accept                                   | false, so it would reject     |
+| `double precision` | reject                                   | false, so it would agree      |
+
+One expression, two column types, two different correct answers, and the expression does not carry
+the type. A `bigint` pair adds a third, since Postgres raises on overflow where `BigInt` does not.
+Any single reading is wrong for two of the three in the direction that refuses rows the database
+accepts, which is the failure this parser exists to avoid.
+
+**Ground truth.** 64 probes through a real Postgres (PGlite), one table per constraint so a sibling
+CHECK cannot fail the statement before the value under test is reached, each value put to both the
+database and the emitted insert schema: **0 rows the schema refuses and Postgres accepts**, 58
+agree, 6 wide. Every wide row is a constraint DRZL deliberately enforces nothing for, which is the
+safe direction.
+
+`IS NULL` on its own is read but enforced nowhere, since narrowing a field to only null would mean
+replacing the column's type rather than wrapping it; `drzl doctor` lists it with that reason.
+`NOT`, `NOT IN` and the boolean `IS TRUE` family remain refused.

--- a/docs/generators/constraints.md
+++ b/docs/generators/constraints.md
@@ -219,6 +219,23 @@ otherwise. It can never produce a validation issue, so it never comes back from
 `drzl doctor` reports the same set as a checklist for a human. This is the machine-readable half of
 that report, sitting next to the schemas rather than in terminal output.
 
+A CHECK that **is** enforced but leaves nothing on the issue to match on carries neither `messages`
+nor `bounds` nor `values`. `CHECK (email IS NOT NULL)` is the case: it is enforced by the field not
+being nullable, so the failure is the library's own "expected string, received null" and no string
+DRZL wrote appears in it. The entry says `enforced: true` and offers no message, rather than
+offering one no emitted module ever writes:
+
+```ts
+{
+  id: 'email_set',
+  name: 'email_set',
+  kind: 'check',
+  columns: ['email'],
+  rule: 'CHECK (email IS NOT NULL)',
+  enforced: true,
+}
+```
+
 ## How this differs from `meta`
 
 Both exist, and they answer different questions.

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -141,17 +141,17 @@ itself treats the result as a scalar, so DRZL does too.
 Some Postgres columns do not arrive as scalars at all, and a schema that says otherwise rejects
 every row the database returns:
 
-| Column                      | Runtime value              | Emitted                                 |
-| --------------------------- | -------------------------- | --------------------------------------- |
-| `point()`                   | `[number, number]`         | `z.tuple([z.number(), z.number()])`     |
+| Column                      | Runtime value              | Emitted                                      |
+| --------------------------- | -------------------------- | -------------------------------------------- |
+| `point()`                   | `[number, number]`         | `z.tuple([z.number(), z.number()])`          |
 | `point({ mode: 'xy' })`     | `{ x, y }`                 | `z.object({ x: z.number(), y: z.number() })` |
-| `line()`                    | `[number, number, number]` | `z.tuple([...])`                        |
-| `line({ mode: 'abc' })`     | `{ a, b, c }`              | `z.object({ a, b, c })`                 |
-| `geometry()`                | `[number, number]`         | `z.tuple([z.number(), z.number()])`     |
-| `vector({ dimensions: 3 })` | `number[]`                 | `z.array(z.number()).length(3)`         |
-| `bit({ dimensions: 3 })`    | `'010'`                    | `z.string().regex(/^[01]*$/).length(3)` |
-| `bytea()`                   | `Buffer`                   | `z.instanceof(Uint8Array)`              |
-| `json()`, `jsonb()`         | any JSON value             | `z.json()`                              |
+| `line()`                    | `[number, number, number]` | `z.tuple([...])`                             |
+| `line({ mode: 'abc' })`     | `{ a, b, c }`              | `z.object({ a, b, c })`                      |
+| `geometry()`                | `[number, number]`         | `z.tuple([z.number(), z.number()])`          |
+| `vector({ dimensions: 3 })` | `number[]`                 | `z.array(z.number()).length(3)`              |
+| `bit({ dimensions: 3 })`    | `'010'`                    | `z.string().regex(/^[01]*$/).length(3)`      |
+| `bytea()`                   | `Buffer`                   | `z.instanceof(Uint8Array)`                   |
+| `json()`, `jsonb()`         | any JSON value             | `z.json()`                                   |
 
 `bytea` is typed as `Uint8Array` rather than `Buffer`, which is deliberately wider than
 `drizzle-orm/zod`. A Buffer is a Uint8Array, so nothing official accepts is turned away; the wider
@@ -178,17 +178,17 @@ the comparison is against a scalar literal and describes neither.
 
 The same rules apply, with each dialect's own widths:
 
-| Column                                  | Emitted                                                    |
-| --------------------------------------- | ---------------------------------------------------------- |
-| MySQL `tinyint()`                       | `z.number().int().gte(-128).lte(127)`                      |
-| MySQL `mediumint()`                     | `z.number().int().gte(-8388608).lte(8388607)`              |
-| MySQL `year()`                          | `z.number().int().gte(1901).lte(2155)`                     |
-| MySQL `serial()`                        | `z.number().int().gte(0)`, since it is unsigned            |
-| MySQL `text()`                          | a string capped at 65535 **bytes**, the width the type implies |
+| Column                                  | Emitted                                                          |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| MySQL `tinyint()`                       | `z.number().int().gte(-128).lte(127)`                            |
+| MySQL `mediumint()`                     | `z.number().int().gte(-8388608).lte(8388607)`                    |
+| MySQL `year()`                          | `z.number().int().gte(1901).lte(2155)`                           |
+| MySQL `serial()`                        | `z.number().int().gte(0)`, since it is unsigned                  |
+| MySQL `text()`                          | a string capped at 65535 **bytes**, the width the type implies   |
 | MySQL `binary(4)`                       | a string, capped at 4 characters on select and 4 bytes on insert |
-| SQLite `blob({ mode: 'json' })`         | `z.json()`                                                 |
-| SQLite `blob({ mode: 'bigint' })`       | `z.bigint()` with the 64 bit range                         |
-| SQLite `integer({ mode: 'timestamp' })` | a date                                                     |
+| SQLite `blob({ mode: 'json' })`         | `z.json()`                                                       |
+| SQLite `blob({ mode: 'bigint' })`       | `z.bigint()` with the 64 bit range                               |
+| SQLite `integer({ mode: 'timestamp' })` | a date                                                           |
 
 MySQL's text and blob caps are byte counts. Postgres `text` has no cap and does not get one.
 
@@ -239,8 +239,7 @@ millisecond past it, so a NOT NULL column would accept both.
 ## CHECK constraints
 
 A `check()` in your schema becomes a refinement. **No official Drizzle validator module does
-this**, in any library: a table declaring `check('age_adult', sql\`${t.age} >= 18\`)` produces a
-`drizzle-orm/zod` schema that accepts `{ age: 5 }`.
+this**, in any library: a table declaring `check('age_adult', sql\`${t.age} >= 18\`)`produces a`drizzle-orm/zod`schema that accepts`{ age: 5 }`.
 
 ```ts
 // check('age_adult', sql`${t.age} >= 18`)
@@ -289,6 +288,61 @@ The split walks the expression rather than splitting on the text, so the `AND` i
 and the one inside `'A AND B'` are both left alone. If any single part is not understood, the
 whole constraint is skipped: enforcing half of a constraint is enforcing a different one.
 
+### A disjunction of equalities becomes the same enum
+
+```ts
+// check('status_valid', sql`${t.status} = 'draft' OR ${t.status} = 'live'`)
+status: z.enum(["draft", "live"] as const).nullable(),
+```
+
+`s = 'a' OR s = 'b'` and `s IN ('a','b')` are the same statement in SQL, NULL included, so they
+emit the same schema. That is the only disjunction that is read.
+
+A conjunction splits because every part is independently _necessary_: enforcing one enforces
+something the database enforces too. A disjunction is the opposite. `CHECK (a OR b)` is satisfied
+by a row that breaks `a`, so a schema enforcing `a` refuses rows the database takes. There is no
+partial reading of an `OR`, so one is understood whole or refused whole, and a refusal is listed
+by `drzl doctor` and marked `enforced: false` in the [constraint ledger](/generators/constraints).
+
+Refused, with the reason naming the shape: branches over ranges (`n < 0 OR n > 100`), branches
+naming different columns (`a = 'x' OR b = 'y'`, which is a rule about the row), branches mixing a
+string and a number, and any branch the parser cannot read on its own.
+
+### `IS NOT NULL` narrows the field
+
+```ts
+// check('email_set', sql`${t.email} IS NOT NULL`)   // on a nullable column
+email: z.string(),
+```
+
+The one constraint that cannot be a refinement. A refinement sits inside `.nullable()` precisely
+so `null` skips it, which is what makes every other CHECK match SQL; this one is the statement
+that `null` is not allowed, so it is said by the field not being nullable. On insert the field
+becomes **required**, because a row omitting a nullable column with no default writes `NULL`; a
+column that defaults to a value stays optional.
+
+On a column already declared `.notNull()` it changes nothing and is reported as enforced rather
+than as declined.
+
+`IS NULL` is read but enforced nowhere: narrowing a field to _only_ null would mean replacing the
+column's type rather than wrapping it. It is listed by `drzl doctor`.
+
+### A null guard in front of a predicate reduces to the predicate
+
+```ts
+// check('age_adult', sql`${t.age} IS NULL OR ${t.age} >= 18`)
+age: z.number().int().gte(18).lte(2147483647).nullable(),
+```
+
+Byte for byte what `CHECK (age >= 18)` emits, because the two constrain exactly the same rows: a
+CHECK already passes when it evaluates to NULL, and every operator here yields NULL when its
+column is NULL. The guard is dropped only when the predicate _names_ the guarded column and holds
+no null test of its own, which is what makes the reduction sound; `a IS NULL OR b > 0` is refused,
+since with `a` null it accepts every `b`.
+
+`s IS DISTINCT FROM 'x'` reads the same way. `NULL IS DISTINCT FROM 'x'` is TRUE and `NULL <> 'x'`
+is NULL, and a CHECK passes on both, so it emits exactly what `s <> 'x'` emits.
+
 ### `length()` becomes a character count
 
 ```ts
@@ -322,17 +376,32 @@ against a scalar literal says nothing usable about an array, whereas this one is
 
 **Only unambiguous constraints are translated.** These are skipped rather than guessed at:
 
-| Skipped                            | Why                                                      |
-| ---------------------------------- | -------------------------------------------------------- |
-| `age >= 18 OR age <= 65`           | A disjunction cannot be split the way a conjunction can  |
-| `NOT (age >= 18)`                  | Same: negation changes the scope of everything inside it |
-| `age >= 18 AND lower(n) = 'x'`     | One part is not understood, so neither is enforced       |
-| `email ~ '^[a-z]+$'`               | Postgres `~` is POSIX ERE, not JavaScript's regex dialect |
-| `octet_length(s) <= 5`             | Bytes, and the column's encoding is not in the schema    |
+| Skipped                        | Why                                                                     |
+| ------------------------------ | ----------------------------------------------------------------------- |
+| `age >= 18 OR age <= 65`       | A disjunction over ranges is not a set of values, so it states no union |
+| `a = 'x' OR b = 'y'`           | Its branches name different columns, so it is a rule about the row      |
+| `NOT (age >= 18)`              | Negation changes the scope of everything inside it                      |
+| `x + y < 100`                  | Arithmetic, which the schema cannot compute the way the database does   |
+| `age >= 18 AND lower(n) = 'x'` | One part is not understood, so neither is enforced                      |
+| `email ~ '^[a-z]+$'`           | Postgres `~` is POSIX ERE, not JavaScript's regex dialect               |
+| `octet_length(s) <= 5`         | Bytes, and the column's encoding is not in the schema                   |
+| `flag IS TRUE`                 | A boolean literal, which the parser does not read yet                   |
+
+**Arithmetic between columns is refused deliberately**, and it is the refusal most worth arguing
+for. Postgres computes `numeric` exactly and JavaScript computes in binary floating point:
+`CHECK (x + y <= 0.3)` on two `numeric(10,2)` columns **accepts** `(0.1, 0.2)`, and the same
+expression in JavaScript is `0.30000000000000004` and rejects it. Both measured against Postgres.
+On two `double precision` columns the database computes the same IEEE-754 sum JavaScript does and
+**rejects** the same pair, and a `bigint` pair adds a third answer, since Postgres raises on
+overflow where JavaScript's `BigInt` does not. So the correct translation of one expression
+depends on a column type the expression does not carry, and any single reading would be wrong for
+two of the three in the direction that refuses rows the database accepts. `drzl doctor` names the
+operator and suggests moving the result into a generated column and constraining that.
 
 Applied, and worth naming because they read like exceptions: `start_date < end_date` goes on the
 object as a row-level check, `length()` and `char_length()` count code points, `cardinality()`
-bounds an array, `BETWEEN` folds into the range, and `IN` becomes an enum. A conjunction is
+bounds an array, `BETWEEN` folds into the range, `IN` and a disjunction of equalities both become
+an enum, `IS NOT NULL` narrows the field, and `IS NULL OR p` is exactly `p`. A conjunction is
 applied when **every** part is understood.
 
 A schema that quietly enforces a _guess_ at your constraint is worse than one enforcing nothing,

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -39,7 +39,14 @@ import chalk from 'chalk';
 export type DoctorFindingKind =
   /** A column whose validator will accept any value. */
   | 'unknown-column'
-  /** A CHECK the shared parser refused to translate. */
+  /**
+   * A CHECK nothing DRZL emits enforces.
+   *
+   * Usually one the shared parser refused outright. Also a clause it *reads* and no generator can
+   * state: `col IS NULL` narrows a column to null alone, which would mean replacing the column's
+   * type rather than wrapping it. Reported the same way, because the two are the same fact to the
+   * reader: the constraint is in the schema and the generated schemas do not check it.
+   */
   | 'check-declined'
   /** A CHECK naming a column the table does not have. */
   | 'check-unknown-column'
@@ -105,6 +112,10 @@ export function namedColumns(parsed: Extract<ReturnType<typeof parseCheck>, { ok
   for (const s of parsed.sets ?? []) out.push({ column: s.column, scalar: true });
   for (const l of parsed.lengths ?? []) out.push({ column: l.column, scalar: false });
   for (const c of parsed.cardinalities ?? []) out.push({ column: c.column, scalar: false });
+  // A null test is the one clause that describes every column shape alike: an array, a json
+  // payload and a scalar are each either there or not. So it names its column without claiming
+  // the column is scalar, which would report `CHECK (tags IS NOT NULL)` as a mismatch it is not.
+  for (const n of parsed.nulls ?? []) out.push({ column: n.column, scalar: false });
   for (const r of parsed.rows ?? []) {
     out.push({ column: r.left, scalar: false });
     out.push({ column: r.right, scalar: false });
@@ -142,6 +153,40 @@ function describeShape(c: Column): string {
   }
 }
 
+/**
+ * The generic advice for a declined CHECK, or something the reader can act on.
+ *
+ * The generic sentence is true of every refusal and therefore says nothing about any of them. Two
+ * of the refusals have a fix, and a reader who has just been told their constraint is not enforced
+ * has earned being told what to do instead of being told the rule again.
+ *
+ * Matched on the parser's own reason rather than on a code, because the reason is what the parser
+ * already returns and a second vocabulary beside it is a second thing to keep in step. The default
+ * is the generic sentence, so a reason added later is worded generically rather than wrongly.
+ */
+function declineHint(reason: string): string {
+  if (/combined with/.test(reason))
+    return (
+      'Postgres computes numeric arithmetic exactly and JavaScript computes it in binary ' +
+      'floating point, so `x + y <= 0.3` accepts (0.1, 0.2) in the database and rejects it in ' +
+      'JavaScript. The right translation depends on whether the columns are numeric, double ' +
+      'precision or bigint, and the expression does not say. Put the result in a generated ' +
+      'column and constrain that, or leave this one to the database.'
+    );
+  if (/\bOR\b/.test(reason))
+    return (
+      'A disjunction is read only where the whole of it pins one column to a set of values, ' +
+      "such as `status = 'a' OR status = 'b'`, which becomes the same enum an IN list does. " +
+      'Anything else is refused whole rather than in part: a row satisfying the other branch is ' +
+      'one the database accepts, and enforcing one branch would turn it away.'
+    );
+  return (
+    'Only constraints whose meaning is unambiguous are translated, because a validator ' +
+    'enforcing a guess rejects rows the database accepts. Your database still enforces ' +
+    'this one; nothing DRZL emits does.'
+  );
+}
+
 function checkFindings(table: Table): DoctorFinding[] {
   const out: DoctorFinding[] = [];
   const byName = new Map(table.columns.map((c) => [c.name, c]));
@@ -160,12 +205,30 @@ function checkFindings(table: Table): DoctorFinding[] {
         table: table.tsName,
         constraint: k.name,
         message: `CHECK ${label} on "${table.tsName}" is not translated: ${parsed.reason}. Expression: ${expr}`,
-        hint:
-          'Only constraints whose meaning is unambiguous are translated, because a validator ' +
-          'enforcing a guess rejects rows the database accepts. Your database still enforces ' +
-          'this one; nothing DRZL emits does.',
+        hint: declineHint(parsed.reason),
       });
       continue;
+    }
+
+    // A clause that parsed and that nothing enforces. `col IS NULL` is the only one: narrowing a
+    // field to null *alone* would mean replacing the column's type rather than wrapping it, and no
+    // generator has a hook for that. Reported here rather than left silent, because the parser
+    // learning to read an expression must not be the same event as the doctor forgetting it: the
+    // constraint went from "declined, here is why" to absent from the report entirely.
+    for (const n of parsed.nulls ?? []) {
+      if (n.notNull) continue;
+      out.push({
+        kind: 'check-declined',
+        level: 'warn',
+        table: table.tsName,
+        constraint: k.name,
+        message:
+          `CHECK ${label} on "${table.tsName}" holds "${n.column} IS NULL", which narrows the ` +
+          `column to NULL alone and no generated schema states. Expression: ${expr}`,
+        hint:
+          'A column that may only ever be NULL is usually a constraint written the wrong way ' +
+          'round. Drop the column, or state the rule as a CHECK on the column that decides it.',
+      });
     }
 
     // Reported once per column rather than once per clause, so `a >= 1 AND a <= 9` on a missing

--- a/packages/cli/test/doctor.spec.ts
+++ b/packages/cli/test/doctor.spec.ts
@@ -64,6 +64,8 @@ export const accounts = pgTable(
     check('balance_pos', sql\`\${t.balance} > 0\`),
     check('ghost_col', sql\`nonexistent_column >= 3\`),
     check('row_ghost', sql\`\${t.age} < missing_col\`),
+    check('age_budget', sql\`\${t.age} + \${t.score} < 100\`),
+    check('credit_null', sql\`\${t.credit} IS NULL\`),
   ]
 );
 
@@ -105,6 +107,37 @@ export const users = pgTable('users', { id: serial('id').primaryKey(), name: tex
 export const mv = pgMaterializedView('mv').as((qb) => qb.select({ n: users.name }).from(users));
 `;
 
+/**
+ * The four CHECK shapes this version started reading, none of which should be reported.
+ *
+ * A doctor that keeps listing a constraint after the generators began enforcing it is a doctor
+ * whose list nobody reads. `tags` is an array on purpose: a null test describes it exactly, and
+ * the scalar guard must not claim otherwise.
+ */
+const READS_SCHEMA = `
+import { sql } from 'drizzle-orm';
+import { check, integer, pgTable, serial, text } from 'drizzle-orm/pg-core';
+
+export const rows = pgTable(
+  'rows',
+  {
+    id: serial('id').primaryKey(),
+    status: text('status'),
+    email: text('email'),
+    tier: text('tier'),
+    age: integer('age'),
+    tags: text('tags').array(),
+  },
+  (t) => [
+    check('status_or', sql\`\${t.status} = 'draft' OR \${t.status} = 'live'\`),
+    check('email_set', sql\`\${t.email} IS NOT NULL\`),
+    check('age_guard', sql\`\${t.age} IS NULL OR \${t.age} >= 18\`),
+    check('tier_not', sql\`\${t.tier} IS DISTINCT FROM 'banned'\`),
+    check('tags_set', sql\`\${t.tags} IS NOT NULL\`),
+  ]
+);
+`;
+
 /** The six Gel temporal columns the analyzer deliberately leaves `unknown`. */
 const GEL_SCHEMA = `
 import { gelTable, boolean, localDate, localTime, dateDuration, relDuration, duration, timestamp } from 'drizzle-orm/gel-core';
@@ -133,12 +166,14 @@ let problem: Analysis;
 let clean: Analysis;
 let gel: Analysis;
 let keys: Analysis;
+let reads: Analysis;
 
 beforeAll(async () => {
   problem = await analyzed('problem', PROBLEM_SCHEMA);
   clean = await analyzed('clean', CLEAN_SCHEMA);
   gel = await analyzed('gel', GEL_SCHEMA);
   keys = await analyzed('keys', KEYS_SCHEMA);
+  reads = await analyzed('reads', READS_SCHEMA);
 }, 60_000);
 
 const kinds = (a: Analysis, kind: string) =>
@@ -185,17 +220,47 @@ describe('CHECK constraints DRZL will not enforce', () => {
   it('reports every check the shared parser declines, with its reason', () => {
     const declined = kinds(problem, 'check-declined');
     expect(declined.map((f) => f.constraint).sort()).toEqual([
+      'age_budget',
       'age_not',
       'age_or',
       'blob_bytes',
+      'credit_null',
       'email_re',
       'empty_one',
       'mixed_and',
     ]);
     const byName = new Map(declined.map((f) => [f.constraint, f]));
-    expect(byName.get('age_or')!.message).toContain('contains OR');
+    expect(byName.get('age_or')!.message).toContain('range');
     expect(byName.get('age_not')!.message).toContain('contains NOT');
     expect(byName.get('mixed_and')!.message).toContain('part of an AND');
+  });
+
+  it('advises on the two refusals that have a fix, rather than restating the rule', () => {
+    // A reader who has just been told a constraint is not enforced has earned an answer. Both of
+    // these have one, and the generic sentence is true of every refusal and so says nothing.
+    const byName = new Map(kinds(problem, 'check-declined').map((f) => [f.constraint, f]));
+    expect(byName.get('age_budget')!.message).toContain('combined with "+"');
+    expect(byName.get('age_budget')!.hint).toMatch(/generated column/);
+    expect(byName.get('age_budget')!.hint, 'says why, not just that').toMatch(/floating point/);
+    expect(byName.get('age_or')!.hint).toMatch(/IN list|enum/);
+    expect(byName.get('email_re')!.hint, 'no advice invented for the rest').toMatch(
+      /still enforces this one/
+    );
+  });
+
+  it('leaves the disjunctions and null tests it now reads out of the report', () => {
+    const named = buildDoctorReport(reads, 'x.ts')
+      .findings.map((f) => f.constraint)
+      .filter(Boolean);
+    for (const c of ['status_or', 'email_set', 'age_guard', 'tier_not']) {
+      expect(named, c).not.toContain(c);
+    }
+  });
+
+  it('does not call a null test on an array column a scalar comparison', () => {
+    // `tags IS NOT NULL` is true of an array exactly as it is of a scalar. Reporting it as a
+    // scalar comparison against an array would be a warning about a constraint that is enforced.
+    expect(kinds(reads, 'check-not-scalar')).toHaveLength(0);
   });
 
   it('quotes the expression, since the constraint name alone does not say what was written', () => {
@@ -281,7 +346,7 @@ describe('the report as a whole', () => {
   it('counts what it looked at, so a clean run is distinguishable from a run that did nothing', () => {
     const r = buildDoctorReport(problem, 'schema.ts');
     expect(r.counts.tables).toBe(2);
-    expect(r.counts.checks).toBe(14);
+    expect(r.counts.checks).toBe(16);
     expect(r.counts.columns).toBe(13);
     expect(r.counts.findings).toBe(r.findings.length);
     expect(r.dialect).toBe('postgres');

--- a/packages/generator-arktype/test/or-and-null-checks.spec.ts
+++ b/packages/generator-arktype/test/or-and-null-checks.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * The three CHECK shapes this version started reading, run rather than read.
+ *
+ * `status = 'a' OR status = 'b'` is the same statement as `status IN ('a','b')`, NULL included,
+ * so it becomes the same enum. `col IS NOT NULL` is the one constraint that cannot be a predicate
+ * on the field, because a predicate sits inside the nullable wrapper precisely so NULL skips it;
+ * it is stated by the field not being nullable. `col IS NULL OR P` states nothing beyond `P`,
+ * because a CHECK already passes on NULL, so it reduces to `P`.
+ *
+ * Every value below was put to a real Postgres through PGlite first, and the database agrees with
+ * the emitted schema on every one of them.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { ArkTypeGenerator } from '../src/index';
+import { type } from 'arktype';
+
+const SUFFIX = '.arktype.ts';
+const RUN = (schema: any, input: unknown) => !(schema(input) instanceof type.errors);
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-ornull');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return await import(file);
+}
+
+const num = () =>
+  col('age', { tsType: 'number', dbType: 'INTEGER', integer: true, nullable: true });
+
+describe('a disjunction of equalities on one column', () => {
+  const OR = [{ name: 'status_valid', expression: "status = 'draft' OR status = 'live'" }];
+
+  it('narrows the column to those values, and still accepts NULL', async () => {
+    // `NULL = 'draft' OR NULL = 'live'` is NULL and a CHECK passes on NULL, so null stays legal.
+    const m = await schemasFor([col('status')], OR);
+    expect(RUN(m.SelecttSchema, { status: 'draft' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { status: 'live' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { status: 'deleted' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { status: null })).toBe(true);
+  });
+
+  it('agrees with the IN list it means on every probe value', async () => {
+    // Sequenced, not `Promise.all`: both calls write the same file before renaming it.
+    const a = await schemasFor([col('status')], OR);
+    const b = await schemasFor([col('status')], [{ expression: "status IN ('draft', 'live')" }]);
+    for (const value of ['draft', 'live', 'deleted', null]) {
+      expect(RUN(a.SelecttSchema, { status: value }), String(value)).toBe(
+        RUN(b.SelecttSchema, { status: value })
+      );
+    }
+  });
+
+  it('leaves a disjunction it cannot read enforcing nothing', async () => {
+    // Refused whole, not in part: a row satisfying the dropped branch is one the database takes.
+    const m = await schemasFor([num()], [{ expression: 'age < 0 OR age > 100' }]);
+    expect(RUN(m.SelecttSchema, { age: 50 })).toBe(true);
+  });
+});
+
+describe('a CHECK that forbids NULL', () => {
+  const NOT_NULL = [{ name: 'email_set', expression: 'email IS NOT NULL' }];
+
+  it('refuses null in every mode', async () => {
+    const m = await schemasFor([col('email')], NOT_NULL);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { email: null }), s).toBe(false);
+      expect(RUN(m[s], { email: 'a@b' }), s).toBe(true);
+    }
+  });
+
+  it('makes the field required on insert, since omitting it writes NULL', async () => {
+    const m = await schemasFor([col('email')], NOT_NULL);
+    expect(RUN(m.InserttSchema, {})).toBe(false);
+    // An update naming no column writes nothing, so the constraint is never reached.
+    expect(RUN(m.UpdatetSchema, {})).toBe(true);
+  });
+
+  it('leaves it optional on insert when the column defaults to a value', async () => {
+    const m = await schemasFor([col('email', { hasDefault: true })], NOT_NULL);
+    expect(RUN(m.InserttSchema, {})).toBe(true);
+    expect(RUN(m.InserttSchema, { email: null })).toBe(false);
+  });
+
+  it('touches no other column', async () => {
+    const m = await schemasFor([col('email'), col('note')], NOT_NULL);
+    expect(RUN(m.SelecttSchema, { email: 'a@b', note: null })).toBe(true);
+  });
+});
+
+describe('a null guard in front of a predicate', () => {
+  it('behaves exactly as the predicate alone does', async () => {
+    const guarded = await schemasFor([num()], [{ expression: 'age IS NULL OR age >= 18' }]);
+    const plain = await schemasFor([num()], [{ expression: 'age >= 18' }]);
+    for (const value of [null, 17, 18, 40]) {
+      expect(RUN(guarded.SelecttSchema, { age: value }), String(value)).toBe(
+        RUN(plain.SelecttSchema, { age: value })
+      );
+    }
+    expect(RUN(guarded.SelecttSchema, { age: 17 })).toBe(false);
+    expect(RUN(guarded.SelecttSchema, { age: null })).toBe(true);
+  });
+
+  it('does not read a narrowing out of the guard it dropped', async () => {
+    // The guard branch is what makes NULL legal, so reading it as `IS NOT NULL` would invert the
+    // constraint and refuse every NULL the database takes.
+    const m = await schemasFor([num()], [{ expression: 'age IS NULL OR age >= 18' }]);
+    expect(RUN(m.InserttSchema, {})).toBe(true);
+  });
+});

--- a/packages/generator-effect/test/or-and-null-checks.spec.ts
+++ b/packages/generator-effect/test/or-and-null-checks.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * The three CHECK shapes this version started reading, run rather than read.
+ *
+ * `status = 'a' OR status = 'b'` is the same statement as `status IN ('a','b')`, NULL included,
+ * so it becomes the same enum. `col IS NOT NULL` is the one constraint that cannot be a predicate
+ * on the field, because a predicate sits inside the nullable wrapper precisely so NULL skips it;
+ * it is stated by the field not being nullable. `col IS NULL OR P` states nothing beyond `P`,
+ * because a CHECK already passes on NULL, so it reduces to `P`.
+ *
+ * Every value below was put to a real Postgres through PGlite first, and the database agrees with
+ * the emitted schema on every one of them.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { EffectGenerator } from '../src/index';
+import * as Either from 'effect/Either';
+import * as Schema from 'effect/Schema';
+
+const SUFFIX = '.effect.ts';
+const RUN = (schema: any, input: unknown) =>
+  Either.isRight(Schema.decodeUnknownEither(schema as Schema.Schema<unknown>)(input));
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-ornull');
+  await fs.mkdir(dir, { recursive: true });
+  await new EffectGenerator(analysis).generate({ outDir: dir } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return await import(file);
+}
+
+const num = () =>
+  col('age', { tsType: 'number', dbType: 'INTEGER', integer: true, nullable: true });
+
+describe('a disjunction of equalities on one column', () => {
+  const OR = [{ name: 'status_valid', expression: "status = 'draft' OR status = 'live'" }];
+
+  it('narrows the column to those values, and still accepts NULL', async () => {
+    // `NULL = 'draft' OR NULL = 'live'` is NULL and a CHECK passes on NULL, so null stays legal.
+    const m = await schemasFor([col('status')], OR);
+    expect(RUN(m.SelecttSchema, { status: 'draft' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { status: 'live' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { status: 'deleted' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { status: null })).toBe(true);
+  });
+
+  it('agrees with the IN list it means on every probe value', async () => {
+    // Sequenced, not `Promise.all`: both calls write the same file before renaming it.
+    const a = await schemasFor([col('status')], OR);
+    const b = await schemasFor([col('status')], [{ expression: "status IN ('draft', 'live')" }]);
+    for (const value of ['draft', 'live', 'deleted', null]) {
+      expect(RUN(a.SelecttSchema, { status: value }), String(value)).toBe(
+        RUN(b.SelecttSchema, { status: value })
+      );
+    }
+  });
+
+  it('leaves a disjunction it cannot read enforcing nothing', async () => {
+    // Refused whole, not in part: a row satisfying the dropped branch is one the database takes.
+    const m = await schemasFor([num()], [{ expression: 'age < 0 OR age > 100' }]);
+    expect(RUN(m.SelecttSchema, { age: 50 })).toBe(true);
+  });
+});
+
+describe('a CHECK that forbids NULL', () => {
+  const NOT_NULL = [{ name: 'email_set', expression: 'email IS NOT NULL' }];
+
+  it('refuses null in every mode', async () => {
+    const m = await schemasFor([col('email')], NOT_NULL);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { email: null }), s).toBe(false);
+      expect(RUN(m[s], { email: 'a@b' }), s).toBe(true);
+    }
+  });
+
+  it('makes the field required on insert, since omitting it writes NULL', async () => {
+    const m = await schemasFor([col('email')], NOT_NULL);
+    expect(RUN(m.InserttSchema, {})).toBe(false);
+    // An update naming no column writes nothing, so the constraint is never reached.
+    expect(RUN(m.UpdatetSchema, {})).toBe(true);
+  });
+
+  it('leaves it optional on insert when the column defaults to a value', async () => {
+    const m = await schemasFor([col('email', { hasDefault: true })], NOT_NULL);
+    expect(RUN(m.InserttSchema, {})).toBe(true);
+    expect(RUN(m.InserttSchema, { email: null })).toBe(false);
+  });
+
+  it('touches no other column', async () => {
+    const m = await schemasFor([col('email'), col('note')], NOT_NULL);
+    expect(RUN(m.SelecttSchema, { email: 'a@b', note: null })).toBe(true);
+  });
+});
+
+describe('a null guard in front of a predicate', () => {
+  it('behaves exactly as the predicate alone does', async () => {
+    const guarded = await schemasFor([num()], [{ expression: 'age IS NULL OR age >= 18' }]);
+    const plain = await schemasFor([num()], [{ expression: 'age >= 18' }]);
+    for (const value of [null, 17, 18, 40]) {
+      expect(RUN(guarded.SelecttSchema, { age: value }), String(value)).toBe(
+        RUN(plain.SelecttSchema, { age: value })
+      );
+    }
+    expect(RUN(guarded.SelecttSchema, { age: 17 })).toBe(false);
+    expect(RUN(guarded.SelecttSchema, { age: null })).toBe(true);
+  });
+
+  it('does not read a narrowing out of the guard it dropped', async () => {
+    // The guard branch is what makes NULL legal, so reading it as `IS NOT NULL` would invert the
+    // constraint and refuse every NULL the database takes.
+    const m = await schemasFor([num()], [{ expression: 'age IS NULL OR age >= 18' }]);
+    expect(RUN(m.InserttSchema, {})).toBe(true);
+  });
+});

--- a/packages/generator-json-schema/test/or-and-null-checks.spec.ts
+++ b/packages/generator-json-schema/test/or-and-null-checks.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * The three CHECK shapes this version started reading, compiled and run under ajv.
+ *
+ * A JSON Schema is data, so a keyword in the wrong place is not an error: it is ignored, and the
+ * schema goes on accepting the value it exists to reject. Nothing here asserts on the emitted
+ * object. Every case compiles under ajv strict mode, which refuses an unknown keyword outright,
+ * and then asserts which values it takes.
+ *
+ * The three: a disjunction of equalities becomes the enum the equivalent `IN` list becomes; a
+ * `col IS NOT NULL` takes `null` out of the column's type; and a `col IS NULL OR P` is exactly
+ * `P`, because a CHECK already passes on NULL.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import type { Column, Table } from '@drzl/analyzer';
+import { tableSchemas } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (columns: Column[], checks: { name?: string; expression?: string }[] = []): Table =>
+  ({ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }) as never;
+
+function compile(schema: unknown) {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  addFormats(ajv as never);
+  return ajv.compile(schema as never);
+}
+
+const num = () =>
+  col('age', { tsType: 'number', dbType: 'INTEGER', integer: true, nullable: true });
+
+describe('a disjunction of equalities on one column', () => {
+  const OR = [{ name: 'status_valid', expression: "status = 'draft' OR status = 'live'" }];
+
+  it('narrows the column to those values, and still accepts null', () => {
+    const v = compile(tableSchemas(table([col('status')], OR)).select);
+    expect(v({ status: 'draft' })).toBe(true);
+    expect(v({ status: 'live' })).toBe(true);
+    expect(v({ status: 'deleted' })).toBe(false);
+    expect(v({ status: null })).toBe(true);
+  });
+
+  it('produces the same schema the IN list it means produces', () => {
+    const a = tableSchemas(table([col('status')], OR)).select;
+    const b = tableSchemas(
+      table([col('status')], [{ expression: "status IN ('draft', 'live')" }])
+    ).select;
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('leaves a disjunction it cannot read enforcing nothing', () => {
+    const v = compile(
+      tableSchemas(table([num()], [{ expression: 'age < 0 OR age > 100' }])).select
+    );
+    expect(v({ age: 50 })).toBe(true);
+  });
+});
+
+describe('a CHECK that forbids NULL', () => {
+  const NOT_NULL = [{ name: 'email_set', expression: 'email IS NOT NULL' }];
+
+  it('takes null out of the column type in every mode', () => {
+    const s = tableSchemas(table([col('email'), col('note')], NOT_NULL));
+    for (const [mode, schema] of Object.entries(s)) {
+      if (mode === 'components') continue;
+      const v = compile(schema);
+      expect(v({ email: null, note: null }), mode).toBe(false);
+      expect(v({ email: 'a@b', note: null }), mode).toBe(true);
+    }
+  });
+
+  it('spells it the way the OpenAPI 3.0 target spells nullability', () => {
+    // 3.0 has no type array: it says `nullable: true`. A column that stopped being nullable must
+    // stop saying it there too, or the document keeps promising null in a schema that refuses it.
+    const s = tableSchemas(table([col('email'), col('note')], NOT_NULL), {
+      target: 'openapi-3.0',
+    }).select as any;
+    expect(s.properties.email.nullable).toBeUndefined();
+    expect(s.properties.note.nullable).toBe(true);
+  });
+});
+
+describe('a null guard in front of a predicate', () => {
+  it('produces exactly the schema the predicate alone produces', () => {
+    const guarded = tableSchemas(
+      table([num()], [{ expression: 'age IS NULL OR age >= 18' }])
+    ).select;
+    const plain = tableSchemas(table([num()], [{ expression: 'age >= 18' }])).select;
+    expect(JSON.stringify(guarded)).toBe(JSON.stringify(plain));
+    const v = compile(guarded);
+    expect(v({ age: null })).toBe(true);
+    expect(v({ age: 17 })).toBe(false);
+    expect(v({ age: 18 })).toBe(true);
+  });
+});

--- a/packages/generator-typebox/test/or-and-null-checks.spec.ts
+++ b/packages/generator-typebox/test/or-and-null-checks.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * The three CHECK shapes this version started reading, run rather than read.
+ *
+ * `status = 'a' OR status = 'b'` is the same statement as `status IN ('a','b')`, NULL included,
+ * so it becomes the same enum. `col IS NOT NULL` is the one constraint that cannot be a predicate
+ * on the field, because a predicate sits inside the nullable wrapper precisely so NULL skips it;
+ * it is stated by the field not being nullable. `col IS NULL OR P` states nothing beyond `P`,
+ * because a CHECK already passes on NULL, so it reduces to `P`.
+ *
+ * Every value below was put to a real Postgres through PGlite first, and the database agrees with
+ * the emitted schema on every one of them.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { TypeBoxGenerator } from '../src/index';
+import { Value } from '@sinclair/typebox/value';
+
+const SUFFIX = '.typebox.ts';
+const RUN = (schema: any, input: unknown) => Value.Check(schema, input);
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-ornull');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return await import(file);
+}
+
+const num = () =>
+  col('age', { tsType: 'number', dbType: 'INTEGER', integer: true, nullable: true });
+
+describe('a disjunction of equalities on one column', () => {
+  const OR = [{ name: 'status_valid', expression: "status = 'draft' OR status = 'live'" }];
+
+  it('narrows the column to those values, and still accepts NULL', async () => {
+    // `NULL = 'draft' OR NULL = 'live'` is NULL and a CHECK passes on NULL, so null stays legal.
+    const m = await schemasFor([col('status')], OR);
+    expect(RUN(m.SelecttSchema, { status: 'draft' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { status: 'live' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { status: 'deleted' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { status: null })).toBe(true);
+  });
+
+  it('agrees with the IN list it means on every probe value', async () => {
+    // Sequenced, not `Promise.all`: both calls write the same file before renaming it.
+    const a = await schemasFor([col('status')], OR);
+    const b = await schemasFor([col('status')], [{ expression: "status IN ('draft', 'live')" }]);
+    for (const value of ['draft', 'live', 'deleted', null]) {
+      expect(RUN(a.SelecttSchema, { status: value }), String(value)).toBe(
+        RUN(b.SelecttSchema, { status: value })
+      );
+    }
+  });
+
+  it('leaves a disjunction it cannot read enforcing nothing', async () => {
+    // Refused whole, not in part: a row satisfying the dropped branch is one the database takes.
+    const m = await schemasFor([num()], [{ expression: 'age < 0 OR age > 100' }]);
+    expect(RUN(m.SelecttSchema, { age: 50 })).toBe(true);
+  });
+});
+
+describe('a CHECK that forbids NULL', () => {
+  const NOT_NULL = [{ name: 'email_set', expression: 'email IS NOT NULL' }];
+
+  it('refuses null in every mode', async () => {
+    const m = await schemasFor([col('email')], NOT_NULL);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { email: null }), s).toBe(false);
+      expect(RUN(m[s], { email: 'a@b' }), s).toBe(true);
+    }
+  });
+
+  it('makes the field required on insert, since omitting it writes NULL', async () => {
+    const m = await schemasFor([col('email')], NOT_NULL);
+    expect(RUN(m.InserttSchema, {})).toBe(false);
+    // An update naming no column writes nothing, so the constraint is never reached.
+    expect(RUN(m.UpdatetSchema, {})).toBe(true);
+  });
+
+  it('leaves it optional on insert when the column defaults to a value', async () => {
+    const m = await schemasFor([col('email', { hasDefault: true })], NOT_NULL);
+    expect(RUN(m.InserttSchema, {})).toBe(true);
+    expect(RUN(m.InserttSchema, { email: null })).toBe(false);
+  });
+
+  it('touches no other column', async () => {
+    const m = await schemasFor([col('email'), col('note')], NOT_NULL);
+    expect(RUN(m.SelecttSchema, { email: 'a@b', note: null })).toBe(true);
+  });
+});
+
+describe('a null guard in front of a predicate', () => {
+  it('behaves exactly as the predicate alone does', async () => {
+    const guarded = await schemasFor([num()], [{ expression: 'age IS NULL OR age >= 18' }]);
+    const plain = await schemasFor([num()], [{ expression: 'age >= 18' }]);
+    for (const value of [null, 17, 18, 40]) {
+      expect(RUN(guarded.SelecttSchema, { age: value }), String(value)).toBe(
+        RUN(plain.SelecttSchema, { age: value })
+      );
+    }
+    expect(RUN(guarded.SelecttSchema, { age: 17 })).toBe(false);
+    expect(RUN(guarded.SelecttSchema, { age: null })).toBe(true);
+  });
+
+  it('does not read a narrowing out of the guard it dropped', async () => {
+    // The guard branch is what makes NULL legal, so reading it as `IS NOT NULL` would invert the
+    // constraint and refuse every NULL the database takes.
+    const m = await schemasFor([num()], [{ expression: 'age IS NULL OR age >= 18' }]);
+    expect(RUN(m.InserttSchema, {})).toBe(true);
+  });
+});

--- a/packages/generator-valibot/test/or-and-null-checks.spec.ts
+++ b/packages/generator-valibot/test/or-and-null-checks.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * The three CHECK shapes this version started reading, run rather than read.
+ *
+ * `status = 'a' OR status = 'b'` is the same statement as `status IN ('a','b')`, NULL included,
+ * so it becomes the same enum. `col IS NOT NULL` is the one constraint that cannot be a predicate
+ * on the field, because a predicate sits inside the nullable wrapper precisely so NULL skips it;
+ * it is stated by the field not being nullable. `col IS NULL OR P` states nothing beyond `P`,
+ * because a CHECK already passes on NULL, so it reduces to `P`.
+ *
+ * Every value below was put to a real Postgres through PGlite first, and the database agrees with
+ * the emitted schema on every one of them.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { ValibotGenerator } from '../src/index';
+import * as v from 'valibot';
+
+const SUFFIX = '.valibot.ts';
+const RUN = (schema: any, input: unknown) => v.safeParse(schema, input).success;
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-ornull');
+  await fs.mkdir(dir, { recursive: true });
+  await new ValibotGenerator(analysis).generate({ outDir: dir } as never);
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return await import(file);
+}
+
+const num = () =>
+  col('age', { tsType: 'number', dbType: 'INTEGER', integer: true, nullable: true });
+
+describe('a disjunction of equalities on one column', () => {
+  const OR = [{ name: 'status_valid', expression: "status = 'draft' OR status = 'live'" }];
+
+  it('narrows the column to those values, and still accepts NULL', async () => {
+    // `NULL = 'draft' OR NULL = 'live'` is NULL and a CHECK passes on NULL, so null stays legal.
+    const m = await schemasFor([col('status')], OR);
+    expect(RUN(m.SelecttSchema, { status: 'draft' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { status: 'live' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { status: 'deleted' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { status: null })).toBe(true);
+  });
+
+  it('agrees with the IN list it means on every probe value', async () => {
+    // Sequenced, not `Promise.all`: both calls write the same file before renaming it.
+    const a = await schemasFor([col('status')], OR);
+    const b = await schemasFor([col('status')], [{ expression: "status IN ('draft', 'live')" }]);
+    for (const value of ['draft', 'live', 'deleted', null]) {
+      expect(RUN(a.SelecttSchema, { status: value }), String(value)).toBe(
+        RUN(b.SelecttSchema, { status: value })
+      );
+    }
+  });
+
+  it('leaves a disjunction it cannot read enforcing nothing', async () => {
+    // Refused whole, not in part: a row satisfying the dropped branch is one the database takes.
+    const m = await schemasFor([num()], [{ expression: 'age < 0 OR age > 100' }]);
+    expect(RUN(m.SelecttSchema, { age: 50 })).toBe(true);
+  });
+});
+
+describe('a CHECK that forbids NULL', () => {
+  const NOT_NULL = [{ name: 'email_set', expression: 'email IS NOT NULL' }];
+
+  it('refuses null in every mode', async () => {
+    const m = await schemasFor([col('email')], NOT_NULL);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { email: null }), s).toBe(false);
+      expect(RUN(m[s], { email: 'a@b' }), s).toBe(true);
+    }
+  });
+
+  it('makes the field required on insert, since omitting it writes NULL', async () => {
+    const m = await schemasFor([col('email')], NOT_NULL);
+    expect(RUN(m.InserttSchema, {})).toBe(false);
+    // An update naming no column writes nothing, so the constraint is never reached.
+    expect(RUN(m.UpdatetSchema, {})).toBe(true);
+  });
+
+  it('leaves it optional on insert when the column defaults to a value', async () => {
+    const m = await schemasFor([col('email', { hasDefault: true })], NOT_NULL);
+    expect(RUN(m.InserttSchema, {})).toBe(true);
+    expect(RUN(m.InserttSchema, { email: null })).toBe(false);
+  });
+
+  it('touches no other column', async () => {
+    const m = await schemasFor([col('email'), col('note')], NOT_NULL);
+    expect(RUN(m.SelecttSchema, { email: 'a@b', note: null })).toBe(true);
+  });
+});
+
+describe('a null guard in front of a predicate', () => {
+  it('behaves exactly as the predicate alone does', async () => {
+    const guarded = await schemasFor([num()], [{ expression: 'age IS NULL OR age >= 18' }]);
+    const plain = await schemasFor([num()], [{ expression: 'age >= 18' }]);
+    for (const value of [null, 17, 18, 40]) {
+      expect(RUN(guarded.SelecttSchema, { age: value }), String(value)).toBe(
+        RUN(plain.SelecttSchema, { age: value })
+      );
+    }
+    expect(RUN(guarded.SelecttSchema, { age: 17 })).toBe(false);
+    expect(RUN(guarded.SelecttSchema, { age: null })).toBe(true);
+  });
+
+  it('does not read a narrowing out of the guard it dropped', async () => {
+    // The guard branch is what makes NULL legal, so reading it as `IS NOT NULL` would invert the
+    // constraint and refuse every NULL the database takes.
+    const m = await schemasFor([num()], [{ expression: 'age IS NULL OR age >= 18' }]);
+    expect(RUN(m.InserttSchema, {})).toBe(true);
+  });
+});

--- a/packages/generator-zod/test/or-and-null-checks.spec.ts
+++ b/packages/generator-zod/test/or-and-null-checks.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * The three CHECK shapes this version started reading, run rather than read.
+ *
+ * `status = 'a' OR status = 'b'` is the same statement as `status IN ('a','b')`, NULL included,
+ * so it becomes the same enum. `col IS NOT NULL` is the one constraint that cannot be a predicate
+ * on the field, because a predicate sits inside the nullable wrapper precisely so NULL skips it;
+ * it is stated by the field not being nullable. `col IS NULL OR P` states nothing beyond `P`,
+ * because a CHECK already passes on NULL, so it reduces to `P`.
+ *
+ * Every value below was put to a real Postgres through PGlite first, and the database agrees with
+ * the emitted schema on every one of them. The probe table is in the changeset.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+let seq = 0;
+
+async function schemasFor(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-ornull');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return await import(file);
+}
+
+describe('a disjunction of equalities on one column', () => {
+  const OR = [{ name: 'status_valid', expression: "status = 'draft' OR status = 'live'" }];
+
+  it('narrows the column to those values', async () => {
+    const m = await schemasFor([col('status')], OR);
+    expect(m.SelecttSchema.safeParse({ status: 'draft' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ status: 'live' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ status: 'deleted' }).success).toBe(false);
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    // `NULL = 'draft' OR NULL = 'live'` is NULL, and a CHECK passes on NULL. Measured.
+    const m = await schemasFor([col('status')], OR);
+    expect(m.SelecttSchema.safeParse({ status: null }).success).toBe(true);
+  });
+
+  it('emits exactly what the IN list it means emits', async () => {
+    // Sequenced, not `Promise.all`: both calls write the same `t.zod.ts` before renaming it.
+    const a = await schemasFor([col('status')], OR);
+    const b = await schemasFor([col('status')], [{ expression: "status IN ('draft', 'live')" }]);
+    for (const v of ['draft', 'live', 'deleted', null]) {
+      expect(a.SelecttSchema.safeParse({ status: v }).success, String(v)).toBe(
+        b.SelecttSchema.safeParse({ status: v }).success
+      );
+    }
+  });
+
+  it('leaves a disjunction it cannot read enforcing nothing', async () => {
+    // Refused whole, not in part. A row satisfying the branch that was dropped is a row the
+    // database accepts, and enforcing the other branch would turn it away.
+    const m = await schemasFor(
+      [col('n', { tsType: 'number', dbType: 'INTEGER' })],
+      [{ expression: 'n < 0 OR n > 100' }]
+    );
+    expect(m.SelecttSchema.safeParse({ n: 50 }).success).toBe(true);
+  });
+});
+
+describe('a CHECK that forbids NULL', () => {
+  const NOT_NULL = [{ name: 'email_set', expression: 'email IS NOT NULL' }];
+
+  it('refuses null in every mode', async () => {
+    const m = await schemasFor([col('email')], NOT_NULL);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(m[s].safeParse({ email: null }).success, s).toBe(false);
+      expect(m[s].safeParse({ email: 'a@b' }).success, s).toBe(true);
+    }
+  });
+
+  it('makes the field required on insert, since omitting it writes NULL', async () => {
+    const m = await schemasFor([col('email')], NOT_NULL);
+    expect(m.InserttSchema.safeParse({}).success).toBe(false);
+    // An update naming no column writes nothing, so the constraint is not reached.
+    expect(m.UpdatetSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('leaves it optional on insert when the column defaults to a value', async () => {
+    // Omitting it writes the default, which is not NULL, so the constraint holds.
+    const m = await schemasFor([col('email', { hasDefault: true })], NOT_NULL);
+    expect(m.InserttSchema.safeParse({}).success).toBe(true);
+    expect(m.InserttSchema.safeParse({ email: null }).success).toBe(false);
+  });
+
+  it('touches no other column', async () => {
+    const m = await schemasFor([col('email'), col('note')], NOT_NULL);
+    expect(m.SelecttSchema.safeParse({ email: 'a@b', note: null }).success).toBe(true);
+  });
+
+  it('reaches an array column, which is either there or not like anything else', async () => {
+    const m = await schemasFor(
+      [col('tags', { arrayDimensions: 1 })],
+      [{ expression: 'tags IS NOT NULL' }]
+    );
+    expect(m.SelecttSchema.safeParse({ tags: null }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ tags: ['a'] }).success).toBe(true);
+  });
+});
+
+describe('a null guard in front of a predicate', () => {
+  const num = () => col('age', { tsType: 'number', dbType: 'INTEGER', integer: true });
+
+  it('behaves exactly as the predicate alone does', async () => {
+    const guarded = await schemasFor([num()], [{ expression: 'age IS NULL OR age >= 18' }]);
+    const plain = await schemasFor([num()], [{ expression: 'age >= 18' }]);
+    for (const v of [null, 17, 18, 40]) {
+      expect(guarded.SelecttSchema.safeParse({ age: v }).success, String(v)).toBe(
+        plain.SelecttSchema.safeParse({ age: v }).success
+      );
+    }
+    expect(guarded.SelecttSchema.safeParse({ age: 17 }).success).toBe(false);
+    expect(guarded.SelecttSchema.safeParse({ age: null }).success).toBe(true);
+  });
+
+  it('does not read a narrowing out of the guard it dropped', async () => {
+    // The guard branch is what makes NULL legal, so taking it as `IS NOT NULL` would invert the
+    // constraint and refuse every NULL the database takes.
+    const m = await schemasFor([num()], [{ expression: 'age IS NULL OR age >= 18' }]);
+    expect(m.InserttSchema.safeParse({}).success).toBe(true);
+  });
+});
+
+describe('IS DISTINCT FROM', () => {
+  it('emits byte for byte what the <> it reduces to emits', async () => {
+    // `NULL IS DISTINCT FROM 'x'` is TRUE and `NULL <> 'x'` is NULL, and a CHECK passes on both,
+    // so the two constrain the same rows. Asserted on the emitted text rather than only on
+    // behaviour, because equal output is what makes the reduction cost nothing to review.
+    const dir = path.join(__dirname, '.tmp-ornull');
+    await fs.mkdir(dir, { recursive: true });
+    const emit = async (expression: string) => {
+      const analysis: Analysis = {
+        dialect: 'postgres',
+        tables: [
+          {
+            name: 't',
+            tsName: 't',
+            columns: [col('tier')],
+            unique: [],
+            indexes: [],
+            checks: [{ name: 'tier_ok', expression }],
+          },
+        ] as never,
+        enums: [],
+        relations: [],
+        issues: [],
+      };
+      await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+      return fs.readFile(path.join(dir, 't.zod.ts'), 'utf8');
+    };
+    expect(await emit("tier IS DISTINCT FROM 'banned'")).toBe(await emit("tier <> 'banned'"));
+  });
+});

--- a/packages/validation-core/src/checks.ts
+++ b/packages/validation-core/src/checks.ts
@@ -18,6 +18,11 @@
  *    base expression rather than on the whole field.
  * 2. **A multi-column check cannot live on a field.** `start_date < end_date` is a statement
  *    about the row, so it is not returned here at all.
+ * 3. **A conjunction splits and a disjunction does not.** Every part of an `AND` has to hold on
+ *    its own, so a list of checks says exactly what it says. An `OR` is *weaker* than either
+ *    branch: a schema enforcing one branch turns away every row that satisfied the other. So a
+ *    disjunction is read only where the whole of it collapses to one statement, and refused
+ *    whole otherwise. See `parseDisjunction`.
  */
 
 /** A comparison of one column against one literal, which is the case worth translating. */
@@ -87,6 +92,25 @@ export interface CardinalityCheck {
   name?: string;
 }
 
+/**
+ * A test of whether a column holds NULL, from `CHECK (col IS NOT NULL)`.
+ *
+ * Not a comparison: SQL's comparison operators all yield NULL against a NULL operand, and these
+ * two are the operators that answer TRUE or FALSE instead. That is why they are a kind of their
+ * own rather than another `operator` on `ColumnCheck`, whose whole placement rule is that a check
+ * sits *inside* the nullable wrapper because NULL never reaches it.
+ *
+ * `notNull` is the only direction any emitted schema states, and it states it by not being
+ * nullable rather than by carrying a predicate. `IS NULL` is carried so the constraint can be
+ * reported precisely rather than as "not understood", and is enforced nowhere.
+ */
+export interface NullCheck {
+  column: string;
+  /** `true` for `IS NOT NULL`, `false` for `IS NULL`. */
+  notNull: boolean;
+  name?: string;
+}
+
 /** A check that was understood, or the reason it was not. */
 export type ParsedCheck =
   | {
@@ -96,6 +120,7 @@ export type ParsedCheck =
       rows?: RowCheck[];
       lengths?: LengthCheck[];
       cardinalities?: CardinalityCheck[];
+      nulls?: NullCheck[];
     }
   | { ok: false; reason: string };
 
@@ -112,20 +137,28 @@ const CARDINALITY_OF =
 const LENGTH_OF =
   /^\s*(?:length|char_length)\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)\s*(>=|<=|<>|!=|>|<|=)\s*(\d+)\s*$/i;
 
+/** What a SQL identifier is made of, and so what does and does not end a keyword. */
+const WORD = /[A-Za-z0-9_]/;
+
 /**
- * Split on `AND`s that are at the top level, outside parentheses and outside quotes.
+ * Split on a keyword at the top level, outside parentheses and outside quotes.
  *
  * A naive `split(/AND/i)` would cut through `'A AND B'` as a string literal and through the
  * `AND` inside a `BETWEEN`, which is why this walks the expression instead. Returns a single
  * element when there is nothing to split.
+ *
+ * The keyword is recognised as a whole token rather than as a substring surrounded by spaces.
+ * That is what keeps the `OR` inside `XOR` and the `AND` inside `BRAND` from being read as
+ * operators, and it is also what lets `(a=1)OR(a=2)` split, which Postgres accepts and which the
+ * spaces-only form quietly failed to see.
  */
-function splitTopLevelAnd(expr: string): string[] {
+function splitTopLevel(expr: string, keyword: 'AND' | 'OR'): string[] {
   const parts: string[] = [];
   let depth = 0;
   let inString = false;
   let start = 0;
   for (let i = 0; i < expr.length; i++) {
-    const c = expr[i];
+    const c = expr[i]!;
     if (inString) {
       // SQL escapes a quote by doubling it, so `''` inside a string is not the end of it.
       if (c === "'") {
@@ -140,17 +173,87 @@ function splitTopLevelAnd(expr: string): string[] {
     }
     if (c === '(') depth++;
     else if (c === ')') depth--;
-    else if (depth === 0 && /\s/.test(c)) {
-      const m = /^\s+AND\s+/i.exec(expr.slice(i));
-      if (m) {
-        parts.push(expr.slice(start, i));
-        i += m[0].length - 1;
-        start = i + 1;
-      }
+    else if (depth === 0 && WORD.test(c)) {
+      // Only at the start of a token, and only when nothing word-like follows it.
+      if (i > 0 && WORD.test(expr[i - 1]!)) continue;
+      if (expr.slice(i, i + keyword.length).toUpperCase() !== keyword) continue;
+      const after = expr[i + keyword.length];
+      if (after !== undefined && WORD.test(after)) continue;
+      parts.push(expr.slice(start, i));
+      i += keyword.length - 1;
+      start = i + 1;
     }
   }
   parts.push(expr.slice(start));
   return parts;
+}
+
+/**
+ * Whether the expression negates something logically, as opposed to spelling an `IS NOT` operator.
+ *
+ * `NOT` is refused wherever it appears, because negating a predicate this parser reads produces
+ * one it does not, and pushing the negation inwards is a job for a real parser. But `IS NOT NULL`
+ * and `IS NOT DISTINCT FROM` are not negations: `IS NOT` is one operator, spelled with a space in
+ * it. A guard that could not tell them apart refused every unary null test in the language, which
+ * is exactly the constraint this file was asked to start reading.
+ *
+ * String literals are skipped, so a `NOT` inside `'A NOT B'` is text rather than an operator.
+ */
+function hasLogicalNot(expr: string): boolean {
+  let inString = false;
+  for (let i = 0; i < expr.length; i++) {
+    const c = expr[i]!;
+    if (inString) {
+      if (c === "'") {
+        if (expr[i + 1] === "'") i++;
+        else inString = false;
+      }
+      continue;
+    }
+    if (c === "'") {
+      inString = true;
+      continue;
+    }
+    if (c !== 'N' && c !== 'n') continue;
+    if (i > 0 && WORD.test(expr[i - 1]!)) continue;
+    if (!/^NOT($|[^A-Za-z0-9_])/i.test(expr.slice(i))) continue;
+    // `IS NOT` is one operator. Anything else reaching here negates a predicate.
+    if (/(^|[^A-Za-z0-9_])IS\s+$/i.test(expr.slice(0, i))) continue;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * The arithmetic or concatenation operator combining two operands, if there is one.
+ *
+ * Only for the refusal message: nothing here evaluates one. Requiring whitespace on both sides is
+ * what keeps `balance >= -100` from reading as a subtraction, and it matches how the operator is
+ * written in a `sql` template, where the column interpolations already put spaces around it.
+ */
+const COMBINING = /(?:^|\s)(\|\||[+\-*/%])(?:\s)/;
+function combiningOperator(expr: string): string | undefined {
+  let inString = false;
+  let bare = '';
+  for (let i = 0; i < expr.length; i++) {
+    const c = expr[i]!;
+    if (inString) {
+      if (c === "'") {
+        if (expr[i + 1] === "'") i++;
+        else inString = false;
+      }
+      // A space stands in for the literal, so an operator cannot be read out of its contents and
+      // the operands on either side of it stay separated.
+      continue;
+    }
+    if (c === "'") {
+      inString = true;
+      bare += ' ';
+      continue;
+    }
+    bare += c;
+  }
+  return COMBINING.exec(bare)?.[1];
 }
 
 /** Strip one layer of parentheses wrapping the whole expression, as many times as it is wrapped. */
@@ -214,6 +317,14 @@ function splitTopLevelCommas(list: string): string[] {
 }
 const BETWEEN = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s+BETWEEN\s+(.+?)\s+AND\s+(.+?)\s*$/i;
 
+// The unary `IS` predicates. Unlike `BETWEEN`, none of these holds an `AND` or an `OR` inside it,
+// which is why they are matched *after* the splits rather than before: matched first, the trailing
+// operand of `a IS DISTINCT FROM 5 AND b > 0` would read `5 AND b > 0` and the second predicate
+// would vanish. That is the same trap `BETWEEN` documents, and it points the other way.
+const IS_NULL = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s+IS\s+(NOT\s+)?NULL\s*$/i;
+const IS_DISTINCT = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s+IS\s+(NOT\s+)?DISTINCT\s+FROM\s+(.+?)\s*$/i;
+const IS_BOOLEAN = /^\s*[A-Za-z_][A-Za-z0-9_]*\s+IS\s+(?:NOT\s+)?(TRUE|FALSE|UNKNOWN)\s*$/i;
+
 function literal(raw: string): { value: string; kind: 'number' | 'string' } | undefined {
   const t = raw.trim();
   if (/^-?\d+(\.\d+)?$/.test(t)) return { value: t, kind: 'number' };
@@ -223,24 +334,175 @@ function literal(raw: string): { value: string; kind: 'number' | 'string' } | un
   return undefined;
 }
 
+/** Every column a parsed check talks about, in no particular order. */
+function columnsOf(parsed: Extract<ParsedCheck, { ok: true }>): Set<string> {
+  const out = new Set<string>();
+  for (const c of parsed.checks) out.add(c.column);
+  for (const s of parsed.sets ?? []) out.add(s.column);
+  for (const l of parsed.lengths ?? []) out.add(l.column);
+  for (const a of parsed.cardinalities ?? []) out.add(a.column);
+  for (const n of parsed.nulls ?? []) out.add(n.column);
+  for (const r of parsed.rows ?? []) {
+    out.add(r.left);
+    out.add(r.right);
+  }
+  return out;
+}
+
+/**
+ * A disjunction, read only where the whole of it says one thing.
+ *
+ * This is the half of the file that has to be argued rather than described. A conjunction splits
+ * because each part is independently *necessary*: enforcing one enforces something the database
+ * enforces too. A disjunction is the opposite. `CHECK (a OR b)` is satisfied by a row that breaks
+ * `a`, so a schema enforcing `a` refuses rows the database takes, which is the one failure this
+ * whole file exists to avoid. There is no partial reading of an `OR`: it is understood whole or
+ * refused whole, and the refusal is what `drzl doctor` and the constraint ledger report.
+ *
+ * Two shapes are understood whole.
+ *
+ * **A set.** Every branch pins the same column to a literal, by `=` or by `IN`. `s = 'a' OR
+ * s = 'b'` and `s IN ('a','b')` are the same statement in SQL, NULL included: both yield NULL
+ * when `s` is, and a CHECK passes on NULL. So the union of the branches is returned as the one
+ * `ColumnSet` it already was, and every generator states it the way it already states an `IN`.
+ *
+ * **A null guard.** `col IS NULL OR P` states nothing beyond `P` when `P` is NULL exactly when
+ * `col` is, because a CHECK already passes on NULL. Every operator this parser reads is strict:
+ * it yields NULL whenever any column it names is NULL. So the guard is dropped, and the soundness
+ * condition is that `P` *names* the guarded column and contains no null test of its own, which is
+ * the one predicate here that answers FALSE rather than NULL.
+ */
+function parseDisjunction(branches: string[], name?: string): ParsedCheck {
+  const guarded: string[] = [];
+  const rest: string[] = [];
+  for (const b of branches) {
+    // `m[2]` is the optional `NOT`. Only the bare `IS NULL` is a guard; `IS NOT NULL` is a claim.
+    const m = unwrap(b).match(IS_NULL);
+    if (m && !m[2]) guarded.push(m[1]!);
+    else rest.push(b);
+  }
+
+  const reduced = ((): ParsedCheck => {
+    if (!rest.length)
+      return {
+        ok: false,
+        reason: 'every branch of the OR is a null test, which is a rule about the row',
+      };
+    if (rest.length === 1) return parseCheck(rest[0]!, name);
+    return foldDisjunctionToSet(rest, name);
+  })();
+
+  if (!reduced.ok || !guarded.length) return reduced;
+
+  if (reduced.nulls?.length)
+    return {
+      ok: false,
+      reason: 'a null test guarded by IS NULL, which is true of every row rather than a narrowing',
+    };
+  const named = columnsOf(reduced);
+  const stray = guarded.filter((g) => !named.has(g));
+  if (stray.length)
+    return {
+      ok: false,
+      reason: `${stray.map((s) => `"${s}"`).join(' and ')} IS NULL guards a predicate that does not name it`,
+    };
+  return reduced;
+}
+
+/**
+ * The branches of a disjunction as the one set of literals they pin a column to, or why not.
+ *
+ * Every reason names the shape it found, because the alternative is a `drzl doctor` line that
+ * says "OR" and leaves the reader to work out which of four different things went wrong.
+ */
+function foldDisjunctionToSet(branches: string[], name?: string): ParsedCheck {
+  let column: string | undefined;
+  let kind: 'number' | 'string' | undefined;
+  const values: string[] = [];
+
+  for (const branch of branches) {
+    const parsed = parseCheck(branch, name);
+    if (!parsed.ok)
+      return { ok: false, reason: `part of an OR was not understood: ${parsed.reason}` };
+    if (parsed.rows?.length)
+      return {
+        ok: false,
+        reason: 'a branch of the OR compares two columns, which is a rule about the row',
+      };
+    if (parsed.lengths?.length || parsed.cardinalities?.length)
+      return {
+        ok: false,
+        reason: 'a branch of the OR is a count rather than a value, so the OR states no set',
+      };
+    if (parsed.nulls?.length)
+      return { ok: false, reason: 'a branch of the OR is a null test rather than a value' };
+
+    const set = parsed.sets?.[0];
+    const range = parsed.checks.find((c) => c.operator !== '=');
+    if (range)
+      return {
+        ok: false,
+        reason: `a branch of the OR is a range (${range.column} ${range.operator} ${range.value}) rather than a set of values`,
+      };
+    if (parsed.checks.length + (parsed.sets?.length ?? 0) !== 1)
+      return { ok: false, reason: 'a branch of the OR states more than one thing' };
+
+    const here = set
+      ? { column: set.column, kind: set.kind, values: set.values }
+      : {
+          column: parsed.checks[0]!.column,
+          kind: parsed.checks[0]!.kind,
+          values: [parsed.checks[0]!.value],
+        };
+
+    if (column === undefined) {
+      column = here.column;
+      kind = here.kind;
+    }
+    if (here.column !== column)
+      return {
+        ok: false,
+        reason: `the OR branches constrain different columns (${column}, ${here.column}), so it states a rule about the row rather than about a field`,
+      };
+    if (here.kind !== kind)
+      return { ok: false, reason: 'the OR branches mix a string and a number' };
+    for (const v of here.values) if (!values.includes(v)) values.push(v);
+  }
+
+  return {
+    ok: true,
+    checks: [],
+    sets: [{ column: column!, values, kind: kind!, name }],
+  };
+}
+
 /**
  * Parse one check expression.
  *
  * Deliberately narrow. `BETWEEN` is included because it is common and means exactly two
  * inclusive bounds; `AND` of arbitrary predicates is not, because getting its scope wrong would
  * silently change what is enforced.
+ *
+ * **The order below is load bearing, in both directions.** `BETWEEN` is matched before the `AND`
+ * split because it *holds* an `AND`; splitting first turned every `BETWEEN` into an unparseable
+ * pair and dropped a constraint that had been enforced. The unary `IS` predicates are matched
+ * *after* the splits for the mirror-image reason: none of them holds an `AND` or an `OR`, and
+ * their trailing operand is greedy, so matching first would let `a IS DISTINCT FROM 5 AND b > 0`
+ * swallow the second predicate. `OR` is split before `AND` because SQL binds `AND` tighter, and
+ * no SQL operator spells an `OR` inside itself the way `BETWEEN` spells an `AND`.
  */
 export function parseCheck(expression: string | undefined, name?: string): ParsedCheck {
   const expr = unwrap((expression ?? '').trim());
   if (!expr) return { ok: false, reason: 'empty expression' };
   if (expr.includes('?')) return { ok: false, reason: 'expression contains an unresolved value' };
 
-  // `OR` anywhere disqualifies the whole expression. Conjunction is safe to split because every
-  // part has to hold independently; disjunction is not, and telling the two apart in a mixed
-  // expression needs a real parser. Refusing is the behaviour that cannot silently enforce the
-  // wrong thing.
-  if (/(^|[\s)])OR($|[\s(])/i.test(expr)) return { ok: false, reason: 'contains OR' };
-  if (/(^|[\s(])NOT($|[\s(])/i.test(expr)) return { ok: false, reason: 'contains NOT' };
+  // A disjunction, which is read only where the whole of it collapses to one statement.
+  const branches = splitTopLevel(expr, 'OR');
+  if (branches.length > 1) return parseDisjunction(branches, name);
+
+  // `NOT` still disqualifies the expression: negating a predicate this parser reads produces one
+  // it does not. `IS NOT NULL` is not a negation, and `hasLogicalNot` is what tells them apart.
+  if (hasLogicalNot(expr)) return { ok: false, reason: 'contains NOT' };
 
   // Before the AND split, because the `AND` in `x BETWEEN 1 AND 10` belongs to the operator
   // rather than joining two predicates. Splitting first turned every BETWEEN into an
@@ -263,13 +525,14 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
   // A conjunction: every part must hold, so each becomes its own check. Any part this parser
   // cannot read disqualifies the whole expression rather than being dropped, since enforcing
   // half of a constraint is enforcing a different constraint.
-  const parts = splitTopLevelAnd(expr);
+  const parts = splitTopLevel(expr, 'AND');
   if (parts.length > 1) {
     const checks: ColumnCheck[] = [];
     const sets: ColumnSet[] = [];
     const rows: RowCheck[] = [];
     const lengths: LengthCheck[] = [];
     const cardinalities: CardinalityCheck[] = [];
+    const nulls: NullCheck[] = [];
     for (const part of parts) {
       const parsed = parseCheck(part, name);
       if (!parsed.ok)
@@ -279,6 +542,7 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
       if (parsed.rows) rows.push(...parsed.rows);
       if (parsed.lengths) lengths.push(...parsed.lengths);
       if (parsed.cardinalities) cardinalities.push(...parsed.cardinalities);
+      if (parsed.nulls) nulls.push(...parsed.nulls);
     }
     return {
       ok: true,
@@ -287,8 +551,47 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
       ...(rows.length ? { rows } : {}),
       ...(lengths.length ? { lengths } : {}),
       ...(cardinalities.length ? { cardinalities } : {}),
+      ...(nulls.length ? { nulls } : {}),
     };
   }
+
+  // The unary `IS` predicates, after both splits: see the ordering note on this function.
+  //
+  // `IS NOT NULL` on a nullable column is the one narrowing here that no predicate can carry. A
+  // check sits *inside* the nullable wrapper precisely because NULL never reaches it, so the only
+  // way to state this is for the field to stop being nullable, which is what
+  // `insertColumns`/`selectColumns`/`updateColumns` do with it. `IS NULL` is read so it can be
+  // reported precisely; nothing narrows a column to NULL alone.
+  const isNull = expr.match(IS_NULL);
+  if (isNull) {
+    return {
+      ok: true,
+      checks: [],
+      nulls: [{ column: isNull[1]!, notNull: !!isNull[2], ...(name ? { name } : {}) }],
+    };
+  }
+
+  // `col IS DISTINCT FROM <literal>` is the NULL-safe `<>`, and as a *CHECK* it constrains exactly
+  // the rows `<>` does: `NULL IS DISTINCT FROM 5` is TRUE and `NULL <> 5` is NULL, and a CHECK
+  // passes on both. Verified against Postgres. `IS NOT DISTINCT FROM` is not symmetric with that:
+  // it answers FALSE on NULL, so it is an equality that also refuses NULL, and it says so.
+  const isDistinct = expr.match(IS_DISTINCT);
+  if (isDistinct) {
+    const value = literal(isDistinct[3]!);
+    if (!value) return { ok: false, reason: 'the right side of IS DISTINCT FROM is not a literal' };
+    const column = isDistinct[1]!;
+    const negated = !!isDistinct[2];
+    return {
+      ok: true,
+      checks: [
+        { column, operator: negated ? '=' : '<>', value: value.value, kind: value.kind, name },
+      ],
+      ...(negated ? { nulls: [{ column, notNull: true, ...(name ? { name } : {}) }] } : {}),
+    };
+  }
+
+  if (IS_BOOLEAN.test(expr))
+    return { ok: false, reason: 'a boolean IS test, whose literal this version does not read' };
 
   // `length(col) <op> n`: a character-count bound. The only function call this parser reads, and
   // it is read rather than refused because the mapping is exact, which is more than can be said
@@ -344,8 +647,30 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
     };
   }
 
+  /**
+   * Arithmetic between operands, refused by name rather than as "not a comparison".
+   *
+   * This is a decision and not a gap. `CHECK (x + y <= 0.3)` on two `numeric` columns accepts
+   * (0.1, 0.2), because Postgres computes `numeric` exactly; the same expression in JavaScript is
+   * 0.30000000000000004 and rejects it. Measured, both halves. On two `double precision` columns
+   * Postgres computes the same IEEE-754 sum JavaScript does and rejects it too, so the *correct*
+   * translation of one expression depends on a column type the expression does not carry, and a
+   * `bigint` pair adds a third answer: Postgres raises on overflow where JS `BigInt` does not.
+   * One reading would be wrong for two of the three, in the direction that refuses rows the
+   * database accepts, so none is emitted.
+   */
+  const combining = combiningOperator(expr);
+  const arithmetic = () =>
+    ({
+      ok: false as const,
+      reason: `columns combined with "${combining}", which this version does not evaluate`,
+    }) satisfies ParsedCheck;
+
   const cmp = expr.match(COMPARISON);
-  if (!cmp) return { ok: false, reason: 'not a single comparison this version understands' };
+  if (!cmp) {
+    if (combining) return arithmetic();
+    return { ok: false, reason: 'not a single comparison this version understands' };
+  }
 
   const value = literal(cmp[3]);
   if (!value) {
@@ -357,7 +682,8 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
       const op = cmp[2] === '!=' ? '<>' : (cmp[2] as ColumnCheck['operator']);
       return { ok: true, checks: [], rows: [{ left: cmp[1], right, operator: op, name }] };
     }
-    // Anything else is an expression this parser does not model, such as `a + b`.
+    if (combining) return arithmetic();
+    // Anything else is an expression this parser does not model.
     return { ok: false, reason: 'right side is not a literal' };
   }
 

--- a/packages/validation-core/src/constraints.ts
+++ b/packages/validation-core/src/constraints.ts
@@ -34,6 +34,7 @@ import {
   type ColumnCheck,
   type ColumnSet,
   type LengthCheck,
+  type NullCheck,
   type RowCheck,
 } from './checks.js';
 
@@ -64,6 +65,9 @@ function cardinalityText(k: CardinalityCheck): string {
 }
 function rowText(k: RowCheck): string {
   return labelled(k.name, `${k.left} ${k.operator} ${k.right}`);
+}
+function nullText(k: NullCheck): string {
+  return labelled(k.name, `${k.column} IS ${k.notNull ? 'NOT NULL' : 'NULL'}`);
 }
 
 /**
@@ -135,6 +139,16 @@ export interface CheckPart {
   bound?: { column: string; operator: ColumnCheck['operator']; value: string };
   /** Present when the clause was folded into a set of literals instead of a predicate. */
   set?: { column: string; values: string[]; kind: 'number' | 'string' };
+  /**
+   * Present when the clause is enforced by the field's shape rather than by a predicate.
+   *
+   * The third fold, after a bound and a set, and the one that leaves *nothing* to match on:
+   * `CHECK (col IS NOT NULL)` is enforced by the field not being nullable, and the failure it
+   * produces is the library's own "expected string, received null". Marked so `tableConstraints`
+   * does not offer the clause text as a message, which would have the error map keying on a
+   * string no emitted module writes.
+   */
+  shape?: 'notNull';
 }
 
 /** One declared CHECK, with each of its clauses placed. */
@@ -226,6 +240,37 @@ export function classifyTableChecks(table: Table): ClassifiedCheck[] {
         cardinalityText(a),
         (c) => !!c.arrayDimensions,
         (c) => `"${c.name}" is not an array, so it has no elements to count`
+      );
+    }
+    for (const n of parsed.nulls ?? []) {
+      const text = nullText(n);
+      if (!byName.has(n.column)) {
+        parts.push({
+          text,
+          columns: [n.column],
+          place: 'none',
+          reason: `"${n.column}" is not a column of that table`,
+        });
+        continue;
+      }
+      // `IS NOT NULL` reaches every column shape: an array, a json payload and a scalar are all
+      // either there or not, so there is no shape guard to apply. It is enforced whichever way the
+      // column arrived at not being nullable, by its own declaration or by this constraint, which
+      // is why nothing here reads `c.nullable`: `selectColumns` has already applied it and the two
+      // answers must not be able to differ.
+      //
+      // `IS NULL` is the other direction and nothing states it. Narrowing a field to *only* null
+      // would mean replacing the column's type rather than wrapping it, and no generator has a
+      // hook for that; reported rather than guessed at.
+      parts.push(
+        n.notNull
+          ? { text, columns: [n.column], place: 'column', shape: 'notNull' }
+          : {
+              text,
+              columns: [n.column],
+              place: 'none',
+              reason: 'the column may hold only NULL, which these schemas do not narrow it to',
+            }
       );
     }
     for (const r of parsed.rows ?? []) {
@@ -396,7 +441,7 @@ export function tableConstraints(table: Table): TableConstraints {
     const columns: string[] = [];
     for (const p of k.parts) for (const c of p.columns) if (!columns.includes(c)) columns.push(c);
     const messages = k.parts
-      .filter((p) => p.place !== 'none' && !p.bound && !p.set)
+      .filter((p) => p.place !== 'none' && !p.bound && !p.set && !p.shape)
       .map((p) => p.text);
     const bounds = k.parts.filter((p) => p.bound).map((p) => p.bound!);
     const set = k.parts.find((p) => p.set)?.set;

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { Analysis, Column } from '@drzl/analyzer';
 import type { BrandingOption } from './branding.js';
+import { parseCheck } from './checks.js';
 import type { ImportExtension } from './files.js';
 import type { AffixOptions } from './naming.js';
 
@@ -22,6 +23,13 @@ export interface Table {
   tsName: string;
   columns: Column[];
   primaryKey?: { columns: string[] };
+  /**
+   * The declared CHECK constraints, because one of them decides whether a column is nullable.
+   *
+   * Structurally the analyzer's `Check[]`, and here rather than only there because the three
+   * column selectors below have to read it and this is the shape they are declared against.
+   */
+  checks?: { name?: string; expression?: string }[];
 }
 
 export type ValidationLibrary = 'zod' | 'valibot' | 'arktype' | 'typebox' | 'effect';
@@ -377,8 +385,50 @@ export function nonFiniteAccepted(c: Column): { nan: boolean; infinity: boolean 
   return { nan: c.allowsNaN === true, infinity: c.allowsInfinity === true };
 }
 
+/**
+ * The columns a `CHECK (col IS NOT NULL)` on this table forbids NULL in.
+ *
+ * The whole constraint has to parse, not just the clause: `email IS NOT NULL OR my_fn(email) > 1`
+ * holds those four words and forbids nothing, because either branch may be the one that holds.
+ * `parseCheck` refuses that expression outright, so nothing here has to know about it.
+ */
+function notNullByCheck(table: Table): Set<string> {
+  const out = new Set<string>();
+  for (const k of table.checks ?? []) {
+    const parsed = parseCheck(k.expression, k.name);
+    if (!parsed.ok) continue;
+    for (const n of parsed.nulls ?? []) if (n.notNull) out.add(n.column);
+  }
+  return out;
+}
+
+/**
+ * The column list with any `IS NOT NULL` CHECK applied to it.
+ *
+ * `IS NOT NULL` is the one constraint in this parser that cannot be a predicate on the field. A
+ * check is emitted *inside* the nullable wrapper, precisely because SQL never applies a comparison
+ * to NULL and a CHECK passes on it; this constraint is the statement that NULL is not allowed, so
+ * the only place it can be said is the wrapper. Saying it here rather than in each generator is
+ * what makes it one answer: all five read their columns through these three functions, and none of
+ * them has to learn a new kind of check to honour it.
+ *
+ * Applied in every mode. On select the database guarantees the column is there; on insert a row
+ * omitting a nullable column with no default writes NULL, which the constraint forbids, so the
+ * field becomes required; on update `SET col = NULL` is refused for the same reason.
+ *
+ * Returns the same array when nothing narrows, so the ordinary table pays one `Set` and no copy.
+ */
+function withCheckNullability(table: Table, cols: Column[]): Column[] {
+  const notNull = notNullByCheck(table);
+  if (!notNull.size) return cols;
+  return cols.map((c) => (c.nullable && notNull.has(c.name) ? { ...c, nullable: false } : c));
+}
+
 export function insertColumns(table: Table): Column[] {
-  return table.columns.filter((c) => !isGeneratedColumn(c));
+  return withCheckNullability(
+    table,
+    table.columns.filter((c) => !isGeneratedColumn(c))
+  );
 }
 
 /**
@@ -396,11 +446,14 @@ export function insertColumns(table: Table): Column[] {
  */
 export function updateColumns(table: Table): Column[] {
   const pkCols = table.primaryKey?.columns ?? [];
-  return table.columns.filter((c) => !isGeneratedColumn(c) && !pkCols.includes(c.name));
+  return withCheckNullability(
+    table,
+    table.columns.filter((c) => !isGeneratedColumn(c) && !pkCols.includes(c.name))
+  );
 }
 
 export function selectColumns(table: Table): Column[] {
-  return table.columns;
+  return withCheckNullability(table, table.columns);
 }
 
 /**

--- a/packages/validation-core/test/check-nullability.spec.ts
+++ b/packages/validation-core/test/check-nullability.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * `CHECK (col IS NOT NULL)`, which narrows a field rather than adding a predicate to it.
+ *
+ * Every other CHECK this parser reads sits *inside* the nullable wrapper, because SQL applies a
+ * comparison only to a value that is there and a CHECK passes on NULL. This one is the exception:
+ * it is the constraint that says NULL is not allowed, so the only place it can live is the
+ * wrapper itself. It is applied here, in the three functions every generator asks for its column
+ * list, so no generator has to know about it and none of the five can disagree with the others.
+ *
+ * Verified against a real Postgres: a nullable column carrying this constraint refuses NULL on
+ * insert and refuses `SET col = NULL` on update, and a row omitting the column is refused too
+ * unless the column defaults to something that is not NULL.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Column, Table } from '@drzl/analyzer';
+import { insertColumns, selectColumns, updateColumns } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (cols: Column[], checks: { name?: string; expression?: string }[] = []): Table =>
+  ({ name: 't', tsName: 't', columns: cols, unique: [], indexes: [], checks }) as Table;
+
+const nullableOf = (cols: Column[], name: string) => cols.find((c) => c.name === name)!.nullable;
+
+describe('a CHECK that forbids NULL', () => {
+  const t = () =>
+    table([col('email'), col('note')], [{ name: 'email_set', expression: 'email IS NOT NULL' }]);
+
+  it('makes the column not nullable in every mode', () => {
+    for (const pick of [insertColumns, updateColumns, selectColumns]) {
+      expect(nullableOf(pick(t()), 'email'), pick.name).toBe(false);
+    }
+  });
+
+  it('leaves every other column exactly as it was', () => {
+    expect(nullableOf(selectColumns(t()), 'note')).toBe(true);
+  });
+
+  it('does not mutate the analysis it was handed', () => {
+    // The generators read `table.columns` for other things, and a shared object edited in place
+    // would make the answer depend on which generator ran first.
+    const analysed = t();
+    insertColumns(analysed);
+    expect(analysed.columns.find((c) => c.name === 'email')!.nullable).toBe(true);
+  });
+
+  it('reads the constraint out of a conjunction and a null guard alike', () => {
+    const both = table([col('email')], [{ expression: "email IS NOT NULL AND email <> ''" }]);
+    expect(nullableOf(selectColumns(both), 'email')).toBe(false);
+  });
+
+  it('is not claimed by IS NULL, which narrows nothing', () => {
+    const t2 = table([col('email')], [{ expression: 'email IS NULL' }]);
+    expect(nullableOf(selectColumns(t2), 'email')).toBe(true);
+  });
+
+  it('is not claimed by a null guard, whose IS NULL branch is dropped', () => {
+    // `email IS NULL OR length(email) > 3` reduces to the length bound and says nothing about
+    // nullability. Reading a narrowing out of it would refuse every NULL the database takes.
+    const t2 = table([col('email')], [{ expression: 'email IS NULL OR length(email) > 3' }]);
+    expect(nullableOf(selectColumns(t2), 'email')).toBe(true);
+  });
+
+  it('is ignored when the constraint as a whole was not understood', () => {
+    const t2 = table([col('email')], [{ expression: 'email IS NOT NULL OR my_fn(email) > 1' }]);
+    expect(nullableOf(selectColumns(t2), 'email')).toBe(true);
+  });
+
+  it('names a column the table does not have without disturbing the others', () => {
+    const t2 = table([col('email')], [{ expression: 'nowhere IS NOT NULL' }]);
+    expect(selectColumns(t2).map((c) => c.name)).toEqual(['email']);
+    expect(nullableOf(selectColumns(t2), 'email')).toBe(true);
+  });
+
+  it('costs nothing on a table with no such constraint', () => {
+    // Same array identity, so the common path allocates nothing.
+    const plain = table([col('a')], [{ expression: "a <> 'x'" }]);
+    expect(selectColumns(plain)[0]).toBe(plain.columns[0]);
+  });
+
+  it('leaves a column already declared NOT NULL exactly as it was', () => {
+    const t2 = table([col('email', { nullable: false })], [{ expression: 'email IS NOT NULL' }]);
+    expect(selectColumns(t2)[0]).toBe(t2.columns[0]);
+  });
+});

--- a/packages/validation-core/test/checks.spec.ts
+++ b/packages/validation-core/test/checks.spec.ts
@@ -83,11 +83,12 @@ describe('what it refuses, and why that matters', () => {
     expect(rejected('age >= ?')).toMatch(/unresolved/);
   });
 
-  it('refuses a disjunction, whose scope cannot be split', () => {
+  it('refuses a disjunction it cannot state as one set of values', () => {
     // A conjunction is safe to break apart because every part has to hold on its own. A
-    // disjunction is not, and telling the two apart inside a mixed expression needs a real
-    // parser, so anything containing OR or NOT is refused outright.
-    expect(rejected('age >= 18 OR age <= 65')).toMatch(/OR/);
+    // disjunction is not: it is *weaker* than any one branch, so enforcing a branch would turn
+    // away rows the database takes. Only the shape that collapses to a single set of literal
+    // values is read; everything else is refused whole. See the `disjunctions` block below.
+    expect(rejected('age >= 18 OR age <= 65')).toMatch(/range/);
     expect(rejected('NOT (age >= 18)')).toMatch(/NOT/);
   });
 
@@ -157,6 +158,22 @@ describe('conjunctions', () => {
     const r = parseCheck("label = 'A AND B'");
     expect(r.ok && r.checks).toHaveLength(1);
     expect(r.ok && r.checks[0].value).toBe('A AND B');
+  });
+
+  it('splits a bare AND with no spaces around it', () => {
+    // Postgres accepts `(a=1)AND(b=2)`. The keyword is matched as a whole token rather than as a
+    // substring with spaces on both sides, which is also what keeps the AND inside `BRAND` shut.
+    expect(parseCheck('(a=1)AND(b=2)').ok && parseCheck('(a=1)AND(b=2)')).toMatchObject({
+      checks: [{ column: 'a' }, { column: 'b' }],
+    });
+    expect(parseCheck('brand = 1').ok).toBe(true);
+  });
+
+  it('reads a NOT inside a string literal as text, not as a negation', () => {
+    // The guard walks the expression rather than matching it, so a constraint on a column whose
+    // value happens to contain the word is enforced rather than refused.
+    const r = parseCheck("label = 'A NOT B'");
+    expect(r.ok && r.checks[0].value).toBe('A NOT B');
   });
 });
 
@@ -290,5 +307,233 @@ describe('array cardinality', () => {
   it('carries both ends of a conjunction', () => {
     const r = parseCheck('cardinality(a) > 0 AND cardinality(a) < 10');
     expect(r.ok && r.cardinalities).toHaveLength(2);
+  });
+});
+
+describe('disjunctions', () => {
+  // A conjunction splits because every part holds independently. A disjunction does not: it is
+  // weaker than any of its branches, so enforcing one branch rejects rows the database accepts.
+  // The one shape that survives that is a disjunction of equalities on a single column, which is
+  // the same statement as an IN list and is returned as one.
+  it('folds equalities on one column into the set they describe', () => {
+    const r = parseCheck("status = 'draft' OR status = 'live'", 'status_valid');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.checks, 'stated as a set rather than as two predicates').toHaveLength(0);
+    expect(r.sets).toEqual([
+      { column: 'status', values: ['draft', 'live'], kind: 'string', name: 'status_valid' },
+    ]);
+  });
+
+  it('folds a numeric disjunction the same way', () => {
+    const r = parseCheck('level = 1 OR level = 2 OR level = 3');
+    expect(r.ok && r.sets![0]).toMatchObject({ values: ['1', '2', '3'], kind: 'number' });
+  });
+
+  it('absorbs an IN list standing beside an equality', () => {
+    const r = parseCheck("s IN ('a', 'b') OR s = 'c'");
+    expect(r.ok && r.sets![0].values).toEqual(['a', 'b', 'c']);
+  });
+
+  it('drops a value the disjunction names twice', () => {
+    const r = parseCheck("s = 'a' OR s = 'a'");
+    expect(r.ok && r.sets![0].values).toEqual(['a']);
+  });
+
+  it('is case insensitive and sees through parentheses around each branch', () => {
+    const r = parseCheck("(s = 'a') or (s = 'b')");
+    expect(r.ok && r.sets![0].values).toEqual(['a', 'b']);
+  });
+
+  it('splits on a bare OR with no spaces around it', () => {
+    expect(parseCheck("(s='a')OR(s='b')").ok).toBe(true);
+  });
+
+  it('does not split an OR inside a string literal', () => {
+    const r = parseCheck("label = 'A OR B'");
+    expect(r.ok && r.checks[0].value).toBe('A OR B');
+  });
+
+  it('does not read the OR inside a longer word', () => {
+    // `XOR` is one token. Splitting on the OR inside it would cut an operator in half and hand
+    // both halves to a parser that would read them as something else.
+    expect(rejected('a XOR b')).not.toMatch(/branch/);
+  });
+
+  it('refuses the whole constraint when one branch is not understood', () => {
+    // Not "emit the parseable branch". A disjunction is satisfied by *either* side, so a schema
+    // enforcing only the readable one rejects every row that satisfied the other. The whole
+    // constraint is refused, which is visible in `drzl doctor` and in the constraint ledger.
+    expect(rejected("s = 'a' OR lower(s) = 'b'")).toMatch(/part of an OR/);
+  });
+
+  it('refuses branches over ranges, which are not a set of values', () => {
+    expect(rejected('n < 0 OR n > 100')).toMatch(/range/);
+    expect(rejected('n BETWEEN 1 AND 5 OR n = 9')).toMatch(/range/);
+  });
+
+  it('refuses branches naming different columns, which is a rule about the row', () => {
+    const reason = rejected("a = '1' OR b = '2'");
+    expect(reason).toMatch(/different columns/);
+    expect(reason, 'names them, so the report is actionable').toMatch(/a.*b/);
+  });
+
+  it('refuses a disjunction mixing a string and a number', () => {
+    expect(rejected("s = 'a' OR s = 1")).toMatch(/mix/);
+  });
+
+  it('carries a folded disjunction through a conjunction', () => {
+    const r = parseCheck("(s = 'a' OR s = 'b') AND n > 0");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.sets![0].values).toEqual(['a', 'b']);
+    expect(r.checks).toHaveLength(1);
+  });
+
+  it('refuses a conjunction whose disjunctive part is not understood', () => {
+    expect(rejected('(n < 0 OR n > 9) AND m > 0')).toMatch(/part of an AND/);
+  });
+});
+
+describe('a null guard in front of a predicate', () => {
+  // `CHECK (col IS NULL OR col > 0)` is written defensively and states nothing extra: a CHECK
+  // already passes when it evaluates to NULL, and every operator here yields NULL when its column
+  // is NULL. So the guard branch is dropped and the predicate is read on its own.
+  it('reduces to the predicate it guards', () => {
+    const r = parseCheck('age IS NULL OR age >= 18', 'age_adult');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.checks).toEqual([
+      { column: 'age', operator: '>=', value: '18', kind: 'number', name: 'age_adult' },
+    ]);
+    expect(r.nulls ?? [], 'the guard itself narrows nothing').toHaveLength(0);
+  });
+
+  it('reduces in front of a set, and in front of a folded disjunction', () => {
+    expect(parseCheck("s IS NULL OR s IN ('a','b')").ok && true).toBe(true);
+    const r = parseCheck("s IS NULL OR s = 'a' OR s = 'b'");
+    expect(r.ok && r.sets![0].values).toEqual(['a', 'b']);
+  });
+
+  it('reduces in front of a character count on the same column', () => {
+    const r = parseCheck('name IS NULL OR length(name) > 3');
+    expect(r.ok && r.lengths).toHaveLength(1);
+  });
+
+  it('reduces in front of a comparison of two columns, one of them the guarded one', () => {
+    // `a IS NULL OR a < b` and `a < b` accept the same rows: with `a` NULL the first is TRUE and
+    // the second is NULL, and a CHECK passes on both. Measured against Postgres.
+    const r = parseCheck('a IS NULL OR a < b');
+    expect(r.ok && r.rows).toEqual([{ left: 'a', right: 'b', operator: '<', name: undefined }]);
+  });
+
+  it('refuses a guard on a column the predicate never names', () => {
+    // `a IS NULL OR b > 0` is not `b > 0`: with `a` NULL every row passes whatever `b` holds.
+    // The reduction is sound only because the predicate is NULL exactly when its column is.
+    expect(rejected('a IS NULL OR b > 0')).toMatch(/does not name/);
+  });
+
+  it('refuses a guard in front of a null test, which is not NULL-yielding', () => {
+    // `a IS NULL OR a IS NOT NULL` is true of every row. Reducing it to `a IS NOT NULL` would
+    // refuse every NULL the database takes.
+    expect(rejected('a IS NULL OR a IS NOT NULL')).toBeTruthy();
+  });
+
+  it('refuses a disjunction of guards, which is a rule about the row', () => {
+    expect(rejected('a IS NULL OR b IS NULL')).toBeTruthy();
+  });
+});
+
+describe('unary predicates', () => {
+  // `IS NOT NULL` holds the word NOT, and the guard that refuses logical negation would otherwise
+  // refuse it. `IS NOT` is one operator, not a negation, and the guard knows the difference.
+  it('reads IS NOT NULL', () => {
+    const r = parseCheck('email IS NOT NULL', 'email_required');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.checks, 'not a value comparison').toHaveLength(0);
+    expect(r.nulls).toEqual([{ column: 'email', notNull: true, name: 'email_required' }]);
+  });
+
+  it('reads IS NULL', () => {
+    const r = parseCheck('email IS NULL');
+    expect(r.ok && r.nulls).toEqual([{ column: 'email', notNull: false }]);
+  });
+
+  it('is case insensitive and sees through wrapping parentheses', () => {
+    expect(parseCheck('(email is not null)').ok).toBe(true);
+  });
+
+  it('carries through a conjunction beside a value comparison', () => {
+    const r = parseCheck('email IS NOT NULL AND age >= 18');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.nulls).toHaveLength(1);
+    expect(r.checks).toHaveLength(1);
+  });
+
+  it('still refuses a logical NOT', () => {
+    expect(rejected('NOT (age >= 18)')).toMatch(/NOT/);
+    expect(rejected('age >= 18 AND NOT (age > 65)')).toMatch(/NOT/);
+    expect(rejected("s NOT IN ('a','b')")).toMatch(/NOT/);
+  });
+
+  it('reads IS DISTINCT FROM as the null-safe <>, which as a CHECK is plain <>', () => {
+    // `NULL IS DISTINCT FROM 5` is TRUE and `NULL <> 5` is NULL, and a CHECK passes on both, so
+    // the two constrain exactly the same rows. Measured against Postgres.
+    const r = parseCheck('n IS DISTINCT FROM 5');
+    expect(r.ok && r.checks).toEqual([
+      { column: 'n', operator: '<>', value: '5', kind: 'number', name: undefined },
+    ]);
+  });
+
+  it('reads IS NOT DISTINCT FROM as an equality that also refuses NULL', () => {
+    const r = parseCheck('n IS NOT DISTINCT FROM 5');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.checks[0]).toMatchObject({ operator: '=', value: '5' });
+    expect(r.nulls).toEqual([{ column: 'n', notNull: true }]);
+  });
+
+  it('refuses a boolean IS test, whose literal this version does not read', () => {
+    const reason = rejected('flag IS TRUE');
+    expect(reason).toMatch(/boolean/);
+    expect(rejected('flag IS NOT FALSE')).toMatch(/boolean/);
+  });
+
+  it('does not let an IS operand swallow a following AND', () => {
+    // The same trap `BETWEEN` documents, in the other direction. `BETWEEN` holds an AND and so is
+    // matched before the split; `IS DISTINCT FROM` does not, so it is matched *after* it. Matched
+    // first, its trailing operand would read `5 AND b > 0` and the second half would be dropped.
+    const r = parseCheck('a IS DISTINCT FROM 5 AND b > 0');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.checks).toHaveLength(2);
+    expect(r.checks.map((c) => c.column)).toEqual(['a', 'b']);
+  });
+});
+
+describe('expressions over two columns beyond a comparison', () => {
+  // Refused, and deliberately. Postgres computes `numeric` arithmetic exactly and JavaScript
+  // computes it in binary floating point: `CHECK (x + y <= 0.3)` on two `numeric` columns accepts
+  // (0.1, 0.2), and the same expression in JavaScript is 0.30000000000000004 and rejects it. The
+  // parser cannot tell a `numeric` column from a `double precision` one, so the only translation
+  // available is one that is wrong for half of them.
+  it('refuses arithmetic between columns, and says that is what it is', () => {
+    for (const e of ['a + b < 100', 'a > b + 1', 'a - b <= 10', 'a * b > 0', 'qty / n < 5']) {
+      expect(rejected(e), e).toMatch(/arithmetic|combin/i);
+    }
+  });
+
+  it('refuses string concatenation the same way', () => {
+    expect(rejected("first || last <> ''")).toMatch(/arithmetic|combin/i);
+  });
+
+  it('names the operator, so the report says which part it could not read', () => {
+    expect(rejected('a + b < 100')).toContain('+');
+  });
+
+  it('does not mistake a negative literal for arithmetic', () => {
+    expect(parseCheck('balance >= -100').ok).toBe(true);
   });
 });

--- a/packages/validation-core/test/constraints.spec.ts
+++ b/packages/validation-core/test/constraints.spec.ts
@@ -188,6 +188,108 @@ describe('a CHECK the database enforces and no schema does', () => {
   });
 });
 
+describe('the forms this version started reading', () => {
+  const nullableCol = (name: string, over: Partial<Column> = {}) =>
+    col(name, { nullable: true, ...over });
+
+  it('folds a disjunction of equalities into the same set an IN list produces', () => {
+    const t = table('t', [col('s')], {
+      checks: [
+        { name: 'or_form', expression: "s = 'a' OR s = 'b'" },
+        { name: 'in_form', expression: "s IN ('a', 'b')" },
+      ],
+    });
+    const m = byId(t);
+    expect(m.get('or_form')!.values).toEqual(m.get('in_form')!.values);
+    expect(m.get('or_form')!.enforced).toBe(true);
+    // Stated as an enum, so the library words the failure and no message carries the name.
+    expect(m.get('or_form')!.messages).toBeUndefined();
+  });
+
+  it('reports a disjunction it cannot read as unenforced, naming the shape it found', () => {
+    const t = table('t', [col('n', { tsType: 'number', dbType: 'INTEGER' })], {
+      checks: [{ name: 'split_range', expression: 'n < 0 OR n > 100' }],
+    });
+    const c = byId(t).get('split_range')!;
+    expect(c.enforced).toBe(false);
+    expect(c.unenforced![0]!.reason).toMatch(/range/);
+  });
+
+  it('says a NOT NULL check is enforced, and attaches no message to it', () => {
+    // The field refuses null by not being nullable, which is a shape rather than a predicate, so
+    // there is no string for an error map to key on. Claiming one would make the map answer with
+    // a constraint for an issue no schema ever writes.
+    const t = table('t', [nullableCol('email')], {
+      checks: [{ name: 'email_set', expression: 'email IS NOT NULL' }],
+    });
+    const c = byId(t).get('email_set')!;
+    expect(c).toMatchObject({ kind: 'check', columns: ['email'], enforced: true });
+    expect(c.messages).toBeUndefined();
+    expect(c.unenforced).toBeUndefined();
+  });
+
+  it('says the same for a column already declared NOT NULL, which enforces it anyway', () => {
+    const t = table('t', [col('email')], {
+      checks: [{ name: 'email_set', expression: 'email IS NOT NULL' }],
+    });
+    expect(byId(t).get('email_set')!.enforced).toBe(true);
+  });
+
+  it('reports IS NULL as unenforced, since nothing narrows a column to NULL alone', () => {
+    const t = table('t', [nullableCol('email')], {
+      checks: [{ name: 'email_unset', expression: 'email IS NULL' }],
+    });
+    const c = byId(t).get('email_unset')!;
+    expect(c.enforced).toBe(false);
+    expect(c.unenforced![0]!.reason).toMatch(/NULL/);
+  });
+
+  it('reports a null check on a column the table does not have', () => {
+    const t = table('t', [col('email')], {
+      checks: [{ name: 'stray', expression: 'nowhere IS NOT NULL' }],
+    });
+    expect(byId(t).get('stray')!.unenforced![0]!.reason).toMatch(/not a column of/);
+  });
+
+  it('reads IS DISTINCT FROM as the <> it constrains the same rows as', () => {
+    const t = table('t', [col('s')], {
+      checks: [{ name: 'not_x', expression: "s IS DISTINCT FROM 'x'" }],
+    });
+    expect(byId(t).get('not_x')!.messages).toEqual(["not_x: s <> 'x'"]);
+  });
+
+  it('reports arithmetic between columns by name rather than as a generic refusal', () => {
+    const t = table(
+      't',
+      [
+        col('x', { tsType: 'number', dbType: 'INTEGER' }),
+        col('y', { tsType: 'number', dbType: 'INTEGER' }),
+      ],
+      { checks: [{ name: 'budget', expression: 'x + y < 100' }] }
+    );
+    const c = byId(t).get('budget')!;
+    expect(c.enforced).toBe(false);
+    expect(c.unenforced![0]!.reason).toMatch(/combined with "\+"/);
+  });
+
+  it('keeps meta and the ledger agreeing about the new forms too', () => {
+    const t = table('t', [col('s'), col('a'), col('b')], {
+      checks: [
+        { name: 'or_form', expression: "s = 'a' OR s = 'b'" },
+        { name: 'bad_or', expression: "s = 'a' OR a = 'b'" },
+        { name: 'arith', expression: 'a + b < 100' },
+      ],
+    });
+    return import('../src/meta').then(({ tableMetaFacts }) => {
+      const facts = tableMetaFacts(t, { mode: 'select' });
+      const declined = tableConstraints(t)
+        .constraints.filter((c) => c.kind === 'check' && !c.enforced)
+        .flatMap((c) => c.unenforced!.map((u) => u.part));
+      expect(new Set(declined)).toEqual(new Set(facts.unenforcedChecks));
+    });
+  });
+});
+
 describe('the declared width, which is a constraint that does produce an issue', () => {
   it('is an entry of its own, carrying the message the schema attaches', () => {
     const c = byId(events()).get('events_name_maxlength')!;


### PR DESCRIPTION
Plan items 41, 42 and 43: one change to one parser, `parseCheck` in `validation-core`.

## The OR refusal was a correctness argument, and it survives

A conjunction splits safely because each part holds independently; **a disjunction is weaker than any branch**, so a schema enforcing one branch refuses rows the database takes. That argument is intact.

What is now accepted is the class where the union **is** the constraint rather than an approximation:

| form | emitted as | why it is exact |
|---|---|---|
| `s = 'a' OR s = 'b'` (all branches pin the **same** column to literals) | the same `ColumnSet` an `IN` list produces: `z.enum` / `v.picklist` / `'a'\|'b'` / `Type.Union` / `Schema.Literal` / JSON `enum` | it is the same SQL statement as `s IN ('a','b')`, NULL included. Byte-identical output asserted. |
| `col IS NOT NULL` | the field stops being nullable; required on insert unless defaulted | a check predicate is emitted *inside* the nullable wrapper precisely so NULL skips it, so this is the one constraint no predicate can carry. Applied once in `insertColumns`/`updateColumns`/`selectColumns`, the chokepoint all six generators read, so **no generator learned a new kind of check**. |
| `col IS NULL OR P` | exactly `P` | a CHECK already passes on NULL and every operator here is strict. Sound only when `P` names the guarded column; `a IS NULL OR b > 0` stays refused. |
| `s IS DISTINCT FROM 'x'` | byte-identical to `<> 'x'` | `NULL IS DISTINCT FROM 'x'` is TRUE, `NULL <> 'x'` is NULL, and a CHECK passes on both. |
| `n IS NOT DISTINCT FROM 5` | `= 5` plus the not-null narrowing | it answers FALSE on NULL, unlike the row above. |

**One branch parseable and another not refuses the whole constraint** — the unreadable branch may be the one a valid row satisfies.

`IS NOT NULL` on an already-`notNull` column is now reported as *enforced* rather than *declined*, removing a false doctor warning.

## Item 43 stays refused, and the refusal is now a measurement

`x + y < 100` used to fall into a generic "not a single comparison". The refusal now names the operator, and `drzl doctor` explains. The argument is measured, not taste:

```
CHECK (x + y <= 0.3), row (0.1, 0.2)
  numeric(10,2)       Postgres ACCEPTS   JS 0.1 + 0.2 <= 0.3 is false -> would reject a valid row
  double precision    Postgres rejects   JS agrees
```

One expression, two column types, two different correct answers, and the expression carries no type. `bigint` adds a third: Postgres raises on overflow, `BigInt` does not.

## Ground truth

64 probes against a real Postgres via PGlite, **one table per constraint** — a first attempt shared one table and a sibling `IS NOT NULL` failed every statement before the value under test was reached, which is the fixture trap this repo's own probes documented.

**Zero cases of the schema refusing what Postgres accepts.** Key rows: `IS NOT NULL` with the key omitted, both sides reject; the same with `DEFAULT 'seed'`, both accept; `n IS NULL OR n >= 18` and `n >= 18` gave identical Postgres answers on all five probes.

## Ledger integration

The shared `classifyTableChecks` means the new forms appear in the constraint ledger (items 39-40) correctly. `IS NULL` alone is parsed but enforced nowhere (narrowing to null-only means replacing the column type, not wrapping it), so it carries a `shape: 'notNull'` marker and the ledger does **not** offer a `messages` entry no emitted module writes.

## Two pre-existing defects found, filed, not fixed

- **BF**: `CHECK (big IN (1,2))` on a `bigint({mode:'bigint'})` column emits `z.literal(1)` number literals, rejecting `1n` — so the select schema refuses every row the driver returns. The OR fold routes into the same path and inherits it rather than adding it.
- **BG**: arktype and typebox silently drop `<> 'banned'` on a string column while zod, valibot and effect enforce it.

Both confirmed identical before this change.

## What I would want added to the gate (not touched)

The `checked` table has 13 constrained columns and none of the new forms, so the gate does not see this change. Add:

```
k_or_set   text    CHECK (k_or_set = 'a' OR k_or_set = 'b'),
k_notnull  text    CHECK (k_notnull IS NOT NULL),
k_nn_def   text    DEFAULT 'seed' CHECK (k_nn_def IS NOT NULL),
k_guard    integer CHECK (k_guard IS NULL OR k_guard >= 18),
k_distinct text    CHECK (k_distinct IS DISTINCT FROM 'banned'),
```

plus a probe asking about the column being **omitted**, not only about values — `k_notnull` vs `k_nn_def` differ only there, and that is the half a value-only pool cannot see.

## Deliberate boundary

Disjoint ranges (`n < 0 OR n > 100`) stay refused with a specific reason: a union of bounds needs a genuinely new representation in all six generators plus `anyOf` in JSON Schema, and it collides with the existing rule that a numeric CHECK folds into the column's own range, which cannot express two ranges.

## Verification

Tests first, failing counts reported. `pnpm -r test` **2207 passing** (+59). `build`, `typecheck`, `lint`, `docs build`, `verify:packed` all green, emitted schemas run rather than diffed in all five validator generators plus ajv-strict for JSON Schema. Rebased onto current master; the ledger base commit was recognised as patch-identical to the #159 squash and skipped.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
