### PR TITLE
feat(checks): byte caps from octet_length, and shared enums in the document

### DIFF
--- a/.changeset/octet-length-byte-caps.md
+++ b/.changeset/octet-length-byte-caps.md
@@ -1,0 +1,66 @@
+---
+'@drzl/validation-core': minor
+'@drzl/generator-arktype': minor
+'@drzl/generator-effect': minor
+'@drzl/generator-json-schema': minor
+'@drzl/generator-typebox': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-zod': minor
+'@drzl/cli': minor
+---
+
+Enforce `CHECK (octet_length(col) <= n)`, which is a byte budget rather than a character count
+
+`parseCheck` refused `octet_length` outright, on the recorded grounds that a byte count "depends on
+the encoding and cannot be derived from a JavaScript string without choosing one". Both halves of
+that are answerable: the encoding is UTF-8, and a `bytea` column does not arrive as a string at all.
+The constraint is now read and routed into the byte-cap machinery MySQL's TEXT family already used.
+
+```ts
+// check('body_bytes', sql`octet_length(${t.body}) <= 5`)      // on a text column
+body: z.string().refine((v) => new TextEncoder().encode(v).length <= 5, {
+  message: 'body_bytes: octet_length(body) <= 5',
+}),
+
+// check('blob_bytes', sql`octet_length(${t.blob}) <= 5`)      // on a bytea column
+blob: z.instanceof(Uint8Array).refine((v) => v.length <= 5, {
+  message: 'blob_bytes: octet_length(blob) <= 5',
+}),
+```
+
+**Three counts, and no two of them agree.** Measured on PostgreSQL 17.5 through PGlite, on a `text`
+holding three emoji and a `bytea` holding six bytes:
+
+| expression        | `text` | `bytea`        | JavaScript                                  |
+| ----------------- | ------ | -------------- | ------------------------------------------- |
+| `octet_length(x)` | 12     | 6              | `new TextEncoder().encode(v).length`        |
+| `length(x)`       | 3      | 6              | `[...v].length`, or `v.length` on the array |
+| `char_length(x)`  | 3      | does not exist | `[...v].length`                             |
+
+`v.length` on a string is none of them: it counts UTF-16 units, which is 6 for those same three
+emoji. So `length` is a character count on a text column and a byte count on a bytea one, and a
+parser that read `octet_length` as one more spelling of `length` would put a character cap on a byte
+budget. Measured on the real constraint: `CHECK (octet_length(t) <= 5)` accepts `'hello'` and one
+emoji and refuses `'hellos'` and two emoji, and it is the last of those, two characters and eight
+bytes, that a character cap takes and the column does not.
+
+The parser now carries a `unit` on `LengthCheck`, and `lengthMeasure(column, check)` turns that plus
+the column into one of three JavaScript expressions. It lives in `@drzl/validation-core` so the five
+validation generators, the constraint ledger, `meta` and `drzl doctor` cannot disagree about what is
+enforced.
+
+**JSON Schema.** No draft has a byte-length keyword, so the same trade the MySQL byte budget already
+made applies: the ceiling becomes `maxLength`, which counts characters and therefore refuses nothing
+the column accepts, and the part it cannot catch is stated in `description`. A `bytea` travels as
+base64, so its cap is the encoded length, `4 * ceil(n / 3)`, which is the padded length of a full
+value and an upper bound on the unpadded one, measured over n = 0 to 20. That also gives a MySQL
+`tinyblob` a bound it never had: 255 bytes is `maxLength: 340`, where the document previously said
+nothing. A byte _floor_ reaches no keyword in either case.
+
+**What is still refused, and now says so.** A count on a MySQL `binary(n)`/`varbinary(n)` cannot be
+answered: the value arrives as a string from a lossy decode, so neither its characters nor their
+re-encoding is the server's byte count. `drzl doctor` reports that as a new finding kind,
+`check-uncountable`, rather than dropping it silently, and the ledger marks it unenforced with the
+reason. The doctor's note that count clauses were "unreachable from a working schema" was true of
+Postgres and is not true of MySQL, which has `OCTET_LENGTH` and a column whose bytes JavaScript
+cannot see.

--- a/.changeset/shared-enum-defs.md
+++ b/.changeset/shared-enum-defs.md
@@ -1,0 +1,85 @@
+---
+'@drzl/generator-json-schema': minor
+---
+
+Write a shared enum once and reference it, instead of inlining it at every use
+
+A `mood` enum on six columns was six copies of the same list in each of the three schemas, and
+eighteen in a document. It is now one definition with references pointing at it.
+
+```jsonc
+// openapi.json, always. The definition is a component.
+{
+  "components": { "schemas": { "mood": { "enum": ["sad", "ok", "happy"] } } },
+  "properties": { "m1": { "$ref": "#/components/schemas/mood" } }
+}
+
+// people.schema.ts, on `sharedEnums: true`. A standalone JSON Schema document.
+{
+  "$defs": { "mood": { "enum": ["sad", "ok", "happy"] } },
+  "properties": { "m1": { "$ref": "#/$defs/mood" }, "m2": { "$ref": "#/$defs/mood" } }
+}
+```
+
+**`sharedEnums` is off by default, and the reason is a consumer pattern rather than a doubt about
+the keyword.** A per-table schema is used two ways: whole, and one property at a time. Reaching into
+`properties[col]` is the JSON Schema equivalent of reading zod's `.shape`, it is how a form builder
+gets one field's rules, and it is how `scripts/verify-packed.sh` checks these schemas against a real
+Postgres. A `$ref` cannot survive that: pulled out of the schema that holds its `$defs` it is a
+dangling reference and ajv refuses to compile it at all, `can't resolve reference #/$defs/mood from
+id #`. Whole, it compiles and validates exactly as before. The OpenAPI document shares regardless,
+because a document is only ever read whole.
+
+**Where the definition goes depends on the document, and the two are not interchangeable.** Measured
+against `@seriousme/openapi-schema-validator`, which carries the real 3.0 and 3.1 meta-schemas:
+
+| placement                                 | OpenAPI 3.0             | OpenAPI 3.1                |
+| ----------------------------------------- | ----------------------- | -------------------------- |
+| `components.schemas` + `#/components/...` | valid                   | valid                      |
+| `$defs` in a schema + `#/$defs/...`       | INVALID, closed object  | INVALID, `$ref` unresolved |
+| `anyOf: [{$ref}, {type: 'null'}]`         | INVALID, no `null` type | valid                      |
+
+3.0's Schema Object is closed, so `$defs` beside `properties` fails the whole document. 3.1 allows
+the keyword and still fails, because a `$ref` inside a document resolves against the document root
+where `#/$defs/mood` names nothing. So `$defs` appears only in the standalone per-table modules on
+the `draft-2020-12` target, and only under `sharedEnums`; the OpenAPI document shares through
+`components.schemas`.
+
+**`components.ts` shares nothing, and that is the one place this stops.** It is a fragment the
+caller spreads into a document, and a `$ref` is a promise about where the thing holding it is
+mounted: `#/components/schemas/mood` resolves once the fragment sits at exactly that path and
+nowhere else. Every entry there stays self-contained, so a caller can hand one schema to a validator
+on its own; ask ajv to compile a cross-referencing entry alone and it answers `can't resolve
+reference #/components/schemas/mood from id #`. `components.ts` is byte-for-byte what it was.
+
+**Nullable columns.** 2020-12 and 3.1 spell a nullable reference as `anyOf: [{ $ref }, { type:
+'null' }]`, which validates. 3.0 has neither half of that: `type: 'null'` is not one of its six
+types, and it defines every sibling of `$ref` to be ignored, so `{ $ref, nullable: true }` is a
+schema that silently refuses null. A nullable enum column in a 3.0 document therefore keeps the
+inline enum it has always had, and the shared definition still serves every other use.
+
+**Only shared enums, and only declared ones.** Two or more columns is the threshold. A single use
+gains nothing from the indirection, and a `CHECK (status IN ('a','b'))` stays inline because it is a
+constraint on one column rather than a named type: two columns whose `IN` lists happen to agree are
+two constraints, and giving them a shared name would invent both the concept and the name. The
+definition's key comes from the analysis's own enum list, since a column carries values and no name.
+An enum whose name collides with a table's schema name, or which sanitises to nothing, stays inline
+rather than being disambiguated into a name that moves when a table is added.
+
+**Size.** A saving on every enum but the very shortest, because
+`{"$ref":"#/components/schemas/mood"}` is 36 bytes and `{"enum":["sad","ok","happy"]}` is 29.
+Measured on an OpenAPI 3.1 document, one table, n columns carrying the enum:
+
+| enum             | 1 col | 2 cols | 3 cols | 6 cols |
+| ---------------- | ----- | ------ | ------ | ------ |
+| 3 short values   | 0     | +58    | +70    | +106   |
+| 5 values         | 0     | -97    | -178   | -421   |
+| 12 country codes | 0     | -147   | -258   | -591   |
+| 20 long values   | 0     | -1697  | -2738  | -5861  |
+
+The threshold stays at two columns rather than becoming "wherever it saves bytes". The point of the
+definition is that the document names a type, so a client generator emits one enum class where six
+inline lists are six anonymous unions it cannot tell are the same thing; a rule keyed on encoded
+length would flip the output when somebody adds a value.
+
+A schema with nothing shared is byte-for-byte what it was.

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -100,7 +100,7 @@ Nothing to report.
 | Primary keys the generators cannot use  | `getById`, `update` and `delete` are keyed on one column                           |
 | Other findings                          | Everything else the analyzer said while reading the schema                         |
 
-Three CHECK cases are distinguished, because they have different fixes:
+Four CHECK cases are distinguished, because they have different fixes:
 
 - **Not translated.** The shared parser refused the expression and says why: `contains OR`,
   `right side is not a literal`, and so on. See the skip list in
@@ -110,6 +110,10 @@ Three CHECK cases are distinguished, because they have different fixes:
 - **Compares an array or structured column against a scalar literal.** `tags = '{}'` on a `text[]`
   says nothing usable about the array, so it is skipped rather than guessed at. On an array column
   only `cardinality(col)` is read.
+- **Counts a column whose count JavaScript cannot take the way the database did.**
+  `octet_length(bin) <= 8` on a MySQL `varbinary(8)`: the value arrives as a string produced by a
+  lossy decode, so neither its characters nor their UTF-8 re-encoding is the number the server took.
+  The same expression on a `text` or a `bytea` column **is** enforced, and is not listed.
 
 A constraint DRZL **does** translate is not listed. `age >= 18` folds into `.gte(18)` and
 `start_date < end_date` becomes an object-level refinement, and listing those would bury the ones
@@ -168,7 +172,7 @@ npx @drzl/cli doctor --json \
 ```
 
 Values are `unknown-column`, `check-declined`, `check-unknown-column`, `check-not-scalar`,
-`no-primary-key`, `partial-primary-key` and `analyzer`.
+`check-uncountable`, `no-primary-key`, `partial-primary-key` and `analyzer`.
 
 ## Runnable config
 

--- a/docs/generators/json-schema.md
+++ b/docs/generators/json-schema.md
@@ -43,19 +43,19 @@ export type SelectpeopleOutput = typeof SelectpeopleSchema;
 { kind: 'json-schema', target: 'openapi-3.0' }
 ```
 
-| `target` | What it is |
-| --- | --- |
-| `draft-2020-12` (default) | The current draft, with a `$schema` declaration |
-| `openapi-3.1` | The same draft, with no `$schema`, which is how a schema appears inside an OpenAPI 3.1 document |
-| `openapi-3.0` | A different dialect, see below |
+| `target`                  | What it is                                                                                      |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| `draft-2020-12` (default) | The current draft, with a `$schema` declaration                                                 |
+| `openapi-3.1`             | The same draft, with no `$schema`, which is how a schema appears inside an OpenAPI 3.1 document |
+| `openapi-3.0`             | A different dialect, see below                                                                  |
 
 OpenAPI 3.0 is not an older superset of 2020-12. It spells things differently:
 
-| | `draft-2020-12` | `openapi-3.0` |
-| --- | --- | --- |
-| nullable | `type: ['string', 'null']` | `type: 'string', nullable: true` |
-| exclusive bound | `exclusiveMinimum: 0` | `minimum: 0, exclusiveMinimum: true` |
-| positional array | `prefixItems: [...]` | no equivalent, falls back to a length |
+|                  | `draft-2020-12`            | `openapi-3.0`                         |
+| ---------------- | -------------------------- | ------------------------------------- |
+| nullable         | `type: ['string', 'null']` | `type: 'string', nullable: true`      |
+| exclusive bound  | `exclusiveMinimum: 0`      | `minimum: 0, exclusiveMinimum: true`  |
+| positional array | `prefixItems: [...]`       | no equivalent, falls back to a length |
 
 This matters more than a formatting preference, because **an unknown keyword is not an error in
 JSON Schema: it is ignored.** A 2020-12 `exclusiveMinimum: 0` dropped into a 3.0 document is read
@@ -139,29 +139,112 @@ accepts**, and it catches every overflow made of one-byte characters. What it ca
 string that fits the character count and not the budget. Asked of a real MySQL 8 on utf8mb4, on a
 `tinytext` column:
 
-| Value | Bytes | Characters | MySQL | This schema |
-| --- | --- | --- | --- | --- |
-| 255 ascii | 255 | 255 | accepts | accepts |
-| 256 ascii | 256 | 256 | refuses | refuses |
-| 63 emoji | 252 | 63 | accepts | accepts |
-| 64 emoji | 256 | 64 | refuses | accepts |
+| Value     | Bytes | Characters | MySQL   | This schema |
+| --------- | ----- | ---------- | ------- | ----------- |
+| 255 ascii | 255   | 255        | accepts | accepts     |
+| 256 ascii | 256   | 256        | refuses | refuses     |
+| 63 emoji  | 252   | 63         | accepts | accepts     |
+| 64 emoji  | 256   | 64         | refuses | accepts     |
 
 The four validation generators encode the string and count the bytes, so they get the last row
 right. `varchar(n)` is genuinely characters in the same database and is unaffected: it keeps
 `maxLength` from its declared length.
+
+A `CHECK (octet_length(col) <= n)` is the same budget written as a constraint and goes the same way.
+The smaller of the two, where a column carries both, is the one the document states.
+
+On a **binary** column the value travels as base64, so the only length the format can bound is the
+encoded string's. Base64 of n bytes is `4 * ceil(n / 3)` characters when padded and fewer when not,
+measured over n = 0 to 20, so that number refuses nothing the column accepts:
+
+```json
+{
+  "type": "string",
+  "contentEncoding": "base64",
+  "maxLength": 340,
+  "description": "At most 255 bytes, which JSON Schema has no keyword for. The value travels as base64, and maxLength counts the characters of that encoding: ..."
+}
+```
+
+Loose by design: 6 bytes encode to the same 8 characters as 5, so a 5 byte cap still admits 6. A
+byte _floor_ reaches no keyword at all, in either case.
+
+## Shared enums
+
+An enum on six columns is six copies of the same list in each of three schemas. The OpenAPI document
+writes it once and references it, and the per-table modules do too when you ask:
+
+```ts
+{ kind: 'json-schema', document: true, sharedEnums: true }
+```
+
+```jsonc
+// users.schema.ts, a standalone JSON Schema document, with sharedEnums: true
+{
+  "$defs": { "mood": { "enum": ["sad", "ok", "happy"] } },
+  "properties": { "m1": { "$ref": "#/$defs/mood" }, "m2": { "$ref": "#/$defs/mood" } },
+}
+```
+
+**`sharedEnums` is off by default, and the reason is a consumer pattern.** A per-table schema is
+used two ways: whole, and one property at a time. Reaching into `properties[col]` is the JSON Schema
+equivalent of reading zod's `.shape`, it is how a form builder gets one field's rules, and it is how
+the packed gate checks these schemas against a real Postgres. A `$ref` cannot survive that: pulled
+out of the schema that holds its `$defs` it is a dangling reference, and ajv refuses to compile it
+at all with `can't resolve reference #/$defs/mood from id #`. Whole, it compiles and validates
+exactly as before. So the trade is stated rather than made for you.
+
+The **OpenAPI document** shares regardless, because a document is only ever read whole and every
+OpenAPI tool resolves `$ref` against it.
+
+**Where the definition goes depends on the document.** Measured against
+`@seriousme/openapi-schema-validator`, which carries the real 3.0 and 3.1 meta-schemas:
+
+| Placement                                 | OpenAPI 3.0             | OpenAPI 3.1                |
+| ----------------------------------------- | ----------------------- | -------------------------- |
+| `components.schemas` + `#/components/...` | valid                   | valid                      |
+| `$defs` in a schema + `#/$defs/...`       | invalid, closed object  | invalid, `$ref` unresolved |
+| `anyOf: [{$ref}, {type: 'null'}]`         | invalid, no `null` type | valid                      |
+
+3.0's Schema Object is closed, so `$defs` beside `properties` fails the whole document. 3.1 allows
+the keyword and still fails, because a `$ref` inside a document resolves against the document root
+where `#/$defs/mood` names nothing. So `$defs` appears only in the per-table modules on the
+`draft-2020-12` target, and only under `sharedEnums`; the OpenAPI document shares through
+`components.schemas`.
+
+**`components.ts` shares nothing, deliberately.** It is a fragment the caller spreads into a
+document, and a `$ref` is a promise about where the thing holding it is mounted:
+`#/components/schemas/mood` resolves once the fragment sits at exactly that path and nowhere else.
+Every entry there stays self-contained, so one schema can be handed to a validator on its own. Ask
+ajv to compile a cross-referencing entry alone and it answers `can't resolve reference
+#/components/schemas/mood from id #`. `document: true` produces a whole document, which knows where
+it is, and that one does share.
+
+A **nullable** enum column is `anyOf: [{ $ref }, { type: 'null' }]` on 2020-12 and 3.1. In a 3.0
+document it keeps its inline enum: `type: 'null'` is not one of that version's six types, and 3.0
+defines every sibling of `$ref` to be ignored, so `{ $ref, nullable: true }` is a schema that
+silently refuses null.
+
+**Two or more columns** is the threshold, and only a declared enum is shared. A single use gains
+nothing from the indirection, and a `CHECK (status IN ('a','b'))` stays inline because it is a
+constraint on one column rather than a named type. The key comes from the analysis's own enum list,
+since a column carries values and no name; an enum whose name collides with a table's schema name
+stays inline rather than being renamed.
+
+A schema with nothing shared is byte-for-byte what it was.
 
 ## Values as they survive JSON
 
 The schema describes the value **after** `JSON.stringify`, which is not always what the TypeScript
 type says:
 
-| Column | Schema |
-| --- | --- |
-| `bigint` | `{ type: 'string', pattern: '^-?\\d+$' }`, because `JSON.stringify` throws on a bigint |
-| `bytea`, `blob` | `{ type: 'string', contentEncoding: 'base64' }` |
-| `timestamp` | `{ type: 'string', format: 'date-time' }` |
-| `json`, `jsonb` | `{}`, which is how the format spells "any JSON value" |
-| `point` | `prefixItems` of two numbers, with `minItems` and `maxItems` |
+| Column                  | Schema                                                                                                                                       |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bigint`                | `{ type: 'string', pattern: '^-?\\d+$' }`, because `JSON.stringify` throws on a bigint                                                       |
+| `bytea`, `blob`         | `{ type: 'string', contentEncoding: 'base64' }`                                                                                              |
+| `timestamp`             | `{ type: 'string', format: 'date-time' }`                                                                                                    |
+| `json`, `jsonb`         | `{}`, which is how the format spells "any JSON value"                                                                                        |
+| `point`                 | `prefixItems` of two numbers, with `minItems` and `maxItems`                                                                                 |
 | `point({ mode: 'xy' })` | `{ type: 'object', properties: { x, y }, required: ['x', 'y'] }`, with no `additionalProperties`, because the column ignores an unlisted key |
 
 `contentEncoding` is worth one warning. In draft 2020-12 and in OpenAPI 3.1 it is an **annotation**,

--- a/docs/generators/openapi.md
+++ b/docs/generators/openapi.md
@@ -128,15 +128,24 @@ a document, and the plain draft is emitted as the 3.1 it already is.
 **OpenAPI 3.0's Schema Object is closed.** Its meta-schema sets `additionalProperties: false` and
 allows nothing beside the keywords it lists except `^x-`. That is stricter than plain JSON Schema,
 where an unknown keyword is merely ignored: in a 3.0 document a keyword from a later draft makes the
-whole document fail validation. Five things are translated for it:
+whole document fail validation. Six things are translated for it:
 
-|                  | `openapi-3.1`               | `openapi-3.0`                         |
-| ---------------- | --------------------------- | ------------------------------------- |
-| nullable         | `type: ['string', 'null']`  | `type: 'string', nullable: true`      |
-| exclusive bound  | `exclusiveMinimum: 0`       | `minimum: 0, exclusiveMinimum: true`  |
-| positional array | `prefixItems: [...]`        | no equivalent, falls back to a length |
-| a pinned value   | `const: 'gold'`             | `enum: ['gold']`                      |
-| base64 bytes     | `contentEncoding: 'base64'` | `format: 'byte'`                      |
+|                     | `openapi-3.1`                     | `openapi-3.0`                         |
+| ------------------- | --------------------------------- | ------------------------------------- |
+| nullable            | `type: ['string', 'null']`        | `type: 'string', nullable: true`      |
+| exclusive bound     | `exclusiveMinimum: 0`             | `minimum: 0, exclusiveMinimum: true`  |
+| positional array    | `prefixItems: [...]`              | no equivalent, falls back to a length |
+| a pinned value      | `const: 'gold'`                   | `enum: ['gold']`                      |
+| base64 bytes        | `contentEncoding: 'base64'`       | `format: 'byte'`                      |
+| a nullable enum ref | `anyOf: [{$ref}, {type: 'null'}]` | no equivalent, the enum stays inline  |
+
+An enum on two or more columns is published once under `components.schemas` and referenced from each
+use, in both versions. Not `$defs`: 3.0 rejects the keyword outright, and 3.1 accepts it and then
+cannot resolve `#/$defs/mood`, because a `$ref` in a document resolves against the document root.
+The last row above is why a nullable enum column keeps its inline list in a 3.0 document: `type:
+'null'` is not one of that version's six types, and 3.0 defines every sibling of `$ref` to be
+ignored, so `{ $ref, nullable: true }` is a schema that silently refuses null. See
+[shared enums](/generators/json-schema#shared-enums).
 
 No `examples` are emitted in either. 3.0 has no such keyword in a schema at all, and DRZL has no
 example data to put there: a Drizzle schema says what a value must look like, never what one is.

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -61,7 +61,7 @@ A constraint with no native form stays a `v.check`. The constraint sits on the i
 evaluates to TRUE **or NULL**.
 
 Only unambiguous comparisons are translated. `start_date < end_date` is applied on the object,
-`length()` and `cardinality()` are applied on the field, and disjunctions, negations, regex
+`length()`, `octet_length()` and `cardinality()` are applied on the field, and negations, regex
 matches and unrecognised function calls are skipped rather
 than guessed at, since a schema enforcing a guess rejects rows the database would accept. See
 [Zod → CHECK constraints](/generators/zod#check-constraints) for the full table.

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -352,12 +352,41 @@ name: z.string()
   .refine((v) => [...v].length <= 8, { message: 'name_len: length(name) <= 8' }),
 ```
 
-The one function call the parser reads, because the mapping is exact. `char_length` is the same
-function and is read too. Counted in code points, so it agrees with the database on emoji.
+`char_length` is the same function and is read too. Counted in code points, so it agrees with the
+database on emoji.
 
-`octet_length` is **not** read: it counts bytes, which depends on the encoding and cannot be
-derived from a JavaScript string without choosing one. Neither is `lower`, which would need a
-locale to be faithful.
+`lower` is **not** read, since it would need a locale to be faithful.
+
+### `octet_length()` becomes a byte count
+
+```ts
+// check('body_bytes', sql`octet_length(${t.body}) <= 5`)      // on a text column
+body: z.string().refine((v) => new TextEncoder().encode(v).length <= 5, {
+  message: 'body_bytes: octet_length(body) <= 5',
+}),
+
+// check('blob_bytes', sql`octet_length(${t.blob}) <= 5`)      // on a bytea column
+blob: z.instanceof(Uint8Array).refine((v) => v.length <= 5, {
+  message: 'blob_bytes: octet_length(blob) <= 5',
+}),
+```
+
+A different measurement of the same value, and it needs a different expression on each column type.
+Measured on PostgreSQL 17.5, on a `text` holding three emoji and a `bytea` holding six bytes:
+
+| expression        | `text` | `bytea`        | JavaScript                                  |
+| ----------------- | ------ | -------------- | ------------------------------------------- |
+| `octet_length(x)` | 12     | 6              | `new TextEncoder().encode(v).length`        |
+| `length(x)`       | 3      | 6              | `[...v].length`, or `v.length` on the array |
+| `char_length(x)`  | 3      | does not exist | `[...v].length`                             |
+
+So `length()` is the character count on a text column and the byte count on a `bytea` one, and both
+are read accordingly. `v.length` on a _string_ is none of the three: it counts UTF-16 units, which is
+6 for those same three emoji.
+
+A count is refused on a MySQL `binary(n)`/`varbinary(n)`. The value arrives as a string produced by a
+lossy decode, so neither its characters nor their re-encoding is the number the server took, and
+`drzl doctor` reports it rather than dropping it.
 
 ### `cardinality()` becomes an element count
 
@@ -384,7 +413,7 @@ against a scalar literal says nothing usable about an array, whereas this one is
 | `x + y < 100`                  | Arithmetic, which the schema cannot compute the way the database does   |
 | `age >= 18 AND lower(n) = 'x'` | One part is not understood, so neither is enforced                      |
 | `email ~ '^[a-z]+$'`           | Postgres `~` is POSIX ERE, not JavaScript's regex dialect               |
-| `octet_length(s) <= 5`         | Bytes, and the column's encoding is not in the schema                   |
+| `octet_length(bin) <= 5`       | On a `varbinary(n)`, whose bytes JavaScript cannot see                  |
 | `flag IS TRUE`                 | A boolean literal, which the parser does not read yet                   |
 
 **Arithmetic between columns is refused deliberately**, and it is the refusal most worth arguing
@@ -399,10 +428,10 @@ two of the three in the direction that refuses rows the database accepts. `drzl 
 operator and suggests moving the result into a generated column and constraining that.
 
 Applied, and worth naming because they read like exceptions: `start_date < end_date` goes on the
-object as a row-level check, `length()` and `char_length()` count code points, `cardinality()`
-bounds an array, `BETWEEN` folds into the range, `IN` and a disjunction of equalities both become
-an enum, `IS NOT NULL` narrows the field, and `IS NULL OR p` is exactly `p`. A conjunction is
-applied when **every** part is understood.
+object as a row-level check, `length()` and `char_length()` count code points, `octet_length()`
+counts bytes, `cardinality()` bounds an array, `BETWEEN` folds into the range, `IN` and a
+disjunction of equalities both become an enum, `IS NOT NULL` narrows the field, and `IS NULL OR p`
+is exactly `p`. A conjunction is applied when **every** part is understood.
 
 A schema that quietly enforces a _guess_ at your constraint is worse than one enforcing nothing,
 because it rejects rows the database would have accepted.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -91,6 +91,17 @@ export const GeneratorSchema = z.object({
   template: z.string().optional(),
   includeRelations: z.boolean().optional(),
   /**
+   * Write an enum used by two or more columns once under `$defs` in the `json-schema` per-table
+   * modules, and `$ref` it at each use.
+   *
+   * Off by default, and the reason is a consumer pattern rather than a doubt about the keyword. A
+   * per-table schema is used whole and one property at a time, and a `$ref` cannot survive being
+   * pulled out with its property: `properties[col]` compiled on its own is a dangling reference
+   * that ajv refuses outright. The OpenAPI document shares regardless, because a document is only
+   * ever read whole.
+   */
+  sharedEnums: z.boolean().optional(),
+  /**
    * Type `json` and `jsonb` columns from the schema rather than leaving them wide.
    *
    * `.$type<T>()` is a compile-time cast, so no runtime-derived validator can see it and

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -27,13 +27,18 @@
  *
  * - A CHECK that DRZL does translate. `age >= 18` folds into `.gte(18)` and `start < end` becomes
  *   an object-level refinement; listing them as findings would drown the ones that matter.
- * - `length(col)` and `cardinality(col)` landing on a column that cannot take them. Some of the
- *   validation generators drop those and some emit something for them, so no single sentence here
- *   is true of all of them. It is also unreachable from a working schema: Postgres has no
- *   `length(anyarray)` and no `cardinality(integer)`, so the DDL is refused before DRZL sees it.
+ * - `cardinality(col)` landing on a column with no elements to count. Unreachable from a working
+ *   schema: Postgres has no `cardinality(integer)`, so the DDL is refused before DRZL sees it.
+ *
+ * `length(col)` and `octet_length(col)` used to be on that list and are not any more, for two
+ * reasons that both stopped being true at once. The five validation generators now ask
+ * `lengthMeasure` the same question rather than each applying its own guard, so one sentence is
+ * true of all of them; and the clause is reachable, because MySQL has `OCTET_LENGTH` and a
+ * `varbinary(n)` column whose byte count in JavaScript is not the one the server took. See
+ * `check-uncountable`.
  */
 import type { Analysis, Column, Issue, Table } from '@drzl/analyzer';
-import { parseCheck } from '@drzl/validation-core';
+import { lengthMeasure, parseCheck, type LengthCheck } from '@drzl/validation-core';
 import chalk from 'chalk';
 
 export type DoctorFindingKind =
@@ -52,6 +57,16 @@ export type DoctorFindingKind =
   | 'check-unknown-column'
   /** A CHECK comparing an array or structured column against a scalar literal. */
   | 'check-not-scalar'
+  /**
+   * A CHECK counting a column whose count JavaScript cannot take the way the database did.
+   *
+   * `CHECK (octet_length(bin) <= 8)` on a MySQL `varbinary(8)` is the reachable case: the value
+   * arrives as a string produced by a lossy decode, so neither its characters nor their UTF-8
+   * re-encoding is the server's byte count, and any predicate written from it would be enforcing a
+   * different constraint. Reported rather than silently dropped, for the same reason `IS NULL` is:
+   * the parser reading an expression must not be the same event as the report forgetting it.
+   */
+  | 'check-uncountable'
   /** A table the generators cannot key. */
   | 'no-primary-key'
   /** A table keyed on more columns than the generators use. */
@@ -153,6 +168,30 @@ function describeShape(c: Column): string {
   }
 }
 
+/** What the clause asked to be counted, in the words the expression used. */
+const countNoun = (l: LengthCheck) => (l.unit === 'bytes' ? 'byte count' : 'character count');
+
+/**
+ * What to do about a count nothing can take, or the generic sentence.
+ *
+ * Only the byte-string column has an answer, and it is the only one reachable from a schema a
+ * database accepted, so the rest get the generic form rather than invented advice.
+ */
+function countHint(c: Column): string {
+  if (c.shape?.kind === 'byteString')
+    return (
+      'A binary(n)/varbinary(n) column hands the caller a string produced by a lossy decode, so ' +
+      'its width is code points coming out and bytes going in and neither is a count of the ' +
+      'value in hand. The column already caps itself at n bytes; a second bound stated here ' +
+      'would be a different measurement. Leave this one to the database.'
+    );
+  return (
+    'Only constraints whose meaning is unambiguous are translated, because a validator ' +
+    'enforcing a guess rejects rows the database accepts. Your database still enforces ' +
+    'this one; nothing DRZL emits does.'
+  );
+}
+
 /**
  * The generic advice for a declined CHECK, or something the reader can act on.
  *
@@ -228,6 +267,26 @@ function checkFindings(table: Table): DoctorFinding[] {
         hint:
           'A column that may only ever be NULL is usually a constraint written the wrong way ' +
           'round. Drop the column, or state the rule as a CHECK on the column that decides it.',
+      });
+    }
+
+    // A count clause the emitted schemas drop. Per clause rather than per column, because the
+    // sentence names the function that was written and `length` and `octet_length` can both be on
+    // one column at once.
+    for (const l of parsed.lengths ?? []) {
+      const col = byName.get(l.column);
+      if (!col || lengthMeasure(col, l)) continue;
+      out.push({
+        kind: 'check-uncountable',
+        level: 'warn',
+        table: table.tsName,
+        column: l.column,
+        constraint: k.name,
+        message:
+          `CHECK ${label} on "${table.tsName}" counts ${describeShape(col)} column ` +
+          `"${l.column}", whose ${countNoun(l)} in JavaScript is not the one the database took, ` +
+          `so it is not translated. Expression: ${expr}`,
+        hint: countHint(col),
       });
     }
 
@@ -369,7 +428,7 @@ const SECTIONS: Array<{ kinds: DoctorFindingKind[]; title: string; why: string }
     why: 'These get a validator that accepts any value.',
   },
   {
-    kinds: ['check-declined', 'check-unknown-column', 'check-not-scalar'],
+    kinds: ['check-declined', 'check-unknown-column', 'check-not-scalar', 'check-uncountable'],
     title: 'CHECK constraints DRZL does not enforce',
     why: 'Your database still enforces these. Nothing DRZL generates does.',
   },

--- a/packages/cli/src/json-schema-options.ts
+++ b/packages/cli/src/json-schema-options.ts
@@ -20,6 +20,7 @@ type GeneratorConfig = ValidationGeneratorConfig & {
   components?: unknown;
   document?: unknown;
   includeRelations?: unknown;
+  sharedEnums?: unknown;
 };
 
 export function jsonSchemaOptions(
@@ -36,5 +37,7 @@ export function jsonSchemaOptions(
     // Read only while emitting a document, where it adds `/users/{id}/posts`. The per-table
     // schemas are flat whatever it says.
     includeRelations: g.includeRelations,
+    // The mirror image: read only for the per-table modules, since the document shares regardless.
+    sharedEnums: g.sharedEnums,
   };
 }

--- a/packages/cli/test/doctor.spec.ts
+++ b/packages/cli/test/doctor.spec.ts
@@ -138,6 +138,47 @@ export const rows = pgTable(
 );
 `;
 
+/**
+ * Byte counts, which is the one clause whose answer depends on the column and not the expression.
+ *
+ * Measured on PostgreSQL 17.5 through PGlite: `octet_length` is the byte count on a `text` and on a
+ * `bytea` alike, and `length` is the character count on the first and the byte count on the second.
+ * Both are answerable in JavaScript, so both are enforced. A MySQL `varbinary(n)` is the one that
+ * is not: the value arrives as a string produced by a lossy decode, so neither its characters nor
+ * their UTF-8 re-encoding is the number the server took.
+ */
+const COUNTS_SCHEMA = `
+import { sql } from 'drizzle-orm';
+import { check as pgCheck, pgTable, serial, text } from 'drizzle-orm/pg-core';
+
+export const files = pgTable(
+  'files',
+  {
+    id: serial('id').primaryKey(),
+    name: text('name').notNull(),
+    body: text('body').notNull(),
+  },
+  (t) => [
+    pgCheck('name_chars', sql\`length(\${t.name}) <= 20\`),
+    pgCheck('body_bytes', sql\`octet_length(\${t.body}) <= 5\`),
+  ]
+);
+`;
+
+const MYSQL_COUNTS_SCHEMA = `
+import { sql } from 'drizzle-orm';
+import { check, int, mysqlTable, varbinary } from 'drizzle-orm/mysql-core';
+
+export const blobs = mysqlTable(
+  'blobs',
+  {
+    id: int('id').primaryKey(),
+    bin: varbinary('bin', { length: 8 }).notNull(),
+  },
+  (t) => [check('bin_bytes', sql\`octet_length(\${t.bin}) <= 8\`)]
+);
+`;
+
 /** The six Gel temporal columns the analyzer deliberately leaves `unknown`. */
 const GEL_SCHEMA = `
 import { gelTable, boolean, localDate, localTime, dateDuration, relDuration, duration, timestamp } from 'drizzle-orm/gel-core';
@@ -167,6 +208,8 @@ let clean: Analysis;
 let gel: Analysis;
 let keys: Analysis;
 let reads: Analysis;
+let counts: Analysis;
+let mysqlCounts: Analysis;
 
 beforeAll(async () => {
   problem = await analyzed('problem', PROBLEM_SCHEMA);
@@ -174,6 +217,8 @@ beforeAll(async () => {
   gel = await analyzed('gel', GEL_SCHEMA);
   keys = await analyzed('keys', KEYS_SCHEMA);
   reads = await analyzed('reads', READS_SCHEMA);
+  counts = await analyzed('counts', COUNTS_SCHEMA);
+  mysqlCounts = await analyzed('mysql-counts', MYSQL_COUNTS_SCHEMA);
 }, 60_000);
 
 const kinds = (a: Analysis, kind: string) =>
@@ -219,11 +264,13 @@ describe('columns DRZL cannot type', () => {
 describe('CHECK constraints DRZL will not enforce', () => {
   it('reports every check the shared parser declines, with its reason', () => {
     const declined = kinds(problem, 'check-declined');
+    // `blob_bytes` used to be here. `octet_length(blob) <= 5` on a `text` column is a byte budget
+    // and the generators state it now, so it is enforced rather than declined; the count that is
+    // still unanswerable is `bin_bytes`, and it is reported as `check-uncountable`.
     expect(declined.map((f) => f.constraint).sort()).toEqual([
       'age_budget',
       'age_not',
       'age_or',
-      'blob_bytes',
       'credit_null',
       'email_re',
       'empty_one',
@@ -233,6 +280,27 @@ describe('CHECK constraints DRZL will not enforce', () => {
     expect(byName.get('age_or')!.message).toContain('range');
     expect(byName.get('age_not')!.message).toContain('contains NOT');
     expect(byName.get('mixed_and')!.message).toContain('part of an AND');
+  });
+
+  it('says nothing about a byte count it can take', () => {
+    // Both are enforced now, so a report naming either would be telling the reader their
+    // constraint is unchecked when it is checked.
+    const found = buildDoctorReport(counts, 'x.ts').findings.filter((f) =>
+      f.kind.startsWith('check-')
+    );
+    expect(found.map((f) => `${f.kind} ${f.constraint}`)).toEqual([]);
+  });
+
+  it('reports a byte count on a column whose bytes JavaScript cannot see', () => {
+    const found = kinds(mysqlCounts, 'check-uncountable');
+    expect(found.map((f) => f.constraint)).toEqual(['bin_bytes']);
+    expect(found[0].column).toBe('bin');
+    expect(found[0].message).toContain('byte-string');
+    expect(found[0].message).toContain('byte count');
+    expect(found[0].hint, 'says what to do, not just what happened').toMatch(/lossy decode/);
+    // Not also reported as a scalar mismatch: a count is not a comparison against a literal.
+    expect(kinds(mysqlCounts, 'check-not-scalar')).toHaveLength(0);
+    expect(kinds(mysqlCounts, 'check-declined')).toHaveLength(0);
   });
 
   it('advises on the two refusals that have a fix, rather than restating the rule', () => {

--- a/packages/cli/test/openapi-branch-parity.e2e.spec.ts
+++ b/packages/cli/test/openapi-branch-parity.e2e.spec.ts
@@ -24,15 +24,18 @@ const CLI = path.resolve(import.meta.dirname, '..', 'dist', 'cli.js');
 const ROOT = path.join(import.meta.dirname, '.tmp-openapi-parity');
 
 const SCHEMA = `
-import { pgTable, integer, serial, text, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgEnum, pgTable, integer, serial, text, uniqueIndex } from 'drizzle-orm/pg-core';
+export const mood = pgEnum('mood', ['sad', 'ok', 'happy']);
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   email: text('email').notNull(),
+  mood: mood('mood').notNull(),
 }, (t) => ({ byEmail: uniqueIndex('users_email_key').on(t.email) }));
 export const posts = pgTable('posts', {
   id: serial('id').primaryKey(),
   authorId: integer('author_id').notNull().references(() => users.id),
   title: text('title').notNull(),
+  mood: mood('mood').notNull(),
 });
 `;
 
@@ -47,6 +50,7 @@ const CONFIG = `export default {
       path: './out/json-schema',
       target: 'openapi-3.0',
       includeRelations: true,
+      sharedEnums: true,
       document: {
         format: 'both',
         info: { title: 'Shop', version: '4.2.0', description: 'the shop api' },
@@ -124,6 +128,27 @@ describe('generate', () => {
     const codes = Object.keys(doc.paths['/users'].post.responses);
     expect(codes, 'validationStatus').toContain('422');
     expect(codes, 'validationStatus').not.toContain('400');
+  });
+
+  it('shares the enum the analysis named, across both tables', () => {
+    // The document shares whatever `sharedEnums` says, since a document is only ever read whole.
+    // `mood` is on one column of each table, so nothing inside one schema could see it twice.
+    const doc = JSON.parse(fromGenerate['openapi.json']);
+    expect(doc.components.schemas.mood).toEqual({ enum: ['sad', 'ok', 'happy'] });
+    expect(doc.components.schemas.usersSelect.properties.mood).toEqual({
+      $ref: '#/components/schemas/mood',
+    });
+    expect(doc.components.schemas.postsSelect.properties.mood).toEqual({
+      $ref: '#/components/schemas/mood',
+    });
+  });
+
+  it('emits no $defs into a 3.0 module, whatever sharedEnums says', () => {
+    // `sharedEnums: true` is set above. `$defs` is a 2020-12 keyword and 3.0's Schema Object is
+    // closed, so the per-table modules on this target keep their inline lists.
+    expect(fromGenerate['users.schema.ts']).not.toContain('$defs');
+    expect(fromGenerate['users.schema.ts']).not.toContain('$ref');
+    expect(fromGenerate['users.schema.ts'], 'the list is still there, inline').toContain('sad');
   });
 });
 

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -23,6 +23,9 @@ import {
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
+  lengthCheckLabel,
+  lengthMeasure,
+  measureExpression,
   nonFiniteAccepted,
   parseCheck,
   parsesToADate,
@@ -959,8 +962,16 @@ function atCapNarrows(c: Column, mode: Mode): string {
   return out.join('');
 }
 
+/**
+ * `length(col)` and `octet_length(col)` as narrows on the object.
+ *
+ * On the object rather than on the field, which is where ArkType has to put them. The measurement
+ * still depends on the column, so the column is looked up here and `lengthMeasure` answers it: a
+ * clause naming a column this schema does not carry, or one whose shape answers no count, is
+ * dropped rather than measured the wrong way.
+ */
 function atLengthNarrows(lengths: LengthCheck[], cols: Column[]): string {
-  const present = new Set(cols.map((c) => c.name));
+  const byName = new Map(cols.map((c) => [c.name, c]));
   const OPS: Record<LengthCheck['operator'], string> = {
     '>=': '>=',
     '>': '>',
@@ -970,13 +981,16 @@ function atLengthNarrows(lengths: LengthCheck[], cols: Column[]): string {
     '<>': '!==',
   };
   return lengths
-    .filter((k) => present.has(k.column))
-    .map((k) => {
+    .flatMap((k) => {
+      const col = byName.get(k.column);
+      const measure = col && lengthMeasure(col, k);
+      if (!measure) return [];
       const v = `o[${JSON.stringify(k.column)}]`;
-      const msg = JSON.stringify(
-        `${k.name ? `${k.name}: ` : ''}length(${k.column}) ${k.operator} ${k.value}`
-      );
-      return `.narrow((o, ctx) => ${v} == null || [...${v}].length ${OPS[k.operator]} ${k.value} || ctx.mustBe(${msg}))`;
+      const msg = JSON.stringify(lengthCheckLabel(k));
+      const count = measureExpression(measure, v);
+      return [
+        `.narrow((o, ctx) => ${v} == null || ${count} ${OPS[k.operator]} ${k.value} || ctx.mustBe(${msg}))`,
+      ];
     })
     .join('');
 }

--- a/packages/generator-arktype/test/octet-length.spec.ts
+++ b/packages/generator-arktype/test/octet-length.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * `CHECK (octet_length(col) <= 5)` in ArkType output.
+ *
+ * See the zod generator's file of the same name for the PGlite measurements this is written
+ * against. ArkType puts the count on the object beside the row checks, for the reason `length.spec`
+ * gives: no declarative string bound counts anything but UTF-16 units, and a byte budget is a third
+ * measurement again.
+ */
+import { describe, it, expect } from 'vitest';
+import { ArkTypeGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { type } from 'arktype';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const GRIN = '\u{1F600}';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const blob = (name = 'blob') =>
+  col(name, { tsType: 'Uint8Array', dbType: 'BYTEA', shape: { kind: 'buffer' } as never });
+
+let seq = 0;
+let lastFile = '';
+
+async function schemasFor(columns: Column[], checks: unknown[]): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-octets');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir } as never);
+  lastFile = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.arktype.ts'), lastFile);
+  return await import(lastFile);
+}
+
+const run = (schema: any, value: unknown) => !(schema(value) instanceof type.errors);
+
+describe('a byte budget on a text column', () => {
+  it('accepts and refuses exactly what Postgres did', async () => {
+    const m = await schemasFor([col('body')], [{ expression: 'octet_length(body) <= 5' }]);
+    expect(run(m.SelecttSchema, { body: 'hello' }), 'five ascii').toBe(true);
+    expect(run(m.SelecttSchema, { body: 'hellos' }), 'six ascii').toBe(false);
+    expect(run(m.SelecttSchema, { body: GRIN }), 'one emoji, four bytes').toBe(true);
+    expect(run(m.SelecttSchema, { body: GRIN.repeat(2) }), 'two emoji, eight bytes').toBe(false);
+  });
+
+  it('names the constraint in the failure', async () => {
+    const m = await schemasFor(
+      [col('body')],
+      [{ name: 'body_bytes', expression: 'octet_length(body) <= 5' }]
+    );
+    const out = m.SelecttSchema({ body: 'hellos' });
+    expect(out instanceof type.errors).toBe(true);
+    expect(String(out)).toContain('body_bytes: octet_length(body) <= 5');
+  });
+
+  it('skips a null, because a CHECK passes on NULL', async () => {
+    const m = await schemasFor(
+      [col('body', { nullable: true })],
+      [{ expression: 'octet_length(body) <= 5' }]
+    );
+    expect(run(m.SelecttSchema, { body: null })).toBe(true);
+  });
+});
+
+describe('a byte budget on a bytea column', () => {
+  it('counts the array, which is what Postgres counted', async () => {
+    const m = await schemasFor([blob()], [{ expression: 'octet_length(blob) <= 5' }]);
+    expect(run(m.SelecttSchema, { blob: new Uint8Array(5) })).toBe(true);
+    expect(run(m.SelecttSchema, { blob: new Uint8Array(6) })).toBe(false);
+  });
+});
+
+describe('a byte budget on a column that cannot answer one', () => {
+  it('emits nothing for a MySQL varbinary', async () => {
+    const bin = col('bin', {
+      dbType: 'VARBINARY',
+      shape: { kind: 'byteString', length: 8 } as never,
+    });
+    await schemasFor([bin], [{ expression: 'octet_length(bin) <= 5' }]);
+    expect(await fs.readFile(lastFile, 'utf8')).not.toContain('octet_length(bin)');
+  });
+});

--- a/packages/generator-effect/src/index.ts
+++ b/packages/generator-effect/src/index.ts
@@ -25,6 +25,9 @@ import {
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
+  lengthCheckLabel,
+  lengthMeasure,
+  measureExpression,
   moduleFileName,
   moduleSpecifier,
   nonFiniteAccepted,
@@ -371,15 +374,18 @@ function capSteps(c: Column, mode: Mode): string[] {
  * Code points, for the reason `capSteps` gives: SQL's `length()` counts characters.
  */
 function lengthSteps(c: Column, lengths: LengthCheck[]): string[] {
-  if (c.arrayDimensions || c.shape) return [];
   return lengths
     .filter((k) => k.column === c.name)
-    .map((k) =>
-      filter(
-        `${CODEPOINT_LENGTH} ${OPS[k.operator]} ${k.value}`,
-        `${k.name ? `${k.name}: ` : ''}length(${c.name}) ${k.operator} ${k.value}`
-      )
-    );
+    .flatMap((k) => {
+      const measure = lengthMeasure(c, k);
+      if (!measure) return [];
+      return [
+        filter(
+          `${measureExpression(measure, 'v')} ${OPS[k.operator]} ${k.value}`,
+          lengthCheckLabel(k)
+        ),
+      ];
+    });
 }
 
 /**
@@ -507,7 +513,10 @@ function exprForColumn(
   replaced: boolean
 ): string {
   const shaped = shapeExpr(c, mode, replaced);
-  if (shaped) return shaped;
+  // A shaped column takes no scalar comparison, but a `bytea` does take a byte count, which is the
+  // one clause `lengthMeasure` answers on a shape. Piped on here rather than folded into
+  // `shapeExpr`, which describes the column and knows nothing about its constraints.
+  if (shaped) return piped(shaped, lengthSteps(c, lengths));
 
   // `CHECK (status IN ('a', 'b'))` is a union of literals, which effect spells as one call.
   const set = sets.find((x) => x.column === c.name);

--- a/packages/generator-effect/test/octet-length.spec.ts
+++ b/packages/generator-effect/test/octet-length.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * `CHECK (octet_length(col) <= 5)` in Effect output.
+ *
+ * See the zod generator's file of the same name for the PGlite measurements this is written
+ * against. The row that matters is two emoji: two characters and eight bytes, refused by Postgres
+ * and accepted by any cap that counts characters.
+ */
+import { describe, it, expect } from 'vitest';
+import { accepts, col, emitColumn, emitText, analysisOf, table } from './fixtures';
+
+const GRIN = '\u{1F600}'; // one code point, four UTF-8 bytes
+
+const S = (m: Record<string, unknown>) => m.SelecttSchema;
+
+const blob = (name = 'blob') =>
+  col(name, { tsType: 'Uint8Array', dbType: 'BYTEA', shape: { kind: 'buffer' } as never });
+
+describe('a byte budget on a text column', () => {
+  it('accepts and refuses exactly what Postgres did', async () => {
+    const m = await emitColumn(col('body'), [{ expression: 'octet_length(body) <= 5' }]);
+    expect(accepts(S(m), { body: 'hello' }), 'five ascii').toBe(true);
+    expect(accepts(S(m), { body: 'hellos' }), 'six ascii').toBe(false);
+    expect(accepts(S(m), { body: GRIN }), 'one emoji, four bytes').toBe(true);
+    expect(accepts(S(m), { body: GRIN.repeat(2) }), 'two emoji, eight bytes').toBe(false);
+  });
+
+  it('names the constraint in the filter description', async () => {
+    const src = await emitText(
+      analysisOf([
+        table('t', [col('body')], {
+          checks: [{ name: 'body_bytes', expression: 'octet_length(body) <= 5' }],
+        } as never),
+      ])
+    );
+    expect(src).toContain('body_bytes: octet_length(body) <= 5');
+  });
+
+  it('skips a null, because a CHECK passes on NULL', async () => {
+    const m = await emitColumn(col('body', { nullable: true }), [
+      { expression: 'octet_length(body) <= 5' },
+    ]);
+    expect(accepts(S(m), { body: null })).toBe(true);
+    expect(accepts(S(m), { body: 'hellos' })).toBe(false);
+  });
+});
+
+describe('a byte budget on a bytea column', () => {
+  it('counts the array, which is what Postgres counted', async () => {
+    const m = await emitColumn(blob(), [{ expression: 'octet_length(blob) <= 5' }]);
+    expect(accepts(S(m), { blob: new Uint8Array(5) })).toBe(true);
+    expect(accepts(S(m), { blob: new Uint8Array(6) })).toBe(false);
+  });
+
+  it('pipes the count onto the shaped schema rather than replacing it', async () => {
+    const m = await emitColumn(blob(), [{ expression: 'octet_length(blob) <= 5' }]);
+    expect(accepts(S(m), { blob: 'hello' }), 'a five character string is not a bytea').toBe(false);
+  });
+});
+
+describe('a byte budget on a column that cannot answer one', () => {
+  it('emits nothing for a MySQL varbinary', async () => {
+    const bin = col('bin', {
+      dbType: 'VARBINARY',
+      shape: { kind: 'byteString', length: 8 } as never,
+    });
+    const src = await emitText(
+      analysisOf([
+        table('t', [bin], { checks: [{ expression: 'octet_length(bin) <= 5' }] } as never),
+      ])
+    );
+    expect(src).not.toContain('octet_length(bin)');
+  });
+});

--- a/packages/generator-json-schema/src/enums.ts
+++ b/packages/generator-json-schema/src/enums.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared enums, written once and referenced.
+ *
+ * A `mood` enum on six columns used to be six copies of the same list, in every schema of every
+ * mode. JSON Schema has had a way to say this since forever and the generator was not using it.
+ *
+ * **Where the definition goes depends on the document, and the two answers are not interchangeable.**
+ * Measured against `@seriousme/openapi-schema-validator`, which carries the real 3.0 and 3.1
+ * meta-schemas:
+ *
+ *   | placement                                   | 3.0       | 3.1                        |
+ *   | ------------------------------------------- | --------- | -------------------------- |
+ *   | `components.schemas` + `#/components/...`    | valid     | valid                      |
+ *   | `$defs` inside a schema + `#/$defs/...`      | INVALID   | INVALID, `$ref` unresolved |
+ *
+ * 3.0's Schema Object is closed, so `$defs` beside `properties` is an unknown keyword and the whole
+ * document fails. 3.1 allows the keyword and still fails, because a `$ref` in a document resolves
+ * against the *document* root: `#/$defs/mood` names nothing there. So a document shares through
+ * `components.schemas` whichever version it is, and `$defs` is only for the standalone per-table
+ * modules, which are real JSON Schema documents with a `$schema` and an `$id` of their own.
+ *
+ * **Only shared enums.** An enum used once gains nothing from the indirection: the reference object
+ * is about as long as the list it replaces, and a reader now has to resolve it to learn anything.
+ * Two uses is where the arithmetic turns, and it is measured rather than assumed in
+ * `test/shared-enums.spec.ts`.
+ *
+ * **Only declared enums.** A `CHECK (status IN ('a','b'))` also renders as an `enum` and is left
+ * inline. It is a constraint on one column rather than a named type, and two columns whose IN lists
+ * happen to agree are two constraints, not one type: giving them a shared name would invent a
+ * concept the schema never declared, and the name would have to be invented too.
+ *
+ * **A reference is used only where it is the whole schema for the column.** `$ref` in OpenAPI 3.0
+ * is defined to make every sibling key be ignored, so `{ $ref, nullable: true }` is a schema that
+ * silently refuses null, and `{ $ref, default: 'x' }` is a default no reader sees. 2020-12 and 3.1
+ * both have an unambiguous spelling for the nullable case, `anyOf: [{ $ref }, { type: 'null' }]`,
+ * which validates; the same shape in a 3.0 document does not, because `type: 'null'` is not one of
+ * that version's six types. So a nullable enum column in a 3.0 document keeps the inline enum it
+ * has always had, and the shared definition still serves every other use of the same enum.
+ */
+import type { Column, Enum, Table } from '@drzl/analyzer';
+
+/** A `$ref` for a column carrying exactly these values, or nothing to leave the enum inline. */
+export type EnumRefResolver = (values: readonly string[]) => string | undefined;
+
+/** What a set of shared enums resolved to, plus the definitions the document has to carry. */
+export interface EnumPlan {
+  /** Hand to `tableSchemas`; records each hit so `definitions` holds only what was referenced. */
+  resolve: EnumRefResolver;
+  /** The definitions actually referenced, keyed by the name they are published under. */
+  definitions(): Record<string, { enum: string[] }>;
+}
+
+/** Values as a key, so two columns declaring the same list are one enum. */
+const identity = (values: readonly string[]) => JSON.stringify([...values]);
+
+/**
+ * A component or `$defs` key derived from the enum's own name.
+ *
+ * OpenAPI constrains a `components.schemas` key to `^[a-zA-Z0-9.\-_]+$`, measured: a key holding a
+ * space, a slash or a non-ASCII letter each made the document invalid or the `$ref` unresolvable.
+ * `$defs` has no such rule, and the same spelling is used for both so one enum has one name
+ * wherever it is published.
+ *
+ * A name that survives sanitising as nothing at all is refused rather than replaced with a
+ * generated one: the enum then stays inline, which is what it did before any of this existed.
+ */
+export function enumKey(name: string): string | undefined {
+  const safe = name.replace(/[^A-Za-z0-9.\-_]/g, '_').replace(/^_+|_+$/g, '');
+  return safe.length ? safe : undefined;
+}
+
+/** Every column that would render as a declared enum, across these columns. */
+function declaredEnumColumns(columns: Column[]): Column[] {
+  // Not `c.enumValues` alone. A column the parser narrowed to a set of literals renders as that set
+  // instead, and a structured column never reaches the enum branch at all, so counting either
+  // would call an enum shared on the strength of a use that does not exist.
+  return columns.filter((c) => !c.shape && c.enumValues && c.enumValues.length);
+}
+
+/**
+ * The enums used by two or more of these columns, as a plan.
+ *
+ * `enums` is the analysis's own list, which is where the *name* comes from: a column carries its
+ * values and nothing else, and `mood` is a better key than anything derivable from `['sad','ok']`.
+ * An enum the analysis does not name is left inline rather than given an invented name.
+ */
+export function planSharedEnums(
+  columns: Column[],
+  enums: Enum[] | undefined,
+  ref: (key: string) => string,
+  reserved: ReadonlySet<string> = new Set()
+): EnumPlan | undefined {
+  if (!enums?.length) return undefined;
+
+  const uses = new Map<string, number>();
+  for (const c of declaredEnumColumns(columns)) {
+    const id = identity(c.enumValues!);
+    uses.set(id, (uses.get(id) ?? 0) + 1);
+  }
+
+  const keyed = new Map<string, { key: string; values: string[] }>();
+  const taken = new Set(reserved);
+  for (const e of enums) {
+    const id = identity(e.values);
+    if ((uses.get(id) ?? 0) < 2) continue;
+    if (keyed.has(id)) continue;
+    const key = enumKey(e.name);
+    // A key already claimed by a table's schema is left alone rather than disambiguated. The
+    // alternative is a suffixed name that changes the moment a table is added, and an enum that
+    // stays inline is exactly what every enum did before.
+    if (!key || taken.has(key)) continue;
+    taken.add(key);
+    keyed.set(id, { key, values: [...e.values] });
+  }
+  if (!keyed.size) return undefined;
+
+  const used = new Set<string>();
+  return {
+    resolve(values) {
+      const hit = keyed.get(identity(values));
+      if (!hit) return undefined;
+      used.add(hit.key);
+      return ref(hit.key);
+    },
+    definitions() {
+      const out: Record<string, { enum: string[] }> = {};
+      for (const { key, values } of keyed.values()) {
+        if (used.has(key)) out[key] = { enum: [...values] };
+      }
+      return out;
+    },
+  };
+}
+
+/** Every column of every table, which is the scope a whole document shares over. */
+export const allColumns = (tables: Table[]): Column[] => tables.flatMap((t) => t.columns);

--- a/packages/generator-json-schema/src/index.ts
+++ b/packages/generator-json-schema/src/index.ts
@@ -14,7 +14,7 @@
  *   components   `components.schemas` for an OpenAPI document, on `components: true`
  *   document     the whole OpenAPI document, paths and all, on `document: true`
  */
-import type { Analysis, Table } from '@drzl/analyzer';
+import type { Analysis, Enum, Table } from '@drzl/analyzer';
 import type { ResolvedAffix, ValidationGenerateOptions } from '@drzl/validation-core';
 import {
   formatCode,
@@ -34,6 +34,7 @@ import { componentsDocument, tableSchemas, type JsonSchemaTarget, type Mode } fr
 
 export * from './schemas.js';
 export * from './openapi.js';
+export * from './enums.js';
 
 const DEFAULT_FILE_SUFFIX = '.schema.ts';
 
@@ -41,10 +42,11 @@ function renderTableModule(
   table: Table,
   affix: ResolvedAffix,
   target: JsonSchemaTarget,
-  applyDefaults: boolean
+  applyDefaults: boolean,
+  enums?: Enum[]
 ): string {
   const T = table.tsName;
-  const schemas = tableSchemas(table, { target, applyDefaults });
+  const schemas = tableSchemas(table, { target, applyDefaults, ...(enums ? { enums } : {}) });
   const decl = (mode: Mode) =>
     `export const ${schemaName(mode, T, affix)} = ${JSON.stringify(schemas[mode], null, 2)} as const;
 
@@ -98,6 +100,21 @@ export interface JsonSchemaGenerateOptions extends ValidationGenerateOptions {
    * document is being emitted; the per-table schemas are flat whatever this says.
    */
   includeRelations?: boolean;
+  /**
+   * Write an enum used by two or more columns once under `$defs`, and `$ref` it at each use.
+   *
+   * **Off by default, and the reason is a consumer pattern rather than a doubt about the keyword.**
+   * A per-table schema is used two ways: whole, and one property at a time. Reaching into
+   * `properties[col]` is the JSON Schema equivalent of reading zod's `.shape`, it is how a form
+   * builder gets one field's rules, and it is how `scripts/verify-packed.sh` checks these schemas
+   * against a real Postgres. A `$ref` cannot survive that: pulled out of the schema that holds its
+   * `$defs`, it is a dangling reference and ajv refuses to compile it at all, `can't resolve
+   * reference #/$defs/mood from id #`. Whole, it compiles and validates exactly as before.
+   *
+   * So this is a trade rather than an improvement, and it is stated rather than made for you. The
+   * OpenAPI document shares regardless, because a document is only ever consumed whole.
+   */
+  sharedEnums?: boolean;
 }
 
 /** `document: true`, `document: {...}` and `document: false` as one shape, or `null` for off. */
@@ -127,7 +144,13 @@ export class JsonSchemaGenerator {
 
     for (const table of this.analysis.tables) {
       const filePath = path.join(out, moduleFileName(table.tsName, fileSuffix));
-      const code = renderTableModule(table, affix, target, !!opts.applyDefaults);
+      const code = renderTableModule(
+        table,
+        affix,
+        target,
+        !!opts.applyDefaults,
+        opts.sharedEnums ? this.analysis.enums : undefined
+      );
       const formatted = await formatCode(
         buildHeader(opts.outputHeader) + code,
         filePath,
@@ -157,6 +180,7 @@ export class JsonSchemaGenerator {
         target,
         applyDefaults: !!opts.applyDefaults,
         includeRelations: !!opts.includeRelations,
+        enums: this.analysis.enums,
         info: document.info,
         servers: document.servers,
         validationStatus: document.validationStatus,
@@ -208,7 +232,8 @@ export class JsonSchemaGenerator {
       table,
       resolveAffix(opts),
       opts?.target ?? 'draft-2020-12',
-      !!opts?.applyDefaults
+      !!opts?.applyDefaults,
+      opts?.sharedEnums ? this.analysis.enums : undefined
     );
   }
 }

--- a/packages/generator-json-schema/src/openapi.ts
+++ b/packages/generator-json-schema/src/openapi.ts
@@ -18,7 +18,13 @@
  */
 import type { Column, Table } from '@drzl/analyzer';
 import { qualifiedForeignTable, qualifiedTableName } from '@drzl/analyzer';
-import { tableSchemas, type JsonSchemaTarget, type Schema } from './schemas.js';
+import {
+  componentSchemaName,
+  documentSchemas,
+  type EnumSharingOptions,
+  type JsonSchemaTarget,
+  type Schema,
+} from './schemas.js';
 
 /** What the document says about itself. DRZL knows the schema and nothing else, so this is input. */
 export interface OpenApiInfo {
@@ -32,7 +38,7 @@ export interface OpenApiServer {
   description?: string;
 }
 
-export interface OpenApiDocumentOptions {
+export interface OpenApiDocumentOptions extends EnumSharingOptions {
   target?: JsonSchemaTarget;
   applyDefaults?: boolean;
   /** Emit `/users/{id}/posts` for a child that names its parent by foreign key. */
@@ -55,8 +61,7 @@ type Mode = 'insert' | 'update' | 'select';
 const ERROR_SCHEMA = 'Error';
 
 /** The map key under `components.schemas`, which is also what a `$ref` to it spells. */
-const componentName = (table: Table, mode: Mode) =>
-  `${table.tsName}${mode[0].toUpperCase()}${mode.slice(1)}`;
+const componentName = componentSchemaName;
 
 const ref = (name: string) => ({ $ref: `#/components/schemas/${name}` });
 
@@ -194,20 +199,38 @@ function build(
     return { operationId: id, tags: [qualifiedTableName(table)], ...rest };
   };
 
+  // Which modes each table contributes, decided before anything is built so a shared enum
+  // definition is published only where the document really points at one.
+  const keys = new Map(tables.map((t) => [t, keyColumns(t)]));
+  const carried = new Map(tables.map((t) => [t, modesFor(t, keys.get(t)!)]));
+  // Every name a table's schema will claim, plus the one this document keeps for itself, so an
+  // enum sharing a name with either stays inline instead of overwriting it.
+  const reserved = new Set([
+    ERROR_SCHEMA,
+    ...tables.flatMap((t) => carried.get(t)!.map((m) => componentName(t, m))),
+  ]);
+  const shared = documentSchemas(tables, {
+    target: schemaTarget,
+    applyDefaults: !!opts.applyDefaults,
+    reserved,
+    modes: (t) => carried.get(t)!,
+    ...(opts.enums ? { enums: opts.enums } : {}),
+  });
+
   const built = tables.map((table) => ({
     table,
-    key: keyColumns(table),
+    key: keys.get(table)!,
     segment: resourceSegment(table),
-    schemas: tableSchemas(table, { target: schemaTarget, applyDefaults: opts.applyDefaults }),
+    schemas: shared.built.get(table)!,
   }));
 
   for (const { table, key, segment, schemas: built3 } of built) {
-    for (const mode of modesFor(table, key)) {
+    for (const mode of carried.get(table)!) {
       // `$schema` and `$id` both have to go. Nested under `components.schemas` a schema inherits
       // the document's dialect, and a 2020-12 `$id` may not contain a fragment, so the obvious
       // `#/components/schemas/<name>` makes a validator refuse the schema outright. The map key is
       // the identity and the `$ref` is written by whatever points at the schema.
-      const { $schema: _dialect, $id: _id, ...rest } = built3[mode];
+      const { $schema: _dialect, $id: _id, ...rest } = built3[mode]!;
       schemas[componentName(table, mode)] = rest;
     }
 
@@ -279,7 +302,7 @@ function build(
       description: `${c.name}, from the primary key of ${table.name}.`,
       // The column's own schema rather than a string, so an integer key is declared as one and a
       // uuid key carries its format. This is the whole point of reading the real key.
-      schema: (built3.select.properties as Record<string, Schema>)[c.name] ?? {},
+      schema: (built3.select!.properties as Record<string, Schema>)[c.name] ?? {},
     }));
     const missing = {
       description: `No ${table.name} row has that ${key.map((c) => c.name).join(' and ')}.`,
@@ -373,7 +396,9 @@ function build(
     }
   }
 
-  return { paths, schemas, tags };
+  // The shared enum definitions, after the table schemas so a stray collision would be visible
+  // rather than silent. `reserved` above is what makes that impossible in the first place.
+  return { paths, schemas: { ...schemas, ...shared.definitions() }, tags };
 }
 
 /**

--- a/packages/generator-json-schema/src/schemas.ts
+++ b/packages/generator-json-schema/src/schemas.ts
@@ -8,7 +8,7 @@
  * Split out of `index.ts` so `openapi.ts` can build a document from these without the two importing
  * each other. Nothing here changed in the move except the two keywords named on `openapi-3.0`.
  */
-import type { Column, Table } from '@drzl/analyzer';
+import type { Column, Enum, Table } from '@drzl/analyzer';
 import type {
   CardinalityCheck,
   ColumnCheck,
@@ -24,6 +24,7 @@ import {
   selectColumns,
   updateColumns,
 } from '@drzl/validation-core';
+import { planSharedEnums, type EnumPlan, type EnumRefResolver } from './enums.js';
 
 export type Mode = 'insert' | 'update' | 'select';
 
@@ -77,7 +78,8 @@ function baseSchema(
   target: JsonSchemaTarget,
   checks: ColumnCheck[],
   sets: ColumnSet[],
-  lengths: LengthCheck[]
+  lengths: LengthCheck[],
+  enumRef?: EnumRefResolver
 ): Schema {
   const s = c.shape;
   if (s) {
@@ -89,9 +91,14 @@ function baseSchema(
       case 'custom':
         // Nothing is known about a custom type's runtime shape, so nothing is claimed.
         return {};
-      case 'buffer':
+      case 'buffer': {
         // Binary cannot travel as JSON. Both spellings say how it did.
-        return base64(target);
+        const bin = base64(target);
+        // `CHECK (octet_length(blob) <= n)` is the one clause a binary column takes, and the
+        // measurement it asks for is the plain byte count. See `applyBinaryLengths`.
+        applyBinaryLengths(bin, c, lengths);
+        return bin;
+      }
       case 'tuple':
         // `prefixItems` is 2020-12. OpenAPI 3.0 has no positional form at all, so it falls back
         // to a homogeneous array of the right length, which is the closest true statement.
@@ -150,7 +157,12 @@ function baseSchema(
   const set = sets.find((x) => x.column === c.name);
   if (set) return { enum: set.values.map((v) => (set.kind === 'string' ? v : Number(v))) };
 
-  if (c.enumValues && c.enumValues.length) return { enum: [...c.enumValues] };
+  if (c.enumValues && c.enumValues.length) {
+    // A declared enum this document publishes once, or the list itself. See `enums.ts` for which
+    // enums are shared and why a reference is not always usable.
+    const ref = enumRef?.(c.enumValues);
+    return ref ? { $ref: ref } : { enum: [...c.enumValues] };
+  }
 
   const mine = c.arrayDimensions ? [] : checks.filter((k) => k.column === c.name);
   const eq = mine.find((k) => k.operator === '=');
@@ -168,7 +180,7 @@ function baseSchema(
       if (c.format === 'uuid') out.format = UUID_FORMAT;
       else if (c.format && COLUMN_FORMATS[c.format]) out.pattern = COLUMN_FORMATS[c.format];
       if (c.maxLength !== undefined) out.maxLength = c.maxLength;
-      applyByteCap(out, c);
+      applyByteCap(out, c, lengths);
       applyLengths(out, c, lengths);
       return out;
     }
@@ -226,16 +238,54 @@ function baseSchema(
  *
  * Before `applyLengths`, so a `CHECK (length(col) <= n)` narrower than the budget still wins:
  * that one is reachable from a real schema, and it is asserted too.
+ *
+ * The budget itself is the smallest of the ones the column carries, whether it came from the type
+ * or from a `CHECK (octet_length(col) <= n)`, so the prose names the number actually in force. Two
+ * budgets with the description written from the wrong one is a document stating a limit looser than
+ * its own `maxLength`.
  */
-function applyByteCap(out: Schema, c: Column) {
-  if (!c.maxBytes) return;
-  out.maxLength = Math.min(Number(out.maxLength ?? Infinity), c.maxBytes);
-  out.description = `At most ${c.maxBytes} bytes of UTF-8, which JSON Schema has no keyword for. maxLength counts characters: it refuses nothing the column accepts, and a string of multi-byte characters can satisfy it and still be too long for the column.`;
+function applyByteCap(out: Schema, c: Column, lengths: LengthCheck[]) {
+  const budget = byteBudget(c, lengths);
+  if (budget === undefined) return;
+  out.maxLength = Math.min(Number(out.maxLength ?? Infinity), budget);
+  out.description = BYTE_BUDGET_NOTE(budget);
 }
 
-/** `length(col) >= n` as `minLength` and `maxLength`, which count characters as SQL does. */
+/** The inclusive upper bound a count clause states, or nothing where it states no ceiling. */
+function ceilingOf(k: LengthCheck): number | undefined {
+  if (k.operator === '<=' || k.operator === '=') return Number(k.value);
+  if (k.operator === '<') return Number(k.value) - 1;
+  return undefined;
+}
+
+/** Every byte ceiling on a column, as the one number that binds: the smallest of them. */
+function byteBudget(c: Column, lengths: LengthCheck[]): number | undefined {
+  const bounds = [
+    ...(c.maxBytes ? [c.maxBytes] : []),
+    ...lengths
+      .filter((k) => k.column === c.name && k.unit === 'bytes')
+      .map(ceilingOf)
+      .filter((n): n is number => n !== undefined),
+  ];
+  return bounds.length ? Math.min(...bounds) : undefined;
+}
+
+/**
+ * `length(col) >= n` as `minLength` and `maxLength`, which count characters as SQL does.
+ *
+ * A `CHECK (octet_length(col) <= n)` is a *byte* budget rather than a character count, so it goes
+ * through `applyByteCap` with the type's own budget and is skipped here. The two are different
+ * measurements of the same string and the difference is the whole reason the parser carries a unit:
+ * measured on PostgreSQL 17.5, a string of three emoji answers 3 to `length()` and 12 to
+ * `octet_length()`, so a byte bound written as a character count would be four times looser than
+ * the constraint at worst.
+ *
+ * A byte *floor* reaches no keyword at all. `octet_length(t) >= 10` implies only `length(t) >= 3`,
+ * since UTF-8 spends at most four bytes per character, which is a bound that catches almost nothing
+ * and one more formula to be wrong about.
+ */
 function applyLengths(out: Schema, c: Column, lengths: LengthCheck[]) {
-  for (const k of lengths.filter((x) => x.column === c.name)) {
+  for (const k of lengths.filter((x) => x.column === c.name && x.unit !== 'bytes')) {
     const n = Number(k.value);
     if (k.operator === '>=') out.minLength = Math.max(Number(out.minLength ?? 0), n);
     else if (k.operator === '>') out.minLength = Math.max(Number(out.minLength ?? 0), n + 1);
@@ -247,6 +297,37 @@ function applyLengths(out: Schema, c: Column, lengths: LengthCheck[]) {
     }
   }
 }
+
+/**
+ * A byte budget on a binary column, as a cap on the base64 string that carries it.
+ *
+ * A `bytea` cannot travel as JSON, so the document describes it as base64 and the only length this
+ * format can bound is the encoded string's. Base64 of n bytes is exactly `4 * ceil(n / 3)`
+ * characters when padded and fewer when not, measured over n = 0 to 20, so that number is an upper
+ * bound under either spelling and refuses nothing the column accepts. It is not a tight one: 6
+ * bytes encode to the same 8 characters as 5, so a cap of 5 bytes still lets a 6 byte value
+ * through. The exact rule goes in `description`, as every other cap this generator cannot state
+ * does.
+ *
+ * Only the ceiling. A base64 *minimum* would have to hold for the unpadded spelling too, and the
+ * two disagree by up to two characters at every length, so the bound would be looser than the
+ * arithmetic makes it look for no gain.
+ */
+function applyBinaryLengths(out: Schema, c: Column, lengths: LengthCheck[]) {
+  const budget = byteBudget(c, lengths);
+  if (budget === undefined) return;
+  out.maxLength = 4 * Math.ceil(budget / 3);
+  out.description =
+    `At most ${budget} bytes, which JSON Schema has no keyword for. The value travels as ` +
+    `base64, and maxLength counts the characters of that encoding: it refuses nothing the ` +
+    `column accepts, and a value one or two bytes over the limit encodes to the same number of ` +
+    `characters as one inside it.`;
+}
+
+const BYTE_BUDGET_NOTE = (n: number) =>
+  `At most ${n} bytes of UTF-8, which JSON Schema has no keyword for. maxLength counts ` +
+  `characters: it refuses nothing the column accepts, and a string of multi-byte characters can ` +
+  `satisfy it and still be too long for the column.`;
 
 /**
  * Declared range and CHECK comparisons as numeric keywords.
@@ -318,6 +399,10 @@ function cardinalityBounds(c: Column, cardinalities: CardinalityCheck[]): Schema
  */
 function makeNullable(s: Schema, target: JsonSchemaTarget): Schema {
   if (target === 'openapi-3.0') return { ...s, nullable: true };
+  // A reference has nothing to add null to, and adding a key beside it is the OpenAPI 3.0 trap in
+  // reverse: `{ $ref, type: [...] }` says nothing about the referenced schema. `anyOf` is the
+  // spelling that does, and it validates against the real 3.1 meta-schema.
+  if ('$ref' in s) return { anyOf: [s, { type: 'null' }] };
   if (s.type === undefined) {
     // `const` and `enum` constrain the value directly, so null has to be added to them instead.
     if (Array.isArray(s.enum)) return { ...s, enum: [...s.enum, null] };
@@ -338,9 +423,17 @@ function columnSchema(
   sets: ColumnSet[],
   lengths: LengthCheck[],
   cardinalities: CardinalityCheck[],
-  applyDefault: boolean
+  applyDefault: boolean,
+  enumRef?: EnumRefResolver
 ): Schema {
-  let s = baseSchema(c, mode, target, checks, sets, lengths);
+  const wantsDefault = mode === 'insert' && applyDefault && c.defaultValue !== undefined;
+  // OpenAPI 3.0 defines every sibling of `$ref` to be ignored, so a reference cannot carry the two
+  // keywords this function adds: `nullable: true` beside one is a schema that refuses null, and a
+  // `default` beside one is a value no reader sees. Both wrappers land on the *column*, so an array
+  // of enums is unaffected: the reference is on the element and the wrapper is on the array.
+  const refBlockedBy30 =
+    target === 'openapi-3.0' && !c.arrayDimensions && (c.nullable || wantsDefault);
+  let s = baseSchema(c, mode, target, checks, sets, lengths, refBlockedBy30 ? undefined : enumRef);
   // Drizzle keeps an array on the element's own column class, so everything above describes the
   // element and the wrapping belongs here.
   const dims = c.arrayDimensions ?? 0;
@@ -378,7 +471,10 @@ function tableSchema(
   mode: Mode,
   target: JsonSchemaTarget,
   applyDefaults: boolean,
-  parsed: ReturnType<typeof collect>
+  parsed: ReturnType<typeof collect>,
+  enums: EnumPlan | undefined,
+  /** `$defs` for a standalone module; absent where the definitions live in the document instead. */
+  localDefs: boolean
 ): Schema {
   const properties: Schema = {};
   const required: string[] = [];
@@ -391,7 +487,8 @@ function tableSchema(
       parsed.sets,
       parsed.lengths,
       parsed.cardinalities,
-      applyDefaults
+      applyDefaults,
+      enums?.resolve
     );
     // An update makes everything optional. On insert a column the database will fill in may be
     // omitted. On select nothing may be: the row came out of the database, so every column has a
@@ -407,6 +504,10 @@ function tableSchema(
     if (!optional) required.push(c.name);
   }
   const desc = rowDescription(parsed.rows, cols);
+  // After the properties, so it holds exactly the enums this schema referenced. A `$defs` entry
+  // nothing points at is dead weight in the consumer's bundle, and one that is missing is a
+  // dangling `$ref` that ajv refuses to compile at all.
+  const defs = localDefs ? (enums?.definitions() ?? {}) : {};
   return {
     ...(target === 'draft-2020-12' ? { $schema: DRAFT } : {}),
     $id: `${table.tsName}.${mode}`,
@@ -416,6 +517,7 @@ function tableSchema(
     properties,
     ...(required.length ? { required } : {}),
     additionalProperties: false,
+    ...(Object.keys(defs).length ? { $defs: defs } : {}),
   };
 }
 
@@ -430,20 +532,85 @@ function collect(table: Table) {
   };
 }
 
-/** The three schemas for one table, as data rather than as source. */
+/** What a caller can say about the enums a set of schemas shares. */
+export interface EnumSharingOptions {
+  /**
+   * The analysis's own enums, which is where a shared definition gets its *name*.
+   *
+   * Omitted, every enum is inlined at every use, which is what this generator did before. A column
+   * carries its values and no name at all, and `mood` is a better key than anything derivable from
+   * `['sad','ok','happy']`, so an enum the analysis does not name stays inline.
+   */
+  enums?: Enum[];
+}
+
+/**
+ * The three schemas for one table, as data rather than as source.
+ *
+ * A shared enum lands in this schema's own `$defs`, and only on `draft-2020-12`. The other two
+ * targets describe a schema destined for an OpenAPI document, where `$defs` is either invalid
+ * outright (3.0's Schema Object is closed) or valid and unresolvable (3.1 resolves a `$ref` against
+ * the document root, so `#/$defs/mood` names nothing). Both measured. A document shares through
+ * `components.schemas` instead; see `componentsDocument`.
+ *
+ * The scope is one schema, so an enum has to be on two columns of *this mode* to be shared. Deciding
+ * it per table instead would put a `$defs` entry with one reference into the insert schema of a
+ * table whose second use is a generated column.
+ */
 export function tableSchemas(
   table: Table,
-  opts: { target?: JsonSchemaTarget; applyDefaults?: boolean } = {}
+  opts: { target?: JsonSchemaTarget; applyDefaults?: boolean } & EnumSharingOptions = {}
 ): Record<Mode, Schema> {
   const target = opts.target ?? 'draft-2020-12';
   const parsed = collect(table);
-  const build = (cols: Column[], mode: Mode) =>
-    tableSchema(table, cols, mode, target, !!opts.applyDefaults, parsed);
+  const localDefs = target === 'draft-2020-12';
+  const build = (cols: Column[], mode: Mode) => {
+    const plan = localDefs
+      ? planSharedEnums(cols, opts.enums, (key) => `#/$defs/${key}`)
+      : undefined;
+    return tableSchema(table, cols, mode, target, !!opts.applyDefaults, parsed, plan, localDefs);
+  };
   return {
     insert: build(insertColumns(table), 'insert'),
     update: build(updateColumns(table), 'update'),
     select: build(selectColumns(table), 'select'),
   };
+}
+
+/**
+ * The same three schemas, sharing enums through a plan somebody else owns.
+ *
+ * `componentsDocument` and `openApiDocument` share over the whole document rather than over one
+ * schema, and they publish the definitions beside the table schemas rather than inside them. So the
+ * plan is built once out there and handed down, and nothing here emits a `$defs`.
+ */
+function tableSchemasWith(
+  table: Table,
+  target: JsonSchemaTarget,
+  applyDefaults: boolean,
+  plan: EnumPlan | undefined,
+  modes: readonly Mode[] = MODES
+): Record<Mode, Schema> {
+  const parsed = collect(table);
+  const columns: Record<Mode, () => Column[]> = {
+    insert: () => insertColumns(table),
+    update: () => updateColumns(table),
+    select: () => selectColumns(table),
+  };
+  const out = {} as Record<Mode, Schema>;
+  for (const mode of modes) {
+    out[mode] = tableSchema(
+      table,
+      columns[mode](),
+      mode,
+      target,
+      applyDefaults,
+      parsed,
+      plan,
+      false
+    );
+  }
+  return out;
 }
 
 /**
@@ -461,19 +628,73 @@ export function tableSchemas(
  *   outright: `data/$id must match pattern "^[^#]*#?$"`. In OpenAPI the **map key** is the
  *   identity, and `$ref: '#/components/schemas/<name>'` is written by whatever points at it, not
  *   by the schema itself.
+ *
+ * **No shared enum definitions here, and that is the one place this differs from `openApiDocument`.**
+ * A `$ref` is a promise about where the thing holding it will be mounted, and this object is a
+ * fragment whose mount point is the caller's: `#/components/schemas/mood` is resolvable once it has
+ * been spread into a document at exactly that path and nowhere else. Every entry here is therefore
+ * self-contained, so a caller can hand one schema to a validator on its own, which
+ * `scripts/verify-packed.sh` does and which a cross-reference silently breaks: ajv answers
+ * `can't resolve reference #/components/schemas/mood from id #`. The whole document knows where it
+ * is and does share; see `openApiDocument`.
  */
 export function componentsDocument(
   tables: Table[],
   opts: { target?: JsonSchemaTarget; applyDefaults?: boolean } = {}
 ): { schemas: Record<string, Schema> } {
+  const target = opts.target ?? 'draft-2020-12';
   const schemas: Record<string, Schema> = {};
   for (const table of tables) {
-    const built = tableSchemas(table, opts);
-    for (const mode of ['insert', 'update', 'select'] as const) {
-      const name = `${table.tsName}${mode[0].toUpperCase()}${mode.slice(1)}`;
+    const built = tableSchemasWith(table, target, !!opts.applyDefaults, undefined);
+    for (const mode of MODES) {
       const { $schema: _dialect, $id: _id, ...rest } = built[mode];
-      schemas[name] = rest;
+      schemas[componentSchemaName(table, mode)] = rest;
     }
   }
   return { schemas };
+}
+
+const MODES = ['insert', 'update', 'select'] as const;
+
+/** The map key a table's schema is published under, which is also what a `$ref` to it spells. */
+export const componentSchemaName = (table: Table, mode: Mode) =>
+  `${table.tsName}${mode[0].toUpperCase()}${mode.slice(1)}`;
+
+/**
+ * Every table's schemas for a document, plus the shared enum definitions to publish beside them.
+ *
+ * The half of `componentsDocument` that `openApiDocument` needs, which is not quite the same thing:
+ * a document carries only the modes something points at, and it reserves `Error` for its own use.
+ */
+export function documentSchemas(
+  tables: Table[],
+  opts: {
+    target: JsonSchemaTarget;
+    applyDefaults: boolean;
+    reserved: ReadonlySet<string>;
+    /**
+     * Which modes of each table the document carries.
+     *
+     * Only those are built, so `definitions()` holds exactly the enums something in the document
+     * points at. Built unconditionally, a table whose only enum column sits in a mode the document
+     * drops would publish a definition nothing references.
+     */
+    modes: (table: Table) => readonly Mode[];
+  } & EnumSharingOptions
+): {
+  built: Map<Table, Partial<Record<Mode, Schema>>>;
+  definitions: () => Record<string, { enum: string[] }>;
+} {
+  const plan = planSharedEnums(
+    tables.flatMap((t) => t.columns),
+    opts.enums,
+    (key) => `#/components/schemas/${key}`,
+    opts.reserved
+  );
+  const built = new Map<Table, Partial<Record<Mode, Schema>>>();
+  for (const table of tables) {
+    const all = tableSchemasWith(table, opts.target, opts.applyDefaults, plan, opts.modes(table));
+    built.set(table, all);
+  }
+  return { built, definitions: () => plan?.definitions() ?? {} };
 }

--- a/packages/generator-json-schema/test/byte-caps.spec.ts
+++ b/packages/generator-json-schema/test/byte-caps.spec.ts
@@ -174,13 +174,17 @@ describe('a byte budget in a format with no byte-length keyword', () => {
     expect(v('a'.repeat(101))).toBe(false);
   });
 
-  it('leaves a base64 column alone, where a character cap would refuse a legal value', async () => {
+  it('caps a base64 column at the encoded length, never at the byte count', async () => {
     // Not hypothetical: MYSQL_TEXT_CAPS covers the blob family too, and scripts/verify-packed.sh
     // records that on drizzle-orm 1.0.0-rc.4 a `tinyblob` column comes back carrying maxBytes
     // 255. Binary travels as base64, which is four characters for every three bytes, so a
     // character cap taken from a byte budget would refuse a full column: 255 bytes is 340 base64
-    // characters. That is the one direction this must never take, and the shape is what keeps it
-    // out, so the assertion is on the emitted keyword rather than on the guard.
+    // characters. That is the one direction this must never take.
+    //
+    // The cap emitted is the *encoded* length, `4 * ceil(255 / 3)` = 340, which is the padded
+    // length of a full column and an upper bound on the unpadded one. It refuses nothing the
+    // column accepts and it does catch a payload too big to be one, which is more than the
+    // keyword-free document said. See `octet-length.spec.ts` for the measurements.
     const s = await emitted(
       col({
         tsType: 'Uint8Array',
@@ -189,9 +193,11 @@ describe('a byte budget in a format with no byte-length keyword', () => {
         shape: { kind: 'buffer' } as never,
       })
     );
-    expect(s.maxLength, 'no character cap on an encoded string').toBeUndefined();
+    expect(s.maxLength, 'the encoded length, not the byte count').toBe(340);
     const v = compile(s);
     expect(v('A'.repeat(340)), 'a full 255 byte value, base64 encoded').toBe(true);
+    expect(v('A'.repeat(344)), '258 bytes, which the column cannot hold').toBe(false);
+    expect(String(s.description)).toContain('At most 255 bytes');
   });
 
   it('carries the cap into the OpenAPI 3.0 spelling too', async () => {

--- a/packages/generator-json-schema/test/octet-length.spec.ts
+++ b/packages/generator-json-schema/test/octet-length.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * `CHECK (octet_length(col) <= n)` in a format with no byte-length keyword.
+ *
+ * The same trade `byte-caps.spec.ts` documents for MySQL's TEXT budget, reached from a CHECK
+ * instead of from the column type, and extended to the one column that carries bytes rather than a
+ * string.
+ *
+ * On a **text** column the cap becomes `maxLength`, which counts characters. UTF-8 spends at least
+ * one byte per character, so every string inside the byte budget is inside a character cap of the
+ * same number: the cap refuses nothing the column accepts. It cannot catch a multi-byte string that
+ * fits the count and not the budget, and that goes in `description` rather than unsaid.
+ *
+ * On a **bytea** column the value travels as base64, so the only length this format can bound is
+ * the encoded string's. Base64 of n bytes is `4 * ceil(n / 3)` characters padded and fewer
+ * unpadded, measured over n = 0 to 20:
+ *
+ *   n       0  1  2  3  4  5  6  7  8  9 10
+ *   padded  0  4  4  4  8  8  8 12 12 12 16
+ *   4ceil   0  4  4  4  8  8  8 12 12 12 16
+ *
+ * so that number is an upper bound under either spelling. It is loose by design: 6 bytes encode to
+ * the same 8 characters as 5, so a 5 byte cap still admits 6 bytes and the exact rule is stated in
+ * prose beside it.
+ *
+ * A byte *floor* is emitted nowhere. `octet_length(t) >= 10` implies only `length(t) >= 3`, which
+ * catches almost nothing, and the base64 minimum differs between the padded and unpadded spellings
+ * at every length.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import type { Analysis, Column, Table } from '@drzl/analyzer';
+import { JsonSchemaGenerator, type JsonSchemaTarget } from '../src/index';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (over: Partial<Column> = {}): Column =>
+  ({
+    name: 'n',
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const blob = () =>
+  col({ tsType: 'Uint8Array', dbType: 'BYTEA', shape: { kind: 'buffer' } as never });
+
+let seq = 0;
+
+async function emitted(
+  c: Column,
+  opts: { target?: JsonSchemaTarget; checks?: { name?: string; expression?: string }[] } = {}
+) {
+  const table: Table = {
+    name: 't',
+    tsName: 't',
+    columns: [c],
+    unique: [],
+    indexes: [],
+    checks: opts.checks ?? [],
+  } as never;
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [table],
+    enums: [],
+    relations: [],
+    issues: [],
+  } as never;
+  const dir = path.join(__dirname, '.tmp-octets');
+  await fs.mkdir(dir, { recursive: true });
+  await new JsonSchemaGenerator(analysis).generate({
+    outDir: dir,
+    ...(opts.target ? { target: opts.target } : {}),
+  } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.schema.ts'), file);
+  const mod = await import(file);
+  return mod.SelecttSchema.properties.n as Record<string, unknown>;
+}
+
+/** Compiled in strict mode, so an invented keyword fails here rather than being ignored. */
+function compile(schema: unknown) {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  return ajv.compile(schema as never);
+}
+
+const GRIN = '\u{1F600}'; // one code point, four bytes
+
+describe('a byte budget on a text column', () => {
+  it('states the ceiling as maxLength, which no draft spells in bytes', async () => {
+    const s = await emitted(col(), { checks: [{ expression: 'octet_length(n) <= 5' }] });
+    expect(s.maxLength).toBe(5);
+    expect(s.minLength, 'nothing invents a floor from a ceiling').toBeUndefined();
+    expect(Object.keys(s)).not.toContain('maxBytes');
+  });
+
+  it('refuses nothing Postgres accepted', async () => {
+    // Measured: Postgres took 'hello' and one emoji, and refused 'hellos' and two emoji.
+    const v = compile(await emitted(col(), { checks: [{ expression: 'octet_length(n) <= 5' }] }));
+    expect(v('hello'), 'five ascii, five bytes').toBe(true);
+    expect(v(GRIN), 'one emoji, one character, four bytes').toBe(true);
+    expect(v('hellos'), 'six ascii, six bytes, which Postgres refused').toBe(false);
+  });
+
+  it('says in prose what a character count cannot enforce, rather than pretending', async () => {
+    const s = await emitted(col(), { checks: [{ expression: 'octet_length(n) <= 5' }] });
+    const v = compile(s);
+    // Two emoji: two characters and eight bytes. Postgres refused the row and no character count
+    // can say so, so the schema takes it and names the budget it cannot check.
+    expect(v(GRIN.repeat(2))).toBe(true);
+    expect(String(s.description)).toContain('At most 5 bytes');
+  });
+
+  it('keeps the narrower of a byte budget and a character count', async () => {
+    // A byte ceiling of 5 and a character ceiling of 3 are two different measurements, and 3
+    // characters is the stricter statement about a string that is also at most 5 bytes.
+    const s = await emitted(col(), {
+      checks: [{ expression: 'octet_length(n) <= 5' }, { expression: 'length(n) <= 3' }],
+    });
+    expect(s.maxLength).toBe(3);
+  });
+
+  it('takes an exclusive bound down to the integer below it', async () => {
+    const s = await emitted(col(), { checks: [{ expression: 'octet_length(n) < 5' }] });
+    expect(s.maxLength).toBe(4);
+  });
+
+  it('emits no keyword for a floor, which no character count can state', async () => {
+    const s = await emitted(col(), { checks: [{ expression: 'octet_length(n) >= 10' }] });
+    expect(s.minLength).toBeUndefined();
+    expect(s.maxLength).toBeUndefined();
+  });
+});
+
+describe('a byte budget on a bytea column', () => {
+  it('caps the base64 string the value travels as', async () => {
+    const s = await emitted(blob(), { checks: [{ expression: 'octet_length(n) <= 5' }] });
+    expect(s.contentEncoding).toBe('base64');
+    // 4 * ceil(5 / 3) = 8, the padded length of five bytes.
+    expect(s.maxLength).toBe(8);
+  });
+
+  it('refuses nothing the column accepts, under either base64 spelling', async () => {
+    const v = compile(await emitted(blob(), { checks: [{ expression: 'octet_length(n) <= 5' }] }));
+    for (let n = 0; n <= 5; n++) {
+      const bytes = Buffer.alloc(n);
+      expect(v(bytes.toString('base64')), `${n} bytes, padded`).toBe(true);
+      expect(v(bytes.toString('base64url')), `${n} bytes, unpadded`).toBe(true);
+    }
+  });
+
+  it('catches an overflow the encoding is wide enough to show', async () => {
+    const v = compile(await emitted(blob(), { checks: [{ expression: 'octet_length(n) <= 5' }] }));
+    expect(v(Buffer.alloc(7).toString('base64')), 'seven bytes, twelve characters').toBe(false);
+    // The gap the prose names: six bytes encode to the same eight characters as five.
+    expect(v(Buffer.alloc(6).toString('base64')), 'six bytes, eight characters').toBe(true);
+  });
+
+  it('names the exact rule in prose, since the keyword is not it', async () => {
+    const s = await emitted(blob(), { checks: [{ expression: 'octet_length(n) <= 5' }] });
+    expect(String(s.description)).toContain('At most 5 bytes');
+    expect(String(s.description)).toContain('base64');
+  });
+
+  it('says the same thing in an OpenAPI 3.0 document, where base64 is a format', async () => {
+    const s = await emitted(blob(), {
+      target: 'openapi-3.0',
+      checks: [{ expression: 'octet_length(n) <= 5' }],
+    });
+    expect(s.format).toBe('byte');
+    expect(s.maxLength).toBe(8);
+    expect(s.contentEncoding, '3.0 has no such keyword and its Schema Object is closed').toBe(
+      undefined
+    );
+  });
+});
+
+describe('a byte budget on a column that cannot answer one', () => {
+  it('emits nothing for a MySQL varbinary', async () => {
+    const bin = col({ dbType: 'VARBINARY', shape: { kind: 'byteString', length: 8 } as never });
+    const s = await emitted(bin, { checks: [{ expression: 'octet_length(n) <= 5' }] });
+    // The column's own declared width survives; the CHECK adds nothing to it.
+    expect(s.maxLength).toBe(8);
+    expect(s.description).toBeUndefined();
+  });
+});

--- a/packages/generator-json-schema/test/shared-enums.spec.ts
+++ b/packages/generator-json-schema/test/shared-enums.spec.ts
@@ -1,0 +1,411 @@
+/**
+ * A shared enum, written once and referenced.
+ *
+ * Three emission sites and two answers, because a schema's home decides how a reference can be
+ * spelled. The table below is measured, not reasoned: `@seriousme/openapi-schema-validator` carries
+ * the real 3.0 and 3.1 meta-schemas, and each row was put in front of it.
+ *
+ *   | placement                                | 3.0                   | 3.1                     |
+ *   | ---------------------------------------- | --------------------- | ----------------------- |
+ *   | `components.schemas` + `#/components/...` | valid                 | valid                   |
+ *   | `$defs` in a schema + `#/$defs/...`       | INVALID, closed object| INVALID, `$ref` dangles |
+ *   | `anyOf: [{$ref}, {type:'null'}]`          | INVALID, no null type | valid                   |
+ *   | key `my.enum` / `my-enum` / `my_enum`     | valid                 | valid                   |
+ *   | key `my enum` / `a/b` / `Ünicode`         | INVALID               | INVALID                 |
+ *
+ * So a standalone per-table module uses `$defs`, an OpenAPI document uses `components.schemas`, and
+ * a nullable enum column in a 3.0 document keeps the inline enum it has always had.
+ *
+ * Nothing here trusts the emitted object either: the schemas are compiled with ajv in strict mode
+ * and real values are pushed through the indirection, because a `$ref` is a string until something
+ * resolves it.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import { Validator } from '@seriousme/openapi-schema-validator';
+import type { Analysis, Column, Enum, Table } from '@drzl/analyzer';
+import {
+  componentsDocument,
+  JsonSchemaGenerator,
+  openApiDocument,
+  tableSchemas,
+  type JsonSchemaTarget,
+  type Schema,
+} from '../src/index';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const MOOD = ['sad', 'ok', 'happy'];
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const moodCol = (name: string, over: Partial<Column> = {}) =>
+  col(name, { enumValues: [...MOOD], ...over });
+
+const table = (over: Partial<Table> & { name: string }): Table =>
+  ({ tsName: over.name, columns: [], unique: [], indexes: [], checks: [], ...over }) as Table;
+
+/** One table whose `mood` enum is on six columns, which is the case the plan item names. */
+const six = () =>
+  table({
+    name: 'people',
+    columns: [
+      col('id', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+      ...['m1', 'm2', 'm3', 'm4', 'm5', 'm6'].map((n) => moodCol(n)),
+    ],
+    primaryKey: { columns: ['id'] },
+  });
+
+const enums: Enum[] = [{ name: 'mood', values: [...MOOD] }];
+
+const analysisOf = (tables: Table[], es: Enum[] = enums): Analysis =>
+  ({ dialect: 'postgres', tables, enums: es, relations: [], issues: [] }) as never;
+
+/** Compiled in strict mode, so an unresolvable `$ref` throws here rather than being ignored. */
+const compile = (schema: unknown) =>
+  new Ajv2020({ strict: true, allErrors: true }).compile(schema as never);
+
+describe('a per-table module', () => {
+  it('writes the enum once under $defs and references it at every use', () => {
+    const s = tableSchemas(six(), { enums }).select;
+    expect(s.$defs).toEqual({ mood: { enum: MOOD } });
+    const props = s.properties as Record<string, Schema>;
+    for (const n of ['m1', 'm2', 'm3', 'm4', 'm5', 'm6']) {
+      expect(props[n], n).toEqual({ $ref: '#/$defs/mood' });
+    }
+  });
+
+  it('validates real values through the indirection, under ajv strict', () => {
+    const validate = compile(tableSchemas(six(), { enums }).select);
+    const row = (mood: unknown) => ({
+      id: 1,
+      m1: mood,
+      m2: 'ok',
+      m3: 'ok',
+      m4: 'ok',
+      m5: 'ok',
+      m6: 'ok',
+    });
+    expect(validate(row('happy')), 'a declared member').toBe(true);
+    expect(validate(row('furious')), 'not a member, refused through the $ref').toBe(false);
+    expect(validate(row(null)), 'a NOT NULL column').toBe(false);
+  });
+
+  it('leaves a single-use enum inline, since the indirection buys nothing', () => {
+    const t = table({ name: 't', columns: [col('id'), moodCol('m1')] });
+    const s = tableSchemas(t, { enums }).select;
+    expect(s.$defs).toBeUndefined();
+    expect((s.properties as Record<string, Schema>).m1).toEqual({ enum: MOOD });
+  });
+
+  it('spells a nullable use as anyOf, which is the one unambiguous 2020-12 form', () => {
+    const t = table({
+      name: 't',
+      columns: [moodCol('m1'), moodCol('m2', { nullable: true })],
+    });
+    const s = tableSchemas(t, { enums }).select;
+    const props = s.properties as Record<string, Schema>;
+    expect(props.m1).toEqual({ $ref: '#/$defs/mood' });
+    expect(props.m2).toEqual({ anyOf: [{ $ref: '#/$defs/mood' }, { type: 'null' }] });
+    const validate = compile(s);
+    expect(validate({ m1: 'ok', m2: null }), 'null on the nullable column').toBe(true);
+    expect(validate({ m1: null, m2: null }), 'null on the NOT NULL one').toBe(false);
+    expect(validate({ m1: 'ok', m2: 'furious' }), 'not a member, even beside null').toBe(false);
+  });
+
+  it('leaves an array of the enum referencing the element', () => {
+    const t = table({
+      name: 't',
+      columns: [moodCol('m1'), moodCol('m2', { arrayDimensions: 1 })],
+    });
+    const s = tableSchemas(t, { enums }).select;
+    expect((s.properties as Record<string, Schema>).m2).toEqual({
+      type: 'array',
+      items: { $ref: '#/$defs/mood' },
+    });
+    const validate = compile(s);
+    expect(validate({ m1: 'ok', m2: ['sad', 'happy'] })).toBe(true);
+    expect(validate({ m1: 'ok', m2: ['sad', 'furious'] })).toBe(false);
+  });
+
+  it('carries a $defs entry only where the schema really points at one', () => {
+    // `m2` is generated, so the insert schema drops it and the enum has one use left there. A plan
+    // scoped to the table rather than to the schema would leave a definition nothing references.
+    const t = table({
+      name: 't',
+      columns: [moodCol('m1'), moodCol('m2', { isGenerated: true })],
+    });
+    const built = tableSchemas(t, { enums });
+    expect(built.select.$defs, 'two uses on select').toEqual({ mood: { enum: MOOD } });
+    expect(built.insert.$defs, 'one use on insert').toBeUndefined();
+    expect((built.insert.properties as Record<string, Schema>).m1).toEqual({ enum: MOOD });
+  });
+
+  it('emits no $defs into a schema destined for a document, whichever version', () => {
+    // Both measured as broken: 3.0's Schema Object is closed, and 3.1 resolves a `$ref` against the
+    // document root, where `#/$defs/mood` names nothing.
+    for (const target of ['openapi-3.0', 'openapi-3.1'] as JsonSchemaTarget[]) {
+      const s = tableSchemas(six(), { enums, target });
+      expect(s.select.$defs, target).toBeUndefined();
+      expect(JSON.stringify(s.select), target).not.toContain('$ref');
+    }
+  });
+
+  it('leaves every enum inline when the analysis names none', () => {
+    const s = tableSchemas(six(), {}).select;
+    expect(s.$defs).toBeUndefined();
+    expect((s.properties as Record<string, Schema>).m1).toEqual({ enum: MOOD });
+  });
+
+  it('leaves an enum inline rather than inventing a key for a name that cannot be one', () => {
+    const s = tableSchemas(six(), { enums: [{ name: '///', values: [...MOOD] }] }).select;
+    expect(s.$defs).toBeUndefined();
+    expect((s.properties as Record<string, Schema>).m1).toEqual({ enum: MOOD });
+  });
+});
+
+/**
+ * The components fragment, which deliberately shares nothing.
+ *
+ * `componentsDocument` returns an object the caller spreads into a document, and a `$ref` is a
+ * promise about where the thing holding it is mounted: `#/components/schemas/mood` resolves once the
+ * fragment sits at exactly that path and nowhere else. So every entry stays self-contained, which is
+ * what lets a caller hand one schema to a validator on its own. Measured: ajv answers
+ * `can't resolve reference #/components/schemas/mood from id #` for a cross-referencing entry
+ * compiled alone, and `scripts/verify-packed.sh` compiles them exactly that way.
+ */
+describe('the components fragment', () => {
+  it('keeps every entry self-contained, and each one compiles on its own', () => {
+    const doc = componentsDocument([six()]);
+    expect(doc.schemas.mood, 'no definition the caller did not ask for').toBeUndefined();
+    const raw = JSON.stringify(doc);
+    expect(raw).not.toContain('$ref');
+    expect(raw).not.toContain('$defs');
+    for (const [name, schema] of Object.entries(doc.schemas)) {
+      expect(() => compile(structuredClone(schema)), name).not.toThrow();
+    }
+  });
+
+  it('is byte-for-byte what it was before enums could be shared', () => {
+    // The generator hands `analysis.enums` to the per-table modules and to the document, and to
+    // this deliberately not at all, so there is no option here to be wrong about.
+    const a = table({ name: 'a', columns: [moodCol('m1'), moodCol('m2')] });
+    const b = table({ name: 'b', columns: [moodCol('m')] });
+    const props = componentsDocument([a, b]).schemas.aSelect.properties as Record<string, Schema>;
+    expect(props.m1).toEqual({ enum: MOOD });
+    expect(props.m2).toEqual({ enum: MOOD });
+  });
+});
+
+describe('the OpenAPI document, against the real specification', () => {
+  const withEnums = () => [
+    table({
+      name: 'people',
+      columns: [
+        col('id', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+        moodCol('m1'),
+        moodCol('m2'),
+        moodCol('m3', { nullable: true }),
+      ],
+      primaryKey: { columns: ['id'] },
+    }),
+    table({
+      name: 'pets',
+      columns: [col('id', { tsType: 'number', dbType: 'INTEGER', integer: true }), moodCol('m1')],
+      primaryKey: { columns: ['id'] },
+    }),
+  ];
+
+  const verdict = async (target: JsonSchemaTarget) => {
+    const doc = openApiDocument(withEnums(), { target, enums });
+    const res = await new Validator().validate(structuredClone(doc) as never);
+    return { doc: doc as Record<string, any>, res };
+  };
+
+  it.each(['openapi-3.1', 'openapi-3.0'] as JsonSchemaTarget[])(
+    'is a valid %s document with the enum shared',
+    async (target) => {
+      const { doc, res } = await verdict(target);
+      expect(JSON.stringify(res.errors ?? [], null, 2)).toBe('[]');
+      expect(res.valid).toBe(true);
+      expect(doc.components.schemas.mood).toEqual({ enum: MOOD });
+    }
+  );
+
+  it('leaves no dangling reference, which the specification does not check', async () => {
+    for (const target of ['openapi-3.1', 'openapi-3.0'] as JsonSchemaTarget[]) {
+      const { doc } = await verdict(target);
+      const raw = JSON.stringify(doc);
+      const declared = new Set(Object.keys(doc.components.schemas));
+      const referenced = [...raw.matchAll(/"\$ref":"#\/components\/schemas\/([^"]+)"/g)].map(
+        (m) => m[1]
+      );
+      expect(referenced.length, `${target} references something`).toBeGreaterThan(0);
+      expect(
+        referenced.filter((r) => !declared.has(r)),
+        target
+      ).toEqual([]);
+    }
+  });
+
+  it('keeps a nullable enum inline in 3.0, where no spelling of the reference works', async () => {
+    // `type: 'null'` is not one of 3.0's six types, so `anyOf: [{$ref}, {type:'null'}]` makes the
+    // document invalid; and 3.0 defines every sibling of `$ref` to be ignored, so
+    // `{ $ref, nullable: true }` is a schema that silently refuses null. Inline is what is left,
+    // and it is what this generator already emitted.
+    const { doc } = await verdict('openapi-3.0');
+    const props = doc.components.schemas.peopleSelect.properties;
+    expect(props.m1).toEqual({ $ref: '#/components/schemas/mood' });
+    expect(props.m3).toEqual({ enum: MOOD, nullable: true });
+  });
+
+  it('uses anyOf for the same column in 3.1, where that spelling validates', async () => {
+    const { doc } = await verdict('openapi-3.1');
+    expect(doc.components.schemas.peopleSelect.properties.m3).toEqual({
+      anyOf: [{ $ref: '#/components/schemas/mood' }, { type: 'null' }],
+    });
+  });
+});
+
+/**
+ * What it costs, which is not always a saving and is measured rather than claimed.
+ *
+ * `{"$ref":"#/components/schemas/mood"}` is 36 bytes and `{"enum":["sad","ok","happy"]}` is 29, so
+ * the very shortest enum grows a document slightly. Measured over an OpenAPI 3.1 document, one
+ * table, n columns carrying the enum:
+ *
+ *   | enum                          | 1 col | 2 cols | 3 cols | 6 cols |
+ *   | ----------------------------- | ----- | ------ | ------ | ------ |
+ *   | 3 short values, `sad`/`ok`    |     0 |    +58 |    +70 |   +106 |
+ *   | 5 values, `draft`/`review`    |     0 |    -97 |   -178 |   -421 |
+ *   | 12 country codes              |     0 |   -147 |   -258 |   -591 |
+ *   | 20 long values                |     0 |  -1697 |  -2738 |  -5861 |
+ *
+ * The rule stays "two or more columns" rather than "wherever it saves bytes". The point of a shared
+ * definition is that the document names a type: a client generator reads `mood` once and emits one
+ * enum class, where six inline lists are six anonymous unions it cannot tell are the same thing. A
+ * threshold on the encoded length would make the output flip when somebody adds a value, and would
+ * withhold the name exactly where it is cheapest to carry.
+ */
+describe('what it costs', () => {
+  const bytes = (v: unknown) => JSON.stringify(v).length;
+  const many = (values: string[], n: number) =>
+    table({
+      name: 'people',
+      columns: [
+        col('id', { tsType: 'number', dbType: 'INTEGER', integer: true }),
+        ...Array.from({ length: n }, (_, i) => col(`m${i}`, { enumValues: values })),
+      ],
+      primaryKey: { columns: ['id'] },
+    });
+  const delta = (values: string[], n: number) => {
+    const t = [many(values, n)];
+    const named: Enum[] = [{ name: 'e', values }];
+    return (
+      bytes(openApiDocument(t, { target: 'openapi-3.1', enums: named })) -
+      bytes(openApiDocument(t, { target: 'openapi-3.1' }))
+    );
+  };
+
+  it('saves on every enum but the very shortest, and grows a little on that one', () => {
+    const short = ['sad', 'ok', 'happy'];
+    const real = ['draft', 'review', 'published', 'archived', 'deleted'];
+    expect(delta(short, 6), 'three short values, six columns').toBeGreaterThan(0);
+    expect(delta(real, 2), 'five values, two columns').toBeLessThan(0);
+    expect(delta(real, 6), 'five values, six columns').toBeLessThan(delta(real, 2));
+  });
+
+  it('costs nothing at all where nothing is shared, byte for byte', () => {
+    const t = table({ name: 't', columns: [col('id'), moodCol('m1')] });
+    expect(bytes(tableSchemas(t, { enums }))).toBe(bytes(tableSchemas(t, {})));
+    expect(bytes(openApiDocument([t], { enums }))).toBe(bytes(openApiDocument([t], {})));
+  });
+});
+
+describe('the emitted files', () => {
+  it('carries the reference into the module a consumer imports', async () => {
+    const dir = path.join(__dirname, '.tmp-shared-enums');
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.mkdir(dir, { recursive: true });
+    await new JsonSchemaGenerator(analysisOf([six()])).generate({
+      outDir: dir,
+      components: true,
+      document: { format: 'both' },
+      sharedEnums: true,
+    } as never);
+
+    const mod = await import(path.join(dir, `people.schema.ts?x=${Date.now()}`));
+    expect(mod.SelectpeopleSchema.$defs).toEqual({ mood: { enum: MOOD } });
+    expect(mod.SelectpeopleSchema.properties.m1).toEqual({ $ref: '#/$defs/mood' });
+    // Compiled from the file rather than from the object built in-process, since a schema is data
+    // all the way down and a keyword that never reached disk looks the same until something reads it.
+    const validate = compile(structuredClone(mod.SelectpeopleSchema));
+    expect(validate({ id: 1, m1: 'ok', m2: 'ok', m3: 'ok', m4: 'ok', m5: 'ok', m6: 'sad' })).toBe(
+      true
+    );
+    expect(validate({ id: 1, m1: 'nope', m2: 'ok', m3: 'ok', m4: 'ok', m5: 'ok', m6: 'ok' })).toBe(
+      false
+    );
+
+    const doc = JSON.parse(await fs.readFile(path.join(dir, 'openapi.json'), 'utf8'));
+    expect(doc.components.schemas.mood).toEqual({ enum: MOOD });
+    expect(doc.components.schemas.peopleSelect.properties.m1).toEqual({
+      $ref: '#/components/schemas/mood',
+    });
+    const res = await new Validator().validate(structuredClone(doc));
+    expect(JSON.stringify(res.errors ?? [], null, 2)).toBe('[]');
+
+    // The components fragment stays self-contained, so each entry still compiles alone.
+    const bundle = await import(path.join(dir, `components.ts?x=${Date.now()}`));
+    for (const [name, schema] of Object.entries(bundle.components.schemas)) {
+      expect(() => compile(structuredClone(schema)), name).not.toThrow();
+    }
+    expect(bundle.components.schemas.mood).toBeUndefined();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('leaves the per-table modules alone unless asked, and shares the document regardless', async () => {
+    // `$defs` is off by default because a `$ref` cannot survive being pulled out with its property:
+    // `properties[col]` compiled alone is a dangling reference, and reaching in like that is how a
+    // form builder reads one field and how `verify-packed.sh` checks these against a real Postgres.
+    // The document has no such consumer, because a document is only ever read whole.
+    const dir = path.join(__dirname, '.tmp-shared-enums-default');
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.mkdir(dir, { recursive: true });
+    await new JsonSchemaGenerator(analysisOf([six()])).generate({
+      outDir: dir,
+      document: { format: 'json' },
+    } as never);
+
+    const mod = await import(path.join(dir, `people.schema.ts?x=${Date.now()}`));
+    expect(mod.SelectpeopleSchema.$defs).toBeUndefined();
+    expect(mod.SelectpeopleSchema.properties.m1).toEqual({ enum: MOOD });
+    // The property on its own, which is what a `$ref` would break.
+    const one = compile(structuredClone(mod.SelectpeopleSchema.properties.m1));
+    expect(one('ok')).toBe(true);
+    expect(one('furious')).toBe(false);
+
+    const doc = JSON.parse(await fs.readFile(path.join(dir, 'openapi.json'), 'utf8'));
+    expect(doc.components.schemas.mood).toEqual({ enum: MOOD });
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('is what a $ref costs a per-property consumer, measured', () => {
+    // The failure the option exists to keep out of the default output.
+    const s = tableSchemas(six(), { enums }).select;
+    const property = (s.properties as Record<string, Schema>).m1;
+    expect(property).toEqual({ $ref: '#/$defs/mood' });
+    expect(() => compile(structuredClone(property))).toThrow(/can't resolve reference/);
+    // Whole, the same schema compiles and validates exactly as it did.
+    expect(() => compile(structuredClone(s))).not.toThrow();
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -25,6 +25,9 @@ import {
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
+  lengthCheckLabel,
+  lengthMeasure,
+  measureExpression,
   moduleFileName,
   moduleSpecifier,
   nonFiniteAccepted,
@@ -977,7 +980,7 @@ function renderTableSchemas(
   );
   const needsRows =
     rows.some((r) => rowCols.some((s) => s.has(r.left) && s.has(r.right))) ||
-    lengths.some((k) => rowCols.some((s) => s.has(k.column))) ||
+    tbHasLengthBranch(lengths, [insertCols, updateCols, selectCols]) ||
     (
       [
         [insertCols, 'insert'],
@@ -994,7 +997,7 @@ function renderTableSchemas(
       const own = parsedChecksFor(tbl);
       return (
         own.rows.some((r) => present.has(r.left) && present.has(r.right)) ||
-        own.lengths.some((k) => present.has(k.column)) ||
+        tbHasLengthBranch(own.lengths, [cs]) ||
         cs.some(
           (c) => tbNeedsCapKind(c) || tbNeedsNonFiniteKind(c) || tbNeedsDateKind(c, m, coerceDates)
         )
@@ -1212,8 +1215,27 @@ function tbCapExpr(c: Column, base: string, mode: Mode): string {
   return out.length ? `Type.Intersect([${base}, ${out.join(', ')}])` : base;
 }
 
+/**
+ * `length(col)` and `octet_length(col)` as intersection branches on the object.
+ *
+ * On the object rather than on the field, which is where TypeBox has to put them. The measurement
+ * depends on the column, so the column is looked up here and `lengthMeasure` answers it; see the
+ * ArkType generator, which resolves it the same way for the same reason.
+ */
+/**
+ * Whether any count clause lands on any of these column sets.
+ *
+ * The same question `tbLengthBranches` answers per set, asked once so the `Kind`/`TypeRegistry`
+ * import cannot be decided by a wider rule than the one that emits the branches. A count on a
+ * column whose shape answers none is dropped, so a condition testing only the column *name* would
+ * import two symbols nothing then uses.
+ */
+function tbHasLengthBranch(lengths: LengthCheck[], sets: Column[][]): boolean {
+  return sets.some((cols) => tbLengthBranches(lengths, cols).length > 0);
+}
+
 function tbLengthBranches(lengths: LengthCheck[], cols: Column[]): string[] {
-  const present = new Set(cols.map((c) => c.name));
+  const byName = new Map(cols.map((c) => [c.name, c]));
   const OPS: Record<LengthCheck['operator'], string> = {
     '>=': '>=',
     '>': '>',
@@ -1222,19 +1244,21 @@ function tbLengthBranches(lengths: LengthCheck[], cols: Column[]): string[] {
     '=': '===',
     '<>': '!==',
   };
-  return lengths
-    .filter((k) => present.has(k.column))
-    .map((k) => {
-      const v = `o[${JSON.stringify(k.column)}]`;
-      const msg = JSON.stringify(
-        `${k.name ? `${k.name}: ` : ''}length(${k.column}) ${k.operator} ${k.value}`
-      );
-      return `Type.Unsafe<unknown>({
+  return lengths.flatMap((k) => {
+    const col = byName.get(k.column);
+    const measure = col && lengthMeasure(col, k);
+    if (!measure) return [];
+    const v = `o[${JSON.stringify(k.column)}]`;
+    const msg = JSON.stringify(lengthCheckLabel(k));
+    const count = measureExpression(measure, v);
+    return [
+      `Type.Unsafe<unknown>({
     [Kind]: 'DrzlRowCheck',
     description: ${msg},
-    assert: (o: any) => o == null || ${v} == null || [...${v}].length ${OPS[k.operator]} ${k.value},
-  })`;
-    });
+    assert: (o: any) => o == null || ${v} == null || ${count} ${OPS[k.operator]} ${k.value},
+  })`,
+    ];
+  });
 }
 
 function tbWrapRows(

--- a/packages/generator-typebox/test/octet-length.spec.ts
+++ b/packages/generator-typebox/test/octet-length.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * `CHECK (octet_length(col) <= 5)` in TypeBox output.
+ *
+ * See the zod generator's file of the same name for the PGlite measurements this is written
+ * against. TypeBox carries the count in the registered kind the row checks use, for the reason
+ * `length.spec` gives: `maxLength` counts UTF-16 units, and a byte budget is a third measurement
+ * again.
+ */
+import { describe, it, expect } from 'vitest';
+import { TypeBoxGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Value } from '@sinclair/typebox/value';
+
+const GRIN = '\u{1F600}';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const blob = (name = 'blob') =>
+  col(name, { tsType: 'Uint8Array', dbType: 'BYTEA', shape: { kind: 'buffer' } as never });
+
+let seq = 0;
+let lastFile = '';
+
+async function schemasFor(columns: Column[], checks: unknown[]): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-octets');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  lastFile = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), lastFile);
+  return await import(lastFile);
+}
+
+describe('a byte budget on a text column', () => {
+  it('accepts and refuses exactly what Postgres did', async () => {
+    const m = await schemasFor([col('body')], [{ expression: 'octet_length(body) <= 5' }]);
+    expect(Value.Check(m.SelecttSchema, { body: 'hello' }), 'five ascii').toBe(true);
+    expect(Value.Check(m.SelecttSchema, { body: 'hellos' }), 'six ascii').toBe(false);
+    expect(Value.Check(m.SelecttSchema, { body: GRIN }), 'one emoji, four bytes').toBe(true);
+    expect(Value.Check(m.SelecttSchema, { body: GRIN.repeat(2) }), 'two emoji, eight bytes').toBe(
+      false
+    );
+  });
+
+  it('names the constraint in the branch description', async () => {
+    await schemasFor(
+      [col('body')],
+      [{ name: 'body_bytes', expression: 'octet_length(body) <= 5' }]
+    );
+    expect(await fs.readFile(lastFile, 'utf8')).toContain('body_bytes: octet_length(body) <= 5');
+  });
+});
+
+describe('a byte budget on a bytea column', () => {
+  it('counts the array, which is what Postgres counted', async () => {
+    const m = await schemasFor([blob()], [{ expression: 'octet_length(blob) <= 5' }]);
+    expect(Value.Check(m.SelecttSchema, { blob: new Uint8Array(5) })).toBe(true);
+    expect(Value.Check(m.SelecttSchema, { blob: new Uint8Array(6) })).toBe(false);
+  });
+});
+
+describe('a byte budget on a column that cannot answer one', () => {
+  it('emits nothing for a MySQL varbinary', async () => {
+    const bin = col('bin', {
+      dbType: 'VARBINARY',
+      shape: { kind: 'byteString', length: 8 } as never,
+    });
+    await schemasFor([bin], [{ expression: 'octet_length(bin) <= 5' }]);
+    expect(await fs.readFile(lastFile, 'utf8')).not.toContain('octet_length(bin)');
+  });
+
+  it('drags in no kind registration for a count it does not emit', async () => {
+    // The registered kind is imported only where a branch uses it, so `needsRows` and
+    // `tbLengthBranches` have to answer the same question. A customType column is the case that
+    // isolates it: it answers no count *and* declares no cap, so the import has no other reason.
+    const custom = col('c', { tsType: 'unknown', shape: { kind: 'custom' } as never });
+    await schemasFor([custom], [{ expression: 'octet_length(c) <= 5' }]);
+    const src = await fs.readFile(lastFile, 'utf8');
+    expect(src).not.toContain('octet_length(c)');
+    expect(src).not.toContain('TypeRegistry');
+  });
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -17,6 +17,9 @@ import {
   importSpecifier,
   insertColumns,
   isIntegerColumn,
+  lengthCheckLabel,
+  lengthMeasure,
+  measureExpression,
   nestedArmNotes,
   nestedNodeColumns,
   nestedSchemaName,
@@ -285,12 +288,14 @@ function vShapeExpr(c: Column, mode: Mode): string | undefined {
 }
 
 /**
- * `v.check(...)` actions for the `length(col)` constraints naming this column.
+ * `v.check(...)` actions for the `length(col)` and `octet_length(col)` constraints naming this
+ * column.
  *
- * Code points, because Postgres counts characters. See the zod generator.
+ * Code points for a character count, because Postgres counts characters; the UTF-8 encoding for a
+ * byte count on a string, and the array's own length for one on a `bytea`. See the zod generator,
+ * and `lengthMeasure` for the one place that choice is made.
  */
 function vLengthChecks(c: Column, lengths: LengthCheck[]): string[] {
-  if (c.arrayDimensions || c.shape) return [];
   const OPS: Record<LengthCheck['operator'], string> = {
     '>=': '>=',
     '>': '>',
@@ -301,11 +306,12 @@ function vLengthChecks(c: Column, lengths: LengthCheck[]): string[] {
   };
   return lengths
     .filter((k) => k.column === c.name)
-    .map((k) => {
-      const msg = JSON.stringify(
-        `${k.name ? `${k.name}: ` : ''}length(${c.name}) ${k.operator} ${k.value}`
-      );
-      return `v.check((val) => [...val].length ${OPS[k.operator]} ${k.value}, ${msg})`;
+    .flatMap((k) => {
+      const measure = lengthMeasure(c, k);
+      if (!measure) return [];
+      const msg = JSON.stringify(lengthCheckLabel(k));
+      const count = measureExpression(measure, 'val');
+      return [`v.check((val) => ${count} ${OPS[k.operator]} ${k.value}, ${msg})`];
     });
 }
 
@@ -344,7 +350,13 @@ function vExprForColumn(
   lengths: LengthCheck[] = []
 ): string {
   const shaped = vShapeExpr(c, mode);
-  if (shaped) return shaped;
+  if (shaped) {
+    // A shaped column takes no scalar comparison, but a `bytea` does take a byte count, which is
+    // the one clause `lengthMeasure` answers on a shape. Piped on here rather than folded into
+    // `vShapeExpr`, which describes the column and knows nothing about its constraints.
+    const shapeChecks = vLengthChecks(c, lengths);
+    return shapeChecks.length ? `v.pipe(${shaped}, ${shapeChecks.join(', ')})` : shaped;
+  }
   // `CHECK (status IN ('a', 'b'))` constrains the column to a set, which is what a picklist is.
   const set = sets.find((x) => x.column === c.name);
   if (set) {

--- a/packages/generator-valibot/test/octet-length.spec.ts
+++ b/packages/generator-valibot/test/octet-length.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * `CHECK (octet_length(col) <= 5)` in valibot output.
+ *
+ * See the zod generator's file of the same name for the PGlite measurements this is written
+ * against. The row that matters is two emoji: two characters and eight bytes, refused by Postgres
+ * and accepted by any cap that counts characters.
+ */
+import { describe, it, expect } from 'vitest';
+import { ValibotGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import * as v from 'valibot';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const GRIN = '\u{1F600}';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const blob = (name = 'blob') =>
+  col(name, { tsType: 'Uint8Array', dbType: 'BYTEA', shape: { kind: 'buffer' } as never });
+
+let seq = 0;
+let lastFile = '';
+
+async function schemasFor(columns: Column[], checks: unknown[]): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-octets');
+  await fs.mkdir(dir, { recursive: true });
+  await new ValibotGenerator(analysis).generate({ outDir: dir } as never);
+  lastFile = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.valibot.ts'), lastFile);
+  return await import(lastFile);
+}
+
+const ok = (schema: any, value: unknown) => v.safeParse(schema, value).success;
+
+describe('a byte budget on a text column', () => {
+  it('accepts and refuses exactly what Postgres did', async () => {
+    const m = await schemasFor([col('body')], [{ expression: 'octet_length(body) <= 5' }]);
+    expect(ok(m.SelecttSchema, { body: 'hello' }), 'five ascii').toBe(true);
+    expect(ok(m.SelecttSchema, { body: 'hellos' }), 'six ascii').toBe(false);
+    expect(ok(m.SelecttSchema, { body: GRIN }), 'one emoji, four bytes').toBe(true);
+    expect(ok(m.SelecttSchema, { body: GRIN.repeat(2) }), 'two emoji, eight bytes').toBe(false);
+  });
+
+  it('names the constraint in the failure, exactly as the ledger records it', async () => {
+    const m = await schemasFor(
+      [col('body')],
+      [{ name: 'body_bytes', expression: 'octet_length(body) <= 5' }]
+    );
+    const r = v.safeParse(m.SelecttSchema, { body: 'hellos' });
+    expect(r.success).toBe(false);
+    expect(r.issues![0].message).toBe('body_bytes: octet_length(body) <= 5');
+  });
+});
+
+describe('a byte budget on a bytea column', () => {
+  it('counts the array, which is what Postgres counted', async () => {
+    const m = await schemasFor([blob()], [{ expression: 'octet_length(blob) <= 5' }]);
+    expect(ok(m.SelecttSchema, { blob: new Uint8Array(5) })).toBe(true);
+    expect(ok(m.SelecttSchema, { blob: new Uint8Array(6) })).toBe(false);
+  });
+
+  it('pipes the count onto the shaped schema rather than replacing it', async () => {
+    const m = await schemasFor([blob()], [{ expression: 'octet_length(blob) <= 5' }]);
+    // The instance check survives, so a string of five characters is still not a bytea.
+    expect(ok(m.SelecttSchema, { blob: 'hello' })).toBe(false);
+    expect(await fs.readFile(lastFile, 'utf8')).toContain('v.instance(Uint8Array)');
+  });
+});
+
+describe('a byte budget on a column that cannot answer one', () => {
+  it('emits nothing for a MySQL varbinary', async () => {
+    const bin = col('bin', {
+      dbType: 'VARBINARY',
+      shape: { kind: 'byteString', length: 8 } as never,
+    });
+    await schemasFor([bin], [{ expression: 'octet_length(bin) <= 5' }]);
+    expect(await fs.readFile(lastFile, 'utf8')).not.toContain('octet_length(bin)');
+  });
+});

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -31,6 +31,9 @@ import {
   importSpecifier,
   insertColumns,
   isIntegerColumn,
+  lengthCheckLabel,
+  lengthMeasure,
+  measureExpression,
   moduleFileName,
   moduleSpecifier,
   nestedArmNotes,
@@ -166,13 +169,15 @@ function foldedIntoBounds(c: Column, checks: ColumnCheck[]): Set<ColumnCheck> {
  * points at the thing in the schema that caused it.
  */
 /**
- * `.refine()` calls for the `length(col)` constraints naming this column.
+ * `.refine()` calls for the `length(col)` and `octet_length(col)` constraints naming this column.
  *
- * Counted in code points, because Postgres counts characters. The same reason `varchar(n)` is not
- * `.max(n)`: `.length` is UTF-16 units and would refuse text the database accepts.
+ * A character count is counted in code points, because Postgres counts characters. The same reason
+ * `varchar(n)` is not `.max(n)`: `.length` is UTF-16 units and would refuse text the database
+ * accepts. A byte count is the UTF-8 encoding of a string and the plain `.length` of a `bytea`'s
+ * Uint8Array, which are two different expressions for the same SQL function. `lengthMeasure`
+ * decides which, once per column, and the constraint ledger asks it the same question.
  */
 function lengthRefinements(c: Column, lengths: LengthCheck[]): string {
-  if (c.arrayDimensions || c.shape) return [].join('');
   const OPS: Record<LengthCheck['operator'], string> = {
     '>=': '>=',
     '>': '>',
@@ -184,10 +189,11 @@ function lengthRefinements(c: Column, lengths: LengthCheck[]): string {
   return lengths
     .filter((k) => k.column === c.name)
     .map((k) => {
-      const msg = JSON.stringify(
-        `${k.name ? `${k.name}: ` : ''}length(${c.name}) ${k.operator} ${k.value}`
-      );
-      return `.refine((v) => [...v].length ${OPS[k.operator]} ${k.value}, { message: ${msg} })`;
+      const measure = lengthMeasure(c, k);
+      if (!measure) return '';
+      const msg = JSON.stringify(lengthCheckLabel(k));
+      const count = measureExpression(measure, 'v');
+      return `.refine((v) => ${count} ${OPS[k.operator]} ${k.value}, { message: ${msg} })`;
     })
     .join('');
 }

--- a/packages/generator-zod/test/octet-length.spec.ts
+++ b/packages/generator-zod/test/octet-length.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * `CHECK (octet_length(col) <= 5)`, which is a byte budget rather than a character count.
+ *
+ * Measured against PostgreSQL 17.5 through PGlite, on the two column types the expression is legal
+ * on, with the emitted schema asked the same four questions:
+ *
+ *   | value                       | `text` with `octet_length(t) <= 5` | a character cap of 5 |
+ *   | --------------------------- | ---------------------------------- | -------------------- |
+ *   | `'hello'`, 5 ascii          | accepted                           | accepts              |
+ *   | `'hellos'`, 6 ascii         | REFUSED                            | refuses              |
+ *   | one emoji, 4 bytes          | accepted                           | accepts              |
+ *   | two emoji, 8 bytes          | REFUSED                            | **accepts**          |
+ *
+ * The last row is the whole point: two emoji are two characters and eight bytes, so a schema that
+ * read `octet_length` as one more spelling of `length` takes a write the column refuses. And on a
+ * `bytea`, where `octet_length(b)` and `length(b)` are the same number, five bytes insert and six
+ * do not.
+ *
+ * The predicate is the same one the MySQL TEXT byte budget already used, so this is that machinery
+ * reached from a CHECK rather than a second copy of it.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const GRIN = '\u{1F600}'; // one code point, four UTF-8 bytes, two UTF-16 units
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const blob = (name = 'blob') =>
+  col(name, { tsType: 'Uint8Array', dbType: 'BYTEA', shape: { kind: 'buffer' } as never });
+
+let seq = 0;
+
+async function schemasFor(columns: Column[], checks: unknown[]): Promise<Record<string, any>> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-octets');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return await import(file);
+}
+
+describe('a byte budget on a text column', () => {
+  it('accepts and refuses exactly what Postgres did', async () => {
+    const m = await schemasFor([col('body')], [{ expression: 'octet_length(body) <= 5' }]);
+    const f = m.SelecttSchema.shape.body;
+    expect(f.safeParse('hello').success, 'five ascii, which Postgres took').toBe(true);
+    expect(f.safeParse('hellos').success, 'six ascii, which Postgres refused').toBe(false);
+    expect(f.safeParse(GRIN).success, 'one emoji, four bytes, which Postgres took').toBe(true);
+    expect(
+      f.safeParse(GRIN.repeat(2)).success,
+      'two emoji, eight bytes, which Postgres refused and a character cap would take'
+    ).toBe(false);
+  });
+
+  it('measures bytes rather than characters or UTF-16 units', async () => {
+    const m = await schemasFor([col('body')], [{ expression: 'octet_length(body) <= 5' }]);
+    // Three characters, six UTF-16 units, twelve bytes. Every count but the byte one is inside 5.
+    expect(m.SelecttSchema.shape.body.safeParse(GRIN.repeat(3)).success).toBe(false);
+  });
+
+  it('names the constraint in the failure, exactly as the ledger records it', async () => {
+    const m = await schemasFor(
+      [col('body')],
+      [{ name: 'body_bytes', expression: 'octet_length(body) <= 5' }]
+    );
+    const r = m.SelecttSchema.shape.body.safeParse('hellos');
+    expect(r.success).toBe(false);
+    expect(r.error.issues[0].message).toBe('body_bytes: octet_length(body) <= 5');
+  });
+
+  it('leaves a nullable column taking null, because a CHECK passes on NULL', async () => {
+    const m = await schemasFor(
+      [col('body', { nullable: true })],
+      [{ expression: 'octet_length(body) <= 5' }]
+    );
+    expect(m.SelecttSchema.shape.body.safeParse(null).success).toBe(true);
+    expect(m.SelecttSchema.shape.body.safeParse('hellos').success).toBe(false);
+  });
+});
+
+describe('a byte budget on a bytea column', () => {
+  it('counts the array, which is what Postgres counted', async () => {
+    const m = await schemasFor([blob()], [{ expression: 'octet_length(blob) <= 5' }]);
+    const f = m.SelecttSchema.shape.blob;
+    expect(f.safeParse(new Uint8Array(5)).success, 'five bytes, which Postgres took').toBe(true);
+    expect(f.safeParse(new Uint8Array(6)).success, 'six bytes, which Postgres refused').toBe(false);
+    expect(f.safeParse(new Uint8Array(0)).success, 'the empty value, which Postgres took').toBe(
+      true
+    );
+  });
+
+  it('reads length() on a bytea as bytes too, which is what Postgres does', async () => {
+    // Measured: `length(b)` and `octet_length(b)` are the same number on a bytea, and
+    // `char_length(bytea)` is not a function Postgres has.
+    const m = await schemasFor([blob()], [{ expression: 'length(blob) <= 5' }]);
+    expect(m.SelecttSchema.shape.blob.safeParse(new Uint8Array(6)).success).toBe(false);
+  });
+
+  it('does not spread the array, which would count differently and cost the copy', async () => {
+    const src = await fs.readFile(
+      path.join(__dirname, '.tmp-octets', `t-${process.pid}-${seq - 1}.ts`),
+      'utf8'
+    );
+    expect(src).toContain('v.length <=');
+    expect(src).not.toContain('[...v].length');
+  });
+});
+
+describe('a byte budget on a column that cannot answer one', () => {
+  it('emits nothing for a MySQL varbinary, whose bytes JavaScript cannot see', async () => {
+    // The value arrives as a string produced by a lossy decode: `<ff ff ff>` from a varbinary(3)
+    // comes back as three code points that re-encode to nine bytes. Neither count is the server's.
+    const bin = col('bin', {
+      dbType: 'VARBINARY',
+      shape: { kind: 'byteString', length: 8 } as never,
+    });
+    const m = await schemasFor([bin], [{ expression: 'octet_length(bin) <= 5' }]);
+    const src = await fs.readFile(
+      path.join(__dirname, '.tmp-octets', `t-${process.pid}-${seq - 1}.ts`),
+      'utf8'
+    );
+    expect(src).not.toContain('octet_length(bin)');
+    // Still a working schema, and still carrying the column's own declared width.
+    expect(m.SelecttSchema.shape.bin.safeParse('abc').success).toBe(true);
+  });
+
+  it('emits nothing for an array, which has no bytes to count', async () => {
+    await schemasFor(
+      [col('tags', { arrayDimensions: 1 })],
+      [{ expression: 'octet_length(tags) <= 5' }]
+    );
+    const src = await fs.readFile(
+      path.join(__dirname, '.tmp-octets', `t-${process.pid}-${seq - 1}.ts`),
+      'utf8'
+    );
+    expect(src).not.toContain('octet_length(tags)');
+  });
+});

--- a/packages/validation-core/README.md
+++ b/packages/validation-core/README.md
@@ -53,9 +53,15 @@ Shared interfaces and helpers used by validation generators.
 - CHECK constraints (shared by every generator that reads them)
   - `parseCheck(expression, name)` -> the parts of a `CHECK` that can be stated with certainty:
     column comparisons, `BETWEEN`, `IN (...)`, top-level `AND`, `length()`/`char_length()`,
-    `cardinality()`/`array_length(col, 1)`, and comparisons between two columns. A disjunction, a
-    negation, `octet_length`, an unrecognised function call and a regex match are all refused
-    whole rather than half-applied.
+    `octet_length()`, `cardinality()`/`array_length(col, 1)`, and comparisons between two columns.
+    A negation, an unrecognised function call and a regex match are all refused whole rather than
+    half-applied, and a disjunction is read only where the whole of it pins one column to a set.
+  - `lengthMeasure(column, check)` -> how to answer a count on a given column, as one of
+    `'codePoints'`, `'utf8Bytes'` or `'byteLength'`, or nothing where no expression answers it.
+    The unit is on the check and the answer needs the column too: measured on PostgreSQL 17.5,
+    `length()` is the character count on a `text` and the byte count on a `bytea`, and
+    `char_length(bytea)` is not a function that exists. `measureExpression(measure, variable)`
+    renders it and `lengthCheckLabel(check)` renders the message the ledger keys on.
   - `COLUMN_FORMATS` -> patterns for the column formats that are expressible. Only `numeric` is:
     Postgres accepts `today`, `January 8, 1999` and `allballs`, so a date or time pattern would
     reject rows the database takes.

--- a/packages/validation-core/src/checks.ts
+++ b/packages/validation-core/src/checks.ts
@@ -65,7 +65,8 @@ export interface RowCheck {
 }
 
 /**
- * A constraint on a column's *character* count, from `CHECK (length(name) > 3)`.
+ * A constraint on a count derived from a column's value, from `CHECK (length(name) > 3)` and
+ * `CHECK (octet_length(blob) <= 5)`.
  *
  * Kept apart from `ColumnCheck` because it is not a comparison of the value: it compares a count
  * derived from it, and the count Postgres takes is code points rather than UTF-16 units. See
@@ -76,7 +77,109 @@ export interface LengthCheck {
   operator: ColumnCheck['operator'];
   /** Decimal, as text, matching how the other bounds are carried. */
   value: string;
+  /**
+   * Which count the expression asked for.
+   *
+   * Absent on a pre-1.x parse, where every count was a character count, so a consumer reading this
+   * treats `undefined` as `'characters'`. `lengthMeasure` is the one place that decision is made.
+   *
+   * This is *not* the whole answer, because the same function means different things on different
+   * column types. Measured on PostgreSQL 17.5 through PGlite, on a `text` holding three emoji and
+   * a `bytea` holding six bytes:
+   *
+   *   | expression        | text | bytea          |
+   *   | ----------------- | ---- | -------------- |
+   *   | `octet_length(x)` | 12   | 6              |
+   *   | `length(x)`       | 3    | 6              |
+   *   | `char_length(x)`  | 3    | does not exist |
+   *
+   * So the unit says what the *expression* asked for and `lengthMeasure` says how to answer it for
+   * a given column.
+   */
+  unit?: 'characters' | 'bytes';
   name?: string;
+}
+
+/**
+ * How a `LengthCheck` is answered in JavaScript, once the column it names is known.
+ *
+ * Three answers, and no two of them agree on the same value:
+ *
+ *   `codePoints`   `[...v].length`                              a character count
+ *   `utf8Bytes`    `new TextEncoder().encode(v).length`         a byte count of a string
+ *   `byteLength`   `v.length`, on a Uint8Array                  a byte count of a binary payload
+ *
+ * `v.length` on a *string* is none of them: it counts UTF-16 units, which is 6 for the three emoji
+ * whose character count is 3 and whose byte count is 12.
+ */
+export type LengthMeasure = 'codePoints' | 'utf8Bytes' | 'byteLength';
+
+/**
+ * How to answer a count on this column, or nothing where no expression answers it.
+ *
+ * The one place the column type and the expression meet, held here rather than in each generator so
+ * the emitted predicate and the constraint ledger cannot disagree about what is enforced.
+ *
+ * Three refusals, each because the count would be a different measurement than the database took:
+ *
+ * - **An array.** Postgres has no `length(anyarray)`; `cardinality` is the array's own count and is
+ *   carried separately.
+ * - **A byte-string column**, MySQL's `binary(n)`/`varbinary(n)`. It arrives as a string produced by
+ *   a lossy decode, so neither its code points nor their UTF-8 re-encoding is the server's byte
+ *   count: `<ff ff ff>` from a `varbinary(3)` comes back as 3 code points that re-encode to 9
+ *   bytes. See `ColumnShape`.
+ * - **Anything that is not a string or a binary payload.** `length` is defined for text, bytea and
+ *   bit strings, so a count on a number column cannot come from a schema the database accepted, and
+ *   spreading a number with `[...v]` would throw rather than fail.
+ *
+ * A `bytea` answers both functions with the same number, which is why the unit is not consulted
+ * there. `char_length(bytea)` is the one spelling that would break that, and Postgres does not have
+ * it: `function char_length(bytea) does not exist`, measured.
+ */
+export function lengthMeasure(
+  column: { tsType?: string; arrayDimensions?: number; shape?: { kind: string } },
+  check: LengthCheck
+): LengthMeasure | undefined {
+  if (column.arrayDimensions) return undefined;
+  if (column.shape?.kind === 'buffer') return 'byteLength';
+  if (column.shape) return undefined;
+  if (column.tsType !== 'string') return undefined;
+  return check.unit === 'bytes' ? 'utf8Bytes' : 'codePoints';
+}
+
+/**
+ * The JavaScript expression that takes one of the three measurements, over a named variable.
+ *
+ * A function of the variable name rather than a constant, because the five validation generators
+ * put the count in three different places: zod and valibot pipe the value itself, while ArkType and
+ * TypeBox reach it off the row object as `o["blob"]`. `CODEPOINT_LENGTH` is the fixed-variable
+ * spelling of the first arm and stays for the call sites that already use it.
+ */
+export function measureExpression(measure: LengthMeasure, variable: string): string {
+  switch (measure) {
+    case 'codePoints':
+      return `[...${variable}].length`;
+    case 'utf8Bytes':
+      return `new TextEncoder().encode(${variable}).length`;
+    case 'byteLength':
+      // A Uint8Array's own `length` is its byte count, unlike a string's, which counts UTF-16
+      // units. Asserted in `test/octet-length.spec.ts` rather than assumed.
+      return `${variable}.length`;
+  }
+}
+
+/**
+ * A count constraint as the sentence every emitted schema attaches and the ledger keys on.
+ *
+ * Held here rather than spelled out in each generator, because the constraint error map matches an
+ * issue's message against this string exactly: the two drifting by one character is a map that
+ * silently answers nothing. `char_length` is normalised to `length`, as it always has been, since
+ * the two are the same function in Postgres.
+ */
+export function lengthCheckLabel(check: LengthCheck): string {
+  const fn = check.unit === 'bytes' ? 'octet_length' : 'length';
+  const rule = `${fn}(${check.column}) ${check.operator} ${check.value}`;
+  return check.name ? `${check.name}: ${rule}` : rule;
 }
 
 /**
@@ -126,16 +229,20 @@ export type ParsedCheck =
 
 const COMPARISON = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(>=|<=|<>|!=|>|<|=)\s*(.+?)\s*$/;
 const IN_LIST = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s+IN\s*\((.+)\)\s*$/i;
-// `length` and `char_length` are the same function in Postgres and both count characters.
-// `octet_length` is deliberately absent: it counts bytes, which depends on the encoding and
-// cannot be derived from a JavaScript string without choosing one.
+// `length` and `char_length` are the same function in Postgres and both count characters *on a
+// text column*; on a `bytea` `length` is the byte count and `char_length` does not exist. That
+// second half is resolved by `lengthMeasure` rather than here, since the expression alone does not
+// say what the column is.
+// `octet_length` is the byte count on both, and is read as its own unit rather than as a third
+// spelling of `length`: a character cap standing in for a byte budget accepts a multi-byte value
+// the column refuses.
 // `cardinality(a)` is the element count. `array_length(a, 1)` is the length of the first
 // dimension, which is the same number for a one-dimensional array; any other dimension is not an
 // element count and is refused.
 const CARDINALITY_OF =
   /^\s*(?:cardinality\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)|array_length\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*1\s*\))\s*(>=|<=|<>|!=|>|<|=)\s*(\d+)\s*$/i;
 const LENGTH_OF =
-  /^\s*(?:length|char_length)\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)\s*(>=|<=|<>|!=|>|<|=)\s*(\d+)\s*$/i;
+  /^\s*(length|char_length|octet_length)\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)\s*(>=|<=|<>|!=|>|<|=)\s*(\d+)\s*$/i;
 
 /** What a SQL identifier is made of, and so what does and does not end a keyword. */
 const WORD = /[A-Za-z0-9_]/;
@@ -593,16 +700,17 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
   if (IS_BOOLEAN.test(expr))
     return { ok: false, reason: 'a boolean IS test, whose literal this version does not read' };
 
-  // `length(col) <op> n`: a character-count bound. The only function call this parser reads, and
-  // it is read rather than refused because the mapping is exact, which is more than can be said
-  // for the others: see the skip list in the docs.
+  // `length(col) <op> n` and `octet_length(col) <op> n`: a bound on a count derived from the value.
+  // The only function calls this parser reads, and they are read rather than refused because the
+  // mapping is exact, which is more than can be said for the others: see the skip list in the docs.
   const lengthOf = expr.match(LENGTH_OF);
   if (lengthOf) {
-    const op = lengthOf[2] === '!=' ? '<>' : (lengthOf[2] as ColumnCheck['operator']);
+    const op = lengthOf[3] === '!=' ? '<>' : (lengthOf[3] as ColumnCheck['operator']);
+    const unit = lengthOf[1]!.toLowerCase() === 'octet_length' ? 'bytes' : 'characters';
     return {
       ok: true,
       checks: [],
-      lengths: [{ column: lengthOf[1], operator: op, value: lengthOf[3], name }],
+      lengths: [{ column: lengthOf[2], operator: op, value: lengthOf[4], unit, name }],
     };
   }
 

--- a/packages/validation-core/src/constraints.ts
+++ b/packages/validation-core/src/constraints.ts
@@ -29,11 +29,12 @@
  */
 import type { Column, ForeignKey, Key, Table } from '@drzl/analyzer';
 import {
+  lengthCheckLabel,
+  lengthMeasure,
   parseCheck,
   type CardinalityCheck,
   type ColumnCheck,
   type ColumnSet,
-  type LengthCheck,
   type NullCheck,
   type RowCheck,
 } from './checks.js';
@@ -57,9 +58,8 @@ function setText(k: ColumnSet): string {
     `${k.column} IN (${k.values.map((v) => literalText(v, k.kind)).join(', ')})`
   );
 }
-function lengthText(k: LengthCheck): string {
-  return labelled(k.name, `length(${k.column}) ${k.operator} ${k.value}`);
-}
+/** Re-exported spelling, so nothing here can render a count differently from a generator. */
+const lengthText = lengthCheckLabel;
 function cardinalityText(k: CardinalityCheck): string {
   return labelled(k.name, `cardinality(${k.column}) ${k.operator} ${k.value}`);
 }
@@ -68,6 +68,32 @@ function rowText(k: RowCheck): string {
 }
 function nullText(k: NullCheck): string {
   return labelled(k.name, `${k.column} IS ${k.notNull ? 'NOT NULL' : 'NULL'}`);
+}
+
+/**
+ * What a shaped column is, for a sentence about a count it cannot answer.
+ *
+ * The same vocabulary `drzl doctor` uses, so a reader meeting a constraint in both places meets one
+ * noun for it. Every `ColumnShape` kind has an arm, so a shape added later reads as "a structured"
+ * rather than as a wrong noun.
+ */
+function shapeArticle(c: Column): string {
+  switch (c.shape?.kind) {
+    case 'json':
+      return 'a JSON';
+    case 'buffer':
+      return 'a binary';
+    case 'numberVector':
+      return 'a vector';
+    case 'bitstring':
+      return 'a bit-string';
+    case 'byteString':
+      return 'a byte-string';
+    case 'custom':
+      return 'a customType';
+    default:
+      return 'a structured';
+  }
 }
 
 /**
@@ -232,7 +258,20 @@ export function classifyTableChecks(table: Table): ClassifiedCheck[] {
       });
     }
     for (const l of parsed.lengths ?? []) {
-      place(l.column, lengthText(l), takesScalarChecks, notScalar);
+      // Not the scalar guard the comparisons use. A count is answerable on a `bytea`, which is a
+      // shaped column, and unanswerable on a `varbinary(n)`, which is not; `lengthMeasure` is the
+      // one place that distinction is made and every generator asks it the same question.
+      place(
+        l.column,
+        lengthText(l),
+        (c) => lengthMeasure(c, l) !== undefined,
+        (c) =>
+          c.arrayDimensions
+            ? `"${c.name}" is an array, so it has no ${l.unit === 'bytes' ? 'bytes' : 'characters'} to count`
+            : c.shape
+              ? `"${c.name}" is ${shapeArticle(c)} column, whose ${l.unit === 'bytes' ? 'byte' : 'character'} count in JavaScript is not the one the database took`
+              : `"${c.name}" is not a string, so it has no ${l.unit === 'bytes' ? 'bytes' : 'characters'} to count`
+      );
     }
     for (const a of parsed.cardinalities ?? []) {
       place(

--- a/packages/validation-core/test/checks.spec.ts
+++ b/packages/validation-core/test/checks.spec.ts
@@ -99,11 +99,10 @@ describe('what it refuses, and why that matters', () => {
   });
 
   it('refuses a function call it cannot map exactly', () => {
-    // `length` is read, because a character count maps exactly. These do not: `lower` would need
-    // a locale to be faithful, and `octet_length` counts bytes, which depends on the encoding and
-    // cannot be derived from a JavaScript string without picking one.
+    // `length` and `octet_length` are read, because each maps exactly onto one JavaScript
+    // measurement: see `test/octet-length.spec.ts`. These do not: `lower` would need a locale to
+    // be faithful, and `abs` is arithmetic on a value this parser never evaluates.
     expect(rejected("lower(name) = 'x'")).toBeTruthy();
-    expect(rejected('octet_length(name) > 3')).toBeTruthy();
     expect(rejected('abs(n) > 3')).toBeTruthy();
   });
 
@@ -250,15 +249,17 @@ describe('row-level comparisons', () => {
 });
 
 describe('character-count constraints', () => {
-  // The one function call this parser reads, because the mapping is exact. Counted in code
-  // points by the generators, since Postgres counts characters and `.length` counts UTF-16 units.
+  // Counted in code points by the generators, since Postgres counts characters and `.length`
+  // counts UTF-16 units. `octet_length` is the byte-count sibling and has its own file.
   it('reads length() and char_length() alike', () => {
     for (const e of ['length(name) > 3', 'char_length(name) > 3', 'LENGTH(name) > 3']) {
       const r = parseCheck(e, 'min_name');
       expect(r.ok, e).toBe(true);
       if (!r.ok) continue;
       expect(r.checks, 'not a value comparison').toHaveLength(0);
-      expect(r.lengths).toEqual([{ column: 'name', operator: '>', value: '3', name: 'min_name' }]);
+      expect(r.lengths).toEqual([
+        { column: 'name', operator: '>', value: '3', unit: 'characters', name: 'min_name' },
+      ]);
     }
   });
 

--- a/packages/validation-core/test/octet-length.spec.ts
+++ b/packages/validation-core/test/octet-length.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * `CHECK (octet_length(col) <= n)`: a byte budget declared as a constraint.
+ *
+ * The measurements this file is written against were taken on PostgreSQL 17.5 through PGlite, and
+ * they are the whole reason the parser needs a `unit` rather than one more operator:
+ *
+ *   | expression            | `text` holding 3 emoji | `bytea` holding 6 bytes |
+ *   | --------------------- | ---------------------- | ----------------------- |
+ *   | `octet_length(x)`     | 12                     | 6                       |
+ *   | `length(x)`           | 3                      | 6                       |
+ *   | `char_length(x)`      | 3                      | does not exist          |
+ *
+ * So `length` is the *character* count on a text column and the *byte* count on a bytea one, and
+ * `octet_length` is the byte count on both. A parser that read `octet_length` as one more spelling
+ * of `length` would emit a character cap for a byte budget, which on a multi-byte string accepts a
+ * value the column refuses. The three JavaScript expressions that answer each of them are asserted
+ * below, because "`.length` on a Uint8Array is a byte count" is exactly the kind of thing that is
+ * obviously true and worth measuring anyway.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Column, Table } from '@drzl/analyzer';
+import { lengthCheckLabel, lengthMeasure, parseCheck, type LengthCheck } from '../src/checks';
+import { classifyTableChecks, tableConstraints } from '../src/constraints';
+import { columnMetaFacts, tableMetaFacts } from '../src/meta';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const blobCol = (name = 'blob') =>
+  col(name, { tsType: 'Uint8Array', dbType: 'BYTEA', sqlType: 'bytea', shape: { kind: 'buffer' } });
+
+const table = (cols: Column[], checks: { name?: string; expression: string }[] = []): Table =>
+  ({
+    name: 'files',
+    tsName: 'files',
+    columns: cols,
+    unique: [],
+    indexes: [],
+    checks,
+  }) as Table;
+
+const lengths = (expr: string): LengthCheck[] => {
+  const r = parseCheck(expr);
+  expect(r.ok, `expected to parse: ${expr}`).toBe(true);
+  return r.ok ? (r.lengths ?? []) : [];
+};
+
+describe('the three counts, as JavaScript answers them', () => {
+  const emoji = '\u{1F600}\u{1F600}\u{1F600}';
+
+  it('matches what Postgres reported for the same values', () => {
+    // Postgres: octet_length = 12, length = char_length = 3.
+    expect(new TextEncoder().encode(emoji).length).toBe(12);
+    expect([...emoji].length).toBe(3);
+    // The one that is neither, and the reason no count here is spelled `.length` on a string.
+    expect(emoji.length).toBe(6);
+  });
+
+  it('measures a Uint8Array in bytes, which is what Postgres counts for a bytea', () => {
+    // Postgres: octet_length(b) = length(b) = 6 for these bytes.
+    const bytes = new Uint8Array([1, 2, 3, 4, 5, 6]);
+    expect(bytes.length).toBe(6);
+    // A Buffer is a Uint8Array, and drizzle hands one of the two up depending on the driver.
+    expect(Buffer.from(bytes).length).toBe(6);
+    // Not the code-point count of anything: the same six bytes decoded as UTF-8 need not be six.
+    expect(new Uint8Array([0xf0, 0x9f, 0x98, 0x80]).length).toBe(4);
+  });
+});
+
+describe('parsing octet_length', () => {
+  it.each([
+    ['octet_length(blob) <= 5', '<=', '5'],
+    ['octet_length(blob) < 5', '<', '5'],
+    ['octet_length(blob) >= 1', '>=', '1'],
+    ['octet_length(blob) > 0', '>', '0'],
+    ['octet_length(blob) = 4', '=', '4'],
+    ['octet_length(blob) <> 4', '<>', '4'],
+  ])('understands %s', (expr, operator, value) => {
+    expect(lengths(expr)[0]).toMatchObject({ column: 'blob', operator, value, unit: 'bytes' });
+  });
+
+  it('normalises != to <>', () => {
+    expect(lengths('octet_length(blob) != 4')[0]!.operator).toBe('<>');
+  });
+
+  it('is case insensitive and tolerates whitespace, as the other function forms are', () => {
+    expect(lengths('OCTET_LENGTH ( blob )  <=  5')[0]).toMatchObject({
+      column: 'blob',
+      unit: 'bytes',
+    });
+  });
+
+  it('keeps length and char_length as character counts', () => {
+    expect(lengths('length(name) >= 3')[0]).toMatchObject({ unit: 'characters' });
+    expect(lengths('char_length(name) >= 3')[0]).toMatchObject({ unit: 'characters' });
+  });
+
+  it('reads it inside a conjunction, where the AND split runs first', () => {
+    const r = parseCheck('octet_length(blob) <= 5 AND octet_length(blob) >= 1');
+    expect(r.ok && r.lengths).toMatchObject([
+      { operator: '<=', value: '5', unit: 'bytes' },
+      { operator: '>=', value: '1', unit: 'bytes' },
+    ]);
+  });
+
+  it('still refuses a non-integer bound, which is not a count', () => {
+    expect(parseCheck('octet_length(blob) <= 5.5').ok).toBe(false);
+    expect(parseCheck("octet_length(blob) <= 'x'").ok).toBe(false);
+  });
+
+  it('still refuses a count compared against another column', () => {
+    expect(parseCheck('octet_length(blob) <= cap').ok).toBe(false);
+  });
+});
+
+describe('how a count is measured, once the column is known', () => {
+  const k = (expr: string) => lengths(expr)[0]!;
+
+  it('counts UTF-8 bytes for octet_length on a string column', () => {
+    expect(lengthMeasure(col('name'), k('octet_length(name) <= 5'))).toBe('utf8Bytes');
+  });
+
+  it('counts code points for length on a string column', () => {
+    expect(lengthMeasure(col('name'), k('length(name) <= 5'))).toBe('codePoints');
+  });
+
+  it('counts bytes for either function on a bytea column', () => {
+    // Measured: `octet_length(b)` and `length(b)` are the same number on a bytea, and
+    // `char_length(bytea)` is not a function Postgres has, so it cannot reach this.
+    expect(lengthMeasure(blobCol(), k('octet_length(blob) <= 5'))).toBe('byteLength');
+    expect(lengthMeasure(blobCol(), k('length(blob) <= 5'))).toBe('byteLength');
+  });
+
+  it('measures nothing on a byte-string column, whose width is two numbers', () => {
+    // A MySQL `varbinary(n)` arrives as a string from a lossy decode, so neither the code points
+    // it hands back nor their UTF-8 re-encoding is the server's byte count. See `ColumnShape`.
+    const bin = col('bin', { dbType: 'VARBINARY', shape: { kind: 'byteString', length: 8 } });
+    expect(lengthMeasure(bin, k('octet_length(bin) <= 5'))).toBeUndefined();
+  });
+
+  it('measures nothing on an array, a json payload or a number', () => {
+    expect(
+      lengthMeasure(col('tags', { arrayDimensions: 1 }), k('length(tags) <= 5'))
+    ).toBeUndefined();
+    expect(
+      lengthMeasure(col('prefs', { shape: { kind: 'json' } }), k('length(prefs) <= 5'))
+    ).toBeUndefined();
+    expect(
+      lengthMeasure(col('n', { tsType: 'number', dbType: 'INTEGER' }), k('length(n) <= 5'))
+    ).toBeUndefined();
+  });
+});
+
+describe('the label, which every emitted message and the ledger both key on', () => {
+  it('names the function the unit came from', () => {
+    expect(lengthCheckLabel(lengths('octet_length(blob) <= 5')[0]!)).toBe(
+      'octet_length(blob) <= 5'
+    );
+    expect(lengthCheckLabel(lengths('length(name) >= 3')[0]!)).toBe('length(name) >= 3');
+  });
+
+  it('normalises char_length to length, as it always has', () => {
+    expect(lengthCheckLabel(lengths('char_length(name) >= 3')[0]!)).toBe('length(name) >= 3');
+  });
+
+  it('carries the constraint name', () => {
+    const r = parseCheck('octet_length(blob) <= 5', 'blob_bytes');
+    expect(r.ok && lengthCheckLabel(r.lengths![0]!)).toBe('blob_bytes: octet_length(blob) <= 5');
+  });
+});
+
+describe('the classification the ledger and meta share', () => {
+  it('places a byte cap on a bytea column', () => {
+    const t = table([blobCol()], [{ name: 'blob_bytes', expression: 'octet_length(blob) <= 5' }]);
+    expect(classifyTableChecks(t)[0]!.parts).toMatchObject([
+      { text: 'blob_bytes: octet_length(blob) <= 5', columns: ['blob'], place: 'column' },
+    ]);
+  });
+
+  it('places a byte cap on a text column', () => {
+    const t = table([col('name')], [{ expression: 'octet_length(name) <= 5' }]);
+    expect(classifyTableChecks(t)[0]!.parts[0]!.place).toBe('column');
+  });
+
+  it('reports a byte cap on a byte-string column as unenforced, with the reason', () => {
+    const bin = col('bin', { dbType: 'VARBINARY', shape: { kind: 'byteString', length: 8 } });
+    const t = table([bin], [{ expression: 'octet_length(bin) <= 5' }]);
+    const part = classifyTableChecks(t)[0]!.parts[0]!;
+    expect(part.place).toBe('none');
+    expect(part.reason).toMatch(/byte-string/);
+  });
+});
+
+describe('the ledger', () => {
+  it('reports a bytea byte cap as enforced, with the message a schema attaches', () => {
+    const t = table([blobCol()], [{ name: 'blob_bytes', expression: 'octet_length(blob) <= 5' }]);
+    const found = tableConstraints(t).constraints.find((c) => c.id === 'blob_bytes');
+    expect(found).toMatchObject({
+      kind: 'check',
+      columns: ['blob'],
+      rule: 'CHECK (octet_length(blob) <= 5)',
+      enforced: true,
+      messages: ['blob_bytes: octet_length(blob) <= 5'],
+    });
+    expect(found!.unenforced).toBeUndefined();
+  });
+});
+
+describe('meta', () => {
+  it('carries the byte cap on the column it constrains', () => {
+    const t = table([blobCol()], [{ name: 'blob_bytes', expression: 'octet_length(blob) <= 5' }]);
+    expect(columnMetaFacts(t.columns[0], t).checks).toEqual([
+      'blob_bytes: octet_length(blob) <= 5',
+    ]);
+    expect(tableMetaFacts(t, { mode: 'insert' }).unenforcedChecks).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Plan items 48 and 49.

## Item 48: byte caps from `CHECK (octet_length(col) <= n)`

Previously declined outright. The measurement that makes it correct, PostgreSQL via PGlite, a `text` holding 3 emoji and a `bytea` holding 6 bytes:

| expression | text | bytea | JS that answers it |
|---|---|---|---|
| `octet_length(x)` | 12 | 6 | `new TextEncoder().encode(v).length` |
| `length(x)` | 3 | 6 | `[...v].length`, or `.length` on the array |
| `char_length(x)` | 3 | **does not exist** | `[...v].length` |

`v.length` on a *string* is none of these (6 for those emoji). The decisive probe: a 2-emoji string is **8 bytes**, so `octet_length(t) <= 5` refuses the exact row a character cap accepts. On `bytea`: 5 bytes accepted, 6 refused, NULL accepted.

**One shared function** (`lengthMeasure`) now answers "which measure does this check use" for all five validation generators, the constraint ledger, `meta` and `drzl doctor` — so they cannot disagree, which is the drift class BE and BG record. `length()` on a `bytea` routes to bytes because Postgres says it is bytes.

```ts
body: z.string().refine((v) => new TextEncoder().encode(v).length <= 5, ...)
blob: z.instanceof(Uint8Array).refine((v) => v.length <= 5, ...)
```

JSON Schema: a text byte cap becomes `maxLength: n` plus the byte-budget description (the necessary-condition trade `applyByteCap` already documents); a `bytea` cap becomes `maxLength: 4*ceil(n/3)` on the base64 string, **measured exact for padded output over n = 0..20**. `octet_length` on a MySQL `varbinary` is refused as uncountable, with a new doctor kind saying so — a lossy decode cannot be measured. The doctor's old reason for silence ("unreachable from a working schema") was Postgres-only and now false, so it was replaced rather than left.

## Item 49: shared enums, landing differently in three places

Measured against `@seriousme/openapi-schema-validator`, not reasoned:

| placement | 3.0 | 3.1 |
|---|---|---|
| `components.schemas` + `$ref` | valid | valid |
| `$defs` in a schema | **INVALID** (closed object) | **INVALID** standalone |
| `anyOf: [{$ref},{type:'null'}]` | **INVALID** (no null type) | valid |

- **OpenAPI document**: shares by default via `components.schemas`. The gate reports `12 of 12 component schema(s) referenced`.
- **Per-table modules**: `$defs` behind `sharedEnums`, **default off, and the gate itself proved why**: it compiles extracted properties standalone, and a `$ref` pulled away from the schema holding its `$defs` is a dangler. Whole, it compiles. That trade is now a test rather than a comment.
- **`components.ts`**: shares nothing. It is a fragment whose mount point belongs to the caller, so every entry stays independently compilable.

Nullable references: `anyOf` with `type: 'null'` on 3.1/2020-12; **inline on 3.0**, where `type: 'null'` is invalid and `{$ref, nullable: true}` silently refuses null per spec.

**Only declared enums used by ≥2 columns in scope.** A CHECK `IN` list stays inline (a constraint, not a named type). The threshold is a count, not bytes, so adding a value to an enum cannot flip the output shape. Size table shows the shortest 3-value enum actually *grows* under a `$ref` (36 bytes vs 29 inline), while a 12-value enum on 6 columns saves 591 bytes — the named-type payoff, not the bytes, is the reason for the rule.

## Ground truth and verification

- Tests first: `octet-length.spec.ts` **23 failed / 4 passed** before implementation. **+94 tests**, all green across 8 packages.
- Emitted schemas run, not diffed; ajv strict compiles the emitted JSON Schema and validates values **through** the `$defs` indirection, including the negative case.
- `build`, `-r test`, `typecheck`, `lint`, `docs build`, `verify:packed` all green (28 stages). The agent's run failed twice en route and both failures were real findings, now tests.

## What I would want added to the gate (not touched)

1. An `octet_length` CHECK on a `text` and a `bytea` column in the ground-truth fixture, putting the new form under the 53-probe CHECK arbitration.
2. A `#/$defs/` dangling-ref walker beside the existing `#/components/schemas/` one.
3. A per-property compile probe under `sharedEnums: true`: whole schema compiles, one extracted property does not — pinning the exact trade the option exists for.

## Filed, not fixed

**BH**: MySQL's `LENGTH()` is bytes where Postgres's is characters. The parser is dialect-agnostic and reads characters — the safe direction (nothing valid refused) but under-enforcing. Needs the dialect reachable at `classifyTableChecks` and a real MySQL to ground-truth.

Claude-Session: https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
