### PR TITLE
fix: CHECK literals follow the column's wire type (addendum BF, Tier A)

### DIFF
--- a/.changeset/bigint-in-literals.md
+++ b/.changeset/bigint-in-literals.md
@@ -1,0 +1,53 @@
+---
+'@drzl/validation-core': patch
+'@drzl/generator-zod': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-arktype': patch
+'@drzl/generator-typebox': patch
+'@drzl/generator-effect': patch
+'@drzl/generator-json-schema': patch
+---
+
+Spell a CHECK's number literals in the column's wire type, so a set on a `bigint({ mode:
+'bigint' })` column stops rejecting every row the driver returns
+
+`CHECK (big IN (1, 2))` on a bigint-mode column emitted `z.union([z.literal(1), z.literal(2)])`,
+and the driver returns `1n` there: strict equality between a bigint and a number is false in
+JavaScript, so the select schema refused every row the database handed back, and the insert schema
+refused every value the driver wants. The OR fold routes `big = 1 OR big = 2` into the same set,
+and the single `big = 1` and `big <> 1` predicates compared with `===`/`!==` had the same wire
+mismatch: the equality never held and the inequality always did, so one rejected everything and
+the other enforced nothing. `bigint({ mode: 'number' })` was always correct, because the driver
+really returns a number there; the fix keys on the analyzer's per-mode `tsType`, which is the
+value's measured wire type, rather than on the SQL type name.
+
+The spelling per library was measured against the installed versions rather than assumed:
+
+- **zod, valibot**: `z.literal(1n)` and `v.literal(1n)` accept `1n`, reject `3n` and reject the
+  number `1`, so the set stays the same union with the members suffixed. The `=`/`<>` refinements
+  compare against `1n`.
+- **ArkType**: the string DSL parses bigint literals. `type('1n | 2n')` enforces the set,
+  `type('9223372036854775807n')` holds the 64 bit value exactly, and `type('(1n | 2n)[]')` keeps
+  the array wrap. The single equality already went through `atBigintNarrow` and was correct.
+- **TypeBox**: `Type.Literal(1n)` constructs and passes `Value.Check`, and
+  `TypeCompiler.Compile` then throws "Preflight validation check failed to guard for the given
+  schema", so the literal form would take every compiler-path consumer down. The set and the
+  pinned equality go to the registered `DrzlRowCheck` kind intersected with `Type.BigInt()`, the
+  same escape hatch the character caps use, which both checkers honour; the static type still
+  narrows through `Type.Unsafe<1n | 2n>`, and the document still serialises.
+- **effect**: `Schema.Literal(1n, 2n)` enforces the set; the `<>` filter compares against `1n`.
+- **JSON Schema**: a bigint column is already a digits string in a JSON document, because
+  `JSON.stringify` throws on a bigint, so the set becomes `{ enum: ['1', '2'] }` and a pinned
+  equality `{ const: '1' }`, in the wire the serialised row can actually hold. This also unrounds
+  the 64 bit case: `Number('9223372036854775807')` becomes 9223372036854775808 the moment it is a
+  number, and the digit string stays exact.
+
+A non-integer member has no bigint spelling at all: `1.5n` is a syntax error, and an emitted
+module carrying it would throw at import. Such a member keeps its number spelling, which no stored
+bigint ever equals, exactly as the database says: no bigint column value is 1.5, so `big IN (1.5,
+2)` narrows to the 2. The shared decision lives in `wireNumberLiteral` in
+`@drzl/validation-core`, so the six emitters cannot answer it differently.
+
+The driver-side ground truth is the analyzer's own: `decimal-modes.spec.ts` pins `db.select()`
+returning a real bigint in bigint mode on all three engines, and the `PgBigInt53`/`PgBigInt64`
+arms pin the number mode returning a number, which is why those literals do not change.

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -38,6 +38,7 @@ import {
   resolveAffix,
   schemaName,
   typeName,
+  wireNumberLiteral,
 } from '@drzl/validation-core';
 
 type Mode = 'insert' | 'update' | 'select';
@@ -233,11 +234,19 @@ function atTypeForColumn(
   const shaped = atShapeType(c);
   if (shaped) return shaped;
   // `CHECK (status IN ('a', 'b'))` is a literal union, which is exactly how ArkType states a set.
+  //
+  // A number-kind member is spelled in the column's wire type: `'1 | 2'` on a
+  // `bigint({ mode: 'bigint' })` column refused every `1n` the driver returns, so the select
+  // schema rejected every row. The DSL does parse bigint literals, measured on the installed
+  // arktype: `type('1n | 2n')` takes `1n` and refuses `3n` and the number `1`, and
+  // `type('9223372036854775807n')` holds the 64 bit value exactly where the number spelling
+  // rounds. `wireNumberLiteral` decides the spelling, and it leaves a non-integer member as a
+  // number, since `1.5n` would throw at import and no stored bigint equals 1.5 anyway.
   const set = sets.find((x) => x.column === c.name);
   if (set) {
     return set.kind === 'string'
       ? set.values.map((v) => `'${v.replace(/'/g, "\\'")}'`).join(' | ')
-      : set.values.join(' | ');
+      : set.values.map((v) => wireNumberLiteral(c, v)).join(' | ');
   }
   // A parsed check compares the column to a scalar literal, which describes the array rather
   // than an element. Folded in anyway, `CHECK (tags = 'x')` became `('x')[]`, demanding that

--- a/packages/generator-arktype/test/bigint-in-literals.spec.ts
+++ b/packages/generator-arktype/test/bigint-in-literals.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * `CHECK (big IN (1, 2))` on a `bigint({ mode: 'bigint' })` column, run against the wire type the
+ * driver actually returns.
+ *
+ * The driver hands a select back as `bigint` in that mode: ground truth in
+ * `packages/analyzer/test/decimal-modes.spec.ts` (measured through PGlite, mysql2 and
+ * better-sqlite3) and the `PgBigInt53`/`PgBigInt64` arms of `packages/analyzer/src/index.ts`.
+ *
+ * The DSL `'1 | 2'` states number literals, which no bigint satisfies, so it rejected every row.
+ * ArkType does parse bigint literals in the DSL: measured on the installed arktype, `type('1n |
+ * 2n')` accepts `1n`, rejects `3n` and rejects the number `1`; `type('9223372036854775807n')`
+ * holds the 64 bit value exactly; and `type('(1n | 2n)[]')` parses, so the array wrap survives.
+ *
+ * The single equality `big = 1` already went through `atBigintNarrow`, which spells the literal
+ * `1n` and guards the non-integer member; it is asserted here anyway, since it is one branch of
+ * the OR fold standing alone and the wire rule has to hold for both.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { ArkTypeGenerator } from '../src/index';
+import { type } from 'arktype';
+
+const SUFFIX = '.arktype.ts';
+const RUN = (schema: any, input: unknown) => !(schema(input) instanceof type.errors);
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+/** `bigint({ mode: 'bigint' })` as the analyzer records it: tsType bigint, int64 range. */
+const bigB = () =>
+  col('big', {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+
+/** `bigint({ mode: 'number' })`: the driver returns a JS number there. */
+const bigN = () =>
+  col('big', {
+    tsType: 'number',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9007199254740991',
+    max: '9007199254740991',
+  });
+
+let seq = 0;
+
+async function emit(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<{ modules: Record<string, any>; text: string }> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-bigint-in');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir } as never);
+  const text = await fs.readFile(path.join(dir, `t${SUFFIX}`), 'utf8');
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return { modules: await import(file), text };
+}
+
+describe('CHECK (big IN (1, 2)) on bigint mode bigint', () => {
+  const IN = [{ name: 'big_valid', expression: 'big IN (1, 2)' }];
+
+  it('accepts the bigints the driver returns and rejects the rest, in every mode', async () => {
+    const { modules: m } = await emit([bigB()], IN);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { big: 1n }), `${s} 1n`).toBe(true);
+      expect(RUN(m[s], { big: 2n }), `${s} 2n`).toBe(true);
+      expect(RUN(m[s], { big: 3n }), `${s} 3n`).toBe(false);
+      // The wire carries bigints, so the number 1 is not a value this column ever holds.
+      expect(RUN(m[s], { big: 1 }), `${s} number 1`).toBe(false);
+    }
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    const { modules: m } = await emit([bigB()], IN);
+    expect(RUN(m.SelecttSchema, { big: null })).toBe(true);
+  });
+
+  it('keeps a 64 bit member exact instead of rounding it', async () => {
+    const { modules: m } = await emit(
+      [bigB()],
+      [{ expression: 'big IN (9223372036854775807)' }]
+    );
+    expect(RUN(m.SelecttSchema, { big: 9223372036854775807n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 9223372036854775806n })).toBe(false);
+  });
+
+  it('reaches the element of an array column', async () => {
+    // Drizzle keeps an array on the element's column class, so the set describes the element.
+    const { modules: m } = await emit(
+      [bigB()].map((c) => ({ ...c, arrayDimensions: 1 })),
+      IN
+    );
+    expect(RUN(m.SelecttSchema, { big: [1n, 2n] })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: [3n] })).toBe(false);
+  });
+});
+
+describe('the OR fold of the same constraint', () => {
+  it('emits byte for byte what the IN list it means emits', async () => {
+    const a = await emit([bigB()], [{ name: 'big_valid', expression: 'big = 1 OR big = 2' }]);
+    const b = await emit([bigB()], [{ name: 'big_valid', expression: 'big IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+
+  it('accepts 1n and rejects 3n like the IN it folds to', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big = 1 OR big = 2' }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+  });
+});
+
+describe('a single equality on the bigint wire', () => {
+  it('CHECK (big = 1) accepts 1n and rejects 2n', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big = 1' }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(false);
+  });
+});
+
+describe('bigint mode number keeps its number literals', () => {
+  it('accepts the numbers the driver returns there and refuses a bigint', async () => {
+    const { modules: m } = await emit([bigN()], [{ expression: 'big IN (1, 2)' }]);
+    expect(RUN(m.SelecttSchema, { big: 1 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3 })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(false);
+  });
+});
+
+describe('a non-integer member of the set', () => {
+  it('cannot become a bigint literal, and the module still loads and enforces the rest', async () => {
+    // `1.5n` is a syntax error in the emitted module, so that member keeps its number spelling,
+    // which no stored bigint ever equals, exactly as the database says.
+    const { modules: m } = await emit([bigB()], [{ expression: 'big IN (1.5, 2)' }]);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+  });
+});

--- a/packages/generator-effect/src/index.ts
+++ b/packages/generator-effect/src/index.ts
@@ -40,6 +40,7 @@ import {
   selectColumns,
   typeName,
   updateColumns,
+  wireNumberLiteral,
 } from '@drzl/validation-core';
 
 type Mode = 'insert' | 'update' | 'select';
@@ -425,7 +426,10 @@ function checkSteps(c: Column, checks: ColumnCheck[]): string[] {
   return checks
     .filter((k) => k.column === c.name && !folded.has(k))
     .map((k) => {
-      const literal = k.kind === 'string' ? JSON.stringify(k.value) : k.value;
+      // The wire-type spelling matters for `<>`, which is compared with strict equality:
+      // `v !== 1` is true of every `1n`, so the constraint silently never fired on a bigint
+      // column. The message keeps the SQL spelling either way.
+      const literal = k.kind === 'string' ? JSON.stringify(k.value) : wireNumberLiteral(c, k.value);
       return filter(
         `v ${OPS[k.operator]} ${literal}`,
         `${k.name ? `${k.name}: ` : ''}${c.name} ${k.operator} ${k.value}`
@@ -519,9 +523,16 @@ function exprForColumn(
   if (shaped) return piped(shaped, lengthSteps(c, lengths));
 
   // `CHECK (status IN ('a', 'b'))` is a union of literals, which effect spells as one call.
+  //
+  // A number-kind member is spelled in the column's wire type: effect compares a literal with
+  // strict equality, so `Schema.Literal(1)` on a `bigint({ mode: 'bigint' })` column refused every
+  // `1n` the driver returns and the select schema rejected every row. `wireNumberLiteral` decides
+  // the spelling, and it also keeps a 64 bit member exact rather than rounding it.
   const set = sets.find((x) => x.column === c.name);
   if (set) {
-    const values = set.values.map((v) => (set.kind === 'string' ? JSON.stringify(v) : v));
+    const values = set.values.map((v) =>
+      set.kind === 'string' ? JSON.stringify(v) : wireNumberLiteral(c, v)
+    );
     return `${NS}.Literal(${values.join(', ')})`;
   }
   // A parsed check compares the column against a scalar literal, which describes an element rather
@@ -532,9 +543,10 @@ function exprForColumn(
   }
 
   // An equality pins the value outright, so it supersedes every other constraint on the column.
+  // Spelled in the wire type for the same reason the set above is.
   const eq = checks.find((k) => k.column === c.name && k.operator === '=');
   if (eq && !c.shape) {
-    return `${NS}.Literal(${eq.kind === 'string' ? JSON.stringify(eq.value) : eq.value})`;
+    return `${NS}.Literal(${eq.kind === 'string' ? JSON.stringify(eq.value) : wireNumberLiteral(c, eq.value)})`;
   }
 
   const rest = [...checkSteps(c, checks), ...lengthSteps(c, lengths)];

--- a/packages/generator-effect/test/bigint-in-literals.spec.ts
+++ b/packages/generator-effect/test/bigint-in-literals.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * `CHECK (big IN (1, 2))` on a `bigint({ mode: 'bigint' })` column, run against the wire type the
+ * driver actually returns.
+ *
+ * The driver hands a select back as `bigint` in that mode: ground truth in
+ * `packages/analyzer/test/decimal-modes.spec.ts` (measured through PGlite, mysql2 and
+ * better-sqlite3) and the `PgBigInt53`/`PgBigInt64` arms of `packages/analyzer/src/index.ts`.
+ *
+ * `Schema.Literal(1, 2)` refuses `1n`: effect compares a literal with strict equality, and a
+ * bigint never strictly equals a number. Measured on the installed effect,
+ * `Schema.Literal(1n, 2n)` decodes `1n`, refuses `3n` and refuses the number `1`, so the set is
+ * spelled in the wire type.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { EffectGenerator } from '../src/index';
+import * as Either from 'effect/Either';
+import * as Schema from 'effect/Schema';
+
+const SUFFIX = '.effect.ts';
+const RUN = (schema: any, input: unknown) =>
+  Either.isRight(Schema.decodeUnknownEither(schema as Schema.Schema<unknown>)(input));
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+/** `bigint({ mode: 'bigint' })` as the analyzer records it: tsType bigint, int64 range. */
+const bigB = () =>
+  col('big', {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+
+/** `bigint({ mode: 'number' })`: the driver returns a JS number there. */
+const bigN = () =>
+  col('big', {
+    tsType: 'number',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9007199254740991',
+    max: '9007199254740991',
+  });
+
+let seq = 0;
+
+async function emit(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<{ modules: Record<string, any>; text: string }> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-bigint-in');
+  await fs.mkdir(dir, { recursive: true });
+  await new EffectGenerator(analysis).generate({ outDir: dir } as never);
+  const text = await fs.readFile(path.join(dir, `t${SUFFIX}`), 'utf8');
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return { modules: await import(file), text };
+}
+
+describe('CHECK (big IN (1, 2)) on bigint mode bigint', () => {
+  const IN = [{ name: 'big_valid', expression: 'big IN (1, 2)' }];
+
+  it('accepts the bigints the driver returns and rejects the rest, in every mode', async () => {
+    const { modules: m } = await emit([bigB()], IN);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { big: 1n }), `${s} 1n`).toBe(true);
+      expect(RUN(m[s], { big: 2n }), `${s} 2n`).toBe(true);
+      expect(RUN(m[s], { big: 3n }), `${s} 3n`).toBe(false);
+      // The wire carries bigints, so the number 1 is not a value this column ever holds.
+      expect(RUN(m[s], { big: 1 }), `${s} number 1`).toBe(false);
+    }
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    const { modules: m } = await emit([bigB()], IN);
+    expect(RUN(m.SelecttSchema, { big: null })).toBe(true);
+  });
+
+  it('keeps a 64 bit member exact instead of rounding it', async () => {
+    const { modules: m } = await emit(
+      [bigB()],
+      [{ expression: 'big IN (9223372036854775807)' }]
+    );
+    expect(RUN(m.SelecttSchema, { big: 9223372036854775807n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 9223372036854775806n })).toBe(false);
+  });
+});
+
+describe('the OR fold of the same constraint', () => {
+  it('emits byte for byte what the IN list it means emits', async () => {
+    const a = await emit([bigB()], [{ name: 'big_valid', expression: 'big = 1 OR big = 2' }]);
+    const b = await emit([bigB()], [{ name: 'big_valid', expression: 'big IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+
+  it('accepts 1n and rejects 3n like the IN it folds to', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big = 1 OR big = 2' }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+  });
+});
+
+describe('a single equality and inequality on the bigint wire', () => {
+  it('CHECK (big = 1) accepts 1n and rejects 2n', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big = 1' }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(false);
+  });
+
+  it('CHECK (big <> 1) rejects 1n and accepts 2n', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big <> 1' }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+  });
+});
+
+describe('bigint mode number keeps its number literals', () => {
+  it('accepts the numbers the driver returns there and refuses a bigint', async () => {
+    const { modules: m } = await emit([bigN()], [{ expression: 'big IN (1, 2)' }]);
+    expect(RUN(m.SelecttSchema, { big: 1 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3 })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(false);
+  });
+});
+
+describe('a non-integer member of the set', () => {
+  it('cannot become a bigint literal, and the module still loads and enforces the rest', async () => {
+    // `1.5n` is a syntax error, so that member keeps its number spelling, which no stored bigint
+    // ever equals, exactly as the database says.
+    const { modules: m } = await emit([bigB()], [{ expression: 'big IN (1.5, 2)' }]);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+  });
+});

--- a/packages/generator-json-schema/src/schemas.ts
+++ b/packages/generator-json-schema/src/schemas.ts
@@ -154,8 +154,19 @@ function baseSchema(
   }
 
   // `CHECK (status IN ('a', 'b'))` is exactly what `enum` means.
+  //
+  // A number-kind member follows the column's wire: a bigint column is a *string* in a JSON
+  // document, per the digits-string policy on the `bigint` arm below, so its members stay the
+  // digit strings a serialised row can actually hold. `{ enum: [1, 2] }` there refused every row,
+  // and `Number(v)` also rounds a 64 bit member the moment it becomes a number.
   const set = sets.find((x) => x.column === c.name);
-  if (set) return { enum: set.values.map((v) => (set.kind === 'string' ? v : Number(v))) };
+  if (set) {
+    return {
+      enum: set.values.map((v) =>
+        set.kind === 'string' || c.tsType === 'bigint' ? v : Number(v)
+      ),
+    };
+  }
 
   if (c.enumValues && c.enumValues.length) {
     // A declared enum this document publishes once, or the list itself. See `enums.ts` for which
@@ -167,7 +178,9 @@ function baseSchema(
   const mine = c.arrayDimensions ? [] : checks.filter((k) => k.column === c.name);
   const eq = mine.find((k) => k.operator === '=');
   if (eq) {
-    const only = eq.kind === 'string' ? eq.value : Number(eq.value);
+    // The wire rule the set above applies: on a bigint column the serialised value is a digit
+    // string, so the pinned value is one too, and it stays exact where `Number` would round.
+    const only = eq.kind === 'string' || c.tsType === 'bigint' ? eq.value : Number(eq.value);
     // OpenAPI 3.0 has no `const`, and its Schema Object is closed, so emitting one there does not
     // merely lose the constraint: the document fails validation. A one-value `enum` is the same
     // statement in a keyword that dialect has, and a validator accepts exactly the same value.

--- a/packages/generator-json-schema/test/bigint-in-literals.spec.ts
+++ b/packages/generator-json-schema/test/bigint-in-literals.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * `CHECK (big IN (1, 2))` on a `bigint({ mode: 'bigint' })` column, compiled and run under ajv.
+ *
+ * A bigint column is a string in a JSON document: `JSON.stringify` throws on a bigint, so this
+ * generator already emits `{ type: 'string', pattern: '^-?\\d+$' }` for the bare column. The set
+ * has to follow the same wire: `{ enum: [1, 2] }` states numbers, and no serialised row ever
+ * holds one, so the select document refused every row. The digit strings are also what keeps a
+ * 64 bit member exact: `Number('9223372036854775807')` rounds to 9223372036854775808 the moment
+ * it becomes a number.
+ *
+ * The driver-side ground truth is in `packages/analyzer/test/decimal-modes.spec.ts` and the
+ * `PgBigInt53`/`PgBigInt64` arms of `packages/analyzer/src/index.ts`; the digit-string policy for
+ * this generator is beside the `bigint` arm in `src/schemas.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import type { Column, Table } from '@drzl/analyzer';
+import { tableSchemas } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (columns: Column[], checks: { name?: string; expression?: string }[] = []): Table =>
+  ({ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }) as never;
+
+function compile(schema: unknown) {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  addFormats(ajv as never);
+  return ajv.compile(schema as never);
+}
+
+/** `bigint({ mode: 'bigint' })` as the analyzer records it: tsType bigint, int64 range. */
+const bigB = () =>
+  col('big', {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+
+/** `bigint({ mode: 'number' })`: a JS number, which serialises as a JSON number. */
+const bigN = () =>
+  col('big', {
+    tsType: 'number',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9007199254740991',
+    max: '9007199254740991',
+  });
+
+describe('CHECK (big IN (1, 2)) on bigint mode bigint', () => {
+  const IN = [{ name: 'big_valid', expression: 'big IN (1, 2)' }];
+
+  it('accepts the digit strings a serialised row holds and rejects the rest, in every mode', () => {
+    const s = tableSchemas(table([bigB()], IN));
+    for (const [mode, schema] of Object.entries(s)) {
+      if (mode === 'components') continue;
+      const v = compile(schema);
+      expect(v({ big: '1' }), `${mode} '1'`).toBe(true);
+      expect(v({ big: '2' }), `${mode} '2'`).toBe(true);
+      expect(v({ big: '3' }), `${mode} '3'`).toBe(false);
+      // The serialised wire is a string: the number 1 is not a value this column ever renders as.
+      expect(v({ big: 1 }), `${mode} number 1`).toBe(false);
+    }
+  });
+
+  it('still accepts null, which the database does', () => {
+    const v = compile(tableSchemas(table([bigB()], IN)).select);
+    expect(v({ big: null })).toBe(true);
+  });
+
+  it('keeps a 64 bit member exact instead of rounding it', () => {
+    const v = compile(
+      tableSchemas(table([bigB()], [{ expression: 'big IN (9223372036854775807)' }])).select
+    );
+    expect(v({ big: '9223372036854775807' })).toBe(true);
+    expect(v({ big: '9223372036854775806' })).toBe(false);
+    expect(v({ big: '9223372036854775808' })).toBe(false);
+  });
+
+  it('produces the same schema the OR fold of it produces', () => {
+    const a = tableSchemas(table([bigB()], [{ expression: 'big = 1 OR big = 2' }])).select;
+    const b = tableSchemas(table([bigB()], [{ expression: 'big IN (1, 2)' }])).select;
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});
+
+describe('a single equality on the bigint wire', () => {
+  it('CHECK (big = 1) accepts the digit string and rejects the neighbour', () => {
+    const v = compile(tableSchemas(table([bigB()], [{ expression: 'big = 1' }])).select);
+    expect(v({ big: '1' })).toBe(true);
+    expect(v({ big: '2' })).toBe(false);
+    expect(v({ big: 1 })).toBe(false);
+  });
+
+  it('keeps a 64 bit equality exact', () => {
+    const v = compile(
+      tableSchemas(table([bigB()], [{ expression: 'big = 9223372036854775807' }])).select
+    );
+    expect(v({ big: '9223372036854775807' })).toBe(true);
+    expect(v({ big: '9223372036854775806' })).toBe(false);
+  });
+});
+
+describe('bigint mode number keeps its number members', () => {
+  it('accepts the numbers a serialised row holds there and refuses a digit string', () => {
+    const v = compile(tableSchemas(table([bigN()], [{ expression: 'big IN (1, 2)' }])).select);
+    expect(v({ big: 1 })).toBe(true);
+    expect(v({ big: 3 })).toBe(false);
+    expect(v({ big: '1' })).toBe(false);
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -14,6 +14,7 @@ import type { BrandPlan } from '@drzl/validation-core';
 import {
   buildBrandPlan,
   buildNestedPlan,
+  describeSet,
   formatCode,
   importSpecifier,
   nestedArmNotes,
@@ -40,6 +41,7 @@ import {
   selectColumns,
   typeName,
   updateColumns,
+  wireNumberLiteral,
 } from '@drzl/validation-core';
 
 type Mode = 'insert' | 'update' | 'select';
@@ -343,6 +345,62 @@ function tbEqualityLiteral(c: Column, checks: ColumnCheck[]): string | undefined
   return `Type.Literal(${eq.kind === 'string' ? JSON.stringify(eq.value) : eq.value})`;
 }
 
+/**
+ * The number-kind set or equality on this column that has to leave the literal forms, or nothing.
+ *
+ * On a `bigint({ mode: 'bigint' })` column the driver returns `1n`, and `Type.Literal(1)` refuses
+ * it, so the emitted union rejected every row the database returned. The repair is not
+ * `Type.Literal(1n)` either: measured on TypeBox 0.34.52, that constructs and passes
+ * `Value.Check`, and `TypeCompiler.Compile` then throws "Preflight validation check failed to
+ * guard for the given schema", which takes every compiler-path consumer with it. So the set goes
+ * to the `DrzlRowCheck` registered kind, the same escape hatch the character caps and the row
+ * checks use, which both checkers honour; `test/bigint-in-literals.spec.ts` runs both.
+ *
+ * Shared by the emitter and the preamble condition on purpose: the two being separate copies of
+ * one condition is exactly the drift `tbNeedsCapKind` documents, and what a drifted copy emits is
+ * `[Kind]` into a file that did not import it. The guards mirror `tbExprForColumn`'s branch order
+ * exactly: a shaped column never reaches the set branch, a string-kind set returns its literal
+ * union and hides the equality behind it, and an array or enum column never reaches the equality.
+ */
+function tbBigintKindTarget(
+  c: Column,
+  checks: ColumnCheck[],
+  sets: ColumnSet[]
+): { set: ColumnSet } | { eq: ColumnCheck } | undefined {
+  if (c.tsType !== 'bigint' || c.shape) return undefined;
+  const set = sets.find((x) => x.column === c.name);
+  if (set) return set.kind === 'number' ? { set } : undefined;
+  if (c.arrayDimensions) return undefined;
+  if (c.enumValues && c.enumValues.length) return undefined;
+  const eq = checks.find((k) => k.column === c.name && k.operator === '=');
+  return eq && eq.kind === 'number' ? { eq } : undefined;
+}
+
+/**
+ * The kind branch for a bigint-wire set or equality, intersected onto `Type.BigInt()`.
+ *
+ * The base keeps the document saying "a bigint" when serialised, exactly as the cap branches sit
+ * beside `Type.String()`; the kind branch itself renders as its description alone. The static
+ * type narrows to the members the runtime can actually accept: a non-integer member has no
+ * bigint spelling, `1.5n` being a syntax error, so it stays a number inside the predicate, which
+ * no bigint ever equals, exactly as the database says. A set of only such members accepts no
+ * bigint at all, and `never` is that statement.
+ */
+function tbBigintKindExpr(c: Column, target: { set: ColumnSet } | { eq: ColumnCheck }): string {
+  const values = 'set' in target ? target.set.values : [target.eq.value];
+  const members = values.map((v) => wireNumberLiteral(c, v));
+  const statics = members.filter((m) => m.endsWith('n'));
+  const description =
+    'set' in target
+      ? describeSet(target.set)
+      : `${target.eq.name ? `${target.eq.name}: ` : ''}${c.name} = ${target.eq.value}`;
+  return `Type.Intersect([Type.BigInt(), Type.Unsafe<${statics.length ? statics.join(' | ') : 'never'}>({
+    [Kind]: 'DrzlRowCheck',
+    description: ${JSON.stringify(description)},
+    assert: (v: any) => typeof v === 'bigint' && (${members.map((m) => `v === ${m}`).join(' || ')}),
+  })])`;
+}
+
 function tbCheckOptions(c: Column, checks: ColumnCheck[]): Array<[string, string]> {
   const out: Array<[string, string]> = [];
   for (const k of checks.filter((x) => x.column === c.name)) {
@@ -494,6 +552,10 @@ function tbExprForColumn(
 ): string {
   const shaped = tbShapeExpr(c, mode, typedJsonRef);
   if (shaped) return shaped;
+  // A number-kind set or equality on a bigint wire cannot be a literal at all: see
+  // `tbBigintKindTarget` for the two measured refusals that force it to the registered kind.
+  const bigintKind = tbBigintKindTarget(c, checks, sets);
+  if (bigintKind) return tbBigintKindExpr(c, bigintKind);
   // `CHECK (status IN ('a', 'b'))` is a union of literals. `Type.Literal` is the only form
   // TypeBox enforces: a `const` option parses and then accepts anything.
   const set = sets.find((x) => x.column === c.name);
@@ -989,7 +1051,11 @@ function renderTableSchemas(
       ] as Array<[Column[], Mode]>
     ).some(([cs, m]) =>
       cs.some(
-        (c) => tbNeedsCapKind(c) || tbNeedsNonFiniteKind(c) || tbNeedsDateKind(c, m, coerceDates)
+        (c) =>
+          tbNeedsCapKind(c) ||
+          tbNeedsNonFiniteKind(c) ||
+          tbNeedsDateKind(c, m, coerceDates) ||
+          !!tbBigintKindTarget(c, checks, sets)
       )
     ) ||
     nestedByMode.some(([cs, m, tbl]) => {
@@ -999,7 +1065,11 @@ function renderTableSchemas(
         own.rows.some((r) => present.has(r.left) && present.has(r.right)) ||
         tbHasLengthBranch(own.lengths, [cs]) ||
         cs.some(
-          (c) => tbNeedsCapKind(c) || tbNeedsNonFiniteKind(c) || tbNeedsDateKind(c, m, coerceDates)
+          (c) =>
+            tbNeedsCapKind(c) ||
+            tbNeedsNonFiniteKind(c) ||
+            tbNeedsDateKind(c, m, coerceDates) ||
+            !!tbBigintKindTarget(c, own.checks, own.sets)
         )
       );
     });

--- a/packages/generator-typebox/test/bigint-in-literals.spec.ts
+++ b/packages/generator-typebox/test/bigint-in-literals.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * `CHECK (big IN (1, 2))` on a `bigint({ mode: 'bigint' })` column, run against the wire type the
+ * driver actually returns.
+ *
+ * The driver hands a select back as `bigint` in that mode: ground truth in
+ * `packages/analyzer/test/decimal-modes.spec.ts` (measured through PGlite, mysql2 and
+ * better-sqlite3) and the `PgBigInt53`/`PgBigInt64` arms of `packages/analyzer/src/index.ts`.
+ *
+ * `Type.Literal(1)` refuses `1n`, so the emitted union rejected every row. The repair is not
+ * `Type.Literal(1n)`: measured on the installed TypeBox, that constructs and passes `Value.Check`,
+ * and `TypeCompiler.Compile` then throws "Preflight validation check failed to guard for the given
+ * schema", so every consumer on the compiler path would throw at compile time. The set goes to the
+ * `DrzlRowCheck` registered kind instead, the same escape hatch the character caps and the row
+ * checks already use, which both `Value.Check` and `TypeCompiler` honour; measured here by running
+ * both.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { TypeBoxGenerator } from '../src/index';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+
+const SUFFIX = '.typebox.ts';
+const RUN = (schema: any, input: unknown) => Value.Check(schema, input);
+/** The same question through the compiler, whose preflight refuses what Value.Check does not. */
+const COMPILED = (schema: any, input: unknown) => TypeCompiler.Compile(schema).Check(input);
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+/** `bigint({ mode: 'bigint' })` as the analyzer records it: tsType bigint, int64 range. */
+const bigB = () =>
+  col('big', {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+
+/** `bigint({ mode: 'number' })`: the driver returns a JS number there. */
+const bigN = () =>
+  col('big', {
+    tsType: 'number',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9007199254740991',
+    max: '9007199254740991',
+  });
+
+let seq = 0;
+
+async function emit(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<{ modules: Record<string, any>; text: string }> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-bigint-in');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  const text = await fs.readFile(path.join(dir, `t${SUFFIX}`), 'utf8');
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return { modules: await import(file), text };
+}
+
+describe('CHECK (big IN (1, 2)) on bigint mode bigint', () => {
+  const IN = [{ name: 'big_valid', expression: 'big IN (1, 2)' }];
+
+  it('accepts the bigints the driver returns and rejects the rest, in every mode', async () => {
+    const { modules: m } = await emit([bigB()], IN);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { big: 1n }), `${s} 1n`).toBe(true);
+      expect(RUN(m[s], { big: 2n }), `${s} 2n`).toBe(true);
+      expect(RUN(m[s], { big: 3n }), `${s} 3n`).toBe(false);
+      // The wire carries bigints, so the number 1 is not a value this column ever holds.
+      expect(RUN(m[s], { big: 1 }), `${s} number 1`).toBe(false);
+    }
+  });
+
+  it('compiles under TypeCompiler and answers the same there', async () => {
+    // The reason the fix is not Type.Literal(1n): that form passes Value.Check and then throws in
+    // the compiler's preflight, taking every compiler-path consumer with it.
+    const { modules: m } = await emit([bigB()], IN);
+    expect(COMPILED(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(COMPILED(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(COMPILED(m.SelecttSchema, { big: 3n })).toBe(false);
+    expect(COMPILED(m.SelecttSchema, { big: 1 })).toBe(false);
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    const { modules: m } = await emit([bigB()], IN);
+    expect(RUN(m.SelecttSchema, { big: null })).toBe(true);
+  });
+
+  it('keeps a 64 bit member exact instead of rounding it', async () => {
+    const { modules: m } = await emit(
+      [bigB()],
+      [{ expression: 'big IN (9223372036854775807)' }]
+    );
+    expect(RUN(m.SelecttSchema, { big: 9223372036854775807n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 9223372036854775806n })).toBe(false);
+  });
+
+  it('serialises to a JSON document that stays valid', async () => {
+    // The kind branch carries only a description, so JSON.stringify still renders the schema. A
+    // bigint literal in `const` would either throw there or write a value JSON does not have.
+    const { modules: m } = await emit([bigB()], IN);
+    expect(() => JSON.stringify(m.SelecttSchema)).not.toThrow();
+  });
+});
+
+describe('the OR fold of the same constraint', () => {
+  it('emits byte for byte what the IN list it means emits', async () => {
+    const a = await emit([bigB()], [{ name: 'big_valid', expression: 'big = 1 OR big = 2' }]);
+    const b = await emit([bigB()], [{ name: 'big_valid', expression: 'big IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+
+  it('accepts 1n and rejects 3n like the IN it folds to', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big = 1 OR big = 2' }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+  });
+});
+
+describe('a single equality on the bigint wire', () => {
+  it('CHECK (big = 1) accepts 1n and rejects 2n, under both checkers', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big = 1' }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(false);
+    expect(COMPILED(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(COMPILED(m.SelecttSchema, { big: 2n })).toBe(false);
+  });
+});
+
+describe('bigint mode number keeps its number literals', () => {
+  it('accepts the numbers the driver returns there and refuses a bigint', async () => {
+    const { modules: m } = await emit([bigN()], [{ expression: 'big IN (1, 2)' }]);
+    expect(RUN(m.SelecttSchema, { big: 1 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3 })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(false);
+  });
+});
+
+describe('a non-integer member of the set', () => {
+  it('cannot become a bigint literal, and the module still loads and enforces the rest', async () => {
+    // `1.5n` is a syntax error, so that member keeps its number spelling inside the predicate,
+    // which no stored bigint ever equals, exactly as the database says.
+    const { modules: m } = await emit([bigB()], [{ expression: 'big IN (1.5, 2)' }]);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+  });
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -40,6 +40,7 @@ import {
   resolveAffix,
   schemaName,
   typeName,
+  wireNumberLiteral,
 } from '@drzl/validation-core';
 
 type Mode = 'insert' | 'update' | 'select';
@@ -180,7 +181,9 @@ function vChecks(c: Column, checks: ColumnCheck[]): string[] {
   return checks
     .filter((k) => k.column === c.name && !folded.has(k))
     .map((k) => {
-      const rhs = k.kind === 'string' ? JSON.stringify(k.value) : k.value;
+      // Strict equality for `=` and `<>` demands the wire type: `val === 1` is false for every
+      // `1n` a bigint-mode column returns. The message keeps the SQL spelling either way.
+      const rhs = k.kind === 'string' ? JSON.stringify(k.value) : wireNumberLiteral(c, k.value);
       const shown = k.kind === 'string' ? `'${k.value}'` : k.value;
       const msg = JSON.stringify(`${k.name ? `${k.name}: ` : ''}${c.name} ${k.operator} ${shown}`);
       return `v.check((val) => val ${OPS[k.operator]} ${rhs}, ${msg})`;
@@ -358,11 +361,16 @@ function vExprForColumn(
     return shapeChecks.length ? `v.pipe(${shaped}, ${shapeChecks.join(', ')})` : shaped;
   }
   // `CHECK (status IN ('a', 'b'))` constrains the column to a set, which is what a picklist is.
+  //
+  // A number-kind member is spelled in the column's wire type: `v.literal(1)` on a
+  // `bigint({ mode: 'bigint' })` column refused every `1n` the driver returns, so the select
+  // schema rejected every row. `wireNumberLiteral` decides the spelling, and it also keeps a
+  // 64 bit member exact: written as a number it rounds the moment it is parsed.
   const set = sets.find((x) => x.column === c.name);
   if (set) {
     return set.kind === 'string'
       ? `v.picklist([${set.values.map((v) => JSON.stringify(v)).join(', ')}] as const)`
-      : `v.union([${set.values.map((v) => `v.literal(${v})`).join(', ')}])`;
+      : `v.union([${set.values.map((v) => `v.literal(${wireNumberLiteral(c, v)})`).join(', ')}])`;
   }
   const extra = [...vChecks(c, checks), ...vLengthChecks(c, lengths)];
   /** Fold the constraint actions into whatever base this column maps to. */

--- a/packages/generator-valibot/test/bigint-in-literals.spec.ts
+++ b/packages/generator-valibot/test/bigint-in-literals.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * `CHECK (big IN (1, 2))` on a `bigint({ mode: 'bigint' })` column, run against the wire type the
+ * driver actually returns.
+ *
+ * The driver hands a select back as `bigint` in that mode: ground truth in
+ * `packages/analyzer/test/decimal-modes.spec.ts` (measured through PGlite, mysql2 and
+ * better-sqlite3) and the `PgBigInt53`/`PgBigInt64` arms of `packages/analyzer/src/index.ts`.
+ *
+ * `v.literal(1)` refuses `1n`: strict equality between a bigint and a number is false, so number
+ * literals reject every row the driver returns. The set is spelled in the wire type instead, and
+ * the measured library facts back it: `v.literal(1n)` on the installed valibot accepts `1n`,
+ * rejects `3n` and rejects the number `1`.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { ValibotGenerator } from '../src/index';
+import * as v from 'valibot';
+
+const SUFFIX = '.valibot.ts';
+const RUN = (schema: any, input: unknown) => v.safeParse(schema, input).success;
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+/** `bigint({ mode: 'bigint' })` as the analyzer records it: tsType bigint, int64 range. */
+const bigB = () =>
+  col('big', {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+
+/** `bigint({ mode: 'number' })`: the driver returns a JS number there. */
+const bigN = () =>
+  col('big', {
+    tsType: 'number',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9007199254740991',
+    max: '9007199254740991',
+  });
+
+let seq = 0;
+
+async function emit(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<{ modules: Record<string, any>; text: string }> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-bigint-in');
+  await fs.mkdir(dir, { recursive: true });
+  await new ValibotGenerator(analysis).generate({ outDir: dir } as never);
+  const text = await fs.readFile(path.join(dir, `t${SUFFIX}`), 'utf8');
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, `t${SUFFIX}`), file);
+  return { modules: await import(file), text };
+}
+
+describe('CHECK (big IN (1, 2)) on bigint mode bigint', () => {
+  const IN = [{ name: 'big_valid', expression: 'big IN (1, 2)' }];
+
+  it('accepts the bigints the driver returns and rejects the rest, in every mode', async () => {
+    const { modules: m } = await emit([bigB()], IN);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { big: 1n }), `${s} 1n`).toBe(true);
+      expect(RUN(m[s], { big: 2n }), `${s} 2n`).toBe(true);
+      expect(RUN(m[s], { big: 3n }), `${s} 3n`).toBe(false);
+      // The wire carries bigints, so the number 1 is not a value this column ever holds.
+      expect(RUN(m[s], { big: 1 }), `${s} number 1`).toBe(false);
+    }
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    const { modules: m } = await emit([bigB()], IN);
+    expect(RUN(m.SelecttSchema, { big: null })).toBe(true);
+  });
+
+  it('keeps a 64 bit member exact instead of rounding it', async () => {
+    const { modules: m } = await emit(
+      [bigB()],
+      [{ expression: 'big IN (9223372036854775807)' }]
+    );
+    expect(RUN(m.SelecttSchema, { big: 9223372036854775807n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 9223372036854775806n })).toBe(false);
+  });
+});
+
+describe('the OR fold of the same constraint', () => {
+  it('emits byte for byte what the IN list it means emits', async () => {
+    const a = await emit([bigB()], [{ name: 'big_valid', expression: 'big = 1 OR big = 2' }]);
+    const b = await emit([bigB()], [{ name: 'big_valid', expression: 'big IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+
+  it('accepts 1n and rejects 3n like the IN it folds to', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big = 1 OR big = 2' }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+  });
+});
+
+describe('a single equality and inequality on the bigint wire', () => {
+  it('CHECK (big = 1) accepts 1n and rejects 2n', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big = 1' }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(false);
+  });
+
+  it('CHECK (big <> 1) rejects 1n and accepts 2n', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big <> 1' }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+  });
+});
+
+describe('bigint mode number keeps its number literals', () => {
+  it('accepts the numbers the driver returns there and refuses a bigint', async () => {
+    const { modules: m } = await emit([bigN()], [{ expression: 'big IN (1, 2)' }]);
+    expect(RUN(m.SelecttSchema, { big: 1 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3 })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(false);
+  });
+});
+
+describe('a non-integer member of the set', () => {
+  it('cannot become a bigint literal, and the module still loads and enforces the rest', async () => {
+    // `1.5n` is a syntax error, so that member keeps its number spelling, which no stored bigint
+    // ever equals, exactly as the database says.
+    const { modules: m } = await emit([bigB()], [{ expression: 'big IN (1.5, 2)' }]);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+  });
+});

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -47,6 +47,7 @@ import {
   selectColumns,
   typeName,
   updateColumns,
+  wireNumberLiteral,
 } from '@drzl/validation-core';
 
 type Mode = 'insert' | 'update' | 'select';
@@ -248,7 +249,10 @@ function checkRefinements(c: Column, checks: ColumnCheck[]): string {
 
   return mine
     .map((k) => {
-      const rhs = k.kind === 'string' ? JSON.stringify(k.value) : k.value;
+      // The right side is compared with strict equality for `=` and `<>`, so it has to be spelled
+      // in the column's wire type: `v === 1` is false for every `1n` a bigint-mode column returns.
+      // The message keeps the SQL spelling either way.
+      const rhs = k.kind === 'string' ? JSON.stringify(k.value) : wireNumberLiteral(c, k.value);
       const label = k.name ? `${k.name}: ` : '';
       const msg = JSON.stringify(
         `${label}${c.name} ${k.operator} ${k.kind === 'string' ? `'${k.value}'` : k.value}`
@@ -348,11 +352,17 @@ function zodExprForColumn(
   // `CHECK (status IN ('a', 'b'))` constrains the column to a set, which is what an enum is. It
   // takes the same shape here as a declared enum rather than becoming a predicate, so the static
   // type narrows too. No official validator module enforces it at all.
+  //
+  // A number-kind member is spelled in the column's wire type: `z.literal(1)` on a
+  // `bigint({ mode: 'bigint' })` column refused every `1n` the driver returns, so the select
+  // schema rejected every row. `wireNumberLiteral` is where that spelling is decided, and it also
+  // keeps a 64 bit member exact: written as a number, 9223372036854775807 rounds the moment it is
+  // parsed.
   const set = sets.find((x) => x.column === c.name);
   if (set) {
     return set.kind === 'string'
       ? `z.enum([${set.values.map((v) => JSON.stringify(v)).join(', ')}] as const)`
-      : `z.union([${set.values.map((v) => `z.literal(${v})`).join(', ')}])`;
+      : `z.union([${set.values.map((v) => `z.literal(${wireNumberLiteral(c, v)})`).join(', ')}])`;
   }
   if (c.enumValues && c.enumValues.length) {
     const vals = c.enumValues.map((v) => `'${v.replace(/'/g, "\\'")}'`).join(', ');

--- a/packages/generator-zod/test/bigint-in-literals.spec.ts
+++ b/packages/generator-zod/test/bigint-in-literals.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * `CHECK (big IN (1, 2))` on a `bigint({ mode: 'bigint' })` column, run against the wire type the
+ * driver actually returns.
+ *
+ * The driver hands a select back as `bigint` in that mode. Measured ground truth lives in
+ * `packages/analyzer/test/decimal-modes.spec.ts`, whose header pins `db.select()` returning
+ * `9007199254740993n` for the bigint mode on all three engines (PGlite, mysql2, better-sqlite3),
+ * and in the `PgBigInt53`/`PgBigInt64` arms of `packages/analyzer/src/index.ts`, which type the
+ * number mode `number` and the bigint mode `bigint` for the same reason.
+ *
+ * `z.literal(1)` refuses `1n`: strict equality between a bigint and a number is false in
+ * JavaScript, so a set emitted as number literals turns away every row the driver returns, which
+ * is the read-path failure class. The set has to be spelled in the column's wire type: `1n` on a
+ * bigint wire, `1` on a number wire. The OR fold routes `big = 1 OR big = 2` into the same
+ * `ColumnSet`, so both spellings of the same constraint are asserted here, and so is the single
+ * equality `big = 1`, which is one branch of that OR standing alone.
+ *
+ * A non-integer member is the one value the bigint spelling cannot carry: `1.5n` is a JavaScript
+ * syntax error, and an emitted module that does not parse throws at import. The database says no
+ * stored bigint ever equals 1.5, so that member keeps its number spelling, which no bigint
+ * satisfies either, and the module keeps loading.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+/** `bigint({ mode: 'bigint' })` as the analyzer records it: tsType bigint, int64 range. */
+const bigB = () =>
+  col('big', {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+
+/** `bigint({ mode: 'number' })`: the driver returns a JS number there, so number literals fit. */
+const bigN = () =>
+  col('big', {
+    tsType: 'number',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9007199254740991',
+    max: '9007199254740991',
+  });
+
+let seq = 0;
+
+async function emit(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<{ modules: Record<string, any>; text: string }> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-bigint-in');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  const text = await fs.readFile(path.join(dir, 't.zod.ts'), 'utf8');
+  // Unique per call: the module cache is process-global.
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return { modules: await import(file), text };
+}
+
+describe('CHECK (big IN (1, 2)) on bigint mode bigint', () => {
+  const IN = [{ name: 'big_valid', expression: 'big IN (1, 2)' }];
+
+  it('accepts the bigints the driver returns and rejects the rest, in every mode', async () => {
+    const { modules: m } = await emit([bigB()], IN);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(m[s].safeParse({ big: 1n }).success, `${s} 1n`).toBe(true);
+      expect(m[s].safeParse({ big: 2n }).success, `${s} 2n`).toBe(true);
+      expect(m[s].safeParse({ big: 3n }).success, `${s} 3n`).toBe(false);
+      // The wire carries bigints, so the number 1 is not a value this column ever holds.
+      expect(m[s].safeParse({ big: 1 }).success, `${s} number 1`).toBe(false);
+    }
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    const { modules: m } = await emit([bigB()], IN);
+    expect(m.SelecttSchema.safeParse({ big: null }).success).toBe(true);
+  });
+
+  it('keeps a 64 bit member exact instead of rounding it', async () => {
+    const { modules: m } = await emit(
+      [bigB()],
+      [{ expression: 'big IN (9223372036854775807)' }]
+    );
+    expect(m.SelecttSchema.safeParse({ big: 9223372036854775807n }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: 9223372036854775806n }).success).toBe(false);
+  });
+});
+
+describe('the OR fold of the same constraint', () => {
+  it('emits byte for byte what the IN list it means emits', async () => {
+    const a = await emit([bigB()], [{ name: 'big_valid', expression: 'big = 1 OR big = 2' }]);
+    const b = await emit([bigB()], [{ name: 'big_valid', expression: 'big IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+
+  it('accepts 1n and rejects 3n like the IN it folds to', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big = 1 OR big = 2' }]);
+    expect(m.SelecttSchema.safeParse({ big: 1n }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: 2n }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: 3n }).success).toBe(false);
+  });
+});
+
+describe('a single equality and inequality on the bigint wire', () => {
+  it('CHECK (big = 1) accepts 1n and rejects 2n', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big = 1' }]);
+    expect(m.SelecttSchema.safeParse({ big: 1n }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: 2n }).success).toBe(false);
+  });
+
+  it('CHECK (big <> 1) rejects 1n and accepts 2n', async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: 'big <> 1' }]);
+    expect(m.SelecttSchema.safeParse({ big: 1n }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ big: 2n }).success).toBe(true);
+  });
+});
+
+describe('bigint mode number keeps its number literals', () => {
+  const IN = [{ expression: 'big IN (1, 2)' }];
+
+  it('accepts the numbers the driver returns there and refuses a bigint', async () => {
+    const { modules: m } = await emit([bigN()], IN);
+    expect(m.SelecttSchema.safeParse({ big: 1 }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: 3 }).success).toBe(false);
+    // That wire carries numbers: `1n` is not a value `bigint({ mode: 'number' })` returns.
+    expect(m.SelecttSchema.safeParse({ big: 1n }).success).toBe(false);
+  });
+});
+
+describe('a non-integer member of the set', () => {
+  it('cannot become a bigint literal, and the module still loads and enforces the rest', async () => {
+    // `big IN (1.5, 2)`: the database coerces on write and no stored bigint ever equals 1.5, so
+    // the member that has no bigint spelling keeps its number one, which no bigint satisfies.
+    const { modules: m } = await emit([bigB()], [{ expression: 'big IN (1.5, 2)' }]);
+    expect(m.SelecttSchema.safeParse({ big: 2n }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: 1n }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ big: 3n }).success).toBe(false);
+  });
+});

--- a/packages/validation-core/src/checks.ts
+++ b/packages/validation-core/src/checks.ts
@@ -803,6 +803,27 @@ export function parseCheck(expression: string | undefined, name?: string): Parse
 }
 
 /**
+ * A number-kind literal, spelled for the wire type of the column it constrains.
+ *
+ * `CHECK (big IN (1, 2))` on a `bigint({ mode: 'bigint' })` column pins a set of *bigints*: the
+ * driver returns `1n` there, and `1n === 1` is false in JavaScript, so a number literal in the
+ * emitted schema rejects every row the database returns. The literal has to be spelled `1n` on
+ * that wire, and stay `1` where a number really arrives, which is what `bigint({ mode: 'number' })`
+ * does. The wire type is `tsType`, which the analyzer sets per mode from what the driver hands
+ * back (see the `PgBigInt53`/`PgBigInt64` arms and `test/decimal-modes.spec.ts` in the analyzer),
+ * so the decision keys on the value's real type rather than on the SQL type name.
+ *
+ * The integer test is load bearing rather than defensive: `1.5n` is a syntax error, so an emitted
+ * module carrying it throws at import. A non-integer literal also has nothing to gain from the
+ * suffix, because no stored bigint ever equals 1.5; it keeps its number spelling, which no bigint
+ * satisfies either, so the schema and the database agree about every value on the wire while the
+ * module keeps parsing.
+ */
+export function wireNumberLiteral(column: { tsType?: string }, value: string): string {
+  return column.tsType === 'bigint' && /^-?\d+$/.test(value) ? `${value}n` : value;
+}
+
+/**
  * A human-readable rendering of a set constraint, for an error message.
  *
  * Values are re-quoted the way SQL wrote them, so the message reads like the constraint in the


### PR DESCRIPTION
Fixes plan addendum BF (Tier A): `CHECK (big IN (1, 2))` on `bigint({ mode: 'bigint' })` emitted number literals in every generator, and the driver returns `1n`, so the generated SELECT schema rejected every row the database returned. Equality and inequality carried the same wound: `v === 1` is never true for `1n` (rejects every row) and `v !== 1` is always true (enforces nothing).

## The rule

One shared decision, `wireNumberLiteral(column, value)` in `packages/validation-core/src/checks.ts`: CHECK literals are spelled in the column's **wire type**, keyed on the analyzer's measured `tsType`, never the SQL type name. Integer-formed members gain the `n` suffix on bigint wires; non-integer members keep number spellings, which no stored bigint equals, exactly matching the database (no bigint column value is 1.5). `bigint({ mode: 'number' })` is untouched since the driver really returns numbers there. Wire-type ground truth is cited from the analyzer's own PGlite/mysql2/better-sqlite3 measurements rather than adding a dependency.

## Red-first proof

Six specs written and run before the fix: zod 6/9 red, valibot 6/9, arktype 5/9 (equality already correct via its narrow; only sets broken), typebox 6/10, effect 6/9, json-schema 4/7. Central assertion: `SelecttSchema.safeParse({ big: 1n }).success` was false for the IN-carrying column. All 53 green after, including the OR-fold spelling (`big = 1 OR big = 2` routes through the same path), 64-bit members surviving unrounded, and the insert/update direction.

## Library capabilities, measured on installed versions

- zod 4.4.3 and valibot: bigint literals exact at 64 bits, accept `1n`, reject `3n` and number `1`.
- arktype: DSL parses `1n`, negative and 64-bit forms, and `'(1n | 2n)[]'` array wraps.
- **typebox 0.34: `Type.Literal(1n)` constructs and passes `Value.Check` but `TypeCompiler.Compile` throws its preflight error**, so bigint sets ride the registered `DrzlRowCheck` kind instead, proven under BOTH checkers and still `JSON.stringify`-safe; a shared predicate keeps the emitter and the `Kind`/`TypeRegistry` preamble from drifting. The emitted form was additionally compiled with real tsc since vitest alone would not catch a type-position `1n` problem.
- effect 3.22.1: `Schema.Literal(1n, 2n)` behaves three-ways correctly.
- json-schema has no bigint: digits-string enum/const matching that generator's existing policy, ajv-strict validated, and 64-bit members are no longer rounded through `Number()`.

## Honest divergences reported, not silently fixed

Pre-existing neighbours found while measuring, filed as plan addenda with mechanisms:
- **BK (Tier A):** the analyzer mistypes v1 `bigint({ mode: 'string' })` (`codec: 'bigint:string'`) as `tsType 'number'` while the driver returns a string, so every schema for such a column rejects every row, CHECKs or not. Analyzer int64-arm fix, v1-only.
- **BL (Tier A, design needed):** numeric string-wire columns still get number literals from IN (driver returns `'1'`/`'1.00'`, so exact string literals are also wrong at scale; needs a scale-insensitive compare).
- Smaller, pinned by tests: effect drops folded range CHECKs on bigint (leniency direction), arktype/typebox leave `<>` unstated on bigint as they already do on numbers, quoted literals on numeric wires keep the kind-vs-wire question open.

## Gates

Full suite green (20 workspaces, CLI 563/563, typecheck, lint, docs). `pnpm verify:packed` unmodified exits 0: 1476/1476 column comparisons at parity, both ledgers asserted in both directions, **no ALLOWED/DEFECTS changes needed** (the gate's probe tables carry IN only on a number-wire column, byte-identical emission there). Changeset: patch across the seven touched packages; the route generators consume these builders as dependencies and changesets carries them via `updateInternalDependencies`.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
