### PR TITLE
fix(analyzer): v1 bigint mode string is string-wire (addendum BK, Tier A)

### DIFF
--- a/.changeset/bigint-string-mode-tstype.md
+++ b/.changeset/bigint-string-mode-tstype.md
@@ -1,0 +1,28 @@
+---
+'@drzl/analyzer': patch
+---
+
+Type a v1 `bigint({ mode: 'string' })` column as the string the driver returns, so its generated
+select schemas stop rejecting every row
+
+Drizzle 1.0.0-rc.4 stamps `dataType: 'string int64'` on the string mode, with codec
+`bigint:string` on pg and mysql and no codec at all on singlestore and mssql, measured off real
+columns (`PgBigIntString`, `MySqlBigIntString`, `SingleStoreBigIntString`, `MsSqlBigInt`). The
+int64 arm keyed tsType on `js === 'bigint'` alone, so this shape came back `number`, and every
+generator keys on tsType, so every emitted select schema refused every value the column returns
+and every insert schema refused the string the driver wants.
+
+The driver side was measured rather than assumed: the `bigint:string` codec casts the column to
+text on the wire and registers no normalize, where `bigint` normalizes with `BigInt` and
+`bigint:number` with `Number`, and a live read through PGlite on the same rc hands back `'123'`
+and `'9223372036854775807'` as JS strings. `drizzle-orm/zod` at the same rc agrees, accepting
+'123' and refusing both `123` and `123n`.
+
+The shape carries no numeric facts, mirroring `string numeric`: `isIntegerColumn` reads "min and
+max both present" as an integer column, and the generators' string arms state none. Bounding the
+string by digits pattern and int64 range, as the official generator does, is a recorded follow-up.
+
+v1-only: drizzle-orm 0.45.2 spells `PgBigIntConfig<'number' | 'bigint'>` and branches only on
+`mode === "number"`, so 0.4x has no string mode, and a type-invalid `mode: 'string'` there
+silently builds the `PgBigInt64` bigint mode, which really does return a bigint and keeps its
+class-map answer.

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -739,6 +739,31 @@ export function describeV1Column(column: any): Partial<Column> | null {
         if (range) [out.min, out.max] = range;
         break;
       }
+      // `bigint({ mode: 'string' })` stamps `string int64`: codec `bigint:string` on pg and
+      // mysql, no codec at all on singlestore and mssql, measured off real 1.0.0-rc.4 columns
+      // (`PgBigIntString`, `MySqlBigIntString`, `SingleStoreBigIntString`, `MsSqlBigInt`). The
+      // driver really returns a string: the `bigint:string` codec casts the column to text on the
+      // wire and registers no normalize, where the `bigint` codec normalizes with `BigInt` and
+      // `bigint:number` with `Number`, and a live read through PGlite on the same rc hands back
+      // `'123'` and `'9223372036854775807'` as JS strings. Keying tsType on `js === 'bigint'`
+      // alone sent this shape to `number`, so every generated select schema rejected every row
+      // the column returns. The js half is the reliable key: two of the four dialects state no
+      // codec for it.
+      //
+      // No numeric facts on the string shape, mirroring the `numeric` arm below:
+      // `isIntegerColumn` in validation-core reads "min and max both present" as an integer
+      // column, and the generators' string arms state no numeric facts to begin with. Bounding
+      // the string by pattern and range is a recorded follow-up, not this shape.
+      //
+      // v1-only: drizzle-orm 0.45.2 spells `PgBigIntConfig<'number' | 'bigint'>` and branches
+      // only on `mode === "number"`, so 0.4x has no string mode and a type-invalid
+      // `mode: 'string'` silently builds the `PgBigInt64` bigint mode, which really does return
+      // a bigint and keeps its class-map answer.
+      if (semantic === 'int64' && js === 'string') {
+        out.tsType = 'string';
+        out.dbType = 'BIGINT';
+        break;
+      }
       // Every width Drizzle names. Missing `int8` and `int24` did not leave MySQL's `tinyint` and
       // `mediumint` alone: they fell through to the bare-number arm below, whose safe-integer
       // bounds then *overrode* the correct ones the class-name table had supplied, so a tinyint

--- a/packages/analyzer/test/fuzz/expected.json
+++ b/packages/analyzer/test/fuzz/expected.json
@@ -55,8 +55,6 @@
     "drizzle-orm/mysql-core mysqlEnum(\"c\", {\"withTimezone\":true,\"mode\":\"string\"})",
     "drizzle-orm/mysql-core mysqlEnum(\"c\", {\"withTimezone\":true,\"precision\":3})",
     "drizzle-orm/mysql-core mysqlEnum(\"c\", {\"withTimezone\":true})",
-    "drizzle-orm/pg-core pgEnum(\"c\")",
-    "drizzle-orm/sqlite-core blob(\"c\")",
-    "drizzle-orm/sqlite-core int(\"c\", {\"mode\":\"timestamp_ms\"})"
+    "drizzle-orm/pg-core pgEnum(\"c\")"
   ]
 }

--- a/packages/analyzer/test/v1-column-types.spec.ts
+++ b/packages/analyzer/test/v1-column-types.spec.ts
@@ -48,6 +48,41 @@ describe('numbers', () => {
     });
   });
 
+  it('types bigint mode string by the string the driver returns', () => {
+    // `bigint({ mode: 'string' })` stamps `string int64` with codec `bigint:string` on pg and
+    // mysql, measured off real 1.0.0-rc.4 columns (`PgBigIntString`, `MySqlBigIntString`). The
+    // driver really returns a string there: the `bigint:string` codec casts the column to text on
+    // the wire and registers no normalize, so the text passes through untouched, and a live read
+    // through PGlite on the same rc hands back `'123'` and `'9223372036854775807'` as JS strings.
+    // The int64 arm keyed only on `js === 'bigint'`, so this shape came back `tsType: 'number'`
+    // and every generated select schema rejected every row the column returns.
+    expect(describeV1Column(col('string int64', 'bigint:string'))).toMatchObject({
+      tsType: 'string',
+      dbType: 'BIGINT',
+    });
+    // SingleStore states the same dataType and no codec at all, measured on a real
+    // `singlestoreTable`; the semantic half alone must be enough, as it is for its float.
+    expect(describeV1Column({ dataType: 'string int64', dimensions: 0 })).toMatchObject({
+      tsType: 'string',
+      dbType: 'BIGINT',
+    });
+    // No numeric facts on the string shape, deliberately, mirroring `string numeric` above:
+    // `isIntegerColumn` reads "min and max both present" as an integer column, and the string
+    // arms of the generators state no numeric facts to begin with. The digits-and-range
+    // tightening is a recorded follow-up, not this shape.
+    const d = describeV1Column(col('string int64', 'bigint:string'));
+    expect(d?.min).toBeUndefined();
+    expect(d?.max).toBeUndefined();
+    expect(d?.integer).toBeUndefined();
+    // The element description survives an array dimension, as every other element type does.
+    expect(describeV1Column(col('string int64', 'bigint:string', { dimensions: 1 }))).toMatchObject(
+      {
+        tsType: 'string',
+        arrayDimensions: 1,
+      }
+    );
+  });
+
   it('takes the 4 byte float bound from the codec, because the two databases differ', () => {
     // Postgres refuses a `real` past 3.4028235677973366e38 and MySQL refuses a `FLOAT` past
     // 3.4028234663852886e38, both bisected against a real server, so one bound for `number float`

--- a/packages/generator-zod/test/bigint-string-mode-v1.spec.ts
+++ b/packages/generator-zod/test/bigint-string-mode-v1.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * `bigint({ mode: 'string' })` on Drizzle v1: a real `pgTable` from 1.0.0-rc.4 through the real
+ * analyzer and the real zod generator, with the emitted module imported and run.
+ *
+ * What v1 states, read off real 1.0.0-rc.4 columns rather than assumed:
+ *
+ *   builder                       dataType       codec
+ *   bigint({ mode: 'number' })    number int53   bigint:number
+ *   bigint({ mode: 'bigint' })    bigint int64   bigint
+ *   bigint({ mode: 'string' })    string int64   bigint:string
+ *
+ * GROUND TRUTH, PGlite through `drizzle-orm/pglite` 1.0.0-rc.4 on a `bigint` column per mode:
+ * mode number selects back `123` as a number, mode bigint `123n` as a bigint, and mode string
+ * `'123'` and `'9223372036854775807'` as strings. The mechanism is the codec table: the
+ * `bigint:string` codec casts the column to text on the wire and registers no normalize, so the
+ * text passes through untouched, where `bigint` normalizes with `BigInt` and `bigint:number` with
+ * `Number`. `drizzle-orm/zod` at the same rc agrees: its select schema for mode string accepts
+ * '123' and refuses both 123 and 123n.
+ *
+ * The analyzer's int64 arm keyed tsType only on `js === 'bigint'`, so this column came back
+ * `number` and the emitted select schema rejected every row the database returns, in every
+ * generator, because they all key on tsType. This spec is the zod half of the repair; the two
+ * sibling modes are asserted beside it so the fix cannot overreach.
+ *
+ * v1-only: drizzle-orm 0.45.2 spells `PgBigIntConfig<'number' | 'bigint'>` and branches only on
+ * `mode === "number"`, so 0.4x has no string mode at all and a type-invalid `mode: 'string'`
+ * silently builds the `PgBigInt64` bigint mode, which really does return a bigint.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer, type Column } from '@drzl/analyzer';
+import { ZodGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-bigint-string-v1');
+
+const SCHEMA = `
+  import { pgTable, bigint, integer } from 'drizzle-orm-v1/pg-core';
+  export const t = pgTable('t', {
+    id: integer('id').primaryKey(),
+    b_str: bigint('b_str', { mode: 'string' }).notNull(),
+    b_num: bigint('b_num', { mode: 'number' }).notNull(),
+    b_big: bigint('b_big', { mode: 'bigint' }).notNull(),
+  });
+`;
+
+let mod: Record<string, any>;
+let columns: Map<string, Column>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  const schema = path.join(DIR, 'schema.mjs');
+  await fs.writeFile(schema, SCHEMA, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  const table = analysis.tables[0];
+  expect(table, `no table analyzed: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  columns = new Map(table.columns.map((c) => [c.name, c]));
+  await new ZodGenerator(analysis).generate({ outDir: DIR } as never);
+  const emitted = path.join(DIR, `t-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 't.zod.ts'), emitted);
+  mod = await import(emitted);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const accepts = (schema: any, v: unknown) => schema.safeParse(v).success;
+
+describe('the analyzer, over a real v1 table', () => {
+  it('types the string mode as the string the driver returns', () => {
+    expect(columns.get('b_str')).toMatchObject({ tsType: 'string', dbType: 'BIGINT' });
+  });
+
+  it('leaves the sibling modes exactly where they were', () => {
+    expect(columns.get('b_num')).toMatchObject({ tsType: 'number', dbType: 'BIGINT' });
+    expect(columns.get('b_big')).toMatchObject({ tsType: 'bigint', dbType: 'BIGINT' });
+  });
+});
+
+describe('the emitted module, against what the v1 driver returned', () => {
+  it('takes the strings the driver hands back, at both ordinary and int64-edge magnitude', () => {
+    const s = mod.SelecttSchema.shape.b_str;
+    expect(accepts(s, '123'), 'the row the column handed back').toBe(true);
+    expect(accepts(s, '9223372036854775807'), 'the int64 maximum, as the driver spells it').toBe(
+      true
+    );
+  });
+
+  it('refuses the two wire types this column never returns', () => {
+    const s = mod.SelecttSchema.shape.b_str;
+    expect(accepts(s, 123n), 'a bigint never arrives on this wire').toBe(false);
+    expect(accepts(s, 123), 'a number never arrives on this wire').toBe(false);
+    expect(accepts(s, null), 'null on a NOT NULL column').toBe(false);
+  });
+
+  it('still holds the sibling modes to their own wire types', () => {
+    const num = mod.SelecttSchema.shape.b_num;
+    expect(accepts(num, 123)).toBe(true);
+    expect(accepts(num, '123')).toBe(false);
+    const big = mod.SelecttSchema.shape.b_big;
+    expect(accepts(big, 123n)).toBe(true);
+    expect(accepts(big, '123')).toBe(false);
+  });
+
+  it('accepts the string on insert too, which is what mapToDriverValue passes through', () => {
+    const s = mod.InserttSchema.shape.b_str;
+    expect(accepts(s, '123')).toBe(true);
+    expect(accepts(s, 123)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes plan addendum BK (Tier A): the analyzer typed v1 `bigint({ mode: 'string' })` as `tsType 'number'` while the driver returns strings, so every generated select schema rejected every row for those columns, with or without CHECKs, in every generator.

## Ground truth, three independent legs

1. **Source mechanism**: v1's codec tables register `bigint:string` with `cast: castToText` and **no normalize** (`bigint` normalizes with `BigInt`, `bigint:number` with `Number`), so the wire text passes through untouched.
2. **Live driver**: PGlite 0.3.14 + drizzle-orm 1.0.0-rc.4 in a throwaway tree returns `'123'` and `'9223372036854775807'` as JS strings for mode string (numbers and bigints for the sibling modes). The `drizzle(client)`-positional trap was hit and avoided per verify-packed's own note.
3. **Official reference**: `drizzle-orm-v1/zod` accepts those strings and rejects `123`, `123n`, `'hello'`, `'12.5'`, `''`, and out-of-range digit strings.

## The fix

One arm in `describeV1Column` (`packages/analyzer/src/index.ts`): `semantic === 'int64' && js === 'string'` maps to `tsType 'string'`, `dbType 'BIGINT'`, no numeric facts (mirroring the `string numeric` arm, since `isIntegerColumn` reads min+max as integer). Keys on the **dataType's js half, not the codec**, because singlestore and mssql state no codec for the same shape; all four dialects measured from real rc.4 column objects. Array elements survive.

Red-first at both layers: the analyzer spec failed with measured `'number'`; a real v1 `pgTable` through the real analyzer and ZodGenerator failed 4 assertions (select accepted `123`, rejected `'123'` and the int64-max string; insert rejected `'123'`). Green after, and sealed end to end: live PGlite rows through v1 select parse clean through the emitted schema.

## Verified, not inherited

- **0.4x is correct as-is**: it has no string mode, and a type-invalid `mode: 'string'` silently builds `PgBigInt64` whose `mapFromDriverValue` really returns a bigint.
- **Blast radius zero**: a sweep for `bigint:string`, `string int64`, and mode-string builders across packages, specs, fixtures, and the fuzz corpus found no prior references; nothing had encoded the wrong expectation because the shape had no coverage at all, including verify-packed's probe tables.

## Filed, not fixed here (addenda updated)

- **BM (gate blind spots)**: the probe tables carry no mode-string bigint (this Tier A shape was invisible to the entire gate), and `fuzz:gate` is wired into neither ci.yml nor verify-packed.sh, so its `expected.json` baseline rotted silently: two entries stopped reproducing on master when their columns were fixed. Deleted here exactly as the gate's own failure message instructs; mechanism confirmed by running master's built analyzer against those builders.
- **BL interaction, measured and stated**: range CHECKs on the string wire happen to enforce via JS coercion (`'99'` refused for `b >= 100`), but `IN (1, 2)` still emits number literals that reject the driver's `'1'`; that is BL's quoted-vs-unquoted-on-string-wires design question.
- **Tightening follow-up**: mode-string now emits bare string schemas; the wire-honest shape is the digits pattern plus int64 range that official v1 zod enforces.

## Gates

Full suite green (build, tests, typecheck, lint, docs); `pnpm verify:packed` **unmodified, exit 0**, parity verdicts and waiver counts unchanged; analyzer `fuzz:gate` green after the baseline cleanup. Changeset: patch for `@drzl/analyzer` only (generator-zod gained a test, no emission change).

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
