### PR TITLE
fix: reconcile CHECK literals with the column's wire (addendum BL, Tier A)

### DIFF
--- a/.changeset/numeric-wire-literals.md
+++ b/.changeset/numeric-wire-literals.md
@@ -1,0 +1,62 @@
+---
+'@drzl/validation-core': patch
+'@drzl/generator-zod': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-arktype': patch
+'@drzl/generator-typebox': patch
+'@drzl/generator-effect': patch
+'@drzl/generator-json-schema': patch
+---
+
+Reconcile a CHECK's literal kind with the column's wire by the database's comparison semantics,
+so a set on a `numeric()` column stops rejecting every row the driver returns
+
+`CHECK (n IN (1, 2))` on a `numeric()` column (string mode, the default) emitted
+`z.union([z.literal(1), z.literal(2)])`, and the driver returns *decimal text* there, spelled by
+the declared scale: measured through PGlite on both drizzle majors, a stored 1 comes back `'1'`
+from a bare `numeric`, `'1.00'` from a `numeric(10,2)` and `'1.0000000000'` from a
+`numeric(20,10)`, and mysql2 returns the same shapes for `decimal`. So the select schema refused
+every row the database handed back. Exact string literals are no repair: `'1'` fails against the
+`'1.00'` the scaled column returns, and a bare `numeric` even preserves the insert's own zeros
+(`1.000000` came back `'1.000000'` and `CHECK (n IN (1, 2))` admitted it, because SQL numeric
+equality is scale insensitive: `1 = 1.00` is true, measured on PostgreSQL 17.5 and MySQL 8.4.11).
+
+The same rule gap ran the other way. The database coerces a quoted literal to the column's type
+before comparing (`bigint CHECK (big IN ('1','2'))` admitted 1 and refused 3;
+`integer CHECK (age IN ('18'))` admitted 18), while the emitted schemas compared the raw text:
+`z.enum(["1","2"])` refused every `1n` a bigint-mode column returns, `big = '1'` compared
+`v === "1"` which no bigint ever satisfies, and `age IN ('18')` refused the number 18.
+
+The repair is one shared policy in `@drzl/validation-core`, extending `wireNumberLiteral`'s rule
+to the whole comparison: the literal's kind and the column's wire are reconciled by what the
+database does, never by the source spelling.
+
+- **Numeric string wires** (`numeric`/`decimal` string modes, v1 `bigint({ mode: 'string' })`):
+  equality, inequality and sets compare *canonical decimal spellings* through a `DrzlNumericCanon`
+  helper emitted once per file, dependency free: sign normalised, leading integer zeros and
+  trailing fraction zeros stripped, a bare trailing dot dropped, then compared as strings. Exact
+  at any precision on purpose: `Number()` is not usable here, because a numeric column carries
+  more digits than a double holds and `Number('99999999999999999999')` equals
+  `Number('99999999999999999998')`. zod and valibot refine, ArkType narrows, TypeBox rides the
+  registered `DrzlRowCheck` kind under both checkers, effect filters. JSON Schema cannot run a
+  function, so the set becomes a `pattern`: one alternation branch per member, accepting exactly
+  the spellings that canonicalise to it, ajv strict valid on every target; the cost is the
+  regex's readability, not admitted rows. Ranges there keep their coerced numeric compare,
+  now spelled `Number(v) >= 1` so the comparison is visible and the module typechecks.
+- **Number and bigint wires**: quoted plain-decimal literals are respelled to their number-kind
+  selves (canonicalised first: `018` and `018n` are syntax errors in an emitted module) and every
+  existing arm applies, `wireNumberLiteral`'s bigint suffix included. `big IN ('1','2')` now
+  emits byte for byte what `big IN (1, 2)` emits.
+- **What no exact compare can state is left unenforced and reported, never guessed.** Three
+  measured shapes: a number literal against a text column (Postgres refuses the DDL outright;
+  MySQL creates it and admits `'1.00'`, `'1'` and `'2.0'` through double coercion), quoted text
+  that is not plain decimal on a number or bigint wire, and a member outside the canonical domain
+  on a numeric wire (`CHECK (n IN ('1e3', '2'))` is valid DDL whose rows come back `'1000'`).
+  Each falls back to the base schema, which accepts every value the driver returns for admitted
+  rows, and the constraint ledger carries the reason: enforcing a guess would reject rows the
+  database admits, which is the defect class this fixes.
+
+The ledger and `meta` apply the same policy through `classifyTableChecks`, so a respelled
+constraint renders the message the emitted module writes and an unenforced clause says why
+instead of being claimed. TypeBox also stops planting a dead `minimum` keyword on
+`Type.String()`, which validated nothing and serialised as if enforced.

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -65,9 +65,11 @@ export interface Column {
   /**
    * A coarse label for the column's kind, not its type.
    *
-   * `varchar`, `char` and `text` are all `TEXT` here, deliberately: exactly one consumer reads
-   * this, `isIntegerColumn`, and it only asks whether a number is whole. Use `sqlType` for the
-   * question this name suggests it answers.
+   * `varchar`, `char` and `text` are all `TEXT` here, deliberately: two consumers read this and
+   * both ask coarse questions. `isIntegerColumn` asks whether a number is whole, and
+   * `comparisonWire` in `@drzl/validation-core` asks whether a string wire carries decimal text
+   * the database compares numerically, which is `NUMERIC` (every decimal family) and `BIGINT`
+   * (the v1 string mode). Use `sqlType` for the question this name suggests it answers.
    */
   dbType: string;
   /**

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -21,12 +21,20 @@ import {
   resolveNestedDepth,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
+  applyWirePolicy,
+  canonicalMembers,
+  canonicalNumericText,
+  comparisonWire,
+  describeSet,
   insertColumns,
   isIntegerColumn,
   lengthCheckLabel,
   lengthMeasure,
   measureExpression,
+  needsNumericCanon,
   nonFiniteAccepted,
+  NUMERIC_CANON_NAME,
+  NUMERIC_CANON_SOURCE,
   parseCheck,
   parsesToADate,
   renderDuplicateFinder,
@@ -244,6 +252,12 @@ function atTypeForColumn(
   // number, since `1.5n` would throw at import and no stored bigint equals 1.5 anyway.
   const set = sets.find((x) => x.column === c.name);
   if (set) {
+    // On a numeric string wire no literal union can state the set: the driver spells one
+    // admitted value many ways by declared scale ('1.00' for a stored 1, measured) and the
+    // database admits them all. The DSL cannot run the canonical compare, so the base stays
+    // `string` and `atNumericCanonNarrows` states the set as a narrow, the same escape hatch
+    // the character caps use.
+    if (comparisonWire(c) === 'numeric-string') return 'string';
     return set.kind === 'string'
       ? set.values.map((v) => `'${v.replace(/'/g, "\\'")}'`).join(' | ')
       : set.values.map((v) => wireNumberLiteral(c, v)).join(' | ');
@@ -260,9 +274,16 @@ function atTypeForColumn(
     // checked against arktype itself, accepting a valid value and rejecting an invalid one,
     // because an expression it cannot parse throws at import and takes the router with it.
     case 'string': {
-      // An equality check pins the value, which ArkType states as a literal type.
+      // An equality check pins the value, which ArkType states as a literal type. Only on a
+      // text wire: on a numeric string wire the driver's spelling varies by scale, so the
+      // literal `'2.50'` rejected the '2.5' a bare numeric returns, and the equality is stated
+      // by `atNumericCanonNarrows` instead.
       const eq = checks.find(
-        (k) => k.column === c.name && k.operator === '=' && k.kind === 'string'
+        (k) =>
+          k.column === c.name &&
+          k.operator === '=' &&
+          k.kind === 'string' &&
+          comparisonWire(c) === 'text'
       );
       if (eq) return `'${eq.value.replace(/'/g, "\\'")}'`;
       if (c.format === 'uuid') return 'string.uuid';
@@ -603,6 +624,7 @@ function renderObjectShape(
       const caps =
         atCapNarrows(c, mode) +
         atBigintNarrow(c, checks) +
+        atNumericCanonNarrows(c, checks, sets) +
         atNonFiniteNarrow(c, checks) +
         // Mutually exclusive with the one above it: that one is reached only where the column
         // admits `NaN` and this one only where it does not.
@@ -729,6 +751,45 @@ function atNarrow(c: Column, predicate: (v: string) => string, message: string):
     body = `${name(i - 1)}.every((${name(i)}) => ${name(i)} == null || ${body})`;
   }
   return `.narrow((v, ctx) => v == null || ${body} || ctx.mustBe(${JSON.stringify(message)}))`;
+}
+
+/**
+ * The equality class on a numeric string wire, as narrows over the canonical spelling.
+ *
+ * The driver spells one admitted value many ways by declared scale ('1', '1.00', measured), and
+ * the database compares them as numbers, so a DSL literal can never meet the wire. The narrow is
+ * the same escape hatch the character caps use, over the `DrzlNumericCanon` helper the preamble
+ * emits; `needsNumericCanon` in validation-core is the shared condition that keeps the two in
+ * step, for the reason the TypeBox generator records on `tbNeedsCapKind`.
+ *
+ * `<>` rides here too, though the number wires leave it unstated: on those the declarative forms
+ * have no spelling for it, while on this wire every form is a narrow anyway and the predicate is
+ * exact. Ranges stay with the base pattern, unstated, as they always were here.
+ */
+function atNumericCanonNarrows(c: Column, checks: ColumnCheck[], sets: ColumnSet[]): string {
+  if (comparisonWire(c) !== 'numeric-string') return '';
+  let out = '';
+  const set = sets.find((x) => x.column === c.name);
+  if (set) {
+    const members = canonicalMembers(set.values);
+    out += atNarrow(
+      c,
+      (v) =>
+        `(${members.map((m) => `${NUMERIC_CANON_NAME}(${v}) === ${JSON.stringify(m)}`).join(' || ')})`,
+      describeSet(set)
+    );
+  }
+  for (const k of checks.filter(
+    (x) => x.column === c.name && (x.operator === '=' || x.operator === '<>')
+  )) {
+    const canon = JSON.stringify(canonicalNumericText(k.value));
+    const op = k.operator === '=' ? '===' : '!==';
+    const label = `${k.name ? `${k.name}: ` : ''}${c.name} ${k.operator} ${
+      k.kind === 'string' ? `'${k.value}'` : k.value
+    }`;
+    out += atNarrow(c, (v) => `${NUMERIC_CANON_NAME}(${v}) ${op} ${canon}`, label);
+  }
+  return out;
 }
 
 /**
@@ -1007,9 +1068,17 @@ function atLengthNarrows(lengths: LengthCheck[], cols: Column[]): string {
 /** Every CHECK on a table that the shared parser understands, split by what it constrains. */
 function parsedChecksFor(table: Table) {
   const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  // The wire policy, exactly as in the zod generator: quoted literals the database compares
+  // numerically come back respelled number-kind, and clauses no exact compare can state are
+  // dropped, left to the base type and reported by the constraint ledger.
+  const { checks, sets } = applyWirePolicy(
+    table.columns,
+    parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : []))
+  );
   return {
-    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
-    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    checks,
+    sets,
     rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
     lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
     cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),
@@ -1136,12 +1205,7 @@ function renderTableSchemas(
   const insertCols = insertColumns(table);
   const updateCols = updateColumns(table);
   const selectCols = selectColumns(table);
-  const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
-  const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
-  const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
-  const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
-  const cardinalities = parsedChecks.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : []));
-  const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
+  const { checks, sets, rows, cardinalities, lengths } = parsedChecksFor(table);
   const forBrands = brands ? { plan: brands, tsName: T } : undefined;
   const bodyInsert = renderObjectShape(
     insertCols,
@@ -1192,8 +1256,26 @@ function renderTableSchemas(
     .join('\n\n');
   const brandCode = brandAliases ? `\n${brandAliases}\n` : '';
 
-  return `import { type } from 'arktype';
+  // The canonical helper, once per file that compares on a numeric string wire, nested tables
+  // included: their fields render into this same module. Conditional because an unused
+  // declaration fails `noUnusedLocals` downstream.
+  const nestedNodeTables = (node: NestedNode): Table[] => [
+    node.table,
+    ...node.arms.flatMap((a) => nestedNodeTables(a.child)),
+  ];
+  const involved = [
+    table,
+    ...Object.values(nested).flatMap((plan) => (plan ? nestedNodeTables(plan) : [])),
+  ];
+  const canonPreamble = involved.some((t) => {
+    const own = parsedChecksFor(t);
+    return needsNumericCanon(t.columns, own.checks, own.sets);
+  })
+    ? `\n${NUMERIC_CANON_SOURCE}`
+    : '';
 
+  return `import { type } from 'arktype';
+${canonPreamble}
 export const ${insertSchema} = type({
 ${bodyInsert}
 })${atRowNarrows(rows, insertCols)}${atLengthNarrows(lengths, insertCols)};

--- a/packages/generator-arktype/test/numeric-wire-literals.spec.ts
+++ b/packages/generator-arktype/test/numeric-wire-literals.spec.ts
@@ -1,0 +1,210 @@
+/**
+ * CHECK literals reconciled with the column's wire, ArkType half of addendum BL.
+ *
+ * Ground truth and the measurement table live in the zod twin,
+ * `packages/generator-zod/test/numeric-wire-literals.spec.ts`: a `numeric(10,2)` returns '1.00'
+ * for a stored 1 and the database compares scale insensitively, so the DSL union `1 | 2`
+ * rejected every returned row, and `'1' | '2'` on a bigint wire rejected every `1n`.
+ *
+ * The vehicle here is the one the character caps already use: the DSL states the base
+ * (`string`, or the numeric format pattern for an equality), and a `.narrow` carries the
+ * canonical compare over the emitted `DrzlNumericCanon`, since no DSL string can run one.
+ * `<>` rides the same narrow on this wire; on number and bigint wires it stays unenforced,
+ * as it always has here, because those declarative forms have no spelling for it and this
+ * change does not invent one.
+ */
+import { describe, it, expect } from 'vitest';
+import { type } from 'arktype';
+import { ArkTypeGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const RUN = (schema: any, input: unknown) => !(schema(input) instanceof type.errors);
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const numS2 = (name = 'n') =>
+  col(name, {
+    tsType: 'string',
+    dbType: 'NUMERIC',
+    format: 'numeric',
+    integer: false,
+    min: '-99999999.99',
+    max: '99999999.99',
+  });
+const numBare = (name = 'n') =>
+  col(name, { tsType: 'string', dbType: 'NUMERIC', format: 'numeric' });
+const bigB = (name = 'big') =>
+  col(name, {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+const intC = (name = 'age') =>
+  col(name, {
+    tsType: 'number',
+    dbType: 'INTEGER',
+    integer: true,
+    min: '-2147483648',
+    max: '2147483647',
+  });
+
+let seq = 0;
+
+async function emit(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<{ modules: Record<string, any>; text: string }> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-numeric-wire');
+  await fs.mkdir(dir, { recursive: true });
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir } as never);
+  const text = await fs.readFile(path.join(dir, 't.arktype.ts'), 'utf8');
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.arktype.ts'), file);
+  return { modules: await import(file), text };
+}
+
+describe('CHECK (n IN (1, 2)) on the numeric string wire', () => {
+  const IN = [{ name: 'n_valid', expression: 'n IN (1, 2)' }];
+
+  it('accepts every driver spelling of an admitted value and rejects the rest, in every mode', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { n: '1.00' }), `${s} '1.00'`).toBe(true);
+      expect(RUN(m[s], { n: '2.00' }), `${s} '2.00'`).toBe(true);
+      expect(RUN(m[s], { n: '1' }), `${s} '1'`).toBe(true);
+      expect(RUN(m[s], { n: '1.000000' }), `${s} '1.000000'`).toBe(true);
+      expect(RUN(m[s], { n: '3' }), `${s} '3'`).toBe(false);
+      expect(RUN(m[s], { n: '3.00' }), `${s} '3.00'`).toBe(false);
+      expect(RUN(m[s], { n: '1.5' }), `${s} '1.5'`).toBe(false);
+      expect(RUN(m[s], { n: 1 }), `${s} number 1`).toBe(false);
+      expect(RUN(m[s], { n: 'NaN' }), `${s} 'NaN'`).toBe(false);
+    }
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    expect(RUN(m.SelecttSchema, { n: null })).toBe(true);
+  });
+
+  it('keeps a 20 digit member exact instead of rounding it through a double', async () => {
+    const { modules: m } = await emit(
+      [numBare()],
+      [{ expression: 'n IN (99999999999999999999)' }]
+    );
+    expect(RUN(m.SelecttSchema, { n: '99999999999999999999' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '99999999999999999998' })).toBe(false);
+  });
+});
+
+describe('the OR fold of the same constraint', () => {
+  it('emits byte for byte what the IN list it means emits', async () => {
+    const a = await emit([numS2()], [{ name: 'n_valid', expression: 'n = 1 OR n = 2' }]);
+    const b = await emit([numS2()], [{ name: 'n_valid', expression: 'n IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+});
+
+describe('equality and inequality on the numeric string wire', () => {
+  it('CHECK (n = 1) accepts the scale padded return and rejects 2', async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: 'n = 1' }]);
+    expect(RUN(m.SelecttSchema, { n: '1.00' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '1' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '2.00' })).toBe(false);
+  });
+
+  it('CHECK (n <> 1) rejects every spelling of 1 and accepts 2', async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: 'n <> 1' }]);
+    expect(RUN(m.SelecttSchema, { n: '1.00' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { n: '1' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { n: '2.00' })).toBe(true);
+  });
+
+  it("a quoted equality, CHECK (n = '2.50'), no longer pins the raw text", async () => {
+    // Before, the string arm answered the literal type `'2.50'`, which rejects the driver's
+    // '2.5' from a bare numeric and its own '2.50' only survived by luck of scale.
+    const { modules: m } = await emit([numS2()], [{ expression: "n = '2.50'" }]);
+    expect(RUN(m.SelecttSchema, { n: '2.5' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '2.50' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '2.55' })).toBe(false);
+  });
+});
+
+describe('quoted literals on the wrong wires', () => {
+  it("CHECK (big IN ('1', '2')) accepts the bigints the driver returns", async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: "big IN ('1', '2')" }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: '1' })).toBe(false);
+  });
+
+  it('emits byte for byte what the unquoted IN emits', async () => {
+    const a = await emit([bigB()], [{ name: 'c', expression: "big IN ('1', '2')" }]);
+    const b = await emit([bigB()], [{ name: 'c', expression: 'big IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+
+  it("CHECK (big = '1') accepts 1n and rejects 2n through the bigint narrow", async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: "big = '1'" }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(false);
+  });
+
+  it("CHECK (age IN ('18')) accepts the number 18 the driver returns", async () => {
+    const { modules: m } = await emit([intC()], [{ expression: "age IN ('18')" }]);
+    expect(RUN(m.SelecttSchema, { age: 18 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { age: 19 })).toBe(false);
+    expect(RUN(m.SelecttSchema, { age: '18' })).toBe(false);
+  });
+
+  it("a quoted range, CHECK (age >= '18'), folds into the DSL like its unquoted twin", async () => {
+    const { modules: m } = await emit([intC()], [{ expression: "age >= '18'" }]);
+    expect(RUN(m.SelecttSchema, { age: 18 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { age: 17 })).toBe(false);
+  });
+});
+
+describe('members no exact compare can state fall back to leniency', () => {
+  it("CHECK (n IN ('1e3', '2')) enforces nothing rather than rejecting admitted rows", async () => {
+    const { modules: m } = await emit([numBare()], [{ expression: "n IN ('1e3', '2')" }]);
+    expect(RUN(m.SelecttSchema, { n: '1000' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '7' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: 'hello' })).toBe(false);
+  });
+
+  it('CHECK (s IN (1, 2)) on a text wire enforces nothing rather than rejecting rows', async () => {
+    const { modules: m } = await emit([col('s')], [{ expression: 's IN (1, 2)' }]);
+    expect(RUN(m.SelecttSchema, { s: '1.00' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { s: 'x' })).toBe(true);
+  });
+});
+
+describe('what the emitted module carries', () => {
+  it('emits the canonical helper once, and only where a column needs it', async () => {
+    const a = await emit([numS2()], [{ name: 'n_valid', expression: 'n IN (1, 2)' }]);
+    expect(a.text).toContain('DrzlNumericCanon');
+    expect(a.text.split('const DrzlNumericCanon').length).toBe(2);
+    const b = await emit([intC()], [{ expression: 'age IN (18, 21)' }]);
+    expect(b.text).not.toContain('DrzlNumericCanon');
+  });
+});

--- a/packages/generator-effect/src/index.ts
+++ b/packages/generator-effect/src/index.ts
@@ -20,9 +20,17 @@ import {
   nestedSchemaName,
   nestedTypeName,
   resolveNestedDepth,
+  applyWirePolicy,
+  canonicalMembers,
+  canonicalNumericText,
+  comparisonWire,
+  describeSet,
+  needsNumericCanon,
   CODEPOINT_LENGTH,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
+  NUMERIC_CANON_NAME,
+  NUMERIC_CANON_SOURCE,
   insertColumns,
   isIntegerColumn,
   lengthCheckLabel,
@@ -423,17 +431,29 @@ function checkSteps(c: Column, checks: ColumnCheck[]): string[] {
   // literal and the schema rejected every row.
   if (c.arrayDimensions || c.shape) return [];
   const folded = foldedIntoBounds(c, checks);
+  const numericWire = comparisonWire(c) === 'numeric-string';
   return checks
     .filter((k) => k.column === c.name && !folded.has(k))
     .map((k) => {
+      const label = `${k.name ? `${k.name}: ` : ''}${c.name} ${k.operator} ${k.value}`;
+      // On a numeric string wire the driver spells one value many ways ('1', '1.00') and the
+      // database compares them as numbers, so `v === 1` was false for every returned row and
+      // `v !== 1` enforced nothing. Equality goes through the canonical spelling; a range keeps
+      // its coerced numeric compare, spelled `Number(v)` so the comparison it always performed
+      // is visible and the module typechecks. See the zod generator and `wireLiteralFit`.
+      if (numericWire) {
+        if (k.operator === '=' || k.operator === '<>') {
+          const canon = JSON.stringify(canonicalNumericText(k.value));
+          const op = k.operator === '=' ? '===' : '!==';
+          return filter(`${NUMERIC_CANON_NAME}(v) ${op} ${canon}`, label);
+        }
+        return filter(`Number(v) ${OPS[k.operator]} ${k.value}`, label);
+      }
       // The wire-type spelling matters for `<>`, which is compared with strict equality:
       // `v !== 1` is true of every `1n`, so the constraint silently never fired on a bigint
       // column. The message keeps the SQL spelling either way.
       const literal = k.kind === 'string' ? JSON.stringify(k.value) : wireNumberLiteral(c, k.value);
-      return filter(
-        `v ${OPS[k.operator]} ${literal}`,
-        `${k.name ? `${k.name}: ` : ''}${c.name} ${k.operator} ${k.value}`
-      );
+      return filter(`v ${OPS[k.operator]} ${literal}`, label);
     });
 }
 
@@ -530,6 +550,17 @@ function exprForColumn(
   // the spelling, and it also keeps a 64 bit member exact rather than rounding it.
   const set = sets.find((x) => x.column === c.name);
   if (set) {
+    // On a numeric string wire no list of literals can state the set: the driver spells one
+    // admitted value many ways by declared scale ('1.00' for a stored 1, measured) and the
+    // database admits them all. The compare runs over the canonical spelling instead, exact at
+    // any precision where `Number()` rounds. See the zod generator and `wireLiteralFit`.
+    if (comparisonWire(c) === 'numeric-string') {
+      const members = canonicalMembers(set.values);
+      const test = members.map((m) => `canon === ${JSON.stringify(m)}`).join(' || ');
+      return piped(`${NS}.String`, [
+        filter(`((canon) => ${test})(${NUMERIC_CANON_NAME}(v))`, describeSet(set)),
+      ]);
+    }
     const values = set.values.map((v) =>
       set.kind === 'string' ? JSON.stringify(v) : wireNumberLiteral(c, v)
     );
@@ -543,9 +574,11 @@ function exprForColumn(
   }
 
   // An equality pins the value outright, so it supersedes every other constraint on the column.
-  // Spelled in the wire type for the same reason the set above is.
+  // Spelled in the wire type for the same reason the set above is. Not on a numeric string wire,
+  // where no literal can meet the driver's spellings: the equality stays in `checkSteps` as the
+  // canonical compare there.
   const eq = checks.find((k) => k.column === c.name && k.operator === '=');
-  if (eq && !c.shape) {
+  if (eq && !c.shape && comparisonWire(c) !== 'numeric-string') {
     return `${NS}.Literal(${eq.kind === 'string' ? JSON.stringify(eq.value) : wireNumberLiteral(c, eq.value)})`;
   }
 
@@ -743,12 +776,23 @@ function indentBlock(code: string, by = '  '): string {
     .join('\n');
 }
 
-/** Every CHECK on a table that the shared parser understands, split by what it constrains. */
+/**
+ * Every CHECK on a table that the shared parser understands, split by what it constrains.
+ *
+ * The wire policy runs here, exactly as in the zod generator: quoted literals the database
+ * compares numerically come back respelled number-kind, and clauses no exact compare can state
+ * are dropped, left to the base schema and reported by the constraint ledger.
+ */
 function parsedChecksFor(table: Table) {
   const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  const { checks, sets } = applyWirePolicy(
+    table.columns,
+    parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : []))
+  );
   return {
-    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
-    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    checks,
+    sets,
     rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
     lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
     cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),
@@ -988,8 +1032,25 @@ function renderTableSchemas(
     .join('\n\n');
   const brandCode = brandAliases ? `\n${brandAliases}\n` : '';
 
+  // The canonical helper, once per file that compares on a numeric string wire, nested tables
+  // included for the reason the json preamble includes them. Conditional because an unused
+  // declaration fails `noUnusedLocals` downstream.
+  const involved = [
+    table,
+    ...(['insert', 'select'] as const).flatMap((m) => {
+      const plan = nested[m];
+      return plan ? nestedNodes(plan).map((n) => n.table) : [];
+    }),
+  ];
+  const canonPreamble = involved.some((t) => {
+    const own = parsedChecksFor(t);
+    return needsNumericCanon(t.columns, own.checks, own.sets);
+  })
+    ? `\n${NUMERIC_CANON_SOURCE}`
+    : '';
+
   return `import * as ${NS} from 'effect/Schema';
-${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}
+${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}${canonPreamble}
 ${blocks.join('\n\n')}
 ${brandCode}${nestedCode}${duplicates}`;
 }

--- a/packages/generator-effect/test/numeric-wire-literals.spec.ts
+++ b/packages/generator-effect/test/numeric-wire-literals.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * CHECK literals reconciled with the column's wire, Effect half of addendum BL.
+ *
+ * Ground truth and the measurement table live in the zod twin,
+ * `packages/generator-zod/test/numeric-wire-literals.spec.ts`: a `numeric(10,2)` returns '1.00'
+ * for a stored 1 and the database compares scale insensitively, so `Schema.Literal(1, 2)`
+ * rejected every returned row, and `Schema.Literal("1", "2")` on a bigint wire rejected every
+ * `1n`. The canonical compare is a `Schema.filter` over the emitted `DrzlNumericCanon`, the
+ * same vehicle the character caps use.
+ */
+import { describe, it, expect } from 'vitest';
+import * as Schema from 'effect/Schema';
+import * as Either from 'effect/Either';
+import { EffectGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const RUN = (schema: any, input: unknown) =>
+  Either.isRight(Schema.decodeUnknownEither(schema as Schema.Schema<unknown>)(input));
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const numS2 = (name = 'n') =>
+  col(name, {
+    tsType: 'string',
+    dbType: 'NUMERIC',
+    format: 'numeric',
+    integer: false,
+    min: '-99999999.99',
+    max: '99999999.99',
+  });
+const numBare = (name = 'n') =>
+  col(name, { tsType: 'string', dbType: 'NUMERIC', format: 'numeric' });
+const bigB = (name = 'big') =>
+  col(name, {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+const intC = (name = 'age') =>
+  col(name, {
+    tsType: 'number',
+    dbType: 'INTEGER',
+    integer: true,
+    min: '-2147483648',
+    max: '2147483647',
+  });
+
+let seq = 0;
+
+async function emit(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<{ modules: Record<string, any>; text: string }> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-numeric-wire');
+  await fs.mkdir(dir, { recursive: true });
+  await new EffectGenerator(analysis).generate({ outDir: dir } as never);
+  const text = await fs.readFile(path.join(dir, 't.effect.ts'), 'utf8');
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.effect.ts'), file);
+  return { modules: await import(file), text };
+}
+
+describe('CHECK (n IN (1, 2)) on the numeric string wire', () => {
+  const IN = [{ name: 'n_valid', expression: 'n IN (1, 2)' }];
+
+  it('accepts every driver spelling of an admitted value and rejects the rest, in every mode', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { n: '1.00' }), `${s} '1.00'`).toBe(true);
+      expect(RUN(m[s], { n: '2.00' }), `${s} '2.00'`).toBe(true);
+      expect(RUN(m[s], { n: '1' }), `${s} '1'`).toBe(true);
+      expect(RUN(m[s], { n: '1.000000' }), `${s} '1.000000'`).toBe(true);
+      expect(RUN(m[s], { n: '3' }), `${s} '3'`).toBe(false);
+      expect(RUN(m[s], { n: '3.00' }), `${s} '3.00'`).toBe(false);
+      expect(RUN(m[s], { n: '1.5' }), `${s} '1.5'`).toBe(false);
+      expect(RUN(m[s], { n: 1 }), `${s} number 1`).toBe(false);
+      expect(RUN(m[s], { n: 'NaN' }), `${s} 'NaN'`).toBe(false);
+    }
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    expect(RUN(m.SelecttSchema, { n: null })).toBe(true);
+  });
+
+  it('keeps a 20 digit member exact instead of rounding it through a double', async () => {
+    const { modules: m } = await emit(
+      [numBare()],
+      [{ expression: 'n IN (99999999999999999999)' }]
+    );
+    expect(RUN(m.SelecttSchema, { n: '99999999999999999999' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '99999999999999999998' })).toBe(false);
+  });
+});
+
+describe('the OR fold of the same constraint', () => {
+  it('emits byte for byte what the IN list it means emits', async () => {
+    const a = await emit([numS2()], [{ name: 'n_valid', expression: 'n = 1 OR n = 2' }]);
+    const b = await emit([numS2()], [{ name: 'n_valid', expression: 'n IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+});
+
+describe('equality and inequality on the numeric string wire', () => {
+  it('CHECK (n = 1) accepts the scale padded return and rejects 2', async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: 'n = 1' }]);
+    expect(RUN(m.SelecttSchema, { n: '1.00' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '1' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '2.00' })).toBe(false);
+  });
+
+  it('CHECK (n <> 1) rejects every spelling of 1 and accepts 2', async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: 'n <> 1' }]);
+    expect(RUN(m.SelecttSchema, { n: '1.00' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { n: '1' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { n: '2.00' })).toBe(true);
+  });
+});
+
+describe('quoted literals on the wrong wires', () => {
+  it("CHECK (big IN ('1', '2')) accepts the bigints the driver returns", async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: "big IN ('1', '2')" }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: '1' })).toBe(false);
+  });
+
+  it("CHECK (big = '1') accepts 1n and rejects 2n", async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: "big = '1'" }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(false);
+  });
+
+  it("CHECK (age IN ('18')) accepts the number 18 the driver returns", async () => {
+    const { modules: m } = await emit([intC()], [{ expression: "age IN ('18')" }]);
+    expect(RUN(m.SelecttSchema, { age: 18 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { age: 19 })).toBe(false);
+    expect(RUN(m.SelecttSchema, { age: '18' })).toBe(false);
+  });
+});
+
+describe('members no exact compare can state fall back to leniency', () => {
+  it("CHECK (n IN ('1e3', '2')) enforces nothing rather than rejecting admitted rows", async () => {
+    const { modules: m } = await emit([numBare()], [{ expression: "n IN ('1e3', '2')" }]);
+    expect(RUN(m.SelecttSchema, { n: '1000' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '7' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: 'hello' })).toBe(false);
+  });
+
+  it('CHECK (s IN (1, 2)) on a text wire enforces nothing rather than rejecting rows', async () => {
+    const { modules: m } = await emit([col('s')], [{ expression: 's IN (1, 2)' }]);
+    expect(RUN(m.SelecttSchema, { s: '1.00' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { s: 'x' })).toBe(true);
+  });
+});
+
+describe('ranges on the numeric string wire', () => {
+  it('CHECK (n >= 1) compares numerically and is spelled type clean', async () => {
+    const { modules: m, text } = await emit([numS2()], [{ expression: 'n >= 1' }]);
+    expect(RUN(m.SelecttSchema, { n: '1.00' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '0.99' })).toBe(false);
+    expect(text).toContain('Number(');
+  });
+});
+
+describe('what the emitted module carries', () => {
+  it('emits the canonical helper once, and only where a column needs it', async () => {
+    const a = await emit([numS2()], [{ name: 'n_valid', expression: 'n IN (1, 2)' }]);
+    expect(a.text).toContain('DrzlNumericCanon');
+    expect(a.text.split('const DrzlNumericCanon').length).toBe(2);
+    const b = await emit([intC()], [{ expression: 'age IN (18, 21)' }]);
+    expect(b.text).not.toContain('DrzlNumericCanon');
+  });
+});

--- a/packages/generator-json-schema/src/schemas.ts
+++ b/packages/generator-json-schema/src/schemas.ts
@@ -17,6 +17,9 @@ import type {
   RowCheck,
 } from '@drzl/validation-core';
 import {
+  applyWirePolicy,
+  canonicalMembers,
+  comparisonWire,
   COLUMN_FORMATS,
   insertColumns,
   isIntegerColumn,
@@ -64,6 +67,36 @@ const base64 = (target: JsonSchemaTarget): Schema =>
   target === 'openapi-3.0'
     ? { type: 'string', format: 'byte' }
     : { type: 'string', contentEncoding: 'base64' };
+
+/**
+ * A set of numeric-wire members as the pattern accepting exactly their spellings.
+ *
+ * One alternation branch per canonical member. A member `1.5` admits an optional plus sign,
+ * leading integer zeros and trailing fraction zeros ('1.5', '01.50', '+1.500'); a whole member
+ * admits the same plus an optional all-zero fraction and a bare trailing dot ('1', '1.', '1.0');
+ * zero additionally admits either sign, because the database has no negative zero ('-0.00' came
+ * back '0.00', measured). The sign of a nonzero member is fixed: '-1' has no positive spelling.
+ *
+ * `integerOnly` is the bigint string wire, where the fraction forms are left off: '1.0' is not
+ * valid bigint input to Postgres ("invalid input syntax", measured), so admitting it would
+ * accept a write the database refuses for no returned row it could ever match.
+ *
+ * The values arrive canonicalised by the wire policy; `canonicalMembers` here is idempotent and
+ * also dedupes members that name one value.
+ */
+function canonicalSetPattern(values: string[], integerOnly: boolean): string {
+  const branches = canonicalMembers(values).map((member) => {
+    if (member === '0') return integerOnly ? '[+-]?0+' : '[+-]?(?:0+(?:\\.0*)?|0*\\.0+)';
+    const sign = member.startsWith('-') ? '-' : '\\+?';
+    const body = member.startsWith('-') ? member.slice(1) : member;
+    const [int = '', frac = ''] = body.split('.');
+    if (integerOnly) return `${sign}0*${int}`;
+    if (!frac) return `${sign}0*${int}(?:\\.0*)?`;
+    // A zero integer part may be spelled as no integer part at all: '.5' is '0.5'.
+    return int === '0' ? `${sign}0*\\.${frac}0*` : `${sign}0*${int}\\.${frac}0*`;
+  });
+  return `^(?:${branches.join('|')})$`;
+}
 
 /**
  * The JSON Schema for one column, before nullability and defaults are applied.
@@ -161,6 +194,16 @@ function baseSchema(
   // and `Number(v)` also rounds a 64 bit member the moment it becomes a number.
   const set = sets.find((x) => x.column === c.name);
   if (set) {
+    // On a numeric string wire no enum can state the set: the serialised value is the driver's
+    // string, spelled by declared scale ('1.00' for a stored 1, measured), and the database
+    // admits every spelling of a member. A JSON Schema cannot run the canonical compare the
+    // other generators emit, so it becomes a `pattern`: one branch per member, accepting
+    // exactly the spellings that canonicalise to it. That is this format's honest cost: the
+    // document stays ajv strict valid and exact, and what it gives up is the regex's
+    // readability, not admitted rows.
+    if (comparisonWire(c) === 'numeric-string') {
+      return { type: 'string', pattern: canonicalSetPattern(set.values, c.dbType === 'BIGINT') };
+    }
     return {
       enum: set.values.map((v) =>
         set.kind === 'string' || c.tsType === 'bigint' ? v : Number(v)
@@ -178,6 +221,11 @@ function baseSchema(
   const mine = c.arrayDimensions ? [] : checks.filter((k) => k.column === c.name);
   const eq = mine.find((k) => k.operator === '=');
   if (eq) {
+    // A pinned value on a numeric string wire is a one-member set, and takes the same pattern
+    // the set branch takes, for the same reason: the driver spells it by declared scale.
+    if (comparisonWire(c) === 'numeric-string') {
+      return { type: 'string', pattern: canonicalSetPattern([eq.value], c.dbType === 'BIGINT') };
+    }
     // The wire rule the set above applies: on a bigint column the serialised value is a digit
     // string, so the pinned value is one too, and it stays exact where `Number` would round.
     const only = eq.kind === 'string' || c.tsType === 'bigint' ? eq.value : Number(eq.value);
@@ -534,11 +582,22 @@ function tableSchema(
   };
 }
 
+/**
+ * Every CHECK on a table that the shared parser understands, with the wire policy applied:
+ * quoted literals the database compares numerically come back respelled number-kind, and
+ * clauses no exact compare can state are dropped, left to the base schema and reported by the
+ * constraint ledger. See `wireLiteralFit` in `@drzl/validation-core`.
+ */
 function collect(table: Table) {
   const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  const { checks, sets } = applyWirePolicy(
+    table.columns,
+    parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : []))
+  );
   return {
-    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
-    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    checks,
+    sets,
     rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
     lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
     cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),

--- a/packages/generator-json-schema/test/numeric-wire-literals.spec.ts
+++ b/packages/generator-json-schema/test/numeric-wire-literals.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * CHECK literals reconciled with the column's wire, JSON Schema half of addendum BL.
+ *
+ * Ground truth and the measurement table live in the zod twin,
+ * `packages/generator-zod/test/numeric-wire-literals.spec.ts`. In a JSON document a numeric
+ * column is the driver's string, spelled by its declared scale, so `{ enum: [1, 2] }` refused
+ * every serialised row and `{ enum: ['1', '2'] }` would refuse the '1.00' a `numeric(10,2)`
+ * returns.
+ *
+ * A JSON Schema cannot run a function, so the canonical compare becomes a `pattern`: one
+ * alternation, each branch accepting exactly the spellings that canonicalise to one member
+ * (optional plus sign, leading integer zeros, trailing fraction zeros, a bare trailing dot).
+ * That is the honest cost of this format: the document stays ajv strict valid and exact, and
+ * what it gives up is readability of the regex, not admitted rows. On a bigint string wire the
+ * fraction tail is left off, because '1.0' is not valid bigint input to Postgres, measured.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import type { Column, Table } from '@drzl/analyzer';
+import { tableSchemas } from '../src/index';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const table = (columns: Column[], checks: { name?: string; expression?: string }[] = []): Table =>
+  ({ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }) as never;
+
+function compile(schema: unknown) {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  addFormats(ajv as never);
+  return ajv.compile(schema as never);
+}
+
+const numS2 = (name = 'n') =>
+  col(name, {
+    tsType: 'string',
+    dbType: 'NUMERIC',
+    format: 'numeric',
+    integer: false,
+    min: '-99999999.99',
+    max: '99999999.99',
+  });
+const numBare = (name = 'n') =>
+  col(name, { tsType: 'string', dbType: 'NUMERIC', format: 'numeric' });
+const bigB = (name = 'big') =>
+  col(name, {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+const bigS = (name = 'big') => col(name, { tsType: 'string', dbType: 'BIGINT' });
+const intC = (name = 'age') =>
+  col(name, {
+    tsType: 'number',
+    dbType: 'INTEGER',
+    integer: true,
+    min: '-2147483648',
+    max: '2147483647',
+  });
+
+describe('CHECK (n IN (1, 2)) on the numeric string wire', () => {
+  const IN = [{ name: 'n_valid', expression: 'n IN (1, 2)' }];
+
+  it('accepts every driver spelling of an admitted value and rejects the rest, in every mode', () => {
+    const s = tableSchemas(table([numS2()], IN));
+    for (const [mode, schema] of Object.entries(s)) {
+      if (mode === 'components') continue;
+      const v = compile(schema);
+      expect(v({ n: '1.00' }), `${mode} '1.00'`).toBe(true);
+      expect(v({ n: '2.00' }), `${mode} '2.00'`).toBe(true);
+      expect(v({ n: '1' }), `${mode} '1'`).toBe(true);
+      expect(v({ n: '1.000000' }), `${mode} '1.000000'`).toBe(true);
+      expect(v({ n: '3' }), `${mode} '3'`).toBe(false);
+      expect(v({ n: '3.00' }), `${mode} '3.00'`).toBe(false);
+      expect(v({ n: '1.5' }), `${mode} '1.5'`).toBe(false);
+      expect(v({ n: 1 }), `${mode} number 1`).toBe(false);
+      expect(v({ n: 'NaN' }), `${mode} 'NaN'`).toBe(false);
+      expect(v({ n: null }), `${mode} null`).toBe(true);
+    }
+  });
+
+  it('keeps a 20 digit member exact instead of rounding it through a double', () => {
+    const s = tableSchemas(table([numBare()], [{ expression: 'n IN (99999999999999999999)' }]));
+    const v = compile(s.select);
+    expect(v({ n: '99999999999999999999' })).toBe(true);
+    expect(v({ n: '99999999999999999998' })).toBe(false);
+  });
+
+  it('stays ajv strict valid on the openapi target too', () => {
+    const s = tableSchemas(table([numS2()], IN), { target: 'openapi-3.0' } as never);
+    expect(JSON.stringify(s.select)).toContain('pattern');
+  });
+});
+
+describe('equality on the numeric string wire', () => {
+  it('CHECK (n = 1) accepts the scale padded return and rejects 2', () => {
+    const s = tableSchemas(table([numS2()], [{ expression: 'n = 1' }]));
+    const v = compile(s.select);
+    expect(v({ n: '1.00' })).toBe(true);
+    expect(v({ n: '1' })).toBe(true);
+    expect(v({ n: '2.00' })).toBe(false);
+  });
+
+  it('CHECK (n <> 1) stays unenforced here, leniency pinned', () => {
+    // This generator has never stated an inequality in any wire; the format pattern is all
+    // that holds, so both spellings pass and the constraint ledger reports the clause.
+    const s = tableSchemas(table([numS2()], [{ expression: 'n <> 1' }]));
+    const v = compile(s.select);
+    expect(v({ n: '1.00' })).toBe(true);
+    expect(v({ n: '2.00' })).toBe(true);
+  });
+});
+
+describe('quoted literals on the wrong wires', () => {
+  it("CHECK (big IN ('1', '2')) keeps the digit strings a serialised bigint row holds", () => {
+    const s = tableSchemas(table([bigB()], [{ expression: "big IN ('1', '2')" }]));
+    const v = compile(s.select);
+    expect(v({ big: '1' })).toBe(true);
+    expect(v({ big: '2' })).toBe(true);
+    expect(v({ big: '3' })).toBe(false);
+    expect(v({ big: 1 })).toBe(false);
+  });
+
+  it("CHECK (age IN ('18')) accepts the serialised number 18", () => {
+    const s = tableSchemas(table([intC()], [{ expression: "age IN ('18')" }]));
+    const v = compile(s.select);
+    expect(v({ age: 18 })).toBe(true);
+    expect(v({ age: 19 })).toBe(false);
+    expect(v({ age: '18' })).toBe(false);
+  });
+
+  it("CHECK (age = '18') pins the serialised number", () => {
+    const s = tableSchemas(table([intC()], [{ expression: "age = '18'" }]));
+    const v = compile(s.select);
+    expect(v({ age: 18 })).toBe(true);
+    expect(v({ age: 19 })).toBe(false);
+  });
+});
+
+describe('the v1 bigint mode string wire', () => {
+  it('CHECK (big IN (1, 2)) accepts the digit strings the driver returns', () => {
+    const s = tableSchemas(table([bigS()], [{ expression: 'big IN (1, 2)' }]));
+    const v = compile(s.select);
+    expect(v({ big: '1' })).toBe(true);
+    expect(v({ big: '2' })).toBe(true);
+    expect(v({ big: '3' })).toBe(false);
+    // No fraction tail on this wire: '1.0' is not valid bigint input to Postgres.
+    expect(v({ big: '1.0' })).toBe(false);
+  });
+});
+
+describe('members no exact compare can state fall back to leniency', () => {
+  it("CHECK (n IN ('1e3', '2')) enforces nothing rather than rejecting admitted rows", () => {
+    const s = tableSchemas(table([numBare()], [{ expression: "n IN ('1e3', '2')" }]));
+    const v = compile(s.select);
+    expect(v({ n: '1000' })).toBe(true);
+    expect(v({ n: '7' })).toBe(true);
+    expect(v({ n: 'hello' })).toBe(false);
+  });
+
+  it('CHECK (s IN (1, 2)) on a text wire enforces nothing rather than rejecting rows', () => {
+    const s = tableSchemas(table([col('s')], [{ expression: 's IN (1, 2)' }]));
+    const v = compile(s.select);
+    expect(v({ s: '1.00' })).toBe(true);
+    expect(v({ s: 'x' })).toBe(true);
+  });
+});

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -24,6 +24,12 @@ import {
   resolveNestedDepth,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
+  NUMERIC_CANON_NAME,
+  NUMERIC_CANON_SOURCE,
+  applyWirePolicy,
+  canonicalMembers,
+  canonicalNumericText,
+  comparisonWire,
   insertColumns,
   isIntegerColumn,
   lengthCheckLabel,
@@ -31,6 +37,7 @@ import {
   measureExpression,
   moduleFileName,
   moduleSpecifier,
+  needsNumericCanon,
   nonFiniteAccepted,
   parseCheck,
   parsesToADate,
@@ -377,6 +384,72 @@ function tbBigintKindTarget(
 }
 
 /**
+ * The equality class on a numeric string wire, or nothing: the set, plus every `=` and `<>`.
+ *
+ * The same shape and the same sharing rule as `tbBigintKindTarget` above it, and the same
+ * vehicle: no literal can state these, because the driver spells one admitted value many ways by
+ * declared scale ('1.00' for a stored 1, measured) and the database admits them all, so the
+ * compare runs over the canonical spelling inside the registered `DrzlRowCheck` kind, which both
+ * checkers honour. `<>` rides here although the number wires leave it unstated: on this wire the
+ * vehicle is a predicate either way and the predicate is exact, where the declarative forms of
+ * the number wires have no spelling for it and this change does not invent one.
+ */
+function tbNumericCanonTarget(
+  c: Column,
+  checks: ColumnCheck[],
+  sets: ColumnSet[]
+): { set?: ColumnSet; checks: ColumnCheck[] } | undefined {
+  if (comparisonWire(c) !== 'numeric-string') return undefined;
+  if (c.enumValues && c.enumValues.length) return undefined;
+  const set = sets.find((x) => x.column === c.name);
+  const mine = checks.filter(
+    (k) => k.column === c.name && (k.operator === '=' || k.operator === '<>')
+  );
+  if (!set && !mine.length) return undefined;
+  return { ...(set ? { set } : {}), checks: mine };
+}
+
+/**
+ * The kind branches for a numeric-string equality class, intersected onto the string base.
+ *
+ * The base keeps the document saying "a string" when serialised, and for a lone equality it
+ * keeps the numeric format pattern too, exactly as the zod generator keeps its `.regex` under
+ * the canonical refine. The static type stays `string`: the accepted spellings of one member are
+ * unbounded ('1', '1.00', '01'), so no literal union can name them without lying.
+ */
+function tbNumericCanonExpr(
+  c: Column,
+  target: { set?: ColumnSet; checks: ColumnCheck[] }
+): string {
+  const branch = (description: string, test: string) =>
+    `Type.Unsafe<string>({
+    [Kind]: 'DrzlRowCheck',
+    description: ${JSON.stringify(description)},
+    assert: (v: any) => typeof v === 'string' && (${test}),
+  })`;
+  const branches: string[] = [];
+  if (target.set) {
+    const test = canonicalMembers(target.set.values)
+      .map((m) => `${NUMERIC_CANON_NAME}(v) === ${JSON.stringify(m)}`)
+      .join(' || ');
+    branches.push(branch(describeSet(target.set), test));
+  }
+  for (const k of target.checks) {
+    const canon = JSON.stringify(canonicalNumericText(k.value));
+    const op = k.operator === '=' ? '===' : '!==';
+    const label = `${k.name ? `${k.name}: ` : ''}${c.name} ${k.operator} ${
+      k.kind === 'string' ? `'${k.value}'` : k.value
+    }`;
+    branches.push(branch(label, `${NUMERIC_CANON_NAME}(v) ${op} ${canon}`));
+  }
+  // The set replaces the base outright, as it does in every generator; a bare equality keeps the
+  // format pattern underneath it.
+  const fmt = !target.set && c.format ? COLUMN_FORMATS[c.format] : undefined;
+  const base = fmt ? `Type.String({ pattern: ${JSON.stringify(fmt)} })` : 'Type.String()';
+  return `Type.Intersect([${[base, ...branches].join(', ')}])`;
+}
+
+/**
  * The kind branch for a bigint-wire set or equality, intersected onto `Type.BigInt()`.
  *
  * The base keeps the document saying "a bigint" when serialised, exactly as the cap branches sit
@@ -402,6 +475,11 @@ function tbBigintKindExpr(c: Column, target: { set: ColumnSet } | { eq: ColumnCh
 }
 
 function tbCheckOptions(c: Column, checks: ColumnCheck[]): Array<[string, string]> {
+  // Not on a numeric string wire: `minimum` on a `Type.String()` validates nothing in either
+  // checker and serialises a keyword that reads as enforced, which is worse than saying nothing.
+  // The range there is unstated, as the constraint ledger's `bound` fold already implies for
+  // string wires.
+  if (comparisonWire(c) === 'numeric-string') return [];
   const out: Array<[string, string]> = [];
   for (const k of checks.filter((x) => x.column === c.name)) {
     if (k.kind === 'number') {
@@ -556,6 +634,10 @@ function tbExprForColumn(
   // `tbBigintKindTarget` for the two measured refusals that force it to the registered kind.
   const bigintKind = tbBigintKindTarget(c, checks, sets);
   if (bigintKind) return tbBigintKindExpr(c, bigintKind);
+  // The same escape hatch for the numeric string wire, where no literal can meet the driver's
+  // scale-spelled strings: see `tbNumericCanonTarget`.
+  const numericCanon = tbNumericCanonTarget(c, checks, sets);
+  if (numericCanon) return tbNumericCanonExpr(c, numericCanon);
   // `CHECK (status IN ('a', 'b'))` is a union of literals. `Type.Literal` is the only form
   // TypeBox enforces: a `const` option parses and then accepts anything.
   const set = sets.find((x) => x.column === c.name);
@@ -755,12 +837,23 @@ function renderObjectShape(
     .join('\n');
 }
 
-/** Every CHECK on a table that the shared parser understands, split by what it constrains. */
+/**
+ * Every CHECK on a table that the shared parser understands, split by what it constrains.
+ *
+ * The wire policy runs here, exactly as in the zod generator: quoted literals the database
+ * compares numerically come back respelled number-kind, and clauses no exact compare can state
+ * are dropped, left to the base schema and reported by the constraint ledger.
+ */
 function parsedChecksFor(table: Table) {
   const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  const { checks, sets } = applyWirePolicy(
+    table.columns,
+    parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : []))
+  );
   return {
-    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
-    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    checks,
+    sets,
     rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
     lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
     cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),
@@ -960,13 +1053,9 @@ function renderTableSchemas(
   const selectCols = selectColumns(table);
 
   // Only checks the shared parser understands with certainty. Ambiguous ones are skipped rather
-  // than guessed at, identically to the other validation generators.
-  const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
-  const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
-  const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
-  const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
-  const cardinalities = parsedChecks.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : []));
-  const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
+  // than guessed at, identically to the other validation generators, and `parsedChecksFor` also
+  // applies the wire policy: see its note.
+  const { checks, sets, rows, cardinalities, lengths } = parsedChecksFor(table);
 
   const tj = typedJson
     ? { table: T, mode: 'select' as const, allColumns: typedJson.allColumns }
@@ -1055,7 +1144,8 @@ function renderTableSchemas(
           tbNeedsCapKind(c) ||
           tbNeedsNonFiniteKind(c) ||
           tbNeedsDateKind(c, m, coerceDates) ||
-          !!tbBigintKindTarget(c, checks, sets)
+          !!tbBigintKindTarget(c, checks, sets) ||
+          !!tbNumericCanonTarget(c, checks, sets)
       )
     ) ||
     nestedByMode.some(([cs, m, tbl]) => {
@@ -1069,11 +1159,22 @@ function renderTableSchemas(
             tbNeedsCapKind(c) ||
             tbNeedsNonFiniteKind(c) ||
             tbNeedsDateKind(c, m, coerceDates) ||
-            !!tbBigintKindTarget(c, own.checks, own.sets)
+            !!tbBigintKindTarget(c, own.checks, own.sets) ||
+            !!tbNumericCanonTarget(c, own.checks, own.sets)
         )
       );
     });
   const rowImport = needsRows ? `, Kind, TypeRegistry` : '';
+
+  // The canonical helper, once per file that compares on a numeric string wire, nested tables
+  // included for the reason both preambles above include them. `needsNumericCanon` is the shared
+  // condition; a drifted local copy would emit a reference to a helper the file never defined.
+  const needsCanon =
+    needsNumericCanon(table.columns, checks, sets) ||
+    nestedByMode.some(([, , tbl]) => {
+      const own = parsedChecksFor(tbl);
+      return needsNumericCanon(tbl.columns, own.checks, own.sets);
+    });
 
   // Uniqueness is a fact about the table, so no per-row schema can see it. This checks the
   // half that needs no database: whether a batch collides with itself.
@@ -1117,7 +1218,7 @@ function renderTableSchemas(
 
   return `import { Type${rowImport} } from '@sinclair/typebox';
 import type { Static${needsBrand ? ', TSchema, TUnsafe' : ''} } from '@sinclair/typebox';
-${standardImport}${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}${needsRows ? `\n${ROW_PREAMBLE}` : ''}${needsBrand ? `\n${BRAND_PREAMBLE}` : ''}
+${standardImport}${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}${needsRows ? `\n${ROW_PREAMBLE}` : ''}${needsCanon ? `\n${NUMERIC_CANON_SOURCE}` : ''}${needsBrand ? `\n${BRAND_PREAMBLE}` : ''}
 export const ${insertSchema} = ${wrap(tbWrapRows(`Type.Object({\n${bodyInsert}\n})`, rows, insertCols, lengths))};
 
 export const ${updateSchema} = ${wrap(tbWrapRows(`Type.Object({\n${bodyUpdate}\n})`, rows, updateCols, lengths))};

--- a/packages/generator-typebox/test/numeric-wire-literals.spec.ts
+++ b/packages/generator-typebox/test/numeric-wire-literals.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * CHECK literals reconciled with the column's wire, TypeBox half of addendum BL.
+ *
+ * Ground truth and the measurement table live in the zod twin,
+ * `packages/generator-zod/test/numeric-wire-literals.spec.ts`: a `numeric(10,2)` returns '1.00'
+ * for a stored 1 and the database compares scale insensitively, so
+ * `Type.Union([Type.Literal(1), Type.Literal(2)])` rejected every returned row, and the quoted
+ * spellings `Type.Literal("1")` rejected every `1n` a bigint wire returns.
+ *
+ * The canonical compare cannot be a literal at all, so it rides the registered `DrzlRowCheck`
+ * kind, the same escape hatch the character caps and the bigint sets already use, and both
+ * checkers are run here because they disagree about what a schema may carry: `TypeCompiler`
+ * throws its preflight error on shapes `Value.Check` accepts.
+ */
+import { describe, it, expect } from 'vitest';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+import { TypeBoxGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const RUN = (schema: any, input: unknown) => Value.Check(schema, input);
+const COMPILED = (schema: any, input: unknown) => TypeCompiler.Compile(schema).Check(input);
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const numS2 = (name = 'n') =>
+  col(name, {
+    tsType: 'string',
+    dbType: 'NUMERIC',
+    format: 'numeric',
+    integer: false,
+    min: '-99999999.99',
+    max: '99999999.99',
+  });
+const numBare = (name = 'n') =>
+  col(name, { tsType: 'string', dbType: 'NUMERIC', format: 'numeric' });
+const bigB = (name = 'big') =>
+  col(name, {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+const intC = (name = 'age') =>
+  col(name, {
+    tsType: 'number',
+    dbType: 'INTEGER',
+    integer: true,
+    min: '-2147483648',
+    max: '2147483647',
+  });
+
+let seq = 0;
+
+async function emit(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<{ modules: Record<string, any>; text: string }> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-numeric-wire');
+  await fs.mkdir(dir, { recursive: true });
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  const text = await fs.readFile(path.join(dir, 't.typebox.ts'), 'utf8');
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), file);
+  return { modules: await import(file), text };
+}
+
+describe('CHECK (n IN (1, 2)) on the numeric string wire', () => {
+  const IN = [{ name: 'n_valid', expression: 'n IN (1, 2)' }];
+
+  it('accepts every driver spelling of an admitted value under both checkers, in every mode', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      for (const check of [RUN, COMPILED]) {
+        expect(check(m[s], { n: '1.00' }), `${s} '1.00'`).toBe(true);
+        expect(check(m[s], { n: '2.00' }), `${s} '2.00'`).toBe(true);
+        expect(check(m[s], { n: '1' }), `${s} '1'`).toBe(true);
+        expect(check(m[s], { n: '1.000000' }), `${s} '1.000000'`).toBe(true);
+        expect(check(m[s], { n: '3' }), `${s} '3'`).toBe(false);
+        expect(check(m[s], { n: '3.00' }), `${s} '3.00'`).toBe(false);
+        expect(check(m[s], { n: '1.5' }), `${s} '1.5'`).toBe(false);
+        expect(check(m[s], { n: 1 }), `${s} number 1`).toBe(false);
+        expect(check(m[s], { n: 'NaN' }), `${s} 'NaN'`).toBe(false);
+      }
+    }
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    expect(RUN(m.SelecttSchema, { n: null })).toBe(true);
+    expect(COMPILED(m.SelecttSchema, { n: null })).toBe(true);
+  });
+
+  it('keeps a 20 digit member exact instead of rounding it through a double', async () => {
+    const { modules: m } = await emit(
+      [numBare()],
+      [{ expression: 'n IN (99999999999999999999)' }]
+    );
+    expect(RUN(m.SelecttSchema, { n: '99999999999999999999' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '99999999999999999998' })).toBe(false);
+  });
+
+  it('serialises to a valid document rather than throwing on the predicate', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    expect(() => JSON.stringify(m.SelecttSchema)).not.toThrow();
+  });
+});
+
+describe('the OR fold of the same constraint', () => {
+  it('emits byte for byte what the IN list it means emits', async () => {
+    const a = await emit([numS2()], [{ name: 'n_valid', expression: 'n = 1 OR n = 2' }]);
+    const b = await emit([numS2()], [{ name: 'n_valid', expression: 'n IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+});
+
+describe('equality and inequality on the numeric string wire', () => {
+  it('CHECK (n = 1) accepts the scale padded return and rejects 2, under both checkers', async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: 'n = 1' }]);
+    for (const check of [RUN, COMPILED]) {
+      expect(check(m.SelecttSchema, { n: '1.00' })).toBe(true);
+      expect(check(m.SelecttSchema, { n: '1' })).toBe(true);
+      expect(check(m.SelecttSchema, { n: '2.00' })).toBe(false);
+    }
+  });
+
+  it('CHECK (n <> 1) rejects every spelling of 1 and accepts 2', async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: 'n <> 1' }]);
+    expect(RUN(m.SelecttSchema, { n: '1.00' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { n: '1' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { n: '2.00' })).toBe(true);
+  });
+});
+
+describe('quoted literals on the wrong wires', () => {
+  it("CHECK (big IN ('1', '2')) accepts the bigints the driver returns, under both checkers", async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: "big IN ('1', '2')" }]);
+    for (const check of [RUN, COMPILED]) {
+      expect(check(m.SelecttSchema, { big: 1n })).toBe(true);
+      expect(check(m.SelecttSchema, { big: 2n })).toBe(true);
+      expect(check(m.SelecttSchema, { big: 3n })).toBe(false);
+      expect(check(m.SelecttSchema, { big: '1' })).toBe(false);
+    }
+  });
+
+  it('emits byte for byte what the unquoted IN emits', async () => {
+    const a = await emit([bigB()], [{ name: 'c', expression: "big IN ('1', '2')" }]);
+    const b = await emit([bigB()], [{ name: 'c', expression: 'big IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+
+  it("CHECK (big = '1') accepts 1n and rejects 2n", async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: "big = '1'" }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(false);
+  });
+
+  it("CHECK (age IN ('18')) accepts the number 18 the driver returns", async () => {
+    const { modules: m } = await emit([intC()], [{ expression: "age IN ('18')" }]);
+    expect(RUN(m.SelecttSchema, { age: 18 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { age: 19 })).toBe(false);
+    expect(RUN(m.SelecttSchema, { age: '18' })).toBe(false);
+  });
+
+  it("a quoted range, CHECK (age >= '18'), binds like its unquoted twin", async () => {
+    const { modules: m } = await emit([intC()], [{ expression: "age >= '18'" }]);
+    expect(RUN(m.SelecttSchema, { age: 18 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { age: 17 })).toBe(false);
+  });
+});
+
+describe('members no exact compare can state fall back to leniency', () => {
+  it("CHECK (n IN ('1e3', '2')) enforces nothing rather than rejecting admitted rows", async () => {
+    const { modules: m } = await emit([numBare()], [{ expression: "n IN ('1e3', '2')" }]);
+    expect(RUN(m.SelecttSchema, { n: '1000' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '7' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: 'hello' })).toBe(false);
+  });
+
+  it('CHECK (s IN (1, 2)) on a text wire enforces nothing rather than rejecting rows', async () => {
+    const { modules: m } = await emit([col('s')], [{ expression: 's IN (1, 2)' }]);
+    expect(RUN(m.SelecttSchema, { s: '1.00' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { s: 'x' })).toBe(true);
+  });
+});
+
+describe('what the emitted module carries', () => {
+  it('emits the canonical helper and the registered kind once, and only where needed', async () => {
+    const a = await emit([numS2()], [{ name: 'n_valid', expression: 'n IN (1, 2)' }]);
+    expect(a.text).toContain('DrzlNumericCanon');
+    expect(a.text.split('const DrzlNumericCanon').length).toBe(2);
+    expect(a.text).toContain("TypeRegistry.Set('DrzlRowCheck'");
+    const b = await emit([intC()], [{ expression: 'age IN (18, 21)' }]);
+    expect(b.text).not.toContain('DrzlNumericCanon');
+  });
+
+  it('no longer plants a dead minimum keyword on a string schema', async () => {
+    // `Type.String({ minimum: 1 })` validated nothing and serialised a keyword that reads as
+    // enforced. The range on this wire is a coerced compare or nothing.
+    const { text } = await emit([numS2()], [{ expression: 'n >= 1' }]);
+    expect(text).not.toContain('minimum: 1,');
+  });
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -9,11 +9,19 @@ import type { CardinalityCheck, ColumnCheck, ColumnSet, LengthCheck } from '@drz
 import type { NestedMode, NestedNode } from '@drzl/validation-core';
 import type { BrandPlan, ConstraintsOption } from '@drzl/validation-core';
 import {
+  applyWirePolicy,
   buildBrandPlan,
   buildNestedPlan,
+  canonicalMembers,
+  canonicalNumericText,
+  comparisonWire,
+  describeSet,
+  needsNumericCanon,
   COERCIBLE_DATE_STRING,
   COLUMN_FORMATS,
   CONSTRAINTS_MODULE,
+  NUMERIC_CANON_NAME,
+  NUMERIC_CANON_SOURCE,
   importSpecifier,
   insertColumns,
   isIntegerColumn,
@@ -178,14 +186,29 @@ function vChecks(c: Column, checks: ColumnCheck[]): string[] {
     '<>': '!==',
   };
   const folded = foldedIntoBounds(c, checks);
+  const numericWire = comparisonWire(c) === 'numeric-string';
   return checks
     .filter((k) => k.column === c.name && !folded.has(k))
     .map((k) => {
+      const shown = k.kind === 'string' ? `'${k.value}'` : k.value;
+      const msg = JSON.stringify(`${k.name ? `${k.name}: ` : ''}${c.name} ${k.operator} ${shown}`);
+      // On a numeric string wire the driver spells one value many ways ('1', '1.00') and the
+      // database compares them as numbers, so `val === 1` was false for every returned row and
+      // `val !== 1` enforced nothing. Equality goes through the canonical spelling; a range
+      // keeps its coerced numeric compare, spelled `Number(val)` so the comparison it always
+      // performed is visible and the module typechecks. See the zod generator and
+      // `wireLiteralFit`.
+      if (numericWire) {
+        if (k.operator === '=' || k.operator === '<>') {
+          const canon = JSON.stringify(canonicalNumericText(k.value));
+          const op = k.operator === '=' ? '===' : '!==';
+          return `v.check((val) => ${NUMERIC_CANON_NAME}(val) ${op} ${canon}, ${msg})`;
+        }
+        return `v.check((val) => Number(val) ${OPS[k.operator]} ${k.value}, ${msg})`;
+      }
       // Strict equality for `=` and `<>` demands the wire type: `val === 1` is false for every
       // `1n` a bigint-mode column returns. The message keeps the SQL spelling either way.
       const rhs = k.kind === 'string' ? JSON.stringify(k.value) : wireNumberLiteral(c, k.value);
-      const shown = k.kind === 'string' ? `'${k.value}'` : k.value;
-      const msg = JSON.stringify(`${k.name ? `${k.name}: ` : ''}${c.name} ${k.operator} ${shown}`);
       return `v.check((val) => val ${OPS[k.operator]} ${rhs}, ${msg})`;
     });
 }
@@ -368,6 +391,19 @@ function vExprForColumn(
   // 64 bit member exact: written as a number it rounds the moment it is parsed.
   const set = sets.find((x) => x.column === c.name);
   if (set) {
+    // On a numeric string wire no list of literals can state the set: the driver spells one
+    // admitted value many ways by declared scale ('1.00' for a stored 1, measured) and the
+    // database admits them all. The compare runs over the canonical spelling instead, exact at
+    // any precision where `Number()` rounds. See the zod generator and `wireLiteralFit`.
+    if (comparisonWire(c) === 'numeric-string') {
+      const members = canonicalMembers(set.values);
+      const test = members.map((m) => `canon === ${JSON.stringify(m)}`).join(' || ');
+      const msg = JSON.stringify(describeSet(set));
+      return (
+        `v.pipe(v.string(), v.check((val) => { const canon = ${NUMERIC_CANON_NAME}(val); ` +
+        `return ${test}; }, ${msg}))`
+      );
+    }
     return set.kind === 'string'
       ? `v.picklist([${set.values.map((v) => JSON.stringify(v)).join(', ')}] as const)`
       : `v.union([${set.values.map((v) => `v.literal(${wireNumberLiteral(c, v)})`).join(', ')}])`;
@@ -572,12 +608,23 @@ function vRowChecks(rows: RowCheck[], cols: Column[]): string[] {
   );
 }
 
-/** Every CHECK on a table that the shared parser understands, split by what it constrains. */
+/**
+ * Every CHECK on a table that the shared parser understands, split by what it constrains.
+ *
+ * The wire policy runs here, exactly as in the zod generator: quoted literals the database
+ * compares numerically come back respelled number-kind, and clauses no exact compare can state
+ * are dropped, left to the base schema and reported by the constraint ledger.
+ */
 function parsedChecksFor(table: Table) {
   const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  const { checks, sets } = applyWirePolicy(
+    table.columns,
+    parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : []))
+  );
   return {
-    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
-    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    checks,
+    sets,
     rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
     lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
     cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),
@@ -732,13 +779,9 @@ function renderTableSchemas(
   const updateCols = updateColumns(table);
   const selectCols = selectColumns(table);
   // Only checks the shared parser understands with certainty; the rest are skipped rather
-  // than guessed at, exactly as in the Zod generator.
-  const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
-  const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
-  const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
-  const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
-  const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
-  const cardinalities = parsedChecks.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : []));
+  // than guessed at, exactly as in the Zod generator, and `parsedChecksFor` also applies the
+  // wire policy: see its note.
+  const { checks, sets, rows, lengths, cardinalities } = parsedChecksFor(table);
   const tj = typedColumns ? { table: T, mode: 'select' as const } : undefined;
   const tjInsert = typedColumns ? { table: T, mode: 'insert' as const } : undefined;
   // A type-only import: erased at build time, so it adds no runtime dependency on the schema
@@ -827,9 +870,27 @@ function renderTableSchemas(
     .join('\n\n');
   const brandCode = brandAliases ? `\n${brandAliases}\n` : '';
 
+  // The canonical helper, once per file that compares on a numeric string wire, nested tables
+  // included for the reason the json preamble includes them: their fields render into this same
+  // module. Conditional because an unused declaration fails `noUnusedLocals` downstream.
+  const nestedNodeTables = (node: NestedNode): Table[] => [
+    node.table,
+    ...node.arms.flatMap((a) => nestedNodeTables(a.child)),
+  ];
+  const involved = [
+    table,
+    ...Object.values(nested).flatMap((plan) => (plan ? nestedNodeTables(plan) : [])),
+  ];
+  const canonPreamble = involved.some((t) => {
+    const own = parsedChecksFor(t);
+    return needsNumericCanon(t.columns, own.checks, own.sets);
+  })
+    ? `\n${NUMERIC_CANON_SOURCE}`
+    : '';
+
   return `import * as v from 'valibot';
 import type { InferInput, InferOutput } from 'valibot';
-${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}
+${schemaImport}${needsJson ? `\n${JSON_PREAMBLE}` : ''}${canonPreamble}
 export const ${insertSchema} = ${wrapRows(`v.object({\n${bodyInsert}\n})`, rows, insertCols)};
 
 export const ${updateSchema} = ${wrapRows(`v.object({\n${bodyUpdate}\n})`, rows, updateCols)};

--- a/packages/generator-valibot/test/numeric-wire-literals.spec.ts
+++ b/packages/generator-valibot/test/numeric-wire-literals.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * CHECK literals reconciled with the column's wire, valibot half of addendum BL.
+ *
+ * Ground truth and the full measurement table live in the zod twin,
+ * `packages/generator-zod/test/numeric-wire-literals.spec.ts`. The short form: a
+ * `numeric(10,2)` returns '1.00' for a stored 1 and the database compares scale insensitively
+ * (`1 = 1.00` is true, measured on PostgreSQL 17.5 and MySQL 8.4.11), so
+ * `v.union([v.literal(1), v.literal(2)])` rejected every returned row; and
+ * `bigint CHECK (big IN ('1','2'))` admits 1, so `v.picklist(['1','2'])` rejected every `1n`.
+ * The canonical decimal compare is emitted inline as `DrzlNumericCanon`, exact at any precision
+ * where `Number()` rounds.
+ */
+import { describe, it, expect } from 'vitest';
+import * as v from 'valibot';
+import { ValibotGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const RUN = (schema: any, input: unknown) => v.safeParse(schema, input).success;
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const numS2 = (name = 'n') =>
+  col(name, {
+    tsType: 'string',
+    dbType: 'NUMERIC',
+    format: 'numeric',
+    integer: false,
+    min: '-99999999.99',
+    max: '99999999.99',
+  });
+const numBare = (name = 'n') =>
+  col(name, { tsType: 'string', dbType: 'NUMERIC', format: 'numeric' });
+const bigB = (name = 'big') =>
+  col(name, {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+const intC = (name = 'age') =>
+  col(name, {
+    tsType: 'number',
+    dbType: 'INTEGER',
+    integer: true,
+    min: '-2147483648',
+    max: '2147483647',
+  });
+
+let seq = 0;
+
+async function emit(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<{ modules: Record<string, any>; text: string }> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-numeric-wire');
+  await fs.mkdir(dir, { recursive: true });
+  await new ValibotGenerator(analysis).generate({ outDir: dir } as never);
+  const text = await fs.readFile(path.join(dir, 't.valibot.ts'), 'utf8');
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.valibot.ts'), file);
+  return { modules: await import(file), text };
+}
+
+describe('CHECK (n IN (1, 2)) on the numeric string wire', () => {
+  const IN = [{ name: 'n_valid', expression: 'n IN (1, 2)' }];
+
+  it('accepts every driver spelling of an admitted value and rejects the rest, in every mode', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      expect(RUN(m[s], { n: '1.00' }), `${s} '1.00'`).toBe(true);
+      expect(RUN(m[s], { n: '2.00' }), `${s} '2.00'`).toBe(true);
+      expect(RUN(m[s], { n: '1' }), `${s} '1'`).toBe(true);
+      expect(RUN(m[s], { n: '1.000000' }), `${s} '1.000000'`).toBe(true);
+      expect(RUN(m[s], { n: '3' }), `${s} '3'`).toBe(false);
+      expect(RUN(m[s], { n: '3.00' }), `${s} '3.00'`).toBe(false);
+      expect(RUN(m[s], { n: '1.5' }), `${s} '1.5'`).toBe(false);
+      expect(RUN(m[s], { n: 1 }), `${s} number 1`).toBe(false);
+      expect(RUN(m[s], { n: 'NaN' }), `${s} 'NaN'`).toBe(false);
+    }
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    expect(RUN(m.SelecttSchema, { n: null })).toBe(true);
+  });
+
+  it('keeps a 20 digit member exact instead of rounding it through a double', async () => {
+    const { modules: m } = await emit(
+      [numBare()],
+      [{ expression: 'n IN (99999999999999999999)' }]
+    );
+    expect(RUN(m.SelecttSchema, { n: '99999999999999999999' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '99999999999999999998' })).toBe(false);
+  });
+});
+
+describe('the OR fold of the same constraint', () => {
+  it('emits byte for byte what the IN list it means emits', async () => {
+    const a = await emit([numS2()], [{ name: 'n_valid', expression: 'n = 1 OR n = 2' }]);
+    const b = await emit([numS2()], [{ name: 'n_valid', expression: 'n IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+});
+
+describe('equality and inequality on the numeric string wire', () => {
+  it('CHECK (n = 1) accepts the scale padded return and rejects 2', async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: 'n = 1' }]);
+    expect(RUN(m.SelecttSchema, { n: '1.00' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '1' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '2.00' })).toBe(false);
+  });
+
+  it('CHECK (n <> 1) rejects every spelling of 1 and accepts 2', async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: 'n <> 1' }]);
+    expect(RUN(m.SelecttSchema, { n: '1.00' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { n: '1' })).toBe(false);
+    expect(RUN(m.SelecttSchema, { n: '2.00' })).toBe(true);
+  });
+});
+
+describe('quoted literals on the wrong wires', () => {
+  it("CHECK (big IN ('1', '2')) accepts the bigints the driver returns", async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: "big IN ('1', '2')" }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 3n })).toBe(false);
+    expect(RUN(m.SelecttSchema, { big: '1' })).toBe(false);
+  });
+
+  it("CHECK (big = '1') accepts 1n and rejects 2n", async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: "big = '1'" }]);
+    expect(RUN(m.SelecttSchema, { big: 1n })).toBe(true);
+    expect(RUN(m.SelecttSchema, { big: 2n })).toBe(false);
+  });
+
+  it("CHECK (age IN ('18')) accepts the number 18 the driver returns", async () => {
+    const { modules: m } = await emit([intC()], [{ expression: "age IN ('18')" }]);
+    expect(RUN(m.SelecttSchema, { age: 18 })).toBe(true);
+    expect(RUN(m.SelecttSchema, { age: 19 })).toBe(false);
+    expect(RUN(m.SelecttSchema, { age: '18' })).toBe(false);
+  });
+});
+
+describe('members no exact compare can state fall back to leniency', () => {
+  it("CHECK (n IN ('1e3', '2')) enforces nothing rather than rejecting admitted rows", async () => {
+    const { modules: m } = await emit([numBare()], [{ expression: "n IN ('1e3', '2')" }]);
+    expect(RUN(m.SelecttSchema, { n: '1000' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '7' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: 'hello' })).toBe(false);
+  });
+
+  it('CHECK (s IN (1, 2)) on a text wire enforces nothing rather than rejecting rows', async () => {
+    const { modules: m } = await emit([col('s')], [{ expression: 's IN (1, 2)' }]);
+    expect(RUN(m.SelecttSchema, { s: '1.00' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { s: 'x' })).toBe(true);
+  });
+});
+
+describe('ranges on the numeric string wire', () => {
+  it('CHECK (n >= 1) compares numerically and is spelled type clean', async () => {
+    const { modules: m, text } = await emit([numS2()], [{ expression: 'n >= 1' }]);
+    expect(RUN(m.SelecttSchema, { n: '1.00' })).toBe(true);
+    expect(RUN(m.SelecttSchema, { n: '0.99' })).toBe(false);
+    expect(text).toContain('Number(');
+  });
+});
+
+describe('what the emitted module carries', () => {
+  it('emits the canonical helper once, and only where a column needs it', async () => {
+    const a = await emit([numS2()], [{ name: 'n_valid', expression: 'n IN (1, 2)' }]);
+    expect(a.text).toContain('DrzlNumericCanon');
+    expect(a.text.split('const DrzlNumericCanon').length).toBe(2);
+    expect(a.text).toContain('n_valid: n IN (1, 2)');
+    const b = await emit([intC()], [{ expression: 'age IN (18, 21)' }]);
+    expect(b.text).not.toContain('DrzlNumericCanon');
+  });
+});

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -15,13 +15,21 @@ import type { NestedNode, NestedMode } from '@drzl/validation-core';
 import type { BrandPlan } from '@drzl/validation-core';
 import type { ConstraintsOption } from '@drzl/validation-core';
 import {
+  applyWirePolicy,
   buildBrandPlan,
+  canonicalMembers,
+  canonicalNumericText,
   columnMetaFacts,
+  comparisonWire,
+  describeSet,
   formatCode,
+  needsNumericCanon,
   parseCheck,
   renderConstraintsModule,
   resolveConstraints,
   CONSTRAINTS_MODULE,
+  NUMERIC_CANON_NAME,
+  NUMERIC_CANON_SOURCE,
   renderDuplicateFinder,
   resolveConfiguredImport,
   buildNestedPlan,
@@ -247,16 +255,31 @@ function checkRefinements(c: Column, checks: ColumnCheck[]): string {
     '<>': '!==',
   };
 
+  const numericWire = comparisonWire(c) === 'numeric-string';
   return mine
     .map((k) => {
-      // The right side is compared with strict equality for `=` and `<>`, so it has to be spelled
-      // in the column's wire type: `v === 1` is false for every `1n` a bigint-mode column returns.
-      // The message keeps the SQL spelling either way.
-      const rhs = k.kind === 'string' ? JSON.stringify(k.value) : wireNumberLiteral(c, k.value);
       const label = k.name ? `${k.name}: ` : '';
       const msg = JSON.stringify(
         `${label}${c.name} ${k.operator} ${k.kind === 'string' ? `'${k.value}'` : k.value}`
       );
+      // On a numeric string wire the driver spells one value many ways ('1', '1.00'), and the
+      // database compares them as numbers, so `v === 1` was false for every returned row and
+      // `v !== 1` enforced nothing. Equality goes through the canonical spelling; a range keeps
+      // its coerced numeric compare, spelled `Number(v)` so the comparison it always performed
+      // is visible and the module typechecks. The wire policy guarantees the canonical text
+      // exists here; see `wireLiteralFit`.
+      if (numericWire) {
+        if (k.operator === '=' || k.operator === '<>') {
+          const canon = JSON.stringify(canonicalNumericText(k.value));
+          const op = k.operator === '=' ? '===' : '!==';
+          return `.refine((v) => ${NUMERIC_CANON_NAME}(v) ${op} ${canon}, { message: ${msg} })`;
+        }
+        return `.refine((v) => Number(v) ${OPS[k.operator]} ${k.value}, { message: ${msg} })`;
+      }
+      // The right side is compared with strict equality for `=` and `<>`, so it has to be spelled
+      // in the column's wire type: `v === 1` is false for every `1n` a bigint-mode column returns.
+      // The message keeps the SQL spelling either way.
+      const rhs = k.kind === 'string' ? JSON.stringify(k.value) : wireNumberLiteral(c, k.value);
       return `.refine((v) => v ${OPS[k.operator]} ${rhs}, { message: ${msg} })`;
     })
     .join('');
@@ -360,6 +383,20 @@ function zodExprForColumn(
   // parsed.
   const set = sets.find((x) => x.column === c.name);
   if (set) {
+    // On a numeric string wire no list of literals can state the set: the driver spells one
+    // admitted value many ways by declared scale (a `numeric(10,2)` returns '1.00' for a stored
+    // 1, measured), and the database admits them all (`1.000000 IN (1, 2)` is true). The compare
+    // runs over the canonical spelling instead, exact at any precision where `Number()` rounds.
+    // The message keeps the SQL spelling, which is what the constraint ledger keys on.
+    if (comparisonWire(c) === 'numeric-string') {
+      const members = canonicalMembers(set.values);
+      const test = members.map((m) => `canon === ${JSON.stringify(m)}`).join(' || ');
+      const msg = JSON.stringify(describeSet(set));
+      return (
+        `z.string().refine((v) => { const canon = ${NUMERIC_CANON_NAME}(v); ` +
+        `return ${test}; }, { message: ${msg} })`
+      );
+    }
     return set.kind === 'string'
       ? `z.enum([${set.values.map((v) => JSON.stringify(v)).join(', ')}] as const)`
       : `z.union([${set.values.map((v) => `z.literal(${wireNumberLiteral(c, v)})`).join(', ')}])`;
@@ -596,12 +633,24 @@ function rowRefinements(rows: RowCheck[], cols: Column[]): string {
   );
 }
 
-/** Every CHECK on a table that the shared parser understands, split by what it constrains. */
+/**
+ * Every CHECK on a table that the shared parser understands, split by what it constrains.
+ *
+ * The wire policy runs here: quoted literals the database compares numerically come back
+ * respelled as their number-kind selves, and clauses no exact compare can state are dropped from
+ * these lists entirely, which is what leaves them to the base schema. The constraint ledger
+ * applies the same policy and reports the dropped ones with their reasons.
+ */
 function parsedChecksFor(table: Table) {
   const parsed = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
+  const { checks, sets } = applyWirePolicy(
+    table.columns,
+    parsed.flatMap((p) => (p.ok ? p.checks : [])),
+    parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : []))
+  );
   return {
-    checks: parsed.flatMap((p) => (p.ok ? p.checks : [])),
-    sets: parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : [])),
+    checks,
+    sets,
     rows: parsed.flatMap((p) => (p.ok ? (p.rows ?? []) : [])),
     lengths: parsed.flatMap((p) => (p.ok ? (p.lengths ?? []) : [])),
     cardinalities: parsed.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : [])),
@@ -757,13 +806,9 @@ function renderTableSchemas(
   const updateCols = updateColumns(table);
   const selectCols = selectColumns(table);
   // Only the checks this version can translate with certainty. The parser skips anything
-  // ambiguous, since a schema that enforces a guess rejects rows the database would accept.
-  const parsedChecks = (table.checks ?? []).map((k) => parseCheck(k.expression, k.name));
-  const checks = parsedChecks.flatMap((p) => (p.ok ? p.checks : []));
-  const sets = parsedChecks.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
-  const rows = parsedChecks.flatMap((p) => (p.ok ? (p.rows ?? []) : []));
-  const lengths = parsedChecks.flatMap((p) => (p.ok ? (p.lengths ?? []) : []));
-  const cardinalities = parsedChecks.flatMap((p) => (p.ok ? (p.cardinalities ?? []) : []));
+  // ambiguous, since a schema that enforces a guess rejects rows the database would accept, and
+  // `parsedChecksFor` also applies the wire policy: see its note.
+  const { checks, sets, rows, lengths, cardinalities } = parsedChecksFor(table);
   // Insert and select can disagree: a json column with a default is optional on insert, so its
   // inferred type differs. Each shape therefore references the matching inference.
   const tj = typedJson
@@ -882,8 +927,27 @@ export type ${updateType} = z.input<typeof ${updateSchema}>;
     .join('\n\n');
   const brandCode = brandAliases ? `\n${brandAliases}\n` : '';
 
+  // The canonical helper, once per file that compares on a numeric string wire, nested tables
+  // included: their fields render into this same module. Conditional for the reason every other
+  // conditional preamble is: an unused declaration fails `noUnusedLocals` in the consumer's
+  // build.
+  const nestedNodeTables = (node: NestedNode): Table[] => [
+    node.table,
+    ...node.arms.flatMap((a) => nestedNodeTables(a.child)),
+  ];
+  const involved = [
+    table,
+    ...Object.values(nested).flatMap((plan) => (plan ? nestedNodeTables(plan) : [])),
+  ];
+  const canonPreamble = involved.some((t) => {
+    const own = parsedChecksFor(t);
+    return needsNumericCanon(t.columns, own.checks, own.sets);
+  })
+    ? `\n${NUMERIC_CANON_SOURCE}`
+    : '';
+
   return `import { z } from 'zod';
-${schemaImport}
+${schemaImport}${canonPreamble}
 ${writes}export const ${selectSchema} = z.object({
 ${bodySelect}
 })${rowRefinements(rows, selectCols)}${tableMetaFor('select')};

--- a/packages/generator-zod/test/numeric-wire-literals.spec.ts
+++ b/packages/generator-zod/test/numeric-wire-literals.spec.ts
@@ -1,0 +1,307 @@
+/**
+ * CHECK literals reconciled with the column's wire by the database's comparison semantics,
+ * run against the exact strings the driver returns (plan addendum BL).
+ *
+ * GROUND TRUTH, measured on PostgreSQL 17.5 through PGlite, raw and through both drizzle majors
+ * (1.0.0-rc.4 and 0.45.2 over the pglite driver, byte for byte identical), and on MySQL 8.4.11
+ * through mysql2 for decimal. The driver spells one admitted value by the column's declared
+ * scale:
+ *
+ *   stored                 numeric        numeric(10,2)   numeric(20,10)    mysql decimal(10,2)
+ *   1                      '1'            '1.00'          '1.0000000000'    '1.00'
+ *   1.5                    '1.5'          '1.50'          '1.5000000000'    '1.50'
+ *   1.000000               '1.000000'    (a bare numeric keeps the insert's own zeros)
+ *   99999999999999999999   exact, all 20 digits
+ *
+ * The database compares scale insensitively: `1 = 1.00` is true, `1.000000 IN (1, 2)` is true,
+ * and `numeric(10,2) CHECK (n IN (1, 2))` admitted 1, 1.00 and '1.000000' while refusing 3 and
+ * 1.5, returning every admitted row as '1.00'. So `z.union([z.literal(1), z.literal(2)])`
+ * rejected every row this column ever returns, and the exact strings '1'/'2' would too. Quoted
+ * literals point the same way from the other side: `bigint CHECK (big IN ('1','2'))` admitted 1
+ * and refused 3, and `integer CHECK (age IN ('18'))` admitted 18, because the literal is coerced
+ * to the column's type before comparing; `z.enum(["1","2"])` rejected every `1n` the driver
+ * returns. MySQL 8.4.11 agrees on every admission probed.
+ *
+ * The repair is one canonical decimal spelling, emitted inline as `DrzlNumericCanon`: exact at
+ * any precision, where `Number()` merges 99999999999999999998 with ...99. The members no such
+ * compare can state fall back to leniency, never to rejection: Postgres *creates*
+ * `numeric CHECK (n IN ('1e3', '2'))` and admits rows for it, and MySQL creates
+ * `varchar CHECK (s IN (1, 2))` and admits '1.00' through double coercion, so both shapes are
+ * left unenforced and the ledger says why.
+ *
+ * Official drizzle-orm/zod at 1.0.0-rc.4, measured beside this: numeric select is a bare
+ * `z.string()` that accepts 'hello', and a CHECK is invisible to it ('3.00' passes with the IN
+ * declared), so every assertion here is DRZL being stricter than official, never looser than
+ * the database.
+ */
+import { describe, it, expect } from 'vitest';
+import { ZodGenerator } from '../src/index';
+import type { Analysis, Column } from '@drzl/analyzer';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+/** `numeric({ precision: 10, scale: 2 })`, default string mode: the driver returns '1.00'. */
+const numS2 = (name = 'n') =>
+  col(name, {
+    tsType: 'string',
+    dbType: 'NUMERIC',
+    format: 'numeric',
+    integer: false,
+    min: '-99999999.99',
+    max: '99999999.99',
+  });
+
+/** A bare `numeric()`: arbitrary precision, no declared scale, still a string wire. */
+const numBare = (name = 'n') =>
+  col(name, { tsType: 'string', dbType: 'NUMERIC', format: 'numeric' });
+
+/** `bigint({ mode: 'bigint' })`: the driver returns `1n`. */
+const bigB = (name = 'big') =>
+  col(name, {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+
+/** `bigint({ mode: 'string' })` on v1: the driver returns '1'. */
+const bigS = (name = 'big') => col(name, { tsType: 'string', dbType: 'BIGINT' });
+
+/** A plain `integer()`: the driver returns 18. */
+const intC = (name = 'age') =>
+  col(name, {
+    tsType: 'number',
+    dbType: 'INTEGER',
+    integer: true,
+    min: '-2147483648',
+    max: '2147483647',
+  });
+
+let seq = 0;
+
+async function emit(
+  columns: Column[],
+  checks: { name?: string; expression?: string }[]
+): Promise<{ modules: Record<string, any>; text: string }> {
+  const analysis: Analysis = {
+    dialect: 'postgres',
+    tables: [{ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }] as never,
+    enums: [],
+    relations: [],
+    issues: [],
+  };
+  const dir = path.join(__dirname, '.tmp-numeric-wire');
+  await fs.mkdir(dir, { recursive: true });
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  const text = await fs.readFile(path.join(dir, 't.zod.ts'), 'utf8');
+  const file = path.join(dir, `t-${process.pid}-${seq++}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), file);
+  return { modules: await import(file), text };
+}
+
+describe('CHECK (n IN (1, 2)) on the numeric string wire', () => {
+  const IN = [{ name: 'n_valid', expression: 'n IN (1, 2)' }];
+
+  it('accepts every driver spelling of an admitted value and rejects the rest, in every mode', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    for (const s of ['SelecttSchema', 'InserttSchema', 'UpdatetSchema']) {
+      // Measured driver returns for the admitted rows of exactly this CHECK.
+      expect(m[s].safeParse({ n: '1.00' }).success, `${s} '1.00'`).toBe(true);
+      expect(m[s].safeParse({ n: '2.00' }).success, `${s} '2.00'`).toBe(true);
+      expect(m[s].safeParse({ n: '1' }).success, `${s} '1'`).toBe(true);
+      expect(m[s].safeParse({ n: '1.000000' }).success, `${s} '1.000000'`).toBe(true);
+      // Values the database refuses into this CHECK.
+      expect(m[s].safeParse({ n: '3' }).success, `${s} '3'`).toBe(false);
+      expect(m[s].safeParse({ n: '3.00' }).success, `${s} '3.00'`).toBe(false);
+      expect(m[s].safeParse({ n: '1.5' }).success, `${s} '1.5'`).toBe(false);
+      // The wire carries strings: the number 1 is not a value this column ever returns.
+      expect(m[s].safeParse({ n: 1 }).success, `${s} number 1`).toBe(false);
+      // NaN is a value a bare numeric stores, and NaN IN (1, 2) is false in the database.
+      expect(m[s].safeParse({ n: 'NaN' }).success, `${s} 'NaN'`).toBe(false);
+    }
+  });
+
+  it('still accepts NULL, which the database does', async () => {
+    const { modules: m } = await emit([numS2()], IN);
+    expect(m.SelecttSchema.safeParse({ n: null }).success).toBe(true);
+  });
+
+  it('keeps a 20 digit member exact instead of rounding it through a double', async () => {
+    // Number() merges these two spellings; the canonical compare must not.
+    const { modules: m } = await emit(
+      [numBare()],
+      [{ expression: 'n IN (99999999999999999999)' }]
+    );
+    expect(m.SelecttSchema.safeParse({ n: '99999999999999999999' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '99999999999999999998' }).success).toBe(false);
+  });
+});
+
+describe('the OR fold of the same constraint', () => {
+  it('emits byte for byte what the IN list it means emits', async () => {
+    const a = await emit([numS2()], [{ name: 'n_valid', expression: 'n = 1 OR n = 2' }]);
+    const b = await emit([numS2()], [{ name: 'n_valid', expression: 'n IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+
+  it('accepts the padded returns and rejects 3 like the IN it folds to', async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: 'n = 1 OR n = 2' }]);
+    expect(m.SelecttSchema.safeParse({ n: '1.00' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '2.00' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '3.00' }).success).toBe(false);
+  });
+});
+
+describe('equality and inequality on the numeric string wire', () => {
+  it('CHECK (n = 1) accepts the scale padded return and rejects 2', async () => {
+    // The database admitted 1.00 into exactly this CHECK and returned '1.00'.
+    const { modules: m } = await emit([numS2()], [{ expression: 'n = 1' }]);
+    expect(m.SelecttSchema.safeParse({ n: '1.00' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '1' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '2.00' }).success).toBe(false);
+  });
+
+  it('CHECK (n <> 1) rejects every spelling of 1 and accepts 2', async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: 'n <> 1' }]);
+    expect(m.SelecttSchema.safeParse({ n: '1.00' }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ n: '1' }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ n: '2.00' }).success).toBe(true);
+  });
+
+  it("a quoted equality, CHECK (n = '2.50'), meets the same padded wire", async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: "n = '2.50'" }]);
+    expect(m.SelecttSchema.safeParse({ n: '2.5' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '2.50' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '2.55' }).success).toBe(false);
+  });
+});
+
+describe('quoted literals on the numeric string wire', () => {
+  it("CHECK (n IN ('1', '2.5')) accepts the padded spellings of both members", async () => {
+    const { modules: m } = await emit([numS2()], [{ expression: "n IN ('1', '2.5')" }]);
+    expect(m.SelecttSchema.safeParse({ n: '1.00' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '2.50' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '2.5' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '3' }).success).toBe(false);
+  });
+});
+
+describe('quoted literals on the bigint wire', () => {
+  const QIN = [{ expression: "big IN ('1', '2')" }];
+
+  it('accepts the bigints the driver returns and rejects strings and numbers', async () => {
+    // The database admitted 1 and refused 3 into exactly this CHECK: quoting does not make the
+    // comparison textual.
+    const { modules: m } = await emit([bigB()], QIN);
+    expect(m.SelecttSchema.safeParse({ big: 1n }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: 2n }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: 3n }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ big: 1 }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ big: '1' }).success).toBe(false);
+  });
+
+  it('emits byte for byte what the unquoted IN emits', async () => {
+    const a = await emit([bigB()], [{ name: 'c', expression: "big IN ('1', '2')" }]);
+    const b = await emit([bigB()], [{ name: 'c', expression: 'big IN (1, 2)' }]);
+    expect(a.text).toBe(b.text);
+  });
+
+  it("CHECK (big = '1') accepts 1n and rejects 2n", async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: "big = '1'" }]);
+    expect(m.SelecttSchema.safeParse({ big: 1n }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: 2n }).success).toBe(false);
+  });
+
+  it("CHECK (big <> '1') rejects 1n and accepts 2n", async () => {
+    const { modules: m } = await emit([bigB()], [{ expression: "big <> '1'" }]);
+    expect(m.SelecttSchema.safeParse({ big: 1n }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ big: 2n }).success).toBe(true);
+  });
+});
+
+describe('quoted literals on the integer wire', () => {
+  it("CHECK (age IN ('18')) accepts the number 18 the driver returns", async () => {
+    const { modules: m } = await emit([intC()], [{ expression: "age IN ('18')" }]);
+    expect(m.SelecttSchema.safeParse({ age: 18 }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ age: 19 }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ age: '18' }).success).toBe(false);
+  });
+
+  it("a quoted range, CHECK (age >= '18'), binds like its unquoted twin", async () => {
+    const { modules: m } = await emit([intC()], [{ expression: "age >= '18'" }]);
+    expect(m.SelecttSchema.safeParse({ age: 18 }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ age: 17 }).success).toBe(false);
+  });
+});
+
+describe('the v1 bigint mode string wire', () => {
+  it('CHECK (big IN (1, 2)) accepts the digit strings the driver returns', async () => {
+    const { modules: m } = await emit([bigS()], [{ expression: 'big IN (1, 2)' }]);
+    expect(m.SelecttSchema.safeParse({ big: '1' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: '2' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ big: '3' }).success).toBe(false);
+    expect(m.SelecttSchema.safeParse({ big: 1n }).success).toBe(false);
+  });
+});
+
+describe('members no exact compare can state fall back to leniency, never rejection', () => {
+  it("CHECK (n IN ('1e3', '2')) enforces nothing rather than rejecting admitted rows", async () => {
+    // Postgres creates this table and admits 1000, returned as '1000' or '1000.00'. A canonical
+    // decimal compare cannot say that '1e3' names the same value, so the whole set is left to
+    // the base schema and the constraint ledger reports it unenforced.
+    const { modules: m } = await emit([numBare()], [{ expression: "n IN ('1e3', '2')" }]);
+    expect(m.SelecttSchema.safeParse({ n: '1000' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '1000.00' }).success).toBe(true);
+    // Leniency, pinned: the base schema also takes what the CHECK would refuse.
+    expect(m.SelecttSchema.safeParse({ n: '7' }).success).toBe(true);
+    // The numeric format still holds underneath.
+    expect(m.SelecttSchema.safeParse({ n: 'hello' }).success).toBe(false);
+  });
+
+  it('CHECK (s IN (1, 2)) on a text wire enforces nothing rather than rejecting rows', async () => {
+    // Postgres refuses this DDL outright; MySQL creates it and admits '1.00', '1' and '2.0'
+    // through double coercion, refusing 'x'. No exact compare states that coercion, so nothing
+    // is enforced and the ledger says why.
+    const { modules: m } = await emit([col('s')], [{ expression: 's IN (1, 2)' }]);
+    expect(m.SelecttSchema.safeParse({ s: '1.00' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ s: 'x' }).success).toBe(true);
+  });
+});
+
+describe('ranges on the numeric string wire', () => {
+  it('CHECK (n >= 1) compares numerically and is spelled type clean', async () => {
+    const { modules: m, text } = await emit([numS2()], [{ expression: 'n >= 1' }]);
+    expect(m.SelecttSchema.safeParse({ n: '1.00' }).success).toBe(true);
+    expect(m.SelecttSchema.safeParse({ n: '0.99' }).success).toBe(false);
+    // `v >= 1` on a string is a TS2365 in a consumer's build and hides the coercion; the
+    // emitted compare says what it does.
+    expect(text).toContain('Number(');
+  });
+});
+
+describe('what the emitted module carries', () => {
+  it('emits the canonical helper once and keys the compare on it', async () => {
+    const { text } = await emit([numS2()], [{ name: 'n_valid', expression: 'n IN (1, 2)' }]);
+    expect(text).toContain('DrzlNumericCanon');
+    expect(text.split('const DrzlNumericCanon').length).toBe(2);
+    // The message keeps the SQL spelling, which is what the constraint ledger keys on.
+    expect(text).toContain('n_valid: n IN (1, 2)');
+  });
+
+  it('emits no helper where no column needs it', async () => {
+    const { text } = await emit([intC()], [{ expression: 'age IN (18, 21)' }]);
+    expect(text).not.toContain('DrzlNumericCanon');
+  });
+});

--- a/packages/validation-core/src/checks.ts
+++ b/packages/validation-core/src/checks.ts
@@ -833,3 +833,283 @@ export function describeSet(set: ColumnSet): string {
   const shown = set.values.map((v) => (set.kind === 'string' ? `'${v}'` : v)).join(', ');
   return `${set.name ? `${set.name}: ` : ''}${set.column} IN (${shown})`;
 }
+
+/**
+ * How the database compares a CHECK literal against this column, and so how an emitted schema
+ * must state the comparison. `wireNumberLiteral` above decides a literal's *spelling*; this
+ * decides which comparison that spelling takes part in, which is the other half of the same
+ * rule: the literal's kind and the column's wire are reconciled by the database's semantics,
+ * never by whether the schema happened to quote the literal.
+ *
+ *   `number`          the driver hands back a JS number; literals compare with `===`/ranges.
+ *   `bigint`          a JS bigint; same, spelled with the `n` suffix.
+ *   `numeric-string`  the driver hands back *decimal text* and the database compares it as a
+ *                     number: `numeric`/`decimal` in string mode on every dialect, and v1's
+ *                     `bigint({ mode: 'string' })`. Measured on PostgreSQL 17.5 and MySQL
+ *                     8.4.11: `1 = 1.00` is true and a `numeric(10,2)` returns '1.00' for a
+ *                     stored 1, so neither a number literal nor the literal's own text can be
+ *                     compared to what arrives; only a canonical decimal spelling can.
+ *   `text`            ordinary strings, compared as strings.
+ *   `opaque`          everything else: dates, booleans, arrays, shaped columns. No literal
+ *                     policy applies and the existing arms keep their behaviour.
+ *
+ * Keyed on `tsType` plus `dbType` rather than on the SQL type name, for the reason
+ * `wireNumberLiteral` records: `tsType` is the analyzer's measured wire, and `dbType` is the
+ * coarse kind label both majors agree on (`NUMERIC` for every decimal family, `BIGINT` for the
+ * one string-mode integer wire).
+ */
+export type ComparisonWire = 'number' | 'bigint' | 'numeric-string' | 'text' | 'opaque';
+
+export function comparisonWire(c: {
+  tsType?: string;
+  dbType?: string;
+  shape?: { kind: string };
+  arrayDimensions?: number;
+}): ComparisonWire {
+  if (c.shape || c.arrayDimensions) return 'opaque';
+  if (c.tsType === 'number') return 'number';
+  if (c.tsType === 'bigint') return 'bigint';
+  if (c.tsType !== 'string') return 'opaque';
+  return c.dbType === 'NUMERIC' || c.dbType === 'BIGINT' ? 'numeric-string' : 'text';
+}
+
+/**
+ * The canonical spelling of plain decimal text, or nothing for anything else.
+ *
+ * The one name under which '1', '1.00', '01', '+1', '1.' and ' 1 ' are the same value, which is
+ * exactly the equality the database applies on a numeric wire: measured through PGlite, a bare
+ * `numeric` returns '1.000000' for an inserted 1.000000 and admits it into `CHECK (n IN (1, 2))`,
+ * and a `numeric(10,2)` returns '1.00' for a stored 1. Sign is normalised (`numeric` has no
+ * negative zero: '-0.00' comes back '0.00'), leading integer zeros and trailing fraction zeros
+ * are stripped, and a bare trailing dot is dropped.
+ *
+ * String arithmetic deliberately: `Number()` is not usable here. A numeric column carries more
+ * digits than a double holds, and Number('99999999999999999999') and
+ * Number('99999999999999999998') are the same double, so rounding through one would merge
+ * members the database keeps distinct.
+ *
+ * Everything outside plain decimal answers nothing, exponent forms included. Postgres does
+ * accept `'1e3'` as numeric *input*, and `CHECK (n IN ('1e3', 2))` is valid DDL that admits
+ * 1000, but its output spelling is always plain ('1000' came back, measured), and a member this
+ * function cannot name makes the whole constraint unenforceable rather than approximated: see
+ * `wireLiteralFit`.
+ */
+export function canonicalNumericText(text: string): string | undefined {
+  const m = /^([+-]?)(\d*)(?:\.(\d*))?$/.exec(text.trim());
+  if (!m || (!m[2] && !m[3])) return undefined;
+  const int = (m[2] ?? '').replace(/^0+/, '');
+  const frac = (m[3] ?? '').replace(/0+$/, '');
+  if (!int && !frac) return '0';
+  return (m[1] === '-' ? '-' : '') + (int || '0') + (frac ? '.' + frac : '');
+}
+
+/** The canonical forms of a member list, deduplicated, members outside the domain dropped. */
+export function canonicalMembers(values: string[]): string[] {
+  const out: string[] = [];
+  for (const v of values) {
+    const c = canonicalNumericText(v);
+    if (c !== undefined && !out.includes(c)) out.push(c);
+  }
+  return out;
+}
+
+/** Name of the canonical helper emitted into a module that compares on a numeric string wire. */
+export const NUMERIC_CANON_NAME = 'DrzlNumericCanon';
+
+/**
+ * The helper itself, emitted once per file that needs it, in every generator from this one
+ * string so six copies cannot drift. `test/numeric-wire-literals.spec.ts` evaluates it beside
+ * `canonicalNumericText` over the probe corpus to hold the two to one answer.
+ */
+export const NUMERIC_CANON_SOURCE = `/**
+ * The canonical spelling of the plain decimal text a numeric wire carries, or null for anything
+ * else. The driver spells one value many ways by declared scale ('1', '1.00', '1.0000000000',
+ * measured) and the database compares them as numbers, so equality is decided on this form:
+ * sign normalised, leading integer zeros and trailing fraction zeros stripped, a bare trailing
+ * dot dropped. String arithmetic on purpose: Number() is not usable here, because a numeric
+ * column carries more digits than a double holds and rounding would merge values the database
+ * keeps distinct.
+ */
+const ${NUMERIC_CANON_NAME} = (s: string): string | null => {
+  const m = /^([+-]?)(\\d*)(?:\\.(\\d*))?$/.exec(s.trim());
+  if (!m || (!m[2] && !m[3])) return null;
+  const int = (m[2] ?? '').replace(/^0+/, '');
+  const frac = (m[3] ?? '').replace(/0+$/, '');
+  if (!int && !frac) return '0';
+  return (m[1] === '-' ? '-' : '') + (int || '0') + (frac ? '.' + frac : '');
+};
+`;
+
+/** What `wireLiteralFit` is asked about: one literal list, one comparison class. */
+export interface WireLiteralQuestion {
+  kind: 'number' | 'string';
+  values: string[];
+  /** `=`, `<>` and `IN` are `equality`; the four ordering operators are `range`. */
+  comparison: 'equality' | 'range';
+}
+
+/**
+ * Whether these literals can be enforced against this column, and in what form.
+ *
+ *   `keep`        the spelling already follows the wire: nothing changes.
+ *   `respell`     quoted plain decimal on a number or bigint wire. The database coerces the
+ *                 text and compares numerically (`bigint CHECK (big IN ('1','2'))` admitted 1
+ *                 and refused 3, measured), so the literal becomes its canonical number-kind
+ *                 self and every existing number arm applies. Canonical rather than verbatim,
+ *                 because `018` and `018n` are syntax errors in an emitted module.
+ *   `canonical`   any equality on a numeric string wire: the emitted schema compares canonical
+ *                 decimal spellings through `NUMERIC_CANON_NAME`. A range there is `respell`:
+ *                 it is emitted as a coerced numeric compare instead, since ordering needs no
+ *                 exact spelling, only a monotonic one.
+ *   `unenforced`  no exact statement exists. Three shapes land here, each measured: a number
+ *                 literal against a text column (Postgres refuses the DDL outright, MySQL
+ *                 compares through double coercion that admits '1.00' and '2.0'), quoted text
+ *                 that is not plain decimal on a number or bigint wire, and a member outside
+ *                 the canonical domain on a numeric string wire (`'1e3'` is valid DDL whose
+ *                 rows come back '1000'). Enforcing a guess would reject rows the database
+ *                 admits, which is the defect class this policy exists to remove, so these are
+ *                 left to the base schema and reported.
+ */
+export type WireLiteralFit =
+  | { fit: 'keep' }
+  | { fit: 'respell'; values: string[] }
+  | { fit: 'canonical'; canon: string[] }
+  | { fit: 'unenforced'; reason: string };
+
+export function wireLiteralFit(
+  c: {
+    name?: string;
+    tsType?: string;
+    dbType?: string;
+    shape?: { kind: string };
+    arrayDimensions?: number;
+  },
+  q: WireLiteralQuestion
+): WireLiteralFit {
+  const wire = comparisonWire(c);
+  if (wire === 'opaque') return { fit: 'keep' };
+  if (wire === 'text') {
+    if (q.kind === 'string') return { fit: 'keep' };
+    return {
+      fit: 'unenforced',
+      reason:
+        `"${c.name ?? '?'}" is a text column, and the database compares a number literal ` +
+        `against it by coercion rules that differ per dialect, which no exact predicate restates`,
+    };
+  }
+  const canon = q.values.map((v) => canonicalNumericText(v));
+  const bad = q.values[canon.findIndex((x) => x === undefined)];
+  if (wire === 'numeric-string') {
+    if (bad !== undefined)
+      return {
+        fit: 'unenforced',
+        reason:
+          `'${bad}' is not plain decimal text, and the driver spells one numeric value many ` +
+          `ways, so no exact comparison can be stated`,
+      };
+    if (q.comparison === 'range') return { fit: 'respell', values: canon as string[] };
+    return { fit: 'canonical', canon: canonicalMembers(q.values) };
+  }
+  // A number or bigint wire.
+  if (q.kind === 'number') return { fit: 'keep' };
+  if (bad !== undefined)
+    return {
+      fit: 'unenforced',
+      reason:
+        `'${bad}' is quoted text on a ${wire} wire, and it is not plain decimal, so the ` +
+        `numeric comparison the database performs cannot be restated exactly`,
+    };
+  return { fit: 'respell', values: canonicalMembers(q.values) };
+}
+
+/** A clause the wire policy left unenforced, with the reason the ledger reports. */
+export interface UnenforcedLiteral {
+  column: string;
+  reason: string;
+  check?: ColumnCheck;
+  set?: ColumnSet;
+}
+
+/**
+ * The wire policy over a whole table's parsed checks, for the generators.
+ *
+ * Respelled literals come back as the number-kind twins every existing arm already handles,
+ * unenforceable clauses are dropped from the lists and returned beside them, and the
+ * numeric-string clauses pass through untouched for the canonical vehicles to state. The
+ * constraint ledger applies `wireLiteralFit` itself so its texts and reasons cannot drift from
+ * what is emitted here.
+ */
+export function applyWirePolicy(
+  columns: Array<{
+    name: string;
+    tsType?: string;
+    dbType?: string;
+    shape?: { kind: string };
+    arrayDimensions?: number;
+  }>,
+  checks: ColumnCheck[],
+  sets: ColumnSet[]
+): { checks: ColumnCheck[]; sets: ColumnSet[]; unenforced: UnenforcedLiteral[] } {
+  const byName = new Map(columns.map((c) => [c.name, c]));
+  const outChecks: ColumnCheck[] = [];
+  const outSets: ColumnSet[] = [];
+  const unenforced: UnenforcedLiteral[] = [];
+
+  for (const k of checks) {
+    const c = byName.get(k.column);
+    if (!c) {
+      outChecks.push(k);
+      continue;
+    }
+    const fit = wireLiteralFit(c, {
+      kind: k.kind,
+      values: [k.value],
+      comparison: k.operator === '=' || k.operator === '<>' ? 'equality' : 'range',
+    });
+    if (fit.fit === 'unenforced') unenforced.push({ column: k.column, reason: fit.reason, check: k });
+    else if (fit.fit === 'respell') outChecks.push({ ...k, kind: 'number', value: fit.values[0]! });
+    else outChecks.push(k);
+  }
+
+  for (const s of sets) {
+    const c = byName.get(s.column);
+    if (!c) {
+      outSets.push(s);
+      continue;
+    }
+    const fit = wireLiteralFit(c, { kind: s.kind, values: s.values, comparison: 'equality' });
+    if (fit.fit === 'unenforced') unenforced.push({ column: s.column, reason: fit.reason, set: s });
+    else if (fit.fit === 'respell') outSets.push({ ...s, kind: 'number', values: fit.values });
+    else outSets.push(s);
+  }
+
+  return { checks: outChecks, sets: outSets, unenforced };
+}
+
+/**
+ * Whether any column of this table needs `NUMERIC_CANON_SOURCE` emitted beside it.
+ *
+ * One condition shared by every generator's preamble and its field emitter, for the reason the
+ * TypeBox generator records on `tbNeedsCapKind`: two copies of one condition drift, and what a
+ * drifted copy emits is a reference to a helper the file never defined.
+ */
+export function needsNumericCanon(
+  columns: Array<{
+    name: string;
+    tsType?: string;
+    dbType?: string;
+    shape?: { kind: string };
+    arrayDimensions?: number;
+  }>,
+  checks: ColumnCheck[],
+  sets: ColumnSet[]
+): boolean {
+  return columns.some(
+    (c) =>
+      comparisonWire(c) === 'numeric-string' &&
+      (sets.some((s) => s.column === c.name) ||
+        checks.some(
+          (k) => k.column === c.name && (k.operator === '=' || k.operator === '<>')
+        ))
+  );
+}

--- a/packages/validation-core/src/constraints.ts
+++ b/packages/validation-core/src/constraints.ts
@@ -32,6 +32,7 @@ import {
   lengthCheckLabel,
   lengthMeasure,
   parseCheck,
+  wireLiteralFit,
   type CardinalityCheck,
   type ColumnCheck,
   type ColumnSet,
@@ -244,17 +245,56 @@ export function classifyTableChecks(table: Table): ClassifiedCheck[] {
         ? `"${c.name}" is an array, and the clause describes a scalar`
         : `"${c.name}" is a structured column, and the clause describes a scalar`;
 
+    // The wire policy, applied here exactly as the generators apply it through
+    // `applyWirePolicy`: a clause it leaves unenforced is reported with its reason instead of
+    // being claimed, and a respelled literal is rendered in its respelled form, because the
+    // error map matches an issue's message against these texts exactly and the emitted modules
+    // spell their messages from the respelled clause.
+    const literalFit = (
+      column: string,
+      kind: 'number' | 'string',
+      values: string[],
+      comparison: 'equality' | 'range'
+    ) => {
+      const col = byName.get(column);
+      return col ? wireLiteralFit(col, { kind, values, comparison }) : ({ fit: 'keep' } as const);
+    };
+
     for (const c of parsed.checks) {
+      const fit = literalFit(
+        c.column,
+        c.kind,
+        [c.value],
+        c.operator === '=' || c.operator === '<>' ? 'equality' : 'range'
+      );
+      if (fit.fit === 'unenforced') {
+        parts.push({
+          text: columnCheckText(c),
+          columns: [c.column],
+          place: 'none',
+          reason: fit.reason,
+        });
+        continue;
+      }
+      const shown =
+        fit.fit === 'respell' ? { ...c, kind: 'number' as const, value: fit.values[0]! } : c;
       const col = byName.get(c.column);
-      place(c.column, columnCheckText(c), takesScalarChecks, notScalar, {
-        ...(col && foldsIntoBounds(col, c)
-          ? { bound: { column: c.column, operator: c.operator, value: c.value } }
+      place(c.column, columnCheckText(shown), takesScalarChecks, notScalar, {
+        ...(col && foldsIntoBounds(col, shown)
+          ? { bound: { column: c.column, operator: shown.operator, value: shown.value } }
           : {}),
       });
     }
     for (const s of parsed.sets ?? []) {
-      place(s.column, setText(s), takesScalarChecks, notScalar, {
-        set: { column: s.column, values: s.values, kind: s.kind },
+      const fit = literalFit(s.column, s.kind, s.values, 'equality');
+      if (fit.fit === 'unenforced') {
+        parts.push({ text: setText(s), columns: [s.column], place: 'none', reason: fit.reason });
+        continue;
+      }
+      const shown =
+        fit.fit === 'respell' ? { ...s, kind: 'number' as const, values: fit.values } : s;
+      place(s.column, setText(shown), takesScalarChecks, notScalar, {
+        set: { column: s.column, values: shown.values, kind: shown.kind },
       });
     }
     for (const l of parsed.lengths ?? []) {

--- a/packages/validation-core/test/numeric-wire-literals.spec.ts
+++ b/packages/validation-core/test/numeric-wire-literals.spec.ts
@@ -1,0 +1,327 @@
+/**
+ * The wire policy for CHECK literals: the literal's kind and the column's wire reconciled by the
+ * database's comparison semantics, not by the literal's source spelling (plan addendum BL).
+ *
+ * GROUND TRUTH, measured rather than assumed. PostgreSQL 17.5 through PGlite, raw and through
+ * both drizzle majors (1.0.0-rc.4 and 0.45.2 over the pglite driver, byte for byte identical),
+ * and MySQL 8.4.11 through mysql2 for decimal:
+ *
+ *   stored                  numeric        numeric(10,2)   numeric(20,10)    mysql decimal(10,2)
+ *   1                       '1'            '1.00'          '1.0000000000'    '1.00'
+ *   1.5                     '1.5'          '1.50'          '1.5000000000'    '1.50'
+ *   1.000000                '1.000000'
+ *   99999999999999999999    exact, all 20 digits
+ *
+ * So the same admitted value arrives spelled by its declared scale, and a bare `numeric` even
+ * preserves the insert's own trailing zeros. The database compares these values numerically and
+ * scale insensitively: `1 = 1.00` is true, `1.000000 IN (1, 2)` is true, and a
+ * `numeric(10,2) CHECK (n IN (1, 2))` admitted 1, 1.00 and '1.000000' while refusing 3 and 1.5,
+ * handing every admitted row back as '1.00'. MySQL 8.4.11 agrees on every admission probed.
+ *
+ * Quoted literals run the other way and land in the same place: `bigint CHECK (big IN ('1','2'))`
+ * admitted 1 and refused 3, and `integer CHECK (age IN ('18'))` admitted 18, because the literal
+ * is coerced to the column's type before comparing. The schema must follow the wire, not the
+ * quotes.
+ *
+ * DDL survival decides the fallbacks. Postgres refuses `numeric IN ('abc')`,
+ * `integer IN ('1.5')`, `bigint IN ('1.5')` and `text IN (1, 2)` at CREATE TABLE, but it
+ * *creates* `numeric CHECK (n IN ('1e3', '2'))` and admits 1000, returned as '1000' or '1000.00'.
+ * MySQL creates `varchar CHECK (s IN (1, 2))` and admits '1.00', '1' and '2.0' through double
+ * coercion while refusing 'x'. Neither shape can be stated exactly by a canonical decimal
+ * compare, so both are unenforced by policy rather than guessed at: rejecting a returned row is
+ * the defect class this whole addendum exists to remove.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalNumericText,
+  comparisonWire,
+  wireLiteralFit,
+  applyWirePolicy,
+  NUMERIC_CANON_NAME,
+  NUMERIC_CANON_SOURCE,
+  parseCheck,
+} from '../src/checks';
+import { classifyTableChecks } from '../src/constraints';
+import type { Column, Table } from '@drzl/analyzer';
+
+const col = (name: string, over: Partial<Column> = {}): Column =>
+  ({
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    nullable: true,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  }) as Column;
+
+const numS2 = (name = 'n') =>
+  col(name, {
+    tsType: 'string',
+    dbType: 'NUMERIC',
+    format: 'numeric',
+    integer: false,
+    min: '-99999999.99',
+    max: '99999999.99',
+  });
+const bigB = (name = 'big') =>
+  col(name, {
+    tsType: 'bigint',
+    dbType: 'BIGINT',
+    integer: true,
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+const bigS = (name = 'big') => col(name, { tsType: 'string', dbType: 'BIGINT' });
+const intC = (name = 'age') =>
+  col(name, {
+    tsType: 'number',
+    dbType: 'INTEGER',
+    integer: true,
+    min: '-2147483648',
+    max: '2147483647',
+  });
+
+describe('canonicalNumericText', () => {
+  it('gives every driver spelling of one value one name', () => {
+    // Each row is a measured driver return beside the member spelling it must meet.
+    for (const [a, b] of [
+      ['1.00', '1'],
+      ['1.0000000000', '1'],
+      ['1.000000', '1'],
+      ['1.50', '1.5'],
+      ['0.5', '.5'],
+      ['1', '+1'],
+      ['1', '1.'],
+      ['0.00', '-0.00'],
+      ['007', '7'],
+      [' 1 ', '1'],
+    ]) {
+      expect(canonicalNumericText(a!), `${a} vs ${b}`).toBe(canonicalNumericText(b!));
+      expect(canonicalNumericText(a!)).toBeDefined();
+    }
+  });
+
+  it('keeps values distinct that a double would merge', () => {
+    // Number('99999999999999999999') and Number('99999999999999999998') are the same double.
+    expect(canonicalNumericText('99999999999999999999')).toBe('99999999999999999999');
+    expect(canonicalNumericText('99999999999999999998')).toBe('99999999999999999998');
+    expect(canonicalNumericText('99999999999999999999')).not.toBe(
+      canonicalNumericText('99999999999999999998')
+    );
+  });
+
+  it('refuses everything outside plain decimal text', () => {
+    for (const t of ['1e3', '1E3', 'NaN', 'Infinity', '-Infinity', 'abc', '', '.', '+', '0x10']) {
+      expect(canonicalNumericText(t), t).toBeUndefined();
+    }
+  });
+
+  it('normalises sign and zeros the way the emitted comment promises', () => {
+    expect(canonicalNumericText('-0')).toBe('0');
+    expect(canonicalNumericText('-1.50')).toBe('-1.5');
+    expect(canonicalNumericText('000')).toBe('0');
+    expect(canonicalNumericText('0.50')).toBe('0.5');
+  });
+});
+
+describe('the emitted helper source', () => {
+  it('agrees with canonicalNumericText on every probe, so six emitted copies cannot drift', () => {
+    // The emitted text is a const arrow function; evaluating it yields the same decision table,
+    // with null standing where the generation side says undefined.
+    const body = NUMERIC_CANON_SOURCE.replace(`const ${NUMERIC_CANON_NAME} =`, 'return');
+    const emitted = new Function(body.replace(/: string \| null/g, '').replace(/\(s: string\)/g, '(s)'))() as (
+      s: string
+    ) => string | null;
+    for (const t of [
+      '1.00',
+      '1',
+      '1.000000',
+      '1.5',
+      '0.5',
+      '.5',
+      '+1',
+      '1.',
+      '-0.00',
+      '007',
+      ' 1 ',
+      '99999999999999999999',
+      '1e3',
+      'NaN',
+      'Infinity',
+      'abc',
+      '',
+      '-1.50',
+    ]) {
+      expect(emitted(t), t).toBe(canonicalNumericText(t) ?? null);
+    }
+  });
+});
+
+describe('comparisonWire', () => {
+  it('classifies the wires the policy distinguishes', () => {
+    expect(comparisonWire(numS2())).toBe('numeric-string');
+    expect(comparisonWire(bigS())).toBe('numeric-string');
+    expect(comparisonWire(bigB())).toBe('bigint');
+    expect(comparisonWire(intC())).toBe('number');
+    expect(comparisonWire(col('s'))).toBe('text');
+    expect(comparisonWire(col('d', { tsType: 'Date', dbType: 'TIMESTAMP' }))).toBe('opaque');
+    expect(comparisonWire(col('b', { tsType: 'boolean', dbType: 'BOOLEAN' }))).toBe('opaque');
+  });
+});
+
+describe('wireLiteralFit', () => {
+  it('keeps what already follows the wire', () => {
+    expect(wireLiteralFit(intC(), { kind: 'number', values: ['18'], comparison: 'equality' })).toEqual({
+      fit: 'keep',
+    });
+    expect(wireLiteralFit(col('s'), { kind: 'string', values: ['a'], comparison: 'equality' })).toEqual(
+      { fit: 'keep' }
+    );
+  });
+
+  it('respells quoted plain decimal literals for a number or bigint wire', () => {
+    expect(
+      wireLiteralFit(intC(), { kind: 'string', values: ['18'], comparison: 'equality' })
+    ).toEqual({ fit: 'respell', values: ['18'] });
+    // The canonical text is what gets respelled: `018` as a number literal is a syntax error in
+    // an emitted module, and `018n` is one too.
+    expect(
+      wireLiteralFit(bigB(), { kind: 'string', values: ['018', '2.50'], comparison: 'equality' })
+    ).toEqual({ fit: 'respell', values: ['18', '2.5'] });
+  });
+
+  it('sends every equality on a numeric string wire to the canonical compare', () => {
+    expect(
+      wireLiteralFit(numS2(), { kind: 'number', values: ['1', '2'], comparison: 'equality' })
+    ).toEqual({ fit: 'canonical', canon: ['1', '2'] });
+    expect(
+      wireLiteralFit(numS2(), { kind: 'string', values: ['1', '2.50'], comparison: 'equality' })
+    ).toEqual({ fit: 'canonical', canon: ['1', '2.5'] });
+    expect(
+      wireLiteralFit(bigS(), { kind: 'number', values: ['1', '2'], comparison: 'equality' })
+    ).toEqual({ fit: 'canonical', canon: ['1', '2'] });
+  });
+
+  it('dedupes members that canonicalise to one value', () => {
+    expect(
+      wireLiteralFit(numS2(), { kind: 'string', values: ['1', '1.0', '2'], comparison: 'equality' })
+    ).toEqual({ fit: 'canonical', canon: ['1', '2'] });
+  });
+
+  it('respells a range on the numeric string wire so the coerced compare is type clean', () => {
+    expect(wireLiteralFit(numS2(), { kind: 'number', values: ['1'], comparison: 'range' })).toEqual({
+      fit: 'respell',
+      values: ['1'],
+    });
+    expect(wireLiteralFit(numS2(), { kind: 'string', values: ['18'], comparison: 'range' })).toEqual(
+      { fit: 'respell', values: ['18'] }
+    );
+  });
+
+  it('refuses what no exact compare can state, with a reason', () => {
+    const exotic = wireLiteralFit(numS2(), {
+      kind: 'string',
+      values: ['1e3', '2'],
+      comparison: 'equality',
+    });
+    expect(exotic.fit).toBe('unenforced');
+    if (exotic.fit === 'unenforced') expect(exotic.reason).toContain("'1e3'");
+
+    const textNum = wireLiteralFit(col('s'), {
+      kind: 'number',
+      values: ['1', '2'],
+      comparison: 'equality',
+    });
+    expect(textNum.fit).toBe('unenforced');
+
+    const quotedJunk = wireLiteralFit(intC(), {
+      kind: 'string',
+      values: ['x'],
+      comparison: 'equality',
+    });
+    expect(quotedJunk.fit).toBe('unenforced');
+  });
+});
+
+describe('applyWirePolicy', () => {
+  const parse = (columns: Column[], exprs: string[]) => {
+    const parsed = exprs.map((e) => parseCheck(e));
+    const checks = parsed.flatMap((p) => (p.ok ? p.checks : []));
+    const sets = parsed.flatMap((p) => (p.ok ? (p.sets ?? []) : []));
+    return applyWirePolicy(columns, checks, sets);
+  };
+
+  it('drops the unenforceable and respells the dequotable', () => {
+    const out = parse(
+      [intC(), bigB(), col('s')],
+      ["age IN ('18')", "big = '1'", 's IN (1, 2)']
+    );
+    expect(out.sets).toEqual([
+      { column: 'age', values: ['18'], kind: 'number', name: undefined },
+    ]);
+    expect(out.checks).toEqual([
+      { column: 'big', operator: '=', value: '1', kind: 'number', name: undefined },
+    ]);
+    expect(out.unenforced).toHaveLength(1);
+    expect(out.unenforced[0]!.reason).toContain('"s"');
+  });
+
+  it('leaves the canonical wire items in place for the generators to state exactly', () => {
+    const out = parse([numS2()], ['n IN (1, 2)', 'n = 1', 'n <> 1', 'n >= 1']);
+    expect(out.sets).toHaveLength(1);
+    // The two equalities stay string-kind literals on the string wire; the range is respelled to
+    // number kind so the emitted coerced compare is spelled against a number.
+    expect(out.checks.map((k) => [k.operator, k.kind])).toEqual([
+      ['=', 'number'],
+      ['<>', 'number'],
+      ['>=', 'number'],
+    ]);
+  });
+
+  it('touches nothing on wires the policy does not know', () => {
+    const out = parse([col('d', { tsType: 'Date', dbType: 'TIMESTAMP' })], ["d = '2020-01-01'"]);
+    expect(out.checks).toEqual([
+      { column: 'd', operator: '=', value: '2020-01-01', kind: 'string', name: undefined },
+    ]);
+    expect(out.unenforced).toHaveLength(0);
+  });
+});
+
+describe('classifyTableChecks under the wire policy', () => {
+  const tableOf = (columns: Column[], checks: { name?: string; expression: string }[]): Table =>
+    ({ name: 't', tsName: 't', columns, unique: [], indexes: [], checks }) as never;
+
+  it('reports the unenforceable set as unenforced with the mechanism, not as a claim', () => {
+    const classified = classifyTableChecks(tableOf([col('s')], [{ expression: 's IN (1, 2)' }]));
+    expect(classified[0]!.parts[0]!.place).toBe('none');
+    expect(classified[0]!.parts[0]!.reason).toBeTruthy();
+  });
+
+  it('reports the exotic numeric member as unenforced', () => {
+    const classified = classifyTableChecks(
+      tableOf([numS2()], [{ expression: "n IN ('1e3', '2')" }])
+    );
+    expect(classified[0]!.parts[0]!.place).toBe('none');
+    expect(classified[0]!.parts[0]!.reason).toContain("'1e3'");
+  });
+
+  it('renders the respelled set the way the generators will spell their message', () => {
+    const classified = classifyTableChecks(
+      tableOf([bigB()], [{ name: 'c', expression: "big IN ('1', '2')" }])
+    );
+    const part = classified[0]!.parts[0]!;
+    expect(part.place).toBe('column');
+    expect(part.text).toBe('c: big IN (1, 2)');
+    expect(part.set).toEqual({ column: 'big', values: ['1', '2'], kind: 'number' });
+  });
+
+  it('keeps claiming the canonical set, whose message keeps the SQL spelling', () => {
+    const classified = classifyTableChecks(
+      tableOf([numS2()], [{ name: 'c', expression: 'n IN (1, 2)' }])
+    );
+    const part = classified[0]!.parts[0]!;
+    expect(part.place).toBe('column');
+    expect(part.text).toBe('c: n IN (1, 2)');
+  });
+});


### PR DESCRIPTION
Fixes plan addendum BL (Tier A, design required): CHECK literals on numeric string wires emitted number-kind literals that rejected every driver row (`'1.00'` vs `z.literal(1)`), and quoted literals on bigint/integer wires rejected the wire's values (`z.enum(["1","2"])` vs `1n`). Exact string literals were measured equally wrong: scale padding means `'1'` never matches a `numeric(10,2)` driver return of `'1.00'`.

## Ground truth first (all measured, none assumed)

- **Driver returns per scale** (PG 17.5 via PGlite, byte-identical through both drizzle majors; MySQL 8.4.11 via mysql2): bare `numeric` returns `'1'` and preserves the insert's own zeros (`'1.000000'`); `(10,2)` pads to `'1.00'`; 20-digit values return exact.
- **Database admissions, insert-proven**: `1 = 1.00` is true; `numeric(10,2) CHECK (n IN (1,2))` admits 1, 1.00, `'1.000000'` and refuses 3 and 1.5; `bigint CHECK (big IN ('1','2'))` admits 1; `integer CHECK (age IN ('18'))` admits 18. MySQL agreed on every probe.
- **DDL survival mapped**: Postgres refuses `numeric IN ('abc')` and `text IN (1,2)` outright but creates `numeric IN ('1e3')` and `IN ('NaN')`; MySQL creates `varchar CHECK (s IN (1,2))` and admits `'1.00'` through double coercion while refusing `'x'`.
- **Official validators run live** (drizzle-orm/zod at rc.4): numeric select is a bare `z.string()` accepting `'hello'`; the CHECK is invisible there. Every DRZL emission here is stricter than official and never looser than the database; the standing ALLOWED entries already cover the numeric-format strictness.

## The design

One shared policy in validation-core extending BF's `wireNumberLiteral`: `comparisonWire` classifies the wire (number, bigint, numeric-string, text, opaque) off tsType + dbType; `canonicalNumericText` gives every plain-decimal spelling one name (sign, leading integer zeros, trailing fraction zeros, bare dot), exact at any precision; `wireLiteralFit` decides keep / respell (dequoted canonical number-kind literals; canonical because `018n` is a syntax error) / canonical compare / unenforced-with-reason, and both the emitters and `classifyTableChecks` run the SAME fit so ledger texts cannot drift from emissions. The emitted helper is one shared source string per file that needs it, and a core spec evaluates the emitted text beside the library function over the probe corpus so seven copies cannot drift.

Rejected alternatives, each with its measured killer: exact string literals (scale padding), `Number()` equality (merges 20-digit members, proven), exponent-aware runtime canon (driver output never carries exponents on PG/MySQL; exponent members drop to the lenient fallback instead), enforcement on TEXT wires (MySQL double coercion admits `'1abc'`-class values), per-generator canon copies (drift).

## Per generator

zod/valibot/effect: canonical refine/check/filter over the helper; arktype: `.narrow` with `<>` newly enforced on this wire; typebox: the registered `DrzlRowCheck` kind under both `Value.Check` and `TypeCompiler`, a dead `minimum` planted on `Type.String()` removed; json-schema (cannot run a function): per-member canonical `pattern` alternation, ajv-strict compile asserted, cost stated plainly (regex readability; write-side strictness on exotic spellings no serialized row carries). Quoted bigint sets emit `1n | 2n` byte-identical with their unquoted twins. Range refines on numeric-string wires now spell `Number(v) >= 1`, fixing latent TS2365s in consumer builds.

## Verification

- **Red-first: 86 failing tests before the fix** across 7 new spec files (validation-core 18, zod 16, valibot 10, arktype 12, typebox 12, effect 10, json-schema 8), 108 new tests green after, covering driver-shaped strings at three scales, OR-fold byte-identity, `=`/`<>`, quoted sets on all wires, the v1 bigint-string wire, 20-digit exactness, and every leniency pinned as an assertion.
- **Probe byte-identity proven empirically**: master (0e295da) generators rebuilt in a throwaway worktree, the full `checked` probe shape set emitted through both dists, **6/6 generators byte-identical**, so the parity gate's standing verdicts genuinely cover this change.
- Full suite green (18 packages; cli 563/563); `pnpm verify:packed` unmodified exit 0, 1476/1476 comparisons, no ledger changes.

## Leniencies left, mechanisms stated

Members outside the canonical domain drop their clause with the member named in the ledger reason; TEXT wires stay unenforced (MySQL coercion); ranges on numeric-string wires keep the coerced double compare (a 17-digit `>`/`<` bound can round onto an admitted value; `>=`/`<=` safe by monotonicity; a stored NaN under `n >= 1` is admitted by Postgres, which sorts NaN above every numeric, while `Number('NaN') >= 1` rejects: pre-existing, now visible); SQLite's numeric affinity rides the same branch by dbType, reasoned but not measured on-device, strictly narrower than the reject-everything before.

Changeset: patch across the 7 changed packages.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
