### PR TITLE
feat: seed recipe + duplicate finder covers the primary key (item 58)

### DIFF
--- a/.changeset/duplicate-finder-primary-key.md
+++ b/.changeset/duplicate-finder-primary-key.md
@@ -1,0 +1,20 @@
+---
+'@drzl/validation-core': patch
+'@drzl/generator-zod': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-arktype': patch
+'@drzl/generator-typebox': patch
+'@drzl/generator-effect': patch
+---
+
+The duplicate finder now covers the primary key, which is the collision seed data actually has
+
+`findDuplicate<table>` scanned only the declared unique constraints, so two rows carrying the
+same explicit primary key sailed through and failed at the database with
+`duplicate key value violates unique constraint "users_pkey"` (23505, measured on Postgres 17),
+and a table whose only key is its primary key, a natural key like `skus.code`, got no finder at
+all. The database enforces a primary key with a unique index and its own error calls it a unique
+constraint, so the finder treats it as one: the key is checked first, named `<table>_pkey` the
+way Postgres names it, and reported like any other collision. Rows that leave a generated key to
+the database are untouched, because an absent or null column already skips a constraint, exactly
+as a unique index skips NULLs. Emitted output changes only where `duplicateFinder: true` is set.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -105,6 +105,7 @@ export default {
           { text: 'Next.js Server Actions', link: '/examples/nextjs-server-actions' },
           { text: 'React Hook Form', link: '/examples/react-hook-form' },
           { text: 'TanStack Form', link: '/examples/tanstack-form' },
+          { text: 'Seeding and Bulk Inserts', link: '/examples/seed' },
         ],
       },
       {

--- a/docs/examples/seed.md
+++ b/docs/examples/seed.md
@@ -1,0 +1,292 @@
+# Seeding and Bulk Inserts
+
+A seed is a script you own. That is the whole convention: Prisma 7 runs whatever command you
+name in `prisma.config.ts` and only when you invoke `npx prisma db seed` (the automatic run
+after `migrate reset` is gone), and Drizzle's official [`drizzle-seed`](https://www.npmjs.com/package/drizzle-seed)
+generates deterministic fake data at volume. Neither helps with the other half of seeding: the
+rows you actually mean. Demo accounts, lookup tables, the fixture graph your tests point at.
+Those rows carry explicit keys so foreign keys can reference known rows, they hit real CHECK and
+UNIQUE constraints, and when one of five hundred is wrong the database names a constraint rather
+than a row.
+
+DRZL already emits everything that turns that script from insert-and-pray into a checked
+pipeline: insert schemas with the CHECK constraints folded in, a per-table
+[duplicate finder](/generators/zod#duplicatefinder), and the foreign-key graph as plain data in
+[`constraints.ts`](/generators/zod#constraints-the-tables-constraints-as-data). This page
+composes them into a seed script and measures every step.
+
+Measured 2026-08-08 with `drizzle-orm` 0.45.2, `zod` 4.4.3, PostgreSQL 17.10 (the
+`postgres:17-alpine` image) over `pg` 8.22.0, and `@electric-sql/pglite` 0.5.4, on Node 22. The
+script below ran against the real server twice plus two sabotage runs; the outputs are quoted
+where each claim is made.
+
+## The config
+
+```ts
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  schema: 'src/db/schema.ts',
+  outDir: 'src/validators',
+  generators: [
+    {
+      kind: 'zod',
+      path: 'src/validators/zod',
+      duplicateFinder: true, // findDuplicate<table> beside the schemas
+      constraints: true, // constraints.ts: keys and foreign keys as data
+    },
+  ],
+});
+```
+
+`duplicateFinder` exists in all five validator generators; `constraints` in zod and valibot.
+
+## What goes wrong without the pre-flight
+
+A 500-row `users` batch with one bad row (age 15 against `CHECK (age >= 18)`), inserted raw:
+
+```
+new row for relation "users" violates check constraint "users_age_check"
+code: 23514  detail: Failing row contains (372, u371@x.co, U371, 15).
+```
+
+The server names the constraint and the row's values, never the row's position in your batch.
+Nothing was inserted (a single multi-row `INSERT` is atomic, measured: count stayed 0), but the
+serial sequence still advanced: retrying the same batch after two failed attempts showed the
+same row as id 1116, so every failed attempt burns ids and your seeded rows drift away from the
+ids your fixtures expect.
+
+The same batch through the emitted insert schema first:
+
+```
+index 371  age: Too small: expected number to be >=18
+```
+
+Named row, named column, before a connection is opened. The CHECK is already inside the emitted
+schema (`age: z.number().int().gte(18)`), which is what makes this equivalence hold. Cost of the
+pre-flight, measured on 10,000 rows: 8.6ms to validate, 3.9ms to scan for duplicates.
+
+## Step 1: validate
+
+```ts
+const invalid: { table: string; index: number; issues: string[] }[] = [];
+for (const [name, rows] of Object.entries(fixtures)) {
+  rows.forEach((row, index) => {
+    const r = plan[name].schema.safeParse(row);
+    if (!r.success)
+      invalid.push({
+        table: name,
+        index,
+        issues: r.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+      });
+  });
+}
+if (invalid.length) throw new Error('invalid fixtures: ' + JSON.stringify(invalid, null, 2));
+```
+
+## Step 2: refuse batches that collide with themselves
+
+Uniqueness is the one constraint a per-row schema structurally cannot check, so the finder is a
+separate emitted function. What it reports, measured against the emitted module:
+
+| batch | report |
+| ----- | ------ |
+| two rows, same `email`, everything else different | `{ index: 1, constraint: 'email', firstIndex: 0 }` |
+| same values, different property order | reported identically; keys are read by column name |
+| three identical rows | index 1 and index 2, each pointing at `firstIndex: 0` |
+| two rows with the same explicit `id: 7`, different emails | `{ index: 1, constraint: 'users_pkey', firstIndex: 0 }` |
+| two `skus` rows with the same `code` (a natural primary key) | `{ index: 1, constraint: 'skus_pkey', firstIndex: 0 }` |
+| `(userId, org)` pair repeated with a different `role` | one report naming the composite constraint |
+| rows that omit a serial `id`, or hold `null` in a key column | nothing, matching SQL: a unique index permits repeated NULLs, and an absent key is the database's to fill |
+
+The primary key rows are the seed case: fixtures carry explicit ids so foreign keys can point at
+known rows, and the database enforces the key with a unique index (its own error for the `skus`
+collision reads `duplicate key value violates unique constraint "skus_pkey"`, code 23505). What
+the finder cannot see is a collision with rows already stored; that half belongs to
+`onConflictDoNothing` below.
+
+```ts
+const collisions: { table: string; index: number; constraint: string; firstIndex: number }[] = [];
+for (const [name, rows] of Object.entries(fixtures)) {
+  for (const d of plan[name].dupes(rows)) collisions.push({ table: name, ...d });
+}
+if (collisions.length)
+  throw new Error('duplicate fixtures: ' + JSON.stringify(collisions, null, 2));
+```
+
+## Step 3: parents before children
+
+Child first fails, measured:
+
+```
+insert or update on table "posts" violates foreign key constraint "posts_author_id_fkey"
+code: 23503  detail: Key (author_id)=(1) is not present in table "users".
+```
+
+The emitted `constraints.ts` carries every foreign key as data, so the order does not have to be
+maintained by hand as the schema grows:
+
+```ts
+import { constraintsByTable } from './src/validators/zod/constraints';
+
+/** Insert order: every table after the tables its foreign keys point at. */
+function insertOrder(byTable: typeof constraintsByTable): string[] {
+  const bySqlName = new Map(Object.entries(byTable).map(([exp, t]) => [t.table, exp]));
+  const deps = new Map<string, Set<string>>();
+  for (const [exp, t] of Object.entries(byTable)) {
+    const set = new Set<string>();
+    for (const c of t.constraints) {
+      if (c.kind !== 'foreignKey') continue;
+      const parent = bySqlName.get(c.references.table);
+      if (parent && parent !== exp) set.add(parent); // a self-reference orders nothing
+    }
+    deps.set(exp, set);
+  }
+  const order: string[] = [];
+  while (deps.size) {
+    const ready = [...deps.keys()].filter((k) => [...deps.get(k)!].every((d) => !deps.has(d)));
+    if (!ready.length)
+      throw new Error(`circular foreign keys between: ${[...deps.keys()].join(', ')}`);
+    for (const k of ready.sort()) {
+      order.push(k);
+      deps.delete(k);
+    }
+  }
+  return order;
+}
+```
+
+Run against a schema with a `users -> posts -> comments` chain, a `memberships` join table and a
+self-referencing `categories`, this returned
+`["audit", "categories", "skus", "users", "wide", "memberships", "posts", "comments"]`: every
+child after its parents, and the self-reference did not deadlock. A self-referencing table
+orders its own rows, not tables: put parent categories before their children inside the fixture
+array, or seed `parentId: null` and update after.
+
+## Step 4: chunk under the wire limit
+
+The Postgres extended-query protocol counts bind parameters in 16 bits, and each provided column
+of each row is one parameter. Measured against PostgreSQL 17.10 over `pg`, on a 15-column table:
+
+| rows | parameters | result |
+| ---- | ---------- | ------ |
+| 4369 | 65,535 | insert OK, 182ms |
+| 4370 | 65,550 | `bind message has 14 parameter formats but 0 parameters` |
+| 5000 | 75,000 | `bind message has 9464 parameter formats but 0 parameters` |
+
+The ceiling is exactly 65,535. One row past it, nothing on the client objects: the 16-bit count
+silently wraps (65,550 mod 65,536 = 14, and the server's error is quoting your wrapped count
+back at you), the server rejects the malformed message, and nothing is inserted.
+
+PGlite's ceiling is half that, and the failure is worse than an error. Measured with a fresh
+instance per probe:
+
+| rows | parameters | result |
+| ---- | ---------- | ------ |
+| 2184 | 32,760 | insert OK, session fine |
+| 2185 | 32,775 | insert reports OK, then **every later query on that connection returns zero rows**, silently |
+
+Past the signed 16-bit boundary (32,767) the PGlite session is wedged: `select 1` comes back
+empty, no error is thrown. A seed that "succeeded" and then reads nothing back is this.
+
+So the chunk size is derived, not guessed:
+
+```ts
+const width = new Set(rows.flatMap(Object.keys)).size; // provided columns only
+const chunk = Math.floor(32767 / width); // 65535 if PGlite will never run this
+```
+
+Provided columns, not table width: a column you omit renders as `DEFAULT` in the statement and
+carries no parameter (visible in the measured statement text:
+`values (default, $1, $2, $3), ...` for an omitted serial id). The `Set` union across rows is
+conservative when rows provide different keys. And guard the empty batch:
+`values([])` throws `values() must be called with at least one value`.
+
+## Step 5: one transaction, idempotent
+
+Three facts, measured in order:
+
+- Three chunks without a transaction, failure in the second: the 200 rows of chunk one stayed.
+  A partial seed is worse than no seed, so the loop belongs inside `db.transaction` (same
+  failure inside it: 0 rows persisted).
+- `onConflictDoNothing()` makes re-runs idempotent: the second full run inserted 0 rows per
+  table, no error.
+- `onConflictDoNothing()` also swallows collisions **inside** one batch: two rows with the same
+  primary key in one `values()` call succeeded and stored one row. That is exactly the fixture
+  mistake step 2 catches, which is why the finder runs even though the insert would "succeed"
+  without it. The upsert variant does not forgive it: the same batch under `onConflictDoUpdate`
+  fails with `ON CONFLICT DO UPDATE command cannot affect row a second time` (code 21000), so
+  dedupe before an upsert is mandatory, not hygiene.
+
+## The whole script
+
+```ts
+// seed.ts, run with: npx tsx seed.ts
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import * as t from './src/db/schema';
+import * as v from './src/validators/zod';
+import { constraintsByTable } from './src/validators/zod/constraints';
+
+const fixtures = {
+  users: [
+    { id: 1, email: 'ada@example.com', name: 'Ada', age: 36 },
+    { id: 2, email: 'lin@example.com', name: 'Lin', age: 29 },
+  ],
+  posts: [
+    { id: 1, authorId: 1, slug: 'hello', title: 'Hello' },
+    { id: 2, authorId: 2, slug: 'world', title: 'World' },
+  ],
+};
+
+const plan = {
+  users: { table: t.users, schema: v.InsertusersSchema, dupes: v.findDuplicateusers },
+  posts: { table: t.posts, schema: v.InsertpostsSchema, dupes: v.findDuplicateposts },
+};
+
+// insertOrder from step 3 here
+
+async function seed(db: ReturnType<typeof drizzle>) {
+  // 1. validate (step 1)  2. dedupe (step 2), both throwing before any connection is used
+
+  const order = insertOrder(constraintsByTable).filter((n) => fixtures[n]?.length);
+  const counts: Record<string, number> = {};
+  await db.transaction(async (tx) => {
+    for (const name of order) {
+      const rows = fixtures[name];
+      const width = new Set(rows.flatMap(Object.keys)).size;
+      const chunk = Math.floor(32767 / width);
+      let inserted = 0;
+      for (let i = 0; i < rows.length; i += chunk) {
+        const res = await tx
+          .insert(plan[name].table)
+          .values(rows.slice(i, i + chunk))
+          .onConflictDoNothing();
+        inserted += res.rowCount ?? 0;
+      }
+      counts[name] = inserted;
+    }
+  });
+  return counts;
+}
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+console.log(await seed(drizzle(pool)));
+await pool.end();
+```
+
+Measured end to end against PostgreSQL 17.10, with the plan extended to all four fixture tables
+and the step 1 and step 2 guards inlined:
+
+```
+first run:  {"skus":2,"users":2,"memberships":2,"posts":2}
+second run: {"skus":0,"users":0,"memberships":0,"posts":0}
+```
+
+and both sabotage runs (a duplicated explicit id, an under-age row) aborted before any insert.
+`res.rowCount` is the count actually inserted, so the second run reporting zeros is the
+idempotence check for free.
+
+::: tip Need something else?
+If this example doesn't cover what you need, DM me on X (https://x.com/omardulaimidev) and we can scope it together.
+:::

--- a/docs/generators/arktype.md
+++ b/docs/generators/arktype.md
@@ -289,7 +289,7 @@ collision and the error names a constraint rather than a row.
 { kind: 'arktype', path: 'src/validators/arktype', duplicateFinder: true }
 ```
 
-emits, for a table with unique constraints:
+emits, for a table with a primary key or unique constraints:
 
 ```ts
 export function findDuplicateusers(
@@ -305,8 +305,13 @@ findDuplicateusers([
 // [{ index: 1, constraint: 'email', firstIndex: 0 }]
 ```
 
-Two details it follows:
+Three details it follows:
 
+- **The primary key counts.** The database enforces it with a unique index and its own error says
+  so: two rows sharing an explicit key fail with `duplicate key value violates unique constraint
+  "users_pkey"` (23505, measured on Postgres 17). Seed fixtures carry explicit keys so that
+  foreign keys can point at known rows, which makes this the collision bulk data actually has.
+  Rows that leave a generated key to the database report nothing on it.
 - **Null is not equal to null.** A constraint is skipped for any row where one of its columns is
   null or absent, because a unique index accepts any number of NULLs. Reporting those would send
   you chasing rows the database is perfectly happy with.
@@ -314,7 +319,8 @@ Two details it follows:
   `['1', 2]`, which a separator-joined key would.
 
 A batch that passes can still collide with rows already stored. This checks the half that needs no
-round trip.
+round trip. The [seeding recipe](/examples/seed) composes the finder with the emitted schemas into
+a checked bulk-insert pipeline: validate, dedupe, order by foreign keys, chunk, commit.
 
 Off by default: generated code ships in your bundle.
 

--- a/docs/generators/effect.md
+++ b/docs/generators/effect.md
@@ -197,3 +197,53 @@ role: Schema.UUID as unknown as Schema.Schema<(typeof users.$inferSelect)['role'
 The cast exists only at compile time, so every runtime check the wrapped schema carried still runs.
 `typedJson` covers only the columns with no runtime type, where the reference _replaces_ the schema;
 `typedColumns` narrows every column and implies `typedJson`.
+
+## `duplicateFinder`
+
+Uniqueness is the one constraint a per-row validator structurally cannot check: whether a value is
+unique is a fact about the table, not about the row. No first-party validator attempts it, and
+neither does a schema here.
+
+What needs no database is whether a **batch collides with itself**, and that is the half you can
+fix before sending anything. It matters for a bulk insert, where a thousand rows fail whole on one
+collision and the error names a constraint rather than a row.
+
+```ts
+{ kind: 'effect', path: 'src/validators/effect', duplicateFinder: true }
+```
+
+emits, for a table with a primary key or unique constraints:
+
+```ts
+export function findDuplicateusers(
+  rows: readonly InsertusersInput[]
+): Array<{ index: number; constraint: string; firstIndex: number }> { ... }
+```
+
+```ts
+findDuplicateusers([
+  { email: 'a@b.co', org: 'x', handle: 'h' },
+  { email: 'a@b.co', org: 'y', handle: 'h' },
+]);
+// [{ index: 1, constraint: 'email', firstIndex: 0 }]
+```
+
+The emitted function is plain TypeScript with no Effect import, identical to what the other four
+validator generators emit. Three details it follows:
+
+- **The primary key counts.** The database enforces it with a unique index and its own error says
+  so: two rows sharing an explicit key fail with `duplicate key value violates unique constraint
+  "users_pkey"` (23505, measured on Postgres 17). Seed fixtures carry explicit keys so that
+  foreign keys can point at known rows, which makes this the collision bulk data actually has.
+  Rows that leave a generated key to the database report nothing on it.
+- **Null is not equal to null.** A constraint is skipped for any row where one of its columns is
+  null or absent, because a unique index accepts any number of NULLs. Reporting those would send
+  you chasing rows the database is perfectly happy with.
+- **Composite keys compare by value.** The key is JSON, so `[1, '2']` never collides with
+  `['1', 2]`, which a separator-joined key would.
+
+A batch that passes can still collide with rows already stored. This checks the half that needs no
+round trip. The [seeding recipe](/examples/seed) composes the finder with the emitted schemas into
+a checked bulk-insert pipeline: validate, dedupe, order by foreign keys, chunk, commit.
+
+Off by default: generated code ships in your bundle.

--- a/docs/generators/typebox.md
+++ b/docs/generators/typebox.md
@@ -389,7 +389,7 @@ collision and the error names a constraint rather than a row.
 { kind: 'typebox', path: 'src/validators/typebox', duplicateFinder: true }
 ```
 
-emits, for a table with unique constraints:
+emits, for a table with a primary key or unique constraints:
 
 ```ts
 export function findDuplicateusers(
@@ -405,8 +405,13 @@ findDuplicateusers([
 // [{ index: 1, constraint: 'email', firstIndex: 0 }]
 ```
 
-Two details it follows:
+Three details it follows:
 
+- **The primary key counts.** The database enforces it with a unique index and its own error says
+  so: two rows sharing an explicit key fail with `duplicate key value violates unique constraint
+  "users_pkey"` (23505, measured on Postgres 17). Seed fixtures carry explicit keys so that
+  foreign keys can point at known rows, which makes this the collision bulk data actually has.
+  Rows that leave a generated key to the database report nothing on it.
 - **Null is not equal to null.** A constraint is skipped for any row where one of its columns is
   null or absent, because a unique index accepts any number of NULLs. Reporting those would send
   you chasing rows the database is perfectly happy with.
@@ -414,7 +419,8 @@ Two details it follows:
   `['1', 2]`, which a separator-joined key would.
 
 A batch that passes can still collide with rows already stored. This checks the half that needs no
-round trip.
+round trip. The [seeding recipe](/examples/seed) composes the finder with the emitted schemas into
+a checked bulk-insert pipeline: validate, dedupe, order by foreign keys, chunk, commit.
 
 Off by default: generated code ships in your bundle.
 

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -230,7 +230,7 @@ collision and the error names a constraint rather than a row.
 { kind: 'valibot', path: 'src/validators/valibot', duplicateFinder: true }
 ```
 
-emits, for a table with unique constraints:
+emits, for a table with a primary key or unique constraints:
 
 ```ts
 export function findDuplicateusers(
@@ -246,8 +246,13 @@ findDuplicateusers([
 // [{ index: 1, constraint: 'email', firstIndex: 0 }]
 ```
 
-Two details it follows:
+Three details it follows:
 
+- **The primary key counts.** The database enforces it with a unique index and its own error says
+  so: two rows sharing an explicit key fail with `duplicate key value violates unique constraint
+  "users_pkey"` (23505, measured on Postgres 17). Seed fixtures carry explicit keys so that
+  foreign keys can point at known rows, which makes this the collision bulk data actually has.
+  Rows that leave a generated key to the database report nothing on it.
 - **Null is not equal to null.** A constraint is skipped for any row where one of its columns is
   null or absent, because a unique index accepts any number of NULLs. Reporting those would send
   you chasing rows the database is perfectly happy with.
@@ -255,7 +260,8 @@ Two details it follows:
   `['1', 2]`, which a separator-joined key would.
 
 A batch that passes can still collide with rows already stored. This checks the half that needs no
-round trip.
+round trip. The [seeding recipe](/examples/seed) composes the finder with the emitted schemas into
+a checked bulk-insert pipeline: validate, dedupe, order by foreign keys, chunk, commit.
 
 Off by default: generated code ships in your bundle.
 

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -682,7 +682,7 @@ collision and the error names a constraint rather than a row.
 { kind: 'zod', path: 'src/validators/zod', duplicateFinder: true }
 ```
 
-emits, for a table with unique constraints:
+emits, for a table with a primary key or unique constraints:
 
 ```ts
 export function findDuplicateusers(
@@ -698,8 +698,13 @@ findDuplicateusers([
 // [{ index: 1, constraint: 'email', firstIndex: 0 }]
 ```
 
-Two details it follows:
+Three details it follows:
 
+- **The primary key counts.** The database enforces it with a unique index and its own error says
+  so: two rows sharing an explicit key fail with `duplicate key value violates unique constraint
+  "users_pkey"` (23505, measured on Postgres 17). Seed fixtures carry explicit keys so that
+  foreign keys can point at known rows, which makes this the collision bulk data actually has.
+  Rows that leave a generated key to the database report nothing on it.
 - **Null is not equal to null.** A constraint is skipped for any row where one of its columns is
   null or absent, because a unique index accepts any number of NULLs. Reporting those would send
   you chasing rows the database is perfectly happy with.
@@ -707,7 +712,8 @@ Two details it follows:
   `['1', 2]`, which a separator-joined key would.
 
 A batch that passes can still collide with rows already stored. This checks the half that needs no
-round trip.
+round trip. The [seeding recipe](/examples/seed) composes the finder with the emitted schemas into
+a checked bulk-insert pipeline: validate, dedupe, order by foreign keys, chunk, commit.
 
 Off by default: generated code ships in your bundle.
 

--- a/packages/validation-core/README.md
+++ b/packages/validation-core/README.md
@@ -84,9 +84,10 @@ Shared interfaces and helpers used by validation generators.
     name every generator writes it to.
 - Uniqueness
   - `renderDuplicateFinder(table, fnName, rowType)` -> the source of a function returning the rows
-    in a batch that collide with an earlier row on a unique constraint. Plain TypeScript with no
-    reference to any validation library, so all four generators emit the same one. Null and absent
-    columns skip a constraint, matching SQL.
+    in a batch that collide with an earlier row on the primary key or a unique constraint. Plain
+    TypeScript with no reference to any validation library, so every validator generator emits the
+    same one. Null and absent columns skip a constraint, matching SQL, so rows that leave a
+    generated key to the database report nothing on it.
 - Naming (shared by every generator that emits a schema name)
   - `resolveAffix({ affix, schemaSuffix })` -> `ResolvedAffix`
   - `schemaName(mode, tsName, resolved)`, `typeName(mode, tsName, resolved)`

--- a/packages/validation-core/src/duplicates.ts
+++ b/packages/validation-core/src/duplicates.ts
@@ -15,13 +15,31 @@
  */
 import type { Key, Table } from '@drzl/analyzer';
 
-/** The unique constraints worth emitting a finder for. */
+/**
+ * The constraints worth emitting a finder for: the primary key, then the unique constraints.
+ *
+ * The primary key belongs here because the database enforces it with a unique index and says so
+ * in its own error: two rows sharing an explicit key fail with `duplicate key value violates
+ * unique constraint "t_pkey"` (23505, measured on Postgres 17). Seed data is where this bites,
+ * since fixtures carry explicit keys so that foreign keys can point at known rows. Rows that
+ * leave a generated key to the database are unaffected: absence skips the constraint, exactly as
+ * it does for a unique key.
+ *
+ * The analysis does not record a name for the key, so the finder names it the way the default
+ * convention and the constraints module both do: `<table>_pkey`.
+ */
 function usableKeys(table: Table): Key[] {
-  return (table.unique ?? []).filter((k) => k.columns.length > 0);
+  const keys: Key[] = [];
+  const pk = table.primaryKey;
+  if (pk && pk.columns.length > 0) {
+    keys.push({ name: pk.name ?? `${table.name}_pkey`, columns: pk.columns });
+  }
+  keys.push(...(table.unique ?? []).filter((k) => k.columns.length > 0));
+  return keys;
 }
 
 /**
- * `findDuplicate<Table>s` for a table with unique constraints, or nothing.
+ * `findDuplicate<Table>s` for a table with a primary key or unique constraints, or nothing.
  *
  * `rowType` is the name of the insert type, which is what a caller has in hand before an insert.
  * Passed in rather than derived, because each generator names its types differently.
@@ -44,14 +62,15 @@ export function renderDuplicateFinder(
     .join('\n');
 
   return `/**
- * Rows in \`rows\` that collide with an earlier row on a unique constraint.
+ * Rows in \`rows\` that collide with an earlier row on the primary key or a unique constraint.
  *
  * Uniqueness is a fact about the table rather than about a row, so no schema can check it. This
  * checks the half that needs no database: whether the batch collides with itself. A batch that
  * passes here can still collide with rows already stored.
  *
  * A constraint is skipped for any row where one of its columns is null or absent, matching SQL,
- * where NULL is not equal to NULL and a unique index therefore permits repeats.
+ * where NULL is not equal to NULL and a unique index therefore permits repeats. Rows that leave
+ * a generated primary key to the database therefore report nothing on it.
  */
 export function ${fnName}(
   rows: readonly ${rowType}[]

--- a/packages/validation-core/test/duplicates.spec.ts
+++ b/packages/validation-core/test/duplicates.spec.ts
@@ -12,14 +12,20 @@ import os from 'node:os';
 import { renderDuplicateFinder } from '../src/duplicates';
 import type { Table } from '@drzl/analyzer';
 
-const table = (unique: Array<{ name?: string; columns: string[] }>): Table =>
-  ({ name: 't', tsName: 't', columns: [], unique, indexes: [], checks: [] }) as never;
+const table = (
+  unique: Array<{ name?: string; columns: string[] }>,
+  primaryKey?: { name?: string; columns: string[] }
+): Table =>
+  ({ name: 't', tsName: 't', columns: [], unique, primaryKey, indexes: [], checks: [] }) as never;
 
 let seq = 0;
 
 /** Write the emitted function to a module and import it, so the assertions run real code. */
-async function finderFor(unique: Array<{ name?: string; columns: string[] }>) {
-  const src = renderDuplicateFinder(table(unique), 'findDuplicates', 'Row');
+async function finderFor(
+  unique: Array<{ name?: string; columns: string[] }>,
+  primaryKey?: { name?: string; columns: string[] }
+) {
+  const src = renderDuplicateFinder(table(unique, primaryKey), 'findDuplicates', 'Row');
   expect(src, 'nothing emitted').toBeTruthy();
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-dup-'));
   const file = path.join(dir, `d${seq++}.ts`);
@@ -101,9 +107,57 @@ describe('several constraints at once', () => {
   });
 });
 
-describe('a table with no unique constraint', () => {
+describe('the primary key, which the database enforces with a unique index', () => {
+  // Measured against a real Postgres 17: two rows sharing an explicit key fail the insert with
+  // `duplicate key value violates unique constraint "skus_pkey"` (23505). The database's own
+  // error calls the primary key a unique constraint, so the finder covers it as one.
+  it('is a constraint: a table with only a primary key gets a finder', async () => {
+    const f = await finderFor([], { columns: ['code'] });
+    const out = f([
+      { code: 'A1', label: 'first' },
+      { code: 'A1', label: 'second' },
+    ]);
+    expect(out).toEqual([{ index: 1, constraint: 't_pkey', firstIndex: 0 }]);
+  });
+
+  it('reports an explicit key collision even when every unique column differs', async () => {
+    const f = await finderFor([{ name: 'email_uq', columns: ['email'] }], { columns: ['id'] });
+    const out = f([
+      { id: 7, email: 'a@x.co' },
+      { id: 7, email: 'b@x.co' },
+    ]);
+    expect(out).toEqual([{ index: 1, constraint: 't_pkey', firstIndex: 0 }]);
+  });
+
+  it('stays silent for rows that leave the key to the database', async () => {
+    // A serial or defaulted key is absent from seed rows; absence skips the constraint exactly
+    // as it does for a unique key, so generated-key batches report nothing.
+    const f = await finderFor([], { columns: ['id'] });
+    expect(f([{ x: 1 }, { x: 1 }])).toEqual([]);
+  });
+
+  it('treats a composite key as one constraint', async () => {
+    const f = await finderFor([], { columns: ['a', 'b'] });
+    const out = f([
+      { a: 1, b: 1 },
+      { a: 1, b: 2 },
+      { a: 1, b: 1 },
+    ]);
+    expect(out).toEqual([{ index: 2, constraint: 't_pkey', firstIndex: 0 }]);
+  });
+
+  it('uses the declared name when the analysis carries one', async () => {
+    const f = await finderFor([], { name: 'sku_pk', columns: ['code'] });
+    expect(f([{ code: 'x' }, { code: 'x' }])).toEqual([
+      { index: 1, constraint: 'sku_pk', firstIndex: 0 },
+    ]);
+  });
+});
+
+describe('a table with no unique constraint and no primary key', () => {
   it('gets no function at all', () => {
     expect(renderDuplicateFinder(table([]), 'f', 'Row')).toBeUndefined();
     expect(renderDuplicateFinder(table([{ columns: [] }]), 'f', 'Row')).toBeUndefined();
+    expect(renderDuplicateFinder(table([], { columns: [] }), 'f', 'Row')).toBeUndefined();
   });
 });

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -909,6 +909,69 @@ if [ "$doc_failed" -ne 0 ]; then
 fi
 echo "    all $doc_total documented configs generate and typecheck"
 
+# ---------------------------------------------------------------------------------------------
+# duplicateFinder must cover the primary key.
+#
+# Found by item 58: explicit primary keys are the norm in seed fixtures (so foreign keys can
+# reference known rows), and the finder consulted only Table.unique, so a natural-PK table
+# emitted no finder at all and an explicit-key collision passed silently while the database
+# refused the batch with 23505. This file had zero duplicateFinder coverage; this stage is the
+# must-fire control from that fix made permanent. Runs in the same install tree, executing the
+# emitted finder through jiti (a dependency of the installed analyzer), in a child process so
+# its chdir cannot leak into this shell.
+echo "==> duplicateFinder covers the primary key"
+cat > dupfinder-probe.mjs <<'DUPFINDER'
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ZodGenerator } from '@drzl/generator-zod';
+import { mkdtemp, writeFile, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const dir = await mkdtemp(path.join(process.cwd(), 'dupfinder-'));
+await writeFile(
+  path.join(dir, 'schema.ts'),
+  [
+    "import { pgTable, serial, text } from 'drizzle-orm/pg-core';",
+    "export const skus = pgTable('skus', { code: text('code').primaryKey(), label: text('label') });",
+    "export const audit = pgTable('audit', { id: serial('id').primaryKey(), note: text('note') });",
+  ].join('\n')
+);
+process.chdir(dir);
+const analysis = await new SchemaAnalyzer('schema.ts').analyze();
+await new ZodGenerator(analysis).generate({ outDir: 'out', duplicateFinder: true });
+
+const skusSrc = await readFile(path.join(dir, 'out', 'skus.zod.ts'), 'utf8');
+if (!skusSrc.includes('export function findDuplicateskus')) {
+  console.error('FAIL: no finder for a table whose only key is its primary key');
+  process.exit(1);
+}
+
+const { createRequire } = await import('node:module');
+const req = createRequire(import.meta.url);
+const jiti = req('jiti')(import.meta.url, { moduleCache: false, interopDefault: true });
+const skus = jiti(path.join(dir, 'out', 'skus.zod.ts'));
+const audit = jiti(path.join(dir, 'out', 'audit.zod.ts'));
+
+const collision = skus.findDuplicateskus([
+  { code: 'A1', label: 'x' },
+  { code: 'A1', label: 'y' },
+]);
+const expected = JSON.stringify([{ index: 1, constraint: 'skus_pkey', firstIndex: 0 }]);
+if (JSON.stringify(collision) !== expected) {
+  console.error('FAIL: explicit-key collision not reported, got', JSON.stringify(collision));
+  process.exit(1);
+}
+
+const silent = audit.findDuplicateaudit([{ note: 'a' }, { note: 'a' }]);
+if (silent.length !== 0) {
+  console.error('FAIL: serial-omitting batch reported', JSON.stringify(silent));
+  process.exit(1);
+}
+
+console.log('    finder covers the primary key: collision named skus_pkey, serial omission silent');
+DUPFINDER
+node dupfinder-probe.mjs || { echo "FAIL: duplicateFinder primary-key stage" >&2; exit 1; }
+rm -f dupfinder-probe.mjs
+
 echo "==> differential parity against the official drizzle-orm validators"
 # What DRZL claims is that every difference between its generated schemas and the first-party
 # `drizzle-orm/{zod,valibot,arktype,typebox}` modules is known and named. Not that it is at least as


### PR DESCRIPTION
Plan item 58 ("Prisma-style seed helper using the duplicate finder for batch inserts"), closed as **outcome A plus one fix the measurement forced**: a measured recipe page (`docs/examples/seed.md`), a real defect fix in the duplicate finder, and a new gate stage for the coverage hole. No new package.

## The find: the duplicate finder never covered the primary key

`renderDuplicateFinder` consulted only `Table.unique`; the analyzer records the PK in `Table.primaryKey`. Consequences, measured through the real pipeline: a natural-PK table (`skus.code text primaryKey`) emitted **no finder at all**, and two rows with explicit `id: 7` passed silently while PGlite/PG 17 refused the batch with 23505 naming `skus_pkey`. Explicit PKs are the norm in seed fixtures (FKs reference known rows), so the item's central tool missed the most common seed collision. Fix: `usableKeys` puts the primary key first (named `pk.name ?? <table>_pkey`, matching `constraints.ts`); absence/null skip keeps generated-key batches silent. Red-first: 5 new tests failed on master, 15/15 after, re-proven end to end for zod and effect.

## Why no package

- Prisma 7 removed the auto-run-after-migrate hook; seeds run only on explicit `prisma db seed` from config. There is no lifecycle machinery left to imitate; a `drzl seed` command would be `tsx seed.ts` with a config key.
- Official `drizzle-seed` owns fake-data generation. DRZL's honest complement is **real-fixture seeding**, and every ingredient is already emitted: insert schemas with CHECKs folded in, duplicate finders, and the FK graph as data in `constraints.ts`. The composition is a ~60-line user-owned script, printed in full on the page and run twice plus two sabotage runs.
- A runtime `seed()` package would be DRZL's first runtime-dependency package and need a manual first publish, to wrap what the recipe shows.

## Measurements backing the page (PostgreSQL 17.10, PGlite, drizzle 0.45.2)

- **Fail-fast**: a 500-row batch with one CHECK-violating row: the raw insert fails 23514 naming the constraint but never the batch index, inserts nothing, and still burns serial ids; schema-first validation names `index 371` and the column before any connection. Pre-flight on 10k rows: 8.6ms validate + 3.9ms dedupe.
- **FK order**: child-first fails 23503; the page's `insertOrder` snippet against the emitted `constraints.ts` orders the 8-table graph correctly; self-FK does not deadlock.
- **Chunk ceiling, derived not guessed**: the wire limit is exactly **65,535 parameters** (4369x15 rows pass, 4370x15 fails with the Int16 count wrapping mod 65536 client-side); **PGlite silently wedges past 32,767** (reports insert OK, then every later query on the session returns zero rows), hence the default `floor(32767 / providedColumns)`.
- **Atomicity/idempotency**: a chunked loop without a transaction persisted 200 rows before failing; inside `db.transaction`, 0. `onConflictDoNothing` re-runs insert 0 per table; an intra-batch PK duplicate under DoNothing silently stores one row (why the finder still runs first); under DoUpdate it fails 21000.

## The new gate stage (controller-applied in this PR)

The gate had **zero** `duplicateFinder` occurrences. This PR adds a stage after the documented-configs run, adapted from the fix agent's scratch-validated probe (which included a must-fire control: master's renderer emits nothing for the PK-only table, so the stage fires pre-fix): from the packed tarballs, a PK-only table must emit `findDuplicate<T>`, an explicit-key collision must return `[{index: 1, constraint: 'skus_pkey', firstIndex: 0}]`, and a serial-omitting batch must return `[]`.

## Docs and packaging

`docs/examples/seed.md` (new, sidebar added); PK bullet + recipe cross-link on the five generator pages' `duplicateFinder` sections; **effect.md gains its previously missing `duplicateFinder` section**; validation-core README updated. Changeset: patch for validation-core and the five validator generators. Item 89's "bulk insert with the duplicate finder" bullet is covered by this page; its OpenAPI-publishing bullet stays open.

## Worth knowing (meta-find)

Local `@drzl/validation-core` at 3.20.0 is ahead of the published 3.20.0 (pending changesets carry an unreleased module), so tarball-vs-registry controls can differ at equal version numbers while release PR #160 is held. Noted for anyone comparing dists.

Full gates green on the branch before the stage addition: 20 suites, verify:packed exit 0 with parity grids unchanged. The PGlite silent-wedge past 32,767 params looks like an upstream PGlite bug; documented on the page, not yet filed upstream.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
