### PR TITLE
feat: drizzle-kit config interop, schema named once (item 59)

### DIFF
--- a/.changeset/drizzle-kit-interop.md
+++ b/.changeset/drizzle-kit-interop.md
@@ -1,0 +1,25 @@
+---
+'@drzl/cli': minor
+'@drzl/analyzer': minor
+---
+
+drizzle-kit interop: the schema path can come from drizzle.config.ts, so it is written once
+
+A drizzle-kit project already names its schema in `drizzle.config.ts`, and DRZL demanded the
+same path again in `drzl.config.ts`; two files stating one fact is how the copies drift. Now
+`schema` is optional: when omitted, DRZL reads kit's config instead, trying
+`drizzle.config.ts`, `.js`, `.json` in kit's own candidate order (measured on drizzle-kit
+0.31.10), announcing the file it read, and honouring kit's whole `schema` surface: a string, an
+array, glob patterns, and a directory expanded one level exactly as kit expands it. The new
+`drizzleKit` key pins it down when wanted: a path mirrors kit's `--config` flag, `true` makes a
+missing kit config an error, `false` disables the fallback. `schema` always wins when both are
+set, with a warning; neither yielding a schema is an error naming both files. The `dialect` the
+kit config declares is cross-checked against what the analyzer measures and a contradiction
+warns, since a stale dialect line usually means the config points somewhere it should not.
+`watch` treats it all as config surface: the resolved directories are watched (glob bases
+included, so a new file matching the pattern rebuilds), and editing `drizzle.config.ts`
+re-resolves the schema. `SchemaAnalyzer` now takes `string | string[]` so a barrel-less
+multi-file schema analyzes as one schema; duplicate export names are judged by what Drizzle
+says they are (table name, SQL schema, columns), so the ordinary re-export pattern stays
+silent and a genuine disagreement warns as `DRZL_ANL_DUP_EXPORT`, keeping the first file's
+export deterministically.

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -25,7 +25,8 @@ bunx @drzl/cli doctor [schema] [--json] [--strict] [-c drzl.config.ts]
 :::
 
 With no `schema` argument it reads the `schema` path out of your `drzl.config.*`, so a project that
-already has one needs only `drzl doctor`.
+already has one needs only `drzl doctor`. A config without a `schema` key resolves through your
+drizzle-kit config, exactly as `generate` does.
 
 ## Why this is not `analyze`
 

--- a/docs/cli/generate.md
+++ b/docs/cli/generate.md
@@ -29,6 +29,11 @@ Behavior:
 - Analyzes your schema then runs each generator in `generators[]`
 - Prints a file summary per generator kind
 
+When the config has no `schema` key, the path is read from your drizzle-kit config
+(`drizzle.config.ts`, then `.js`, then `.json`), and the run says so:
+`Schema from drizzle.config.ts (3 files)`. See
+[Reading the schema path from drizzle-kit](/guide/configuration#reading-the-schema-path-from-drizzle-kit).
+
 ## `--check`: fail CI when generated output is stale
 
 ```bash

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -2,6 +2,11 @@
 
 Watch schema (and template paths) and regenerate on changes.
 
+A schema resolved from your drizzle-kit config is watched the same way a `schema` path is: the
+directories its entries name (glob bases included, so a new file matching the pattern counts)
+and `drizzle.config.*` itself, whose edits re-resolve the schema on the next rebuild. See
+[Reading the schema path from drizzle-kit](/guide/configuration#reading-the-schema-path-from-drizzle-kit).
+
 Usage:
 
 ::: code-group

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -63,6 +63,71 @@ databaseInjection: {
 },
 ```
 
+## Reading the schema path from drizzle-kit
+
+A drizzle-kit project already names its schema once, in `drizzle.config.ts`. Naming it a second
+time in `drzl.config.ts` is the same fact in two files, and the copies drift. So `schema` is
+optional: when it is omitted, DRZL reads the schema path out of your drizzle-kit config instead.
+
+```ts
+// drizzle.config.ts, exactly as drizzle-kit already has it
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  dialect: 'postgresql',
+  schema: './src/db/schema/*.ts',
+  out: './drizzle',
+});
+```
+
+```ts
+// drzl.config.ts: no schema key at all
+export default {
+  outDir: 'src/api',
+  generators: [{ kind: 'zod', path: 'src/validators/zod' }],
+};
+```
+
+`drzl generate` announces the file it read (`Schema from drizzle.config.ts (3 files)`), so the
+fallback is never silent. The lookup tries `drizzle.config.ts`, then `drizzle.config.js`, then
+`drizzle.config.json`, which are the same candidates in the same order drizzle-kit's own CLI
+uses. Kit's whole `schema` surface is honoured: a single path, an array, glob patterns, and a
+directory (expanded one level, exactly as kit expands it). A multi-file schema needs no barrel;
+the analyzer reads every file as one schema.
+
+The `drizzleKit` key pins the behavior down when the default is not what you want:
+
+- `drizzleKit: './config/drizzle.config.mjs'` reads that file, wherever it is, like kit's own
+  `--config` flag. This is also how a `.mjs`/`.cjs` config is reached, since kit itself does not
+  look for those names.
+- `drizzleKit: true` insists on the fallback: a missing drizzle-kit config becomes an error
+  instead of a quieter one about `schema`.
+- `drizzleKit: false` disables it: omitting `schema` is then an error even beside a
+  `drizzle.config.ts`.
+
+Precedence is one rule: **`schema` wins**. If both `schema` and a truthy `drizzleKit` are set,
+the drizzle-kit config is not read and DRZL warns, because two sources for one fact is how the
+copies drift. If neither yields a schema, the error names both files and both fixes.
+
+Only two things are read from the drizzle-kit config: `schema`, and `dialect`, which is
+cross-checked against what the analyzer measures. When they contradict (the config says
+`mysql`, the columns are Postgres), generation follows the schema and a warning names the
+config, since a stale dialect line usually means the config points somewhere it should not.
+Credentials, migrations settings and everything else in that file are for drizzle-kit alone
+and are ignored.
+
+`drzl watch` treats the drizzle-kit config as part of the config surface: the directories its
+`schema` entries name are watched (including glob bases, so a newly created file that matches
+the pattern triggers a rebuild), and editing `drizzle.config.ts` itself re-resolves the schema
+on the next rebuild.
+
+One option depends on how many files the kit config resolves to. `typedJson` and
+`typedColumns` work by importing the schema module back and referencing
+`typeof table.$inferSelect`, which needs a single module: when the kit `schema` resolves to
+exactly one file they work unchanged, and when it resolves to several there is no one module
+to import, so columns keep their wide types and the generator says so. Point `schema` (or the
+kit config) at a barrel if you want typed columns over a multi-file schema.
+
 ## Router generators share `outDir`
 
 `orpc`, `trpc`, `hono`, `express`, `fastify`, `nestjs` and `graphql` all write to the

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1444,7 +1444,14 @@ function unknownColumnHint(reason: 'custom' | UnnameableReason | undefined): str
 }
 
 export class SchemaAnalyzer {
-  constructor(private readonly schemaPath: string) {}
+  /**
+   * One path or several. The plural exists for drizzle-kit interop: kit's `schema` key names
+   * files in the plural (arrays, globs), and the commonest multi-file layout is a directory of
+   * one file per table with no barrel, so there is no single module to point at. Entries are
+   * concrete files, never globs; expansion is the caller's job, so this class's contract stays
+   * "load exactly these modules and read their exports as one schema".
+   */
+  constructor(private readonly schemaPath: string | readonly string[]) {}
 
   private getSymbol(table: any, key: string) {
     // One resolver rather than two identical ones, so a fallback added to either is reached by
@@ -2658,43 +2665,123 @@ export class SchemaAnalyzer {
     const fs = await import('node:fs/promises');
     const path = await import('node:path');
     const issues: Issue[] = [];
-    const full = path.resolve(process.cwd(), this.schemaPath);
-    try {
-      await fs.access(full);
-    } catch (_e) {
-      issues.push({
-        code: 'DRZL_ANL_NOFILE',
-        level: 'error',
-        message: `Schema file not found: ${this.schemaPath}`,
-      });
+    const listed = Array.isArray(this.schemaPath);
+    const inputs: readonly string[] = listed
+      ? (this.schemaPath as readonly string[])
+      : [this.schemaPath as string];
+    const fulls = inputs.map((p) => path.resolve(process.cwd(), p));
+
+    // All files are checked before any is loaded, so a list with two typos reports both at
+    // once rather than one per run.
+    let missing = false;
+    for (let i = 0; i < fulls.length; i++) {
+      try {
+        await fs.access(fulls[i]);
+      } catch (_e) {
+        missing = true;
+        issues.push({
+          code: 'DRZL_ANL_NOFILE',
+          level: 'error',
+          message: `Schema file not found: ${inputs[i]}`,
+        });
+      }
+    }
+    if (missing) {
       return { dialect: 'unknown', tables: [], enums: [], relations: [], issues };
     }
 
-    // Load the schema module using jiti to support TS/ESM/CJS
-    let mod: any;
-    try {
-      const { default: jiti } = await import('jiti');
-      // `moduleCache: false` is what makes re-analysis see the file as it is now.
-      //
-      // jiti delegates to `require`, whose cache is global to the process, so a second load of
-      // the same path returned the first parse. Constructing a new jiti instance per call does
-      // not help; the cache is not the instance's. In a one-shot `generate` nothing noticed,
-      // but `drzl watch` analyzes repeatedly in one long-lived process: it regenerated on every
-      // save and always described the schema as it was at startup, so a table added after the
-      // watcher began never appeared however many times the file was written.
-      const jit = (jiti as any)(import.meta.url, { moduleCache: false });
-      mod = jit(full);
-    } catch (e) {
-      issues.push({
-        code: 'DRZL_ANL_IMPORT',
-        level: 'error',
-        message: `Failed to import schema: ${String(e)}`,
-      });
-      return { dialect: 'unknown', tables: [], enums: [], relations: [], issues };
-    }
+    // Load each schema module using jiti to support TS/ESM/CJS
+    const { default: jiti } = await import('jiti');
+    // `moduleCache: false` is what makes re-analysis see the file as it is now.
+    //
+    // jiti delegates to `require`, whose cache is global to the process, so a second load of
+    // the same path returned the first parse. Constructing a new jiti instance per call does
+    // not help; the cache is not the instance's. In a one-shot `generate` nothing noticed,
+    // but `drzl watch` analyzes repeatedly in one long-lived process: it regenerated on every
+    // save and always described the schema as it was at startup, so a table added after the
+    // watcher began never appeared however many times the file was written.
+    const jit = (jiti as any)(import.meta.url, { moduleCache: false });
 
-    const exportsObj: Record<string, any> =
-      mod?.default && typeof mod.default === 'object' ? mod.default : mod;
+    // Exports of every file, merged first-wins into one namespace, the way a reader of a
+    // multi-file schema thinks of it. First-wins is deterministic because the caller's list
+    // order is; the CLI sorts what a glob expanded.
+    //
+    // "The same export twice" cannot be decided by object identity here. `moduleCache: false`
+    // re-evaluates a module on every require, so when reexport.ts does
+    // `export { users } from './users'` while users.ts is also in the list, the two `users`
+    // are structurally identical and never `Object.is`-equal; measured by the reexport
+    // fixture in multi-file.spec.ts, which warned spuriously under an identity comparison.
+    // So duplicates are judged by what Drizzle itself says the export is: two tables are the
+    // same when their database name, SQL schema and column keys agree, two enums when their
+    // values do. Only a genuine disagreement warns, because dropping a table in silence is
+    // how a generated API quietly loses endpoints; helpers and other non-schema values are
+    // merged first-wins without comment.
+    const exportsObj: Record<string, any> = {};
+    const exportOrigin = new Map<string, string>();
+    const duplicateDisagreement = (a: any, b: any): string | null => {
+      if (Object.is(a, b)) return null;
+      const aCols = this.getSymbol(a, 'drizzle:Columns');
+      const bCols = this.getSymbol(b, 'drizzle:Columns');
+      if (aCols && bCols) {
+        const aName = this.getSymbol(a, 'drizzle:Name');
+        const bName = this.getSymbol(b, 'drizzle:Name');
+        const aSchema = this.getSymbol(a, 'drizzle:Schema');
+        const bSchema = this.getSymbol(b, 'drizzle:Schema');
+        if (aName !== bName || aSchema !== bSchema) {
+          return `two different tables ("${String(aName)}" and "${String(bName)}")`;
+        }
+        if (Object.keys(aCols).join(',') !== Object.keys(bCols).join(',')) {
+          return `two declarations of table "${String(aName)}" with different columns`;
+        }
+        return null;
+      }
+      if (!!aCols !== !!bCols) return 'a table and a non-table';
+      const aEnum = (a as any)?.enumValues;
+      const bEnum = (b as any)?.enumValues;
+      if (Array.isArray(aEnum) && Array.isArray(bEnum)) {
+        return JSON.stringify(aEnum) === JSON.stringify(bEnum)
+          ? null
+          : 'two enums with different values';
+      }
+      return null;
+    };
+    for (let i = 0; i < fulls.length; i++) {
+      let mod: any;
+      try {
+        mod = jit(fulls[i]);
+      } catch (e) {
+        issues.push({
+          code: 'DRZL_ANL_IMPORT',
+          level: 'error',
+          // The single-path message keeps its historical bytes; a list names the file, since
+          // "the schema" no longer identifies one.
+          message: listed
+            ? `Failed to import schema ${inputs[i]}: ${String(e)}`
+            : `Failed to import schema: ${String(e)}`,
+        });
+        return { dialect: 'unknown', tables: [], enums: [], relations: [], issues };
+      }
+      const one: Record<string, any> =
+        mod?.default && typeof mod.default === 'object' ? mod.default : mod;
+      for (const [name, val] of Object.entries(one)) {
+        if (!(name in exportsObj)) {
+          exportsObj[name] = val;
+          exportOrigin.set(name, inputs[i]);
+          continue;
+        }
+        const disagreement = duplicateDisagreement(exportsObj[name], val);
+        if (!disagreement) continue;
+        issues.push({
+          code: 'DRZL_ANL_DUP_EXPORT',
+          level: 'warn',
+          message:
+            `Export "${name}" is ${disagreement}: defined by both ` +
+            `${exportOrigin.get(name)} and ${inputs[i]}; keeping the one in ` +
+            `${exportOrigin.get(name)}.`,
+          path: name,
+        });
+      }
+    }
     const tables: Table[] = [];
     const relations: Relation[] = [];
     const enums: Enum[] = [];

--- a/packages/analyzer/test/multi-file.spec.ts
+++ b/packages/analyzer/test/multi-file.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * `SchemaAnalyzer` over several files at once.
+ *
+ * drizzle-kit's `schema` key names files in the plural (a string, an array, globs), and real
+ * projects lean on it: a schema directory with one file per table and no barrel is the shape
+ * kit's own docs use. DRZL reading kit's config (item 59) therefore needs the analyzer to accept
+ * a list of concrete files, or the interop would only work for the single-file minority.
+ *
+ * The list is of files, never globs: expansion is the CLI's job, so the analyzer's contract
+ * stays "load exactly these modules".
+ *
+ * Fixtures are written at runtime, like every generated fixture in this suite: the fixtures
+ * directory's .gitignore admits only an enumerated few, so a spec relying on untracked static
+ * files would pass here and fail on a fresh clone.
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SchemaAnalyzer } from '../src/index';
+
+const dir = path.resolve(__dirname, '.tmp-multi-file');
+const fx = (name: string) => path.join(dir, name);
+
+const USERS = `import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+`;
+
+const POSTS = `import { integer, pgTable, serial, varchar } from 'drizzle-orm/pg-core';
+import { users } from './users';
+
+export const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  authorId: integer('author_id').references(() => users.id),
+  title: varchar('title', { length: 200 }).notNull(),
+});
+`;
+
+// The pattern a barrel-less multi-file schema produces constantly: one file imports another's
+// table for a foreign key and re-exports it. The same table under the same name twice must
+// not read as a conflict.
+const REEXPORT = `import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+
+export { users } from './users';
+
+export const tags = pgTable('tags', {
+  id: serial('id').primaryKey(),
+  label: text('label').notNull(),
+});
+`;
+
+// A different table under the same export name as users.ts. Two files disagreeing about what
+// `users` is cannot both win; the analyzer keeps the first and must say so.
+const CONFLICT = `import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users_shadow', {
+  id: serial('id').primaryKey(),
+  handle: text('handle').notNull(),
+});
+`;
+
+beforeAll(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(fx('users.ts'), USERS, 'utf8');
+  await fs.writeFile(fx('posts.ts'), POSTS, 'utf8');
+  await fs.writeFile(fx('reexport.ts'), REEXPORT, 'utf8');
+  await fs.writeFile(fx('conflict.ts'), CONFLICT, 'utf8');
+  await fs.writeFile(
+    fx('throws.ts'),
+    'throw new Error("boom at import time");\nexport const nothing = 1;\n',
+    'utf8'
+  );
+});
+
+afterAll(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('SchemaAnalyzer with a file list', () => {
+  it('merges tables, relations and the dialect across files', async () => {
+    const analyzer = new SchemaAnalyzer([fx('users.ts'), fx('posts.ts')]);
+    const res = await analyzer.analyze({ includeRelations: true });
+    expect(res.tables.map((t) => t.name).sort()).toEqual(['posts', 'users']);
+    expect(res.dialect).toBe('postgres');
+    // The FK in posts.ts references users.ts across the file boundary.
+    expect(
+      res.relations.some((r) => r.kind === 'one' && r.from === 'posts' && r.to === 'users')
+    ).toBe(true);
+    expect(res.issues.filter((i) => i.level === 'error')).toEqual([]);
+  });
+
+  it('treats a re-export of the same table as one table, not a conflict', async () => {
+    const analyzer = new SchemaAnalyzer([fx('users.ts'), fx('reexport.ts')]);
+    const res = await analyzer.analyze();
+    expect(res.tables.filter((t) => t.name === 'users')).toHaveLength(1);
+    expect(res.tables.map((t) => t.name).sort()).toEqual(['tags', 'users']);
+    expect(res.issues.some((i) => i.code === 'DRZL_ANL_DUP_EXPORT')).toBe(false);
+  });
+
+  it('keeps the first of two genuinely different exports under one name, and says so', async () => {
+    const analyzer = new SchemaAnalyzer([fx('users.ts'), fx('conflict.ts')]);
+    const res = await analyzer.analyze();
+    // First file wins, deterministically: the list order is the caller's, and the CLI sorts.
+    const users = res.tables.find((t) => t.name === 'users');
+    expect(users).toBeTruthy();
+    expect(users!.columns.map((c) => c.name)).toContain('email');
+    expect(res.tables.some((t) => t.name === 'users_shadow')).toBe(false);
+    const dup = res.issues.find((i) => i.code === 'DRZL_ANL_DUP_EXPORT');
+    expect(dup?.level).toBe('warn');
+    expect(dup?.message).toContain('users');
+    expect(dup?.message).toContain('conflict.ts');
+  });
+
+  it('reports every missing file of the list and analyzes nothing', async () => {
+    const analyzer = new SchemaAnalyzer([fx('users.ts'), fx('nope.ts'), fx('also-nope.ts')]);
+    const res = await analyzer.analyze();
+    const missing = res.issues.filter((i) => i.code === 'DRZL_ANL_NOFILE' && i.level === 'error');
+    expect(missing).toHaveLength(2);
+    expect(res.tables).toEqual([]);
+  });
+
+  it('an import failure names the file it happened in', async () => {
+    const analyzer = new SchemaAnalyzer([fx('users.ts'), fx('throws.ts')]);
+    const res = await analyzer.analyze();
+    const imp = res.issues.find((i) => i.code === 'DRZL_ANL_IMPORT');
+    expect(imp?.level).toBe('error');
+    expect(imp?.message).toContain('throws.ts');
+  });
+
+  it('a one-element list behaves exactly like the string form', async () => {
+    const single = await new SchemaAnalyzer(fx('users.ts')).analyze();
+    const listed = await new SchemaAnalyzer([fx('users.ts')]).analyze();
+    expect(listed.tables).toEqual(single.tables);
+    expect(listed.dialect).toEqual(single.dialect);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,11 @@ import {
   tableFilterWarnings,
 } from './config.js';
 import { filterColumns } from './column-filter.js';
+import {
+  dialectMismatchWarning,
+  resolveSchemaSource,
+  type ResolvedSchemaSource,
+} from './drizzle-kit.js';
 import { buildDoctorReport, renderDoctorReport } from './doctor.js';
 import { diffSnapshots, restoreSnapshot, snapshotAll } from './drift.js';
 import { GeneratorNotInstalledError, loadGenerator } from './generator-loader.js';
@@ -113,11 +118,14 @@ program
   .action(async (schema: string | undefined, opts: any) => {
     try {
       // A schema path argument, like `analyze`, or the one already named in the config, since a
-      // user who has a config should not have to retype the path they put in it.
-      let target = schema;
+      // user who has a config should not have to retype the path they put in it. Resolution
+      // goes through the same `resolveSchemaSource` as `generate`, so a config whose schema
+      // comes from drizzle-kit's config gets a doctor report too; its failure messages name
+      // both files, which is strictly more useful than the generic line below.
+      let target: string | string[] | undefined = schema;
       if (!target) {
         const cfg = await loadConfig(opts.config);
-        target = cfg?.schema;
+        if (cfg) target = (await resolveSchemaSource(cfg)).schema;
       }
       if (!target) {
         const msg = 'No schema given. Pass a path, or run from a directory with a drzl.config.';
@@ -135,7 +143,10 @@ program
         includeRelations: true,
         validateConstraints: true,
       });
-      const report = buildDoctorReport(analysis, target);
+      const report = buildDoctorReport(
+        analysis,
+        Array.isArray(target) ? target.join(', ') : target
+      );
 
       if (opts.json) console.log(JSON.stringify(report, null, 2));
       else console.log(renderDoctorReport(report));
@@ -175,7 +186,7 @@ program
   )
   .action(async (opts: any) => {
     try {
-      const cfg = await loadConfig(opts.config);
+      let cfg = await loadConfig(opts.config);
       if (!cfg) {
         console.error(
           chalk.red('No config found (DRZL_CFG_001). Create drzl.config.ts or pass --config.')
@@ -183,7 +194,28 @@ program
         process.exit(2);
         return;
       }
-      const analyzer = new SchemaAnalyzer(cfg.schema);
+      // Where the schema comes from: `schema` in the drzl config, or, when that is omitted,
+      // the drizzle-kit config, so a kit user never states the path twice. Resolved before the
+      // spinner starts, because it throws the "neither file names a schema" error.
+      const source = await resolveSchemaSource(cfg);
+      for (const w of source.warnings) console.warn(chalk.yellow(w));
+      // `typedJson`/`typedColumns` need one module to import tables from (`schemaPath` in
+      // validation-options.ts). A drizzle-kit source resolved to exactly one file is that
+      // module, so the option keeps working; several files have no single module, and the
+      // generators already say so at their own call sites when they want types with no path.
+      if (!cfg.schema && Array.isArray(source.schema) && source.schema.length === 1) {
+        cfg = { ...cfg, schema: source.schema[0] };
+      }
+      if (source.source === 'drizzle-kit') {
+        const n = (source.schema as string[]).length;
+        console.log(
+          chalk.gray(
+            `Schema from ${path.relative(process.cwd(), source.drizzleKitConfigPath!)} ` +
+              `(${n} file${n === 1 ? '' : 's'})`
+          )
+        );
+      }
+      const analyzer = new SchemaAnalyzer(source.schema);
       const spinner = ora('Analyzing...').start();
       const t0 = Date.now();
       const analysis = await analyzer.analyze({
@@ -195,6 +227,16 @@ program
       // cannot honour and a thrown error under a live ora spinner prints into a line the spinner
       // then overwrites.
       spinner.succeed(`Analysis complete in ${Date.now() - t0}ms`);
+      // The cross-check the interop makes possible: the drizzle-kit config states a dialect,
+      // the analyzer measures one, and a contradiction usually means the schema paths or the
+      // dialect line are stale. A warning rather than an error, because generation follows the
+      // schema either way. After the spinner for the same overwrite reason as above.
+      const dialectWarning = dialectMismatchWarning({
+        configPath: source.drizzleKitConfigPath ?? '',
+        declared: source.drizzleKitDialect,
+        analyzed: analysis.dialect,
+      });
+      if (dialectWarning) console.warn(chalk.yellow(dialectWarning));
       // Both filters are applied before any generator sees the analysis, so every one of them
       // honours them without needing to know the options exist.
       //
@@ -671,8 +713,25 @@ program
       return !!rel && !rel.startsWith('..') && !path.isAbsolute(rel);
     };
 
+    // Resolved before the watcher exists, because the directories to watch depend on it: a
+    // schema read from drizzle-kit's config lives wherever that config says, and a watcher
+    // that does not cover those directories never fires. A resolution failure here is a
+    // startup failure, exactly like a missing config; inside `run` the same failure is caught
+    // and reported, so a broken edit mid-watch can be fixed by the next save.
+    let source: ResolvedSchemaSource;
+    try {
+      source = await resolveSchemaSource(cfg);
+    } catch (e: any) {
+      console.error(chalk.red(String(e?.message ?? e)));
+      process.exit(2);
+      return;
+    }
+    for (const w of source.warnings) console.warn(chalk.yellow(w));
+
     const ignoredOutDirs = new Set<string>(computeGeneratorOutputDirs(cfg).map(abs));
-    const currentTargets = new Set<string>(computeWatchTargets(cfg).map(abs));
+    const currentTargets = new Set<string>(
+      computeWatchTargets(cfg, process.cwd(), source).map(abs)
+    );
 
     const syncWatcherTargets = (watcher: import('chokidar').FSWatcher, next: Set<string>) => {
       const add: string[] = [];
@@ -742,8 +801,23 @@ program
         if (!reloaded) throw new Error('Config disappeared during watch.');
         cfg = reloaded;
 
+        // Re-resolved on every rebuild, for the same reason the config is: an edit to
+        // drizzle.config.ts mid-watch changes which files are the schema, and a new file that
+        // matches its glob has to join the set. The watch targets are recomputed from the
+        // fresh resolution, so a schema directory added to the kit config starts being
+        // watched on the rebuild that first read it.
+        source = await resolveSchemaSource(cfg);
+        // The same single-file fill `generate` makes, for the same consumer (`schemaPath` in
+        // validation-options.ts), so the two dispatch loops hand the generators the same
+        // options and the branch-parity contract holds for interop configs too.
+        if (!cfg.schema && Array.isArray(source.schema) && source.schema.length === 1) {
+          cfg = { ...cfg, schema: source.schema[0] };
+        }
+
         rebuildIgnoreDirsFrom(cfg);
-        const nextTargets = new Set<string>(computeWatchTargets(cfg).map(abs));
+        const nextTargets = new Set<string>(
+          computeWatchTargets(cfg, process.cwd(), source).map(abs)
+        );
         syncWatcherTargets(watcher, nextTargets);
 
         if (!opts.json) console.clear();
@@ -758,12 +832,23 @@ program
           );
         }
 
-        const analyzer = new SchemaAnalyzer(cfg.schema);
+        // After the console.clear() above, or the warning would be wiped before anyone saw it.
+        if (!opts.json) for (const w of source.warnings) console.warn(chalk.yellow(w));
+
+        const analyzer = new SchemaAnalyzer(source.schema);
         const analysis = await analyzer.analyze({
           includeRelations: cfg.analyzer.includeRelations,
           validateConstraints: cfg.analyzer.validateConstraints,
           includeHeuristicRelations: cfg.analyzer.includeHeuristicRelations,
         });
+        // The same cross-check `generate` makes, in the same wording, so the two commands
+        // cannot disagree about what a contradictory dialect line means.
+        const dialectWarning = dialectMismatchWarning({
+          configPath: source.drizzleKitConfigPath ?? '',
+          declared: source.drizzleKitDialect,
+          analyzed: analysis.dialect,
+        });
+        if (dialectWarning && !opts.json) console.warn(chalk.yellow(dialectWarning));
         // Same order and the same reasons as `generate`. A config edited mid-watch that names a
         // column that does not exist throws here, and `run`'s own catch reports it and keeps
         // watching, so the next save can fix it.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -375,7 +375,35 @@ export const AnalyzerSchema = z.object({
 
 export const ConfigSchema = z
   .object({
-    schema: z.string(),
+    /**
+     * Path to the Drizzle schema module. Optional since drizzle-kit interop: a project that
+     * already names its schema in `drizzle.config.ts` should not have to say it twice, so an
+     * omitted `schema` falls back to reading the drizzle-kit config (see `drizzleKit`). The
+     * "neither file names a schema" error is raised at resolution time, where it can name both
+     * files, rather than here, where "Required" could name only this one.
+     */
+    schema: z.string().optional(),
+    /**
+     * Read the schema path from drizzle-kit's own config instead of `schema`.
+     *
+     * `true` reads `drizzle.config.ts`, then `.js`, then `.json`, the same candidates in the
+     * same order drizzle-kit's CLI uses (measured on drizzle-kit 0.31.10). A string reads that
+     * file, wherever it is, like kit's own `--config` flag. `false` disables the fallback, so
+     * an omitted `schema` is an error even beside a drizzle.config. Unset behaves like `true`
+     * whenever `schema` is omitted, and does nothing when `schema` is set: `schema` always
+     * wins, with a warning when both are stated.
+     *
+     * Only kit's `schema` (string or array, entries may be globs) and `dialect` (cross-checked
+     * against what the analyzer detects) are read. Everything else in that file describes
+     * migrations and database credentials, which DRZL has no use for.
+     */
+    drizzleKit: z
+      .union([z.boolean(), z.string()], {
+        error:
+          'Expected true (read drizzle.config.ts/.js/.json, the same candidates drizzle-kit ' +
+          'uses), false (never read one), or a path to the drizzle-kit config file.',
+      })
+      .optional(),
     outDir: z.string().default('src/api'),
     /**
      * Which tables to generate for, matched against the database table name.
@@ -841,6 +869,44 @@ function finalize(raw: unknown): DrzlConfig {
   return config;
 }
 
+/**
+ * Load a config module fresh from disk: JSON parsed directly, everything else through jiti
+ * with cache-busting, exactly as `loadConfig` always has.
+ *
+ * Extracted so the drizzle-kit interop reads `drizzle.config.ts` through the same loader that
+ * reads `drzl.config.ts`, rather than through a second dependency or a second set of jiti
+ * options that could drift from this one.
+ */
+export async function importFreshConfigModule(p: string): Promise<unknown> {
+  const fsp = await import('node:fs/promises');
+  const ext = path.extname(p).toLowerCase();
+
+  // JSON: read directly
+  if (ext === '.json') {
+    return JSON.parse(await fsp.readFile(p, 'utf8'));
+  }
+
+  // Everything else (TS/JS/MJS/CJS) -> Jiti with cache-busting
+  const { createJiti } = await import('jiti');
+  const stat = await fsp.stat(p);
+
+  // Passing __filename is safe in CJS; fallback to cwd if not defined.
+  const base =
+    typeof __filename !== 'undefined' ? __filename : path.join(process.cwd(), 'index.js');
+
+  const jiti = createJiti(base, {
+    moduleCache: false, // re-evaluate each time
+    fsCache: true, // keep transform cache
+    cacheVersion: String(stat.mtimeMs), // bump on edit
+    interopDefault: true,
+    tryNative: false, // <-- prevent native import of .ts
+    // debug: true,
+  }) as any;
+
+  const mod = await jiti.import(p);
+  return mod?.default ?? mod;
+}
+
 export async function loadConfig(customPath?: string): Promise<DrzlConfig | null> {
   const fsp = await import('node:fs/promises');
 
@@ -861,35 +927,7 @@ export async function loadConfig(customPath?: string): Promise<DrzlConfig | null
     } catch {
       continue;
     }
-
-    const ext = path.extname(p).toLowerCase();
-
-    // JSON: read directly
-    if (ext === '.json') {
-      const raw = JSON.parse(await fsp.readFile(p, 'utf8'));
-      return finalize(raw);
-    }
-
-    // Everything else (TS/JS/MJS/CJS) -> Jiti with cache-busting
-    const { createJiti } = await import('jiti');
-    const stat = await fsp.stat(p);
-
-    // Passing __filename is safe in CJS; fallback to cwd if not defined.
-    const base =
-      typeof __filename !== 'undefined' ? __filename : path.join(process.cwd(), 'index.js');
-
-    const jiti = createJiti(base, {
-      moduleCache: false, // re-evaluate each time
-      fsCache: true, // keep transform cache
-      cacheVersion: String(stat.mtimeMs), // bump on edit
-      interopDefault: true,
-      tryNative: false, // <-- prevent native import of .ts
-      // debug: true,
-    }) as any;
-
-    const mod = await jiti.import(p);
-    const raw = mod?.default ?? mod;
-    return finalize(raw);
+    return finalize(await importFreshConfigModule(p));
   }
 
   return null;
@@ -991,21 +1029,34 @@ export function tableFilterWarnings(
   ];
 }
 
-export function computeWatchTargets(cfg: DrzlConfig, cwd = process.cwd()): string[] {
+export function computeWatchTargets(
+  cfg: DrzlConfig,
+  cwd = process.cwd(),
+  source?: import('./drizzle-kit.js').ResolvedSchemaSource
+): string[] {
   const abs = (p: string) => path.resolve(cwd, p);
-  const schemaAbs = abs(cfg.schema);
-  // The schema's directory, not a glob under it. Chokidar removed glob support in v4 and treats
+  // Directories and files only, never globs. Chokidar removed glob support in v4 and treats
   // `<dir>/**/*.{ts,tsx,js}` as a literal path, so it watched a directory named `**` that does
   // not exist: no event ever fired and `drzl watch` did its initial build and then sat inert.
   // A directory is watched recursively by chokidar itself, and the extension filtering that the
   // glob was doing now happens on the event instead.
   const targets = new Set<string>([
-    path.dirname(schemaAbs),
     abs('drzl.config.ts'),
     abs('drzl.config.js'),
     abs('drzl.config.mjs'),
     abs('drzl.config.cjs'),
   ]);
+  if (source) {
+    // The resolved source's directories cover both shapes: the drzl `schema` file's directory,
+    // or every directory the drizzle-kit config's entries live in (glob bases included, so a
+    // file created later that matches the glob still raises an event). The drizzle-kit config
+    // file itself is watched too: editing it changes which files are the schema, and a watcher
+    // not watching it would keep generating from the old set forever.
+    for (const d of source.watchDirs) targets.add(abs(d));
+    if (source.drizzleKitConfigPath) targets.add(abs(source.drizzleKitConfigPath));
+  } else if (cfg.schema) {
+    targets.add(path.dirname(abs(cfg.schema)));
+  }
   for (const t of resolveTemplateDirsSync(cfg, cwd)) targets.add(t);
   return [...targets];
 }

--- a/packages/cli/src/drizzle-kit.ts
+++ b/packages/cli/src/drizzle-kit.ts
@@ -1,0 +1,342 @@
+/**
+ * drizzle-kit interop: read the schema path from `drizzle.config.ts`, so a drizzle-kit user
+ * does not have to state it a second time in `drzl.config.ts`.
+ *
+ * Everything here mirrors drizzle-kit's measured behavior, read from the published dist of
+ * drizzle-kit 0.31.10 rather than from its docs or from memory:
+ *
+ *   - `Config.schema` is `string | string[]` and entries may be glob patterns (`index.d.mts`).
+ *   - The CLI's default config candidates are `drizzle.config.ts`, then `.js`, then `.json`,
+ *     in that order and nothing else (`drizzleConfigFromFile` in `bin.cjs`); a custom path can
+ *     be anything its `--config` flag can name, which `drizzleKit: '<path>'` mirrors.
+ *   - `prepareFilenames` (bin.cjs) expands each entry with glob.sync, expands a directory
+ *     match one level with readdir rather than recursively, unions the results, and hard-errors
+ *     when nothing matched. It also computes the list of code extensions (.ts .js .cjs .mjs
+ *     .mts .cts) into a variable it never reads, and then requires every match; DRZL applies
+ *     that filter for real, which is strictly friendlier than crashing on a README.md sitting
+ *     in the schema directory.
+ *   - `defineConfig` is the identity function (`index.mjs`), so evaluating the config module
+ *     yields the plain object and no drizzle-kit installation is needed to read it.
+ *
+ * Globs are expanded with `node:fs.globSync`, present since Node 22.0 and quiet on the CLI's
+ * `engines` floor (measured: `*`, `**`, `{a,b}` and literal paths all behave; no
+ * ExperimentalWarning on stderr on 22.22). No new dependency, and the config itself is loaded
+ * through the same jiti path as `drzl.config.ts` (`importFreshConfigModule`), so the two
+ * config files cannot drift onto different loaders.
+ */
+import type { Dialect } from '@drzl/analyzer';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { importFreshConfigModule } from './config.js';
+
+/** The default candidates drizzle-kit's own CLI tries, in its order. `.mjs`/`.cjs` are not
+ * candidates because they are not drizzle-kit's; a project using one names it explicitly via
+ * `drizzleKit: './drizzle.config.mjs'`, exactly as it must pass `--config` to kit itself. */
+export const DRIZZLE_KIT_CONFIG_CANDIDATES = [
+  'drizzle.config.ts',
+  'drizzle.config.js',
+  'drizzle.config.json',
+] as const;
+
+/** The extensions drizzle-kit's `prepareFilenames` names as schema code. */
+const CODE_EXTENSIONS = new Set(['.ts', '.js', '.cjs', '.mjs', '.mts', '.cts']);
+
+export interface DrizzleKitConfig {
+  /** Absolute path of the file this came from. */
+  path: string;
+  schema?: string | string[];
+  dialect?: string;
+  casing?: string;
+}
+
+/**
+ * Where the schema will be read from, decided once and handed to both `generate` and `watch`,
+ * so the two commands cannot resolve differently.
+ */
+export interface ResolvedSchemaSource {
+  source: 'drzl' | 'drizzle-kit';
+  /**
+   * What `SchemaAnalyzer` is constructed with: the drzl config's `schema` string verbatim, or
+   * the expanded, sorted, absolute file list from the drizzle-kit config.
+   */
+  schema: string | string[];
+  /**
+   * Absolute directories that must be watched for schema edits. For a glob this is its static
+   * base, so a file created later that matches the pattern still raises an event; a missing
+   * entry here is the infinite-blindness half of the watch-loop rules.
+   */
+  watchDirs: string[];
+  /** Absolute path of the drizzle-kit config consulted, when source is 'drizzle-kit'. */
+  drizzleKitConfigPath?: string;
+  /** The dialect that config declares, verbatim, for the post-analysis cross-check. */
+  drizzleKitDialect?: string;
+  warnings: string[];
+}
+
+/** The first existing default candidate, in drizzle-kit's own order, or null. */
+export function findDrizzleKitConfig(cwd: string): string | null {
+  for (const name of DRIZZLE_KIT_CONFIG_CANDIDATES) {
+    const p = path.join(cwd, name);
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+/** Load and narrow a drizzle-kit config file. Throws with the file named on anything wrong. */
+export async function loadDrizzleKitConfig(p: string): Promise<DrizzleKitConfig> {
+  let raw: unknown;
+  try {
+    raw = await importFreshConfigModule(p);
+  } catch (e) {
+    throw new Error(
+      `drzl config: failed to load the drizzle-kit config at ${p}: ${(e as any)?.message ?? e}`
+    );
+  }
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`drzl config: ${p} did not export a drizzle-kit config object.`);
+  }
+  const record = raw as Record<string, unknown>;
+  const schema = record.schema;
+  if (
+    schema !== undefined &&
+    typeof schema !== 'string' &&
+    !(Array.isArray(schema) && schema.every((s) => typeof s === 'string'))
+  ) {
+    throw new Error(
+      `drzl config: "schema" in ${p} must be a string or an array of strings, matching ` +
+        `drizzle-kit's own Config type.`
+    );
+  }
+  return {
+    path: p,
+    schema: schema as string | string[] | undefined,
+    dialect: typeof record.dialect === 'string' ? record.dialect : undefined,
+    casing: typeof record.casing === 'string' ? record.casing : undefined,
+  };
+}
+
+/** Whether glob would treat any part of this entry as a pattern rather than a name. */
+function hasGlobMagic(entry: string): boolean {
+  return /[*?{}[\]]/.test(entry) || /[!@+]\(/.test(entry);
+}
+
+/**
+ * The longest leading run of pattern-free path segments, as an absolute directory: what a
+ * watcher can actually watch on behalf of a glob.
+ */
+function staticGlobBase(entry: string, cwd: string): string {
+  const segments = entry.split('/');
+  const kept: string[] = [];
+  for (const s of segments) {
+    if (hasGlobMagic(s)) break;
+    kept.push(s);
+  }
+  // The last static segment before the magic may itself be a filename prefix; treating it as a
+  // directory is still right, because resolve of `src/db` under a pattern `src/db/*.ts` IS the
+  // directory. An entirely magic entry watches the cwd.
+  const joined = kept.join('/');
+  const base = path.resolve(cwd, joined || '.');
+  // `src/*.ts` keeps `src`; `schema-*.ts` keeps nothing and must not watch a file named after
+  // the prefix, so anything that is not an existing directory falls back to its dirname.
+  if (fs.existsSync(base) && fs.statSync(base).isDirectory()) return base;
+  return path.dirname(base);
+}
+
+/** One level of a directory, files only: exactly what kit's `prepareFilenames` does. */
+function filesOneLevel(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of fs.readdirSync(dir)) {
+    const full = path.join(dir, name);
+    if (!fs.lstatSync(full).isDirectory()) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Expand drizzle-kit `schema` entries into concrete files plus the directories a watcher
+ * needs. Deterministic: the file list is deduplicated and sorted, so everything downstream
+ * (first-wins export merging in the analyzer above all) is stable across runs.
+ */
+export function expandSchemaPaths(
+  entries: string | string[],
+  cwd: string
+): { files: string[]; watchDirs: string[] } {
+  const list = typeof entries === 'string' ? [entries] : entries;
+  const files = new Set<string>();
+  const watchDirs = new Set<string>();
+
+  for (const entry of list) {
+    if (hasGlobMagic(entry)) {
+      watchDirs.add(staticGlobBase(entry, cwd));
+      for (const match of fs.globSync(entry, { cwd })) {
+        const full = path.resolve(cwd, match);
+        if (fs.existsSync(full) && fs.statSync(full).isDirectory()) {
+          for (const f of filesOneLevel(full)) files.add(f);
+        } else {
+          files.add(full);
+        }
+      }
+      continue;
+    }
+    const full = path.resolve(cwd, entry);
+    let stat: fs.Stats | null = null;
+    try {
+      stat = fs.statSync(full);
+    } catch {
+      // A missing literal entry contributes nothing, exactly as glob.sync returns [] for it in
+      // kit; the caller's "matched no schema files" check is what reports an all-typo config.
+      // Its directory is still watched, so creating the file later wakes the watcher.
+      watchDirs.add(path.dirname(full));
+      continue;
+    }
+    if (stat.isDirectory()) {
+      watchDirs.add(full);
+      for (const f of filesOneLevel(full)) files.add(f);
+    } else {
+      watchDirs.add(path.dirname(full));
+      files.add(full);
+    }
+  }
+
+  const kept = [...files].filter((f) => CODE_EXTENSIONS.has(path.extname(f).toLowerCase()));
+  return { files: kept.sort(), watchDirs: [...watchDirs] };
+}
+
+/**
+ * drizzle-kit's dialect vocabulary mapped onto the analyzer's, `null` when there is no
+ * confident mapping (in which case the cross-check stays quiet rather than guessing).
+ * `turso` is libsql, which is SQLite on the wire, which is what the analyzer detects.
+ */
+export function mapDrizzleKitDialect(declared: string | undefined): Dialect | null {
+  if (!declared) return null;
+  const map: Record<string, Dialect> = {
+    postgresql: 'postgres',
+    mysql: 'mysql',
+    sqlite: 'sqlite',
+    turso: 'sqlite',
+    singlestore: 'singlestore',
+    gel: 'gel',
+  };
+  if (declared in map) return map[declared];
+  // A future kit dialect that already speaks the analyzer's name (say, 'cockroach') maps to
+  // itself rather than silently losing the cross-check.
+  const analyzerDialects: readonly Dialect[] = [
+    'sqlite',
+    'postgres',
+    'mysql',
+    'singlestore',
+    'mssql',
+    'cockroach',
+    'gel',
+  ];
+  return (analyzerDialects as readonly string[]).includes(declared) ? (declared as Dialect) : null;
+}
+
+/**
+ * The warning for a drizzle-kit config whose `dialect` contradicts what the analyzer measured,
+ * or null when there is nothing to say: agreement, an unmappable declaration, or an analysis
+ * that could not identify a dialect at all (which already warned as DRZL_ANL_DIALECT).
+ */
+export function dialectMismatchWarning(args: {
+  configPath: string;
+  declared: string | undefined;
+  analyzed: Dialect;
+}): string | null {
+  const expected = mapDrizzleKitDialect(args.declared);
+  if (!expected) return null;
+  if (args.analyzed === 'unknown') return null;
+  if (args.analyzed === expected) return null;
+  return (
+    `drzl: ${args.configPath} declares dialect "${args.declared}", but the schema analyzed ` +
+    `as "${args.analyzed}". DRZL follows the schema; if the schema files are the right ones, ` +
+    `the dialect in that config is stale.`
+  );
+}
+
+/**
+ * Decide where the schema comes from. Precedence, in order:
+ *
+ *   1. `schema` in the drzl config wins outright. If `drizzleKit` is also set to something
+ *      that would read a file, that is two sources for one fact, so it warns and reads only
+ *      `schema`; this config parser has shipped silently-dead keys twice before.
+ *   2. Otherwise `drizzleKit` decides: `false` refuses the fallback, a string names the file,
+ *      and `true` or unset searches drizzle-kit's own default candidates. Unset behaving like
+ *      `true` is deliberate: `schema` was required until this feature existed, so no
+ *      pre-existing config can reach the fallback, and the CLI announces the file it read.
+ *   3. Neither yielding a schema is an error that names both files and what to do.
+ */
+export async function resolveSchemaSource(
+  cfg: { schema?: string; drizzleKit?: boolean | string },
+  cwd = process.cwd()
+): Promise<ResolvedSchemaSource> {
+  if (cfg.schema) {
+    const warnings: string[] = [];
+    if (cfg.drizzleKit === true || typeof cfg.drizzleKit === 'string') {
+      warnings.push(
+        `drzl config: both "schema" and "drizzleKit" are set. "schema" wins, so the ` +
+          `drizzle-kit config was not read; remove one of the two to silence this.`
+      );
+    }
+    return {
+      source: 'drzl',
+      schema: cfg.schema,
+      watchDirs: [path.dirname(path.resolve(cwd, cfg.schema))],
+      warnings,
+    };
+  }
+
+  if (cfg.drizzleKit === false) {
+    throw new Error(
+      `drzl config: no "schema" is set and "drizzleKit" is false, so the drizzle-kit fallback ` +
+        `is disabled. Set "schema".`
+    );
+  }
+
+  let configPath: string;
+  if (typeof cfg.drizzleKit === 'string') {
+    configPath = path.resolve(cwd, cfg.drizzleKit);
+    if (!fs.existsSync(configPath)) {
+      throw new Error(`drzl config: "drizzleKit" points at ${configPath}, which does not exist.`);
+    }
+  } else {
+    const found = findDrizzleKitConfig(cwd);
+    if (!found) {
+      const looked = DRIZZLE_KIT_CONFIG_CANDIDATES.join(', ');
+      throw new Error(
+        cfg.drizzleKit === true
+          ? `drzl config: "drizzleKit" is set, but no drizzle-kit config was found (looked ` +
+              `for ${looked} in ${cwd}). Create one, or point "drizzleKit" at its path.`
+          : `drzl config: no "schema" is set and no drizzle-kit config was found (looked for ` +
+              `${looked} in ${cwd}). Set "schema" in your drzl config, or add "drizzleKit" ` +
+              `naming your drizzle-kit config file.`
+      );
+    }
+    configPath = found;
+  }
+
+  const kit = await loadDrizzleKitConfig(configPath);
+  if (kit.schema === undefined) {
+    throw new Error(
+      `drzl config: ${configPath} has no "schema" entry, so there is nothing to analyze. Set ` +
+        `"schema" there, or set "schema" in your drzl config.`
+    );
+  }
+  const { files, watchDirs } = expandSchemaPaths(kit.schema, cwd);
+  if (!files.length) {
+    const shown = (typeof kit.schema === 'string' ? [kit.schema] : kit.schema)
+      .map((s) => JSON.stringify(s))
+      .join(', ');
+    throw new Error(
+      `drzl config: the "schema" patterns in ${configPath} matched no schema files: ${shown}. ` +
+        `DRZL expands them the way drizzle-kit does; check them against your tree.`
+    );
+  }
+  return {
+    source: 'drizzle-kit',
+    schema: files,
+    watchDirs,
+    drizzleKitConfigPath: configPath,
+    drizzleKitDialect: kit.dialect,
+    warnings: [],
+  };
+}

--- a/packages/cli/test/drizzle-kit-interop.e2e.spec.ts
+++ b/packages/cli/test/drizzle-kit-interop.e2e.spec.ts
@@ -1,0 +1,277 @@
+/**
+ * The drizzle-kit interop, driven end to end through the built CLI: a project whose only
+ * statement of the schema path is its `drizzle.config.ts`, exactly the project this feature
+ * exists for.
+ *
+ * The watch half exercises the rule items 51-57 established for every new config surface: the
+ * files the schema really comes from must be watched. Before this feature the watcher derived
+ * its targets from `cfg.schema` alone, so a schema resolved through drizzle-kit's config would
+ * have generated once at startup and then never again; the "picks up an edit" and "sees a new
+ * file matching the glob" tests are the ones that fail in that world.
+ *
+ * Requires a build. CI builds before testing; locally, run `pnpm build` first.
+ */
+import { execFile, spawn } from 'node:child_process';
+import { existsSync, promises as fs } from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const run = promisify(execFile);
+const CLI = path.resolve(import.meta.dirname, '..', 'dist', 'cli.js');
+const ROOT = path.join(import.meta.dirname, '.tmp-dk-interop');
+
+const USERS = `import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+`;
+
+const POSTS = `import { integer, pgTable, serial, varchar } from 'drizzle-orm/pg-core';
+import { users } from './users';
+export const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  authorId: integer('author_id').references(() => users.id),
+  title: varchar('title', { length: 200 }).notNull(),
+});
+`;
+
+// What drizzle-kit's own docs tell a multi-file project to write. defineConfig is declared
+// inline because kit's index.mjs is measured to be the identity function, so the evaluated
+// config is byte-for-byte what an installed drizzle-kit would produce, without making this
+// repo depend on the package.
+const KIT_CONFIG = `const defineConfig = <T,>(config: T): T => config;
+export default defineConfig({
+  dialect: 'postgresql',
+  schema: './src/db/schema/*.ts',
+  out: './drizzle',
+});
+`;
+
+// No schema key at all: the point of the feature.
+const DRZL_CONFIG = `export default {
+  outDir: './out/api',
+  generators: [{ kind: 'zod', path: './out/zod' }],
+};
+`;
+
+async function project(name: string) {
+  const dir = path.join(ROOT, name);
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(path.join(dir, 'src', 'db', 'schema'), { recursive: true });
+  await fs.writeFile(path.join(dir, 'src', 'db', 'schema', 'users.ts'), USERS, 'utf8');
+  await fs.writeFile(path.join(dir, 'src', 'db', 'schema', 'posts.ts'), POSTS, 'utf8');
+  await fs.writeFile(path.join(dir, 'drizzle.config.ts'), KIT_CONFIG, 'utf8');
+  await fs.writeFile(path.join(dir, 'drzl.config.ts'), DRZL_CONFIG, 'utf8');
+  return dir;
+}
+
+async function pollFor(check: () => Promise<boolean> | boolean, ms: number): Promise<boolean> {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (await check()) return true;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return false;
+}
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.mkdir(ROOT, { recursive: true });
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe('drzl generate with no schema in drzl.config', () => {
+  it('reads drizzle.config.ts, expands its glob, and generates for every table', async () => {
+    const dir = await project('generate');
+    const { stdout } = await run(process.execPath, [CLI, 'generate'], {
+      cwd: dir,
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    expect(stdout).toContain('drizzle.config.ts');
+    // `.zod.ts`: the zod generator's default fileSuffix.
+    expect(existsSync(path.join(dir, 'out', 'zod', 'users.zod.ts'))).toBe(true);
+    expect(existsSync(path.join(dir, 'out', 'zod', 'posts.zod.ts'))).toBe(true);
+    const posts = await fs.readFile(path.join(dir, 'out', 'zod', 'posts.zod.ts'), 'utf8');
+    expect(posts).toContain('title');
+  }, 120_000);
+
+  it('warns when the declared dialect contradicts the schema, and still generates', async () => {
+    const dir = await project('dialect-mismatch');
+    await fs.writeFile(
+      path.join(dir, 'drizzle.config.ts'),
+      KIT_CONFIG.replace(`'postgresql'`, `'mysql'`),
+      'utf8'
+    );
+    const { stderr } = await run(process.execPath, [CLI, 'generate'], {
+      cwd: dir,
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    expect(stderr).toContain('declares dialect "mysql"');
+    expect(stderr).toContain('analyzed as "postgres"');
+    expect(existsSync(path.join(dir, 'out', 'zod', 'users.zod.ts'))).toBe(true);
+  }, 120_000);
+
+  it('lets an explicit drzl schema win over the drizzle-kit config, and says so', async () => {
+    const dir = await project('precedence');
+    await fs.mkdir(path.join(dir, 'src', 'other'), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'src', 'other', 'only.ts'),
+      USERS.replace(/users/g, 'accounts'),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(dir, 'drzl.config.ts'),
+      `export default {
+  schema: './src/other/only.ts',
+  drizzleKit: true,
+  outDir: './out/api',
+  generators: [{ kind: 'zod', path: './out/zod' }],
+};
+`,
+      'utf8'
+    );
+    const { stderr } = await run(process.execPath, [CLI, 'generate'], {
+      cwd: dir,
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    expect(stderr).toContain('both "schema" and "drizzleKit"');
+    expect(existsSync(path.join(dir, 'out', 'zod', 'accounts.zod.ts'))).toBe(true);
+    // The kit config's glob was not read, so its tables were not generated.
+    expect(existsSync(path.join(dir, 'out', 'zod', 'users.zod.ts'))).toBe(false);
+  }, 120_000);
+
+  it('keeps typedColumns working when the kit schema resolves to one file', async () => {
+    // `typedColumns` emits `typeof <table>.$inferSelect[...]` and imports the schema module to
+    // do it, which needs a single module. One resolved file is that module, so the option
+    // works exactly as it does with an explicit `schema`.
+    const dir = await project('typed-single');
+    await fs.rm(path.join(dir, 'src', 'db', 'schema', 'posts.ts'));
+    await fs.writeFile(
+      path.join(dir, 'drizzle.config.ts'),
+      KIT_CONFIG.replace(`'./src/db/schema/*.ts'`, `'./src/db/schema/users.ts'`),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(dir, 'drzl.config.ts'),
+      DRZL_CONFIG.replace(
+        `{ kind: 'zod', path: './out/zod' }`,
+        `{ kind: 'zod', path: './out/zod', typedColumns: true }`
+      ),
+      'utf8'
+    );
+    await run(process.execPath, [CLI, 'generate'], { cwd: dir, maxBuffer: 20 * 1024 * 1024 });
+    const users = await fs.readFile(path.join(dir, 'out', 'zod', 'users.zod.ts'), 'utf8');
+    expect(users).toContain('$inferSelect');
+    expect(users).toContain('../../src/db/schema/users');
+  }, 120_000);
+
+  it('says why typedColumns cannot work when the kit schema is several files', async () => {
+    // Several files have no single module to import the tables from, so the generator keeps
+    // its measured fallback: wide types plus the warning naming the reason, rather than a
+    // fabricated import or silence.
+    const dir = await project('typed-multi');
+    await fs.writeFile(
+      path.join(dir, 'drzl.config.ts'),
+      DRZL_CONFIG.replace(
+        `{ kind: 'zod', path: './out/zod' }`,
+        `{ kind: 'zod', path: './out/zod', typedColumns: true }`
+      ),
+      'utf8'
+    );
+    const { stderr } = await run(process.execPath, [CLI, 'generate'], {
+      cwd: dir,
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    expect(stderr).toContain('schema path is unknown');
+    const users = await fs.readFile(path.join(dir, 'out', 'zod', 'users.zod.ts'), 'utf8');
+    expect(users).not.toContain('$inferSelect');
+  }, 120_000);
+
+  it('fails with an error naming both files when neither yields a schema', async () => {
+    const dir = await project('neither');
+    await fs.rm(path.join(dir, 'drizzle.config.ts'));
+    const failed = await run(process.execPath, [CLI, 'generate'], {
+      cwd: dir,
+      maxBuffer: 20 * 1024 * 1024,
+    }).then(
+      () => null,
+      (e: any) => e
+    );
+    expect(failed, 'generate should exit non-zero').toBeTruthy();
+    expect(String(failed.stderr)).toContain('no "schema"');
+    expect(String(failed.stderr)).toContain('drizzle.config.ts');
+  }, 120_000);
+});
+
+describe('drzl watch with the schema resolved from drizzle.config.ts', () => {
+  it('start-up build matches generate byte for byte, and edits keep regenerating', async () => {
+    const dir = await project('watch');
+    const zodOut = path.join(dir, 'out', 'zod');
+
+    await run(process.execPath, [CLI, 'generate'], { cwd: dir, maxBuffer: 20 * 1024 * 1024 });
+    const fromGenerate: Record<string, string> = {};
+    for (const f of (await fs.readdir(zodOut)).sort()) {
+      fromGenerate[f] = await fs.readFile(path.join(zodOut, f), 'utf8');
+    }
+    await fs.rm(path.join(dir, 'out'), { recursive: true, force: true });
+
+    // `--poll` for the reason every watch test here uses it: inotify does not reach chokidar
+    // reliably on WSL, Docker or a network mount, and the test should report the product.
+    const child = spawn(process.execPath, [CLI, 'watch', '--debounce', '50', '--poll'], {
+      cwd: dir,
+      stdio: 'ignore',
+    });
+    try {
+      // Start-up build: same files, same bytes as generate.
+      expect(
+        await pollFor(() => existsSync(path.join(zodOut, 'index.ts')), 60_000),
+        'watch never produced its start-up build'
+      ).toBe(true);
+      await new Promise((r) => setTimeout(r, 500));
+      const fromWatch: Record<string, string> = {};
+      for (const f of (await fs.readdir(zodOut)).sort()) {
+        fromWatch[f] = await fs.readFile(path.join(zodOut, f), 'utf8');
+      }
+      expect(fromWatch).toEqual(fromGenerate);
+
+      // An edit to a file the glob matched regenerates: the kit-config-derived directory is
+      // really among the watch targets.
+      await fs.writeFile(
+        path.join(dir, 'src', 'db', 'schema', 'users.ts'),
+        USERS.replace(
+          `email: text('email').notNull(),`,
+          `email: text('email').notNull(),\n  nickname: text('nickname'),`
+        ),
+        'utf8'
+      );
+      expect(
+        await pollFor(async () => {
+          const body = await fs.readFile(path.join(zodOut, 'users.zod.ts'), 'utf8').catch(() => '');
+          return body.includes('nickname');
+        }, 60_000),
+        'the edited column never reached the regenerated schema'
+      ).toBe(true);
+
+      // A new file matching the glob joins the schema on the rebuild that first sees it: the
+      // glob is re-expanded per run, not frozen at startup.
+      await fs.writeFile(
+        path.join(dir, 'src', 'db', 'schema', 'tags.ts'),
+        USERS.replace(/users/g, 'tags').replace(`text('email')`, `text('label')`),
+        'utf8'
+      );
+      expect(
+        await pollFor(() => existsSync(path.join(zodOut, 'tags.zod.ts')), 60_000),
+        'a new file matching the drizzle-kit glob never produced output'
+      ).toBe(true);
+    } finally {
+      child.kill('SIGTERM');
+    }
+  }, 240_000);
+});

--- a/packages/cli/test/drizzle-kit-interop.spec.ts
+++ b/packages/cli/test/drizzle-kit-interop.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * DRZL reading drizzle-kit's config, so a schema path written once in `drizzle.config.ts` does
+ * not have to be written again in `drzl.config.ts` (item 59).
+ *
+ * Everything here is pinned to drizzle-kit's measured behavior on 0.31.10, read from its
+ * published dist rather than from memory:
+ *
+ *   - `Config.schema` is `string | string[]`, entries may be glob patterns (`index.d.mts`).
+ *   - The CLI's default config candidates are `drizzle.config.ts`, then `.js`, then `.json`,
+ *     in that order (`drizzleConfigFromFile` in `bin.cjs`); `.mjs`/`.cjs` are not candidates,
+ *     though an explicit `--config` path may be anything require() loads.
+ *   - `prepareFilenames` expands each entry with glob.sync, expands a directory match one
+ *     level (readdir, not recursive), and exits when nothing matched.
+ *   - `defineConfig` is the identity function (`index.mjs`).
+ */
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigSchema, computeWatchTargets } from '../src/config';
+import {
+  DRIZZLE_KIT_CONFIG_CANDIDATES,
+  dialectMismatchWarning,
+  expandSchemaPaths,
+  findDrizzleKitConfig,
+  mapDrizzleKitDialect,
+  resolveSchemaSource,
+  type ResolvedSchemaSource,
+} from '../src/drizzle-kit';
+
+const dirs: string[] = [];
+async function scratch(files: Record<string, string>): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-dk-'));
+  dirs.push(dir);
+  for (const [rel, body] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, body, 'utf8');
+  }
+  return dir;
+}
+
+afterEach(async () => {
+  while (dirs.length) await fs.rm(dirs.pop()!, { recursive: true, force: true });
+});
+
+const SCHEMA_TS = `import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', { id: serial('id').primaryKey(), email: text('email').notNull() });
+`;
+
+describe('config schema accepts the interop surface', () => {
+  it('parses a config with drizzleKit and no schema', () => {
+    const cfg = ConfigSchema.parse({ drizzleKit: true, generators: [{ kind: 'zod' }] });
+    expect(cfg.schema).toBeUndefined();
+    expect(cfg.drizzleKit).toBe(true);
+  });
+
+  it('parses a config with neither schema nor drizzleKit, deferring the error to resolution', () => {
+    // The error a missing schema gets is "no schema and no drizzle.config", which can only be
+    // said after looking for a drizzle.config; a parse-time "Required" cannot say it.
+    expect(() => ConfigSchema.parse({ generators: [{ kind: 'zod' }] })).not.toThrow();
+  });
+
+  it('accepts a path for drizzleKit and refuses other types', () => {
+    expect(
+      ConfigSchema.parse({ drizzleKit: './kit.config.ts', generators: [{ kind: 'zod' }] })
+        .drizzleKit
+    ).toBe('./kit.config.ts');
+    expect(() => ConfigSchema.parse({ drizzleKit: 5, generators: [{ kind: 'zod' }] })).toThrow();
+  });
+});
+
+describe('findDrizzleKitConfig', () => {
+  it('mirrors drizzle-kit: ts beats js beats json', async () => {
+    const dir = await scratch({
+      'drizzle.config.ts': 'export default {}',
+      'drizzle.config.js': 'export default {}',
+      'drizzle.config.json': '{}',
+    });
+    expect(findDrizzleKitConfig(dir)).toBe(path.join(dir, 'drizzle.config.ts'));
+    await fs.rm(path.join(dir, 'drizzle.config.ts'));
+    expect(findDrizzleKitConfig(dir)).toBe(path.join(dir, 'drizzle.config.js'));
+    await fs.rm(path.join(dir, 'drizzle.config.js'));
+    expect(findDrizzleKitConfig(dir)).toBe(path.join(dir, 'drizzle.config.json'));
+  });
+
+  it('does not treat .mjs as a candidate, because drizzle-kit itself does not', async () => {
+    const dir = await scratch({ 'drizzle.config.mjs': 'export default {}' });
+    expect(findDrizzleKitConfig(dir)).toBeNull();
+    expect(DRIZZLE_KIT_CONFIG_CANDIDATES).toEqual([
+      'drizzle.config.ts',
+      'drizzle.config.js',
+      'drizzle.config.json',
+    ]);
+  });
+});
+
+describe('expandSchemaPaths', () => {
+  it('expands a glob to the matching files, sorted and absolute', async () => {
+    const dir = await scratch({
+      'src/db/b.ts': '',
+      'src/db/a.ts': '',
+      'src/db/readme.md': '',
+    });
+    const { files } = expandSchemaPaths('./src/db/*.ts', dir);
+    expect(files).toEqual([path.join(dir, 'src/db/a.ts'), path.join(dir, 'src/db/b.ts')]);
+  });
+
+  it('supports arrays, globstar and braces, without duplicates', async () => {
+    const dir = await scratch({
+      'a/one.ts': '',
+      'a/deep/two.ts': '',
+      'b/three.js': '',
+    });
+    const { files } = expandSchemaPaths(['./a/**/*.ts', './b/*.{js,ts}', './a/one.ts'], dir);
+    expect(files).toEqual([
+      path.join(dir, 'a/deep/two.ts'),
+      path.join(dir, 'a/one.ts'),
+      path.join(dir, 'b/three.js'),
+    ]);
+  });
+
+  it('expands a directory entry one level, the way drizzle-kit does', async () => {
+    const dir = await scratch({
+      'schema/users.ts': '',
+      'schema/nested/deep.ts': '',
+    });
+    const { files } = expandSchemaPaths('./schema', dir);
+    // prepareFilenames readdirs a directory without recursing; nested files need a glob.
+    expect(files).toEqual([path.join(dir, 'schema/users.ts')]);
+  });
+
+  it('names watch directories that contain no glob magic', async () => {
+    const dir = await scratch({ 'src/db/schema/users.ts': '', 'flat.ts': '' });
+    const { watchDirs } = expandSchemaPaths(['./src/db/schema/*.ts', './flat.ts'], dir);
+    expect(watchDirs).toContain(path.join(dir, 'src/db/schema'));
+    expect(watchDirs).toContain(dir);
+    for (const d of watchDirs) {
+      expect(path.isAbsolute(d), d).toBe(true);
+      expect(d).not.toMatch(/[*?{}[\]]/);
+    }
+  });
+});
+
+describe('dialect mapping and the mismatch warning', () => {
+  it('maps every dialect drizzle-kit 0.31 can declare', () => {
+    expect(mapDrizzleKitDialect('postgresql')).toBe('postgres');
+    expect(mapDrizzleKitDialect('mysql')).toBe('mysql');
+    expect(mapDrizzleKitDialect('sqlite')).toBe('sqlite');
+    expect(mapDrizzleKitDialect('turso')).toBe('sqlite');
+    expect(mapDrizzleKitDialect('singlestore')).toBe('singlestore');
+    expect(mapDrizzleKitDialect('gel')).toBe('gel');
+    expect(mapDrizzleKitDialect('no-such-dialect')).toBeNull();
+  });
+
+  it('warns when the declared dialect contradicts the analyzed one', () => {
+    const w = dialectMismatchWarning({
+      configPath: '/p/drizzle.config.ts',
+      declared: 'mysql',
+      analyzed: 'postgres',
+    });
+    expect(w).toBe(
+      'drzl: /p/drizzle.config.ts declares dialect "mysql", but the schema analyzed as ' +
+        '"postgres". DRZL follows the schema; if the schema files are the right ones, the ' +
+        'dialect in that config is stale.'
+    );
+  });
+
+  it('stays quiet when they agree, including through the turso alias', () => {
+    expect(
+      dialectMismatchWarning({ configPath: 'x', declared: 'turso', analyzed: 'sqlite' })
+    ).toBeNull();
+    expect(
+      dialectMismatchWarning({ configPath: 'x', declared: 'postgresql', analyzed: 'postgres' })
+    ).toBeNull();
+  });
+
+  it('stays quiet when either side is unknown', () => {
+    expect(
+      dialectMismatchWarning({ configPath: 'x', declared: 'mysql', analyzed: 'unknown' })
+    ).toBeNull();
+    expect(
+      dialectMismatchWarning({ configPath: 'x', declared: 'weird', analyzed: 'postgres' })
+    ).toBeNull();
+  });
+});
+
+describe('resolveSchemaSource precedence', () => {
+  it('an explicit drzl schema wins outright, with no drizzle-kit involvement', async () => {
+    const dir = await scratch({
+      'drizzle.config.ts': `export default { dialect: 'postgresql', schema: './src/other.ts' }`,
+      'src/schema.ts': SCHEMA_TS,
+    });
+    const src = await resolveSchemaSource({ schema: 'src/schema.ts' }, dir);
+    expect(src.source).toBe('drzl');
+    expect(src.schema).toBe('src/schema.ts');
+    expect(src.drizzleKitConfigPath).toBeUndefined();
+    expect(src.warnings).toEqual([]);
+    expect(src.watchDirs).toEqual([path.join(dir, 'src')]);
+  });
+
+  it('warns when both schema and drizzleKit are set, since only schema is read', async () => {
+    const dir = await scratch({ 'src/schema.ts': SCHEMA_TS });
+    const src = await resolveSchemaSource({ schema: 'src/schema.ts', drizzleKit: true }, dir);
+    expect(src.source).toBe('drzl');
+    expect(src.warnings.join('\n')).toContain('both "schema" and "drizzleKit"');
+  });
+
+  it('drizzleKit: true reads the drizzle-kit config and expands its schema', async () => {
+    const dir = await scratch({
+      'drizzle.config.ts': `export default { dialect: 'postgresql', schema: './src/db/*.ts' }`,
+      'src/db/users.ts': SCHEMA_TS,
+      'src/db/posts.ts': SCHEMA_TS.replace(/users/g, 'posts'),
+    });
+    const src = await resolveSchemaSource({ drizzleKit: true }, dir);
+    expect(src.source).toBe('drizzle-kit');
+    expect(src.schema).toEqual([
+      path.join(dir, 'src/db/posts.ts'),
+      path.join(dir, 'src/db/users.ts'),
+    ]);
+    expect(src.drizzleKitConfigPath).toBe(path.join(dir, 'drizzle.config.ts'));
+    expect(src.drizzleKitDialect).toBe('postgresql');
+  });
+
+  it('falls back to drizzle.config automatically when schema is simply omitted', async () => {
+    // Deliberate: until this feature, `schema` was required, so no pre-existing config can
+    // reach this branch; it exists only for configs written with the interop in mind. The
+    // resolution is announced by the caller (the CLI prints the file it read), never silent.
+    const dir = await scratch({
+      'drizzle.config.ts': `export default { dialect: 'postgresql', schema: './src/db/users.ts' }`,
+      'src/db/users.ts': SCHEMA_TS,
+    });
+    const src = await resolveSchemaSource({}, dir);
+    expect(src.source).toBe('drizzle-kit');
+    expect(src.schema).toEqual([path.join(dir, 'src/db/users.ts')]);
+  });
+
+  it('drizzleKit: false disables the fallback even when a drizzle.config exists', async () => {
+    const dir = await scratch({
+      'drizzle.config.ts': `export default { dialect: 'postgresql', schema: './src/db/users.ts' }`,
+      'src/db/users.ts': SCHEMA_TS,
+    });
+    await expect(resolveSchemaSource({ drizzleKit: false }, dir)).rejects.toThrow(
+      /"drizzleKit" is false/
+    );
+  });
+
+  it('accepts an explicit path to the drizzle-kit config, wherever it is', async () => {
+    const dir = await scratch({
+      'conf/kit.config.mjs': `export default { dialect: 'sqlite', schema: './src/db/users.ts' }`,
+      'src/db/users.ts': SCHEMA_TS,
+    });
+    const src = await resolveSchemaSource({ drizzleKit: './conf/kit.config.mjs' }, dir);
+    expect(src.source).toBe('drizzle-kit');
+    expect(src.schema).toEqual([path.join(dir, 'src/db/users.ts')]);
+    expect(src.drizzleKitConfigPath).toBe(path.join(dir, 'conf/kit.config.mjs'));
+  });
+
+  it('reads a .json drizzle-kit config', async () => {
+    const dir = await scratch({
+      'drizzle.config.json': JSON.stringify({ dialect: 'postgresql', schema: './src/db/users.ts' }),
+      'src/db/users.ts': SCHEMA_TS,
+    });
+    const src = await resolveSchemaSource({ drizzleKit: true }, dir);
+    expect(src.schema).toEqual([path.join(dir, 'src/db/users.ts')]);
+  });
+
+  it('reads a config written with defineConfig, which drizzle-kit defines as identity', async () => {
+    const dir = await scratch({
+      // Measured: drizzle-kit's index.mjs is `function defineConfig(config) { return config; }`.
+      'drizzle.config.ts': `const defineConfig = <T,>(c: T): T => c;
+export default defineConfig({ dialect: 'postgresql', schema: ['./src/db/users.ts'] });`,
+      'src/db/users.ts': SCHEMA_TS,
+    });
+    const src = await resolveSchemaSource({ drizzleKit: true }, dir);
+    expect(src.schema).toEqual([path.join(dir, 'src/db/users.ts')]);
+  });
+
+  it('errors naming both files when neither yields a schema', async () => {
+    const dir = await scratch({ 'src/db/users.ts': SCHEMA_TS });
+    await expect(resolveSchemaSource({}, dir)).rejects.toThrow(/no "schema".*drizzle\.config\.ts/s);
+  });
+
+  it('errors when drizzleKit is true but no config file exists', async () => {
+    const dir = await scratch({});
+    await expect(resolveSchemaSource({ drizzleKit: true }, dir)).rejects.toThrow(
+      /drizzleKit.*drizzle\.config\.ts/s
+    );
+  });
+
+  it('errors when the explicit drizzleKit path does not exist', async () => {
+    const dir = await scratch({});
+    await expect(resolveSchemaSource({ drizzleKit: './nope/kit.ts' }, dir)).rejects.toThrow(
+      /nope[/\\]kit\.ts/
+    );
+  });
+
+  it('errors when the drizzle-kit config has no schema entry', async () => {
+    const dir = await scratch({
+      'drizzle.config.ts': `export default { dialect: 'postgresql' }`,
+    });
+    await expect(resolveSchemaSource({ drizzleKit: true }, dir)).rejects.toThrow(/no "schema"/);
+  });
+
+  it('errors when the schema entry is neither string nor string array', async () => {
+    const dir = await scratch({
+      'drizzle.config.ts': `export default { dialect: 'postgresql', schema: 42 }`,
+    });
+    await expect(resolveSchemaSource({ drizzleKit: true }, dir)).rejects.toThrow(
+      /string or an array of strings/
+    );
+  });
+
+  it('errors when the patterns match nothing, naming them', async () => {
+    const dir = await scratch({
+      'drizzle.config.ts': `export default { dialect: 'postgresql', schema: './src/db/*.ts' }`,
+    });
+    await expect(resolveSchemaSource({ drizzleKit: true }, dir)).rejects.toThrow(
+      /matched no schema files.*src\/db\/\*\.ts/s
+    );
+  });
+});
+
+describe('watch targets with a drizzle-kit source', () => {
+  const cwd = path.resolve('/project');
+  const cfg = (over: Record<string, unknown> = {}) =>
+    ({
+      outDir: 'src/api',
+      generators: [{ kind: 'zod', path: 'src/validators/zod' }],
+      analyzer: {},
+      ...over,
+    }) as never;
+  const source: ResolvedSchemaSource = {
+    source: 'drizzle-kit',
+    schema: ['/project/src/db/schema/users.ts'],
+    watchDirs: ['/project/src/db/schema'],
+    drizzleKitConfigPath: '/project/drizzle.config.ts',
+    warnings: [],
+  };
+
+  it('watches the resolved schema directories and the drizzle-kit config file', () => {
+    const targets = computeWatchTargets(cfg(), cwd, source);
+    expect(targets).toContain(path.resolve('/project/src/db/schema'));
+    expect(targets).toContain(path.resolve('/project/drizzle.config.ts'));
+  });
+
+  it('still watches every drzl config filename, and emits no globs', () => {
+    const targets = computeWatchTargets(cfg(), cwd, source);
+    for (const name of ['drzl.config.ts', 'drzl.config.js', 'drzl.config.mjs', 'drzl.config.cjs']) {
+      expect(targets).toContain(path.resolve(cwd, name));
+    }
+    for (const t of targets) {
+      expect(t, `glob in watch target: ${t}`).not.toMatch(/[*?{}[\]]/);
+      expect(path.isAbsolute(t), t).toBe(true);
+    }
+  });
+
+  it('tolerates a config with no schema when no source is passed', () => {
+    // The startup path resolves the source before computing targets, but an old caller
+    // passing only the config must not crash on schema being undefined now.
+    expect(() => computeWatchTargets(cfg(), cwd)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Plan item 59: DRZL reads `drizzle.config.ts` so a drizzle-kit user names their schema once. `schema` in `drzl.config` wins outright; absent it, `drizzleKit: true | './path'` (or the safe unset fallback, unreachable by any existing config since `schema` was previously required) resolves through kit's own candidate order; neither present errors naming both files and both fixes.

## Measured, not assumed

- **Kit's surface** (0.31.10, read from the published dist): `schema: string | string[]` with glob entries, mandatory `dialect` (six values, mapped to DRZL's vocabulary with a pinned cross-check warning), candidates `drizzle.config.ts/.js/.json` in that order, `--config` analog honored via the string form.
- **Kit's own extension filter is dead code**: `prepareFilenames` computes the `.ts/.js/...` filter into a variable it never applies, so kit crashes on a README sitting in a schema directory. DRZL applies the filter for real, strictly friendlier.
- **Real-package proof**: one config with a genuine `import { defineConfig } from 'drizzle-kit'` generated 2 tables identically through `drzl generate` and through `npx drizzle-kit generate`.

## The analyzer is now multi-file

`schemaPath` had exactly 3 uses and everything downstream of the merged exports object was load-agnostic, so the extension cost ~70 lines. Globs expand in the CLI via Node 22's built-in `fs.globSync` (engines floor; `*`, `**`, braces measured): zero new dependencies. Duplicate exports across files are judged by Drizzle's own identity (db name + SQL schema + column keys), because `moduleCache: false` re-evaluates modules so a re-export never survives `Object.is`; re-exports stay silent, genuine disagreements warn (`DRZL_ANL_DUP_EXPORT`) with first-file-wins determinism. `drizzle.config.*` loads through the same extracted jiti loader as `drzl.config.*`.

## Watch and generators

Watch targets include the resolved schema dirs, glob bases, and `drizzle.config.*` itself, re-resolved every rebuild: a new file matching the glob joins mid-watch (tested live), and startup output is byte-identical with generate. `typedJson`/`typedColumns` pass a single resolved file through unchanged; multi-file keeps the generator's measured wide-type warning, documented.

## Verification

Red-first at both layers (analyzer spec failing on `paths[1] must be string`, CLI spec on module-missing), then 6 analyzer + 30 CLI unit + 7 e2e tests green, covering precedence (both set, neither set, false, explicit path), dialect mismatch wording, zero-match patterns, and the live-watch scenarios. Full gates: 20 suites green (cli 600, analyzer 309), typecheck, lint, docs build, and `pnpm verify:packed` unmodified exit 0 run on the final tree. **No controller requests**: the doc extractor's own `schema:`-key rule skips the interop examples, verified against the 29 extracted configs.

## Item 67 reuse

`packages/cli/src/drizzle-kit.ts` exports the candidate walk, loader, glob expansion and `resolveSchemaSource`; `init` can detect a kit config and scaffold `drizzleKit: true` instead of hardcoding `src/db/schema.ts`.

Changeset: minor for `@drzl/cli` and `@drzl/analyzer`.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
