### PR TITLE
docs: provider quickstarts, Supabase/Neon, PlanetScale, Cloudflare D1 (items 60-62)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -40,6 +40,15 @@ export default {
         ],
       },
       {
+        text: 'Provider Quickstarts',
+        collapsed: false,
+        items: [
+          { text: 'Supabase and Neon', link: '/quickstarts/supabase-neon' },
+          { text: 'PlanetScale (MySQL)', link: '/quickstarts/planetscale' },
+          { text: 'Cloudflare D1', link: '/quickstarts/cloudflare-d1' },
+        ],
+      },
+      {
         text: 'CLI',
         collapsed: false,
         items: [

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -130,3 +130,6 @@ Next steps
 - CLI commands → [/cli](/cli)
 - Config reference → [/guide/configuration](/guide/configuration)
 - Adapters → [/adapters/overview](/adapters/overview)
+- Hosting on Supabase/Neon, PlanetScale or Cloudflare D1? → provider quickstarts for
+  [Postgres](/quickstarts/supabase-neon), [MySQL](/quickstarts/planetscale) and
+  [SQLite](/quickstarts/cloudflare-d1)

--- a/docs/quickstarts/cloudflare-d1.md
+++ b/docs/quickstarts/cloudflare-d1.md
@@ -1,0 +1,277 @@
+# Cloudflare D1 (SQLite)
+
+By the end of this page you have a drizzle-kit project pointed at Cloudflare D1 in which the
+schema path is named once, in `drizzle.config.ts`; `drzl generate` reads it from there and emits
+ArkType validators plus a Hono app whose routes validate against them, mounted in a Worker over
+the D1 binding, with the create handler filled in. Along the way it measures the two D1 facts
+that reshape inserts: interactive transactions do not exist here, and bound parameters cap at
+100 per query.
+
+Measured 2026-08-08 with `@drzl/cli` 4.22.0, `drizzle-orm` 0.45.2, `drizzle-kit` 0.31.10,
+`arktype` 2.2.3, `hono` 4.13.1, `@hono/standard-validator` 0.4.0, TypeScript 7.0.2, Node 22.
+Two local stand-ins, each labeled where used: **SQLite semantics** ran on `better-sqlite3`
+13.0.3 (SQLite 3.53.4), and **D1 API behavior** ran on `miniflare` 5.20260801.1-alpha, which
+per the [Cloudflare docs](https://developers.cloudflare.com/workers/development-testing/)
+executes Workers "using the same runtime used in production, workerd" and simulates bound
+resources locally; it is what `wrangler dev` runs. Production D1 is a hosted service this page
+never reached; its limits are quoted from
+[D1's limits page](https://developers.cloudflare.com/d1/platform/limits/) and cross-checked
+against what the simulator enforces. Every snippet typechecks under `strict` with
+`moduleResolution: nodenext`; Worker-side files typecheck against `@cloudflare/workers-types`.
+
+## Install
+
+```bash
+pnpm add drizzle-orm hono @hono/standard-validator arktype
+pnpm add -D @drzl/cli drizzle-kit wrangler @cloudflare/workers-types
+```
+
+Driver choice, with the reasoning: there is no driver package to choose. D1 arrives as a
+binding on your Worker's `env`, per the
+[Drizzle D1 guide](https://orm.drizzle.team/docs/connect-cloudflare-d1), and
+`drizzle-orm/d1` wraps that binding directly: `drizzle(env.DB)`. The binding is declared in
+wrangler config:
+
+```jsonc
+// wrangler.jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "quickstart-db",
+      "database_id": "<your-database-id>",
+      "migrations_dir": "drizzle"
+    }
+  ]
+}
+```
+
+## Name the schema once
+
+drizzle-kit talks to D1 over Cloudflare's HTTP API, per the
+[drizzle-kit D1 guide](https://orm.drizzle.team/docs/guides/d1-http-with-drizzle-kit):
+
+```ts
+// drizzle.config.ts, exactly as drizzle-kit already has it
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  dialect: 'sqlite',
+  driver: 'd1-http',
+  schema: './src/db/schema.ts',
+  out: './drizzle',
+  dbCredentials: {
+    accountId: process.env.CLOUDFLARE_ACCOUNT_ID!,
+    databaseId: process.env.CLOUDFLARE_DATABASE_ID!,
+    token: process.env.CLOUDFLARE_D1_TOKEN!,
+  },
+});
+```
+
+DRZL reads exactly two things from that file, `schema` and `dialect`; the credentials are
+drizzle-kit's alone ([the full rules](/guide/configuration#reading-the-schema-path-from-drizzle-kit)).
+So `drzl.config.ts` names no schema:
+
+```ts
+// drzl.config.ts: no schema key at all
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  drizzleKit: true,
+  outDir: 'src/routes',
+  generators: [
+    { kind: 'arktype', path: 'src/validators/arktype' },
+    {
+      kind: 'hono',
+      validator: 'standard',
+      validation: { useShared: true, library: 'arktype', importPath: '../validators/arktype/index.js' },
+    },
+  ],
+});
+```
+
+Measured, the run announces `Schema from drizzle.config.ts (1 file)` and writes six files:
+three ArkType modules, three route files.
+
+## What the schema carries
+
+Against a `users` table declaring `integer('id').primaryKey({ autoIncrement: true })`,
+`blob('settings', { mode: 'json' })` and `integer('created_at', { mode: 'timestamp' })`, the
+emitted insert schema (excerpt, as generated):
+
+```ts
+export const InsertusersSchema = type({
+  id: "-9223372036854775808 <= number.integer <= 9223372036854775807?",
+  email: "string",
+  name: "string",
+  settings: "(number | object | string | boolean | null | null)?",
+  // createdAt: Date | epoch number | parseable date string | null, narrowed
+});
+```
+
+The id range is SQLite's fact: per the [SQLite docs](https://www.sqlite.org/autoinc.html), an
+`INTEGER PRIMARY KEY` column is an alias for the rowid, "which is always a 64-bit signed
+integer", so the bounds are int8, not int4. `settings` is the JSON union, because `blob({ mode: 'json' })` round-trips any
+JSON value; `blob({ mode: 'bigint' })` and the timestamp mode are in the
+[dialect grid](/generators/zod#dialects-other-than-postgres). One ArkType-specific behavior to
+know from the [React Hook Form page](/examples/react-hook-form#dates): ArkType validates date
+inputs without converting them, so the filled handler below makes the `Date` itself.
+
+Measured on better-sqlite3 (SQLite semantics, not D1-specific): a validated row with
+`settings: { theme: 'dark' }` and a `Date` came back from a drizzle round-trip intact, stored
+as `typeof(settings) = 'blob'` and `created_at = 1786190400` (epoch seconds); a bad row with
+`published: 'yes'` was refused by the emitted schema with `published must be boolean (was
+"yes")`; and SQLite's NUMERIC affinity stored the string `'abc'` unchanged with
+`typeof = 'text'`, which is why
+[no numeric format check is emitted on this dialect](/generators/zod#numeric-and-decimal-columns).
+
+## Mount it in a Worker
+
+The generated `src/routes/index.ts` exports a composed `app`. The Worker hands it requests, and
+handlers build their db from the binding per request:
+
+```ts
+// src/worker.ts
+import { app } from './routes/index.js';
+
+export interface Env {
+  DB: D1Database;
+}
+
+export default {
+  fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    return app.fetch(request, env, ctx);
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+Generated handlers are typed stubs; generated output is granted under your project's license,
+so filling them in place is the intended workflow. The create route, filled:
+
+```ts
+import { drizzle } from 'drizzle-orm/d1';
+import { Hono } from 'hono';
+import { sValidator } from '@hono/standard-validator';
+import { users } from '../db/schema.js';
+import { InsertusersSchema } from '../validators/arktype/index.js';
+
+export const usersRoutes = new Hono<{ Bindings: { DB: D1Database } }>().post(
+  '/',
+  sValidator('json', InsertusersSchema),
+  async (c) => {
+    const db = drizzle(c.env.DB);
+    const input = c.req.valid('json');
+    const [created] = await db
+      .insert(users)
+      .values({
+        ...input,
+        // ArkType validates date inputs without converting them, so the wire
+        // string becomes a Date here, not in the schema.
+        createdAt: input.createdAt == null ? null : new Date(input.createdAt),
+      })
+      .returning();
+    return c.json(created, 201);
+  }
+);
+```
+
+Both files typecheck against `@cloudflare/workers-types`; deploying them needs an account, so
+the deployed path is the one thing here that is compile-verified only. `app.request()` testing
+without a server works as on the [Hono generator page](/generators/hono). SQLite has
+`RETURNING`, so `.returning()` works on this dialect (it ran in the batch measurement below).
+
+## Transactions do not exist here; batches do
+
+`drizzle-orm` 0.45.2's D1 driver implements `db.transaction()` by issuing a raw `begin` (read
+from the installed package's `d1/session.js`). Measured against miniflare's D1, that call
+fails:
+
+```
+transaction: Failed query: begin
+cause: D1_ERROR: To execute a transaction, please use the state.storage.transaction() ...
+```
+
+The runtime refuses `BEGIN` outright. What D1 has instead is `batch`, which its
+[docs](https://developers.cloudflare.com/d1/worker-api/d1-database/) describe plainly:
+"batched statements are SQL transactions". Measured, both halves:
+
+```
+batch of 2: ok
+sabotage batch: D1_ERROR: UNIQUE constraint failed: users.email
+rows from the failed batch: {"n":0}
+```
+
+A two-insert `db.batch([...])` committed; a batch whose second insert collided on a unique
+column failed **and left zero rows behind**, first statement included. So the
+[seed page](/examples/seed)'s "one transaction, idempotent" step translates to D1 as one
+`db.batch` per seed, with the same validate-and-dedupe pre-flight in front of it.
+
+## The 100-parameter ceiling
+
+Per [D1's limits page](https://developers.cloudflare.com/d1/platform/limits/): 100 bound
+parameters per query, 100 KB per SQL statement, 2 MB per row, 10 GB per database (500 MB on the
+free plan). The parameter cap is the one a seed script hits first: each provided column of each
+row in a multi-row insert is one parameter, exactly as on the
+[seed page](/examples/seed#step-4-chunk-under-the-wire-limit), with a budget 655 times smaller.
+
+The local simulator enforces it at the same boundary, measured twice: on a raw prepared
+statement, and on the drizzle insert path with two provided columns per row:
+
+```
+100 bound parameters: ok
+101 bound parameters: D1_ERROR: too many SQL variables at offset 307: SQLITE_ERROR
+50 rows x 2 cols (100 params): ok
+51 rows x 2 cols (102 params): D1_ERROR: too many SQL variables
+```
+
+So the chunk arithmetic is the seed page's with D1's constant, and the chunks then ride one
+atomic batch:
+
+```ts
+const width = new Set(rows.flatMap(Object.keys)).size; // provided columns only
+const chunk = Math.floor(100 / width);
+
+const inserts = Array.from({ length: Math.ceil(rows.length / chunk) }, (_, i) =>
+  db.insert(users).values(rows.slice(i * chunk, (i + 1) * chunk))
+);
+if (inserts.length) await db.batch([inserts[0]!, ...inserts.slice(1)]);
+```
+
+Measured as written against the simulator: 250 two-column rows made `chunk = 50`, five inserts
+rode one batch, and the table held all 250 rows after it.
+
+## Provider notes
+
+- **D1 is SQLite's engine with a guarded SQL surface.** Per the
+  [supported-statements page](https://developers.cloudflare.com/d1/sql-api/sql-statements/), D1
+  runs SQLite's query engine and ships the FTS5, JSON and math-function extensions. The guard
+  is measurable: even `select sqlite_version()` is refused ("not authorized to use function:
+  sqlite_version", measured on the simulator), so this page cannot name a D1 SQLite version,
+  and its SQLite-semantics numbers are labeled with the stand-in's version instead.
+- **Not executed here:** production D1 (every limit above is sourced, with the simulator's
+  enforcement measured where shown), the `d1-http` drizzle-kit credentials path, and the
+  deployed Worker. Local development against the same simulator is
+  `wrangler dev`, sourced above.
+
+## Without drizzle-kit
+
+```ts
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  schema: 'src/db/schema.ts',
+  outDir: 'src/routes',
+  generators: [
+    { kind: 'arktype', path: 'src/validators/arktype' },
+    {
+      kind: 'hono',
+      validator: 'standard',
+      validation: { useShared: true, library: 'arktype', importPath: '../validators/arktype/index.js' },
+    },
+  ],
+});
+```
+
+::: tip Need something else?
+If this quickstart doesn't cover what you need, DM me on X (https://x.com/omardulaimidev) and we can scope it together.
+:::

--- a/docs/quickstarts/planetscale.md
+++ b/docs/quickstarts/planetscale.md
@@ -1,0 +1,239 @@
+# PlanetScale (MySQL)
+
+By the end of this page you have a drizzle-kit project pointed at PlanetScale in which the
+schema path is named once, in `drizzle.config.ts`; `drzl generate` reads it from there and emits
+Valibot validators carrying MySQL's byte-counted text caps, a per-table duplicate finder, the
+foreign-key graph as plain data, and a typed tRPC router over those schemas. One insert runs end
+to end, validated before it touches a connection, against a real MySQL 8.
+
+PlanetScale is Vitess over MySQL, and the two facts that reshape a quickstart are MySQL's, not
+Vitess's: text columns budget **bytes** while `varchar(n)` counts **characters**, and foreign
+key constraints are off by default on PlanetScale, so referential integrity may be yours to
+keep. DRZL has measured tooling for both; this page wires it up. PlanetScale also offers
+Postgres now ([GA announcement](https://planetscale.com/blog/planetscale-for-postgres-is-generally-available));
+for that product use the [Supabase and Neon page](/quickstarts/supabase-neon), which is
+dialect-portable.
+
+Measured 2026-08-08 with `@drzl/cli` 4.22.0, `drizzle-orm` 0.45.2, `drizzle-kit` 0.31.10,
+`valibot` 1.4.2, `@trpc/server` 11.18.0, `mysql2` 3.23.2, `@planetscale/database` 1.20.1,
+TypeScript 7.0.2, Node 22. Runtime measurements ran against MySQL 8.4.11 (Docker, `utf8mb4`
+client charset set explicitly) standing in for PlanetScale's MySQL; per the
+[PlanetScale docs](https://planetscale.com/blog/mysql-charsets-collations), new databases are
+MySQL 8 with `utf8mb4` and `utf8mb4_0900_ai_ci` as defaults, so the stand-in matches the
+defaults it stands in for. Vitess-specific behavior (the foreign-key toggle, sharding limits) is
+sourced from PlanetScale's docs and labeled so. Every snippet typechecks under `strict` with
+`moduleResolution: nodenext`; the `@planetscale/database` connection module was not executed,
+since that needs a PlanetScale endpoint.
+
+## Install
+
+```bash
+pnpm add drizzle-orm @planetscale/database
+pnpm add -D @drzl/cli drizzle-kit
+```
+
+Driver choice, with the reasoning:
+
+- **`@planetscale/database`** is what the
+  [Drizzle PlanetScale guide](https://orm.drizzle.team/docs/connect-planetscale) documents:
+  queries travel over HTTP, which is what serverless and edge runtimes without raw TCP need,
+  and `drizzle-orm/planetscale-serverless` is the matching driver import.
+- **`mysql2`** remains supported for TCP access, per the same guide. It is also what this
+  page's measurements ran over, since it speaks to any MySQL. If you use it, set
+  `charset: 'utf8mb4'` explicitly; otherwise a byte-cap measurement can measure your client's
+  transcoding rather than the server's column.
+
+```ts
+// src/db/client.ts
+import { drizzle } from 'drizzle-orm/planetscale-serverless';
+
+export const db = drizzle({
+  connection: {
+    host: process.env.DATABASE_HOST!,
+    username: process.env.DATABASE_USERNAME!,
+    password: process.env.DATABASE_PASSWORD!,
+  },
+});
+```
+
+## Name the schema once
+
+```ts
+// drizzle.config.ts, exactly as drizzle-kit already has it
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  dialect: 'mysql',
+  schema: './src/db/schema.ts',
+  out: './drizzle',
+  dbCredentials: { url: process.env.DATABASE_URL! },
+});
+```
+
+```ts
+// drzl.config.ts: no schema key at all
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  drizzleKit: true,
+  outDir: 'src/api',
+  generators: [
+    { kind: 'valibot', path: 'src/validators/valibot', duplicateFinder: true, constraints: true },
+    {
+      kind: 'trpc',
+      validation: { useShared: true, library: 'valibot', importPath: '../validators/valibot/index.js' },
+    },
+  ],
+});
+```
+
+`drzl generate` announces the fallback (`Schema from drizzle.config.ts (1 file)`, measured) and
+reads kit's `dialect` as a cross-check against what the analyzer measures from the columns;
+[the full rules](/guide/configuration#reading-the-schema-path-from-drizzle-kit). The same kit
+config drove `drizzle-kit push` against the measurement database, so one file fed both tools.
+
+## Byte caps, folded in
+
+Against a `users` table declaring `varchar('name', { length: 40 })` and a nullable
+`tinytext('bio')`, the emitted insert schema carries two different kinds of cap (excerpt, as
+generated):
+
+```ts
+name: v.pipe(
+  v.string(),
+  v.check((val) => [...val].length <= 40, 'at most 40 characters'),
+),
+bio: v.optional(
+  v.nullable(
+    v.pipe(
+      v.string(),
+      v.check(
+        (val) => new TextEncoder().encode(val).length <= 255,
+        'at most 255 bytes',
+      ),
+    ),
+  ),
+),
+```
+
+`varchar(n)` counts characters (code points, not UTF-16 units); the TEXT family budgets bytes
+in the column's charset. Both facts are measured in the
+[dialect grid](/generators/zod#dialects-other-than-postgres) and the
+[character-limit grid](/generators/valibot#character-limits-count-characters); this page reran
+the pair that shows the difference. 100 thumbs-up emoji is 100 characters and 400 bytes:
+
+```
+schema verdict: at most 255 bytes
+mysql verdict: ER_DATA_TOO_LONG Data too long for column 'bio' at row 1
+```
+
+The schema and MySQL 8.4.11 refuse the same value, one of them before a connection was opened.
+The same run stored a 40-emoji `name` in `varchar(40)` with both sides agreeing it fits.
+
+## Foreign keys are a setting here
+
+Per the
+[PlanetScale docs](https://planetscale.com/docs/vitess/foreign-key-constraints), foreign key
+constraints are supported but must be enabled per database ("Allow foreign key constraints"
+under Settings), and "currently, the foreign key constraints are only supported in unsharded
+environments". The same page documents cases where deploy-request reverts can leave orphaned
+rows. Historically the recommendation was to run without them
+([operating without foreign key constraints](https://planetscale.com/docs/vitess/operating-without-foreign-key-constraints)).
+
+So a PlanetScale schema's `references()` may be documentation rather than enforcement, and the
+generated artifacts are built for that:
+
+- **The constraint ledger.** `constraints: true` emits every key and foreign key as plain data.
+  Measured, the `posts` entry names `FOREIGN KEY (authorId) REFERENCES users (id)` with its
+  columns and target as fields, which is what the
+  [seed page's insert-order derivation](/examples/seed#step-3-parents-before-children) consumes:
+  parents before children without hand-maintaining a list.
+- **The duplicate finder.** Uniqueness inside a batch is the constraint a per-row schema cannot
+  check. Measured against the emitted module, two rows with the same explicit `id: 7` report
+  `{"index":1,"constraint":"users_pkey","firstIndex":0}` before the server ever sees them.
+- **For contrast, the stand-in enforces.** With constraints on (the local MySQL, or PlanetScale
+  with the toggle enabled), inserting a post whose `authorId` matches no user fails with
+  `ER_NO_REFERENCED_ROW_2` (errno 1452, measured). With the toggle off, that same insert
+  succeeds and the orphan is yours. The ledger and finder are how the seed script refuses it
+  first either way.
+
+## The measured end to end
+
+```ts
+// seed.ts, run with: npx tsx seed.ts
+import * as v from 'valibot';
+import { users } from './src/db/schema.js';
+import { InsertusersSchema, findDuplicateusers } from './src/validators/valibot/index.js';
+import { db } from './src/db/client.js';
+
+const rows = [
+  { email: 'ada@example.com', name: 'Ada', bio: 'hello' },
+  { email: 'lin@example.com', name: 'Lin', bio: null },
+];
+
+for (const row of rows) v.parse(InsertusersSchema, row); // throws with column + message
+const dupes = findDuplicateusers(rows);
+if (dupes.length) throw new Error(JSON.stringify(dupes));
+
+await db.insert(users).values(rows);
+const ids = await db.insert(users).values({ email: 'x@example.com', name: 'X' }).$returningId();
+```
+
+This ran as written against the stand-in (over the `mysql2` client rather than the PlanetScale
+one, which is the labeled gap). Two MySQL-isms worth pinning: there is no `RETURNING` in this
+dialect, so drizzle's `$returningId()` is how you get generated ids back (measured:
+`[{"id":3}]`), and the [service generator](/generators/service)'s `dataAccess: 'drizzle'` mode
+emits `.returning()` calls, so it is not in this page's config; the tRPC procedures are typed
+stubs you fill against your own data layer.
+
+## Mount the router
+
+The generated `src/api/index.ts` exports `appRouter`, its `AppRouter` type for clients, and
+`createCallerFactory` for in-process calls:
+
+```ts
+import { appRouter, createCallerFactory } from './api/index.js';
+
+const caller = createCallerFactory(appRouter)({});
+const users = await caller.users.list(); // [] until you fill the stub
+```
+
+Input schemas are already wired. Measured: calling `caller.users.create` with the 400-byte bio
+from above fails at the procedure boundary with `BAD_REQUEST` and the same `at most 255 bytes`
+message, because the router imports the shared Valibot schemas rather than restating them
+([how sharing works](/guide/configuration#sharing-names-with-a-router-generator)).
+
+## Provider notes
+
+- **Sharding.** The foreign-key support above is unsharded-only, per the PlanetScale docs
+  quoted there. Nothing DRZL emits assumes a shard layout either way.
+- **`utf8mb4` is the default and the assumption the caps encode.** The emitted byte checks
+  count UTF-8 bytes (`TextEncoder`, visible in the excerpt above), which is the byte count
+  `utf8mb4` stores, and `utf8mb4` is what new PlanetScale databases speak (sourced above). A
+  column you declare in a legacy single-byte charset would store fewer bytes than the check
+  counts for non-ASCII text.
+- **Not executed here:** the `@planetscale/database` HTTP driver against a real endpoint, and
+  the settings toggle itself. Both are sourced from PlanetScale's and Drizzle's docs above and
+  labeled where they appear.
+
+## Without drizzle-kit
+
+```ts
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  schema: 'src/db/schema.ts',
+  outDir: 'src/api',
+  generators: [
+    { kind: 'valibot', path: 'src/validators/valibot', duplicateFinder: true, constraints: true },
+    {
+      kind: 'trpc',
+      validation: { useShared: true, library: 'valibot', importPath: '../validators/valibot/index.js' },
+    },
+  ],
+});
+```
+
+::: tip Need something else?
+If this quickstart doesn't cover what you need, DM me on X (https://x.com/omardulaimidev) and we can scope it together.
+:::

--- a/docs/quickstarts/supabase-neon.md
+++ b/docs/quickstarts/supabase-neon.md
@@ -1,0 +1,294 @@
+# Supabase and Neon (Postgres)
+
+By the end of this page you have a drizzle-kit project pointed at Supabase or Neon in which the
+schema path is named once, in `drizzle.config.ts`; `drzl generate` reads it from there and emits
+Zod validators with the column rules folded in, a typed service layer, and an oRPC router that
+receives its database through middleware. One insert runs end to end through that stack,
+validated before it touches a connection.
+
+The two providers share a page because they run the same database. Per the
+[Supabase docs](https://supabase.com/docs/guides/database/overview), "every Supabase project
+gets a full Postgres database, not a Postgres abstraction"; the
+[Neon docs](https://neon.com/docs/introduction) describe theirs as serverless Postgres, and
+Neon's WebSocket driver is documented as a drop-in replacement for `pg`. What differs is how
+you connect to them, which is where this page spends its provider-specific attention. Everything DRZL has measured against Postgres transfers unchanged:
+the grids on the [Zod generator page](/generators/zod) and the wire-limit work on the
+[seed page](/examples/seed) apply as written.
+
+Measured 2026-08-08 with `@drzl/cli` 4.22.0, `drizzle-orm` 0.45.2, `drizzle-kit` 0.31.10, `zod`
+4.4.3, `@orpc/server` 1.15.0, `postgres` 3.4.9, `@neondatabase/serverless` 1.1.0, TypeScript
+7.0.2, Node 22. Runtime measurements ran against `@electric-sql/pglite` 0.5.4, a real Postgres
+(reports `PostgreSQL 18.3`) compiled to WASM, standing in for the hosted Postgres both providers
+run; connection-format and pooling claims are from provider docs and are labeled so. Every
+snippet on this page typechecks under `strict` with `moduleResolution: nodenext`; the connection
+modules were not executed against hosted endpoints, since that needs an account.
+
+## Install
+
+::: code-group
+
+```bash [Supabase]
+pnpm add drizzle-orm postgres
+pnpm add -D @drzl/cli drizzle-kit
+```
+
+```bash [Neon]
+pnpm add drizzle-orm @neondatabase/serverless
+pnpm add -D @drzl/cli drizzle-kit
+```
+
+:::
+
+Driver choice, with the reasoning:
+
+- **Supabase: `postgres` (postgres.js).** It is the driver the
+  [Drizzle Supabase guide](https://orm.drizzle.team/docs/connect-supabase) documents, and the
+  one whose pooling caveat below is spelled out in both Supabase's and Drizzle's docs. `pg`
+  works too; nothing DRZL emits cares which.
+- **Neon: `@neondatabase/serverless`.** Neon's own driver. Per the
+  [Neon serverless driver docs](https://neon.com/docs/serverless/serverless-driver), its HTTP
+  interface is for single, non-interactive queries, and its WebSocket `Pool`/`Client` is "a
+  fully compatible drop-in replacement for the `pg` driver" for sessions and interactive
+  transactions. On a long-running server you can use plain `pg` or postgres.js against Neon
+  instead; it is ordinary Postgres over TCP.
+
+## Name the schema once
+
+A drizzle-kit project already names its schema in `drizzle.config.ts`:
+
+```ts
+// drizzle.config.ts, exactly as drizzle-kit already has it
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  dialect: 'postgresql',
+  schema: './src/db/schema.ts',
+  out: './drizzle',
+  dbCredentials: { url: process.env.DATABASE_URL! },
+});
+```
+
+So `drzl.config.ts` does not name it again. `drizzleKit: true` insists on reading kit's config,
+and a missing kit config becomes a loud error rather than a quieter one about `schema`
+([the full rules](/guide/configuration#reading-the-schema-path-from-drizzle-kit)):
+
+```ts
+// drzl.config.ts: no schema key at all
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  drizzleKit: true,
+  outDir: 'src/api',
+  generators: [
+    { kind: 'zod', path: 'src/validators/zod' },
+    {
+      kind: 'service',
+      path: 'src/services',
+      dataAccess: 'drizzle',
+      schemaImportPath: 'src/db/schema',
+    },
+    {
+      kind: 'orpc',
+      template: '@drzl/template-orpc-service',
+      validation: { useShared: true, library: 'zod', importPath: '../validators/zod/index.js' },
+      databaseInjection: {
+        enabled: true,
+        databaseType: "import('drizzle-orm/postgres-js').PostgresJsDatabase",
+      },
+    },
+  ],
+});
+```
+
+The fallback is never silent. Measured on the run below, the first line of output is:
+
+```
+Schema from drizzle.config.ts (1 file)
+```
+
+`drzl generate` then wrote ten files against a two-table schema (`users`, `posts`): three Zod
+modules, four service files, three router files. With Neon, swap the `databaseType` for
+`"import('drizzle-orm/neon-http').NeonHttpDatabase"`; it is emitted verbatim, so no import
+statement is needed either way.
+
+## What the schema carries
+
+For a `users` table declaring an email `varchar(255)`, a name `varchar(40)`, a nullable
+`date('born_on')` and a `timestamp('created_at').defaultNow()`, the emitted insert schema
+(excerpt, as generated):
+
+```ts
+export const InsertusersSchema = z.object({
+  id: z.number().int().gte(-2147483648).lte(2147483647).optional(),
+  email: z
+    .string()
+    .refine((v) => [...v].length <= 255, { message: 'at most 255 characters' }),
+  name: z
+    .string()
+    .refine((v) => [...v].length <= 40, { message: 'at most 40 characters' }),
+  bornOn: z.string().nullable().optional(),
+  // createdAt: a Date, or a string or epoch number coerced to one on insert
+});
+```
+
+Three of those lines are Postgres facts with measured grids behind them, linked rather than
+repeated:
+
+- The character caps count **code points**, not UTF-16 units, because that is what the database
+  counts: [character limits count characters](/generators/zod#character-limits-count-characters).
+- `bornOn` stays a plain string on purpose. Postgres accepts `today`, `January 8, 1999` and
+  `20200101` for a `date`, so any regex DRZL could emit would refuse values the database takes:
+  [why numeric is the only format checked](/generators/zod#why-numeric-is-the-only-format-checked).
+  The measured insert below feeds it one of exactly those strings.
+- `serial` stays optional on insert rather than omitted, because the database accepts an
+  explicit id: [which columns appear on insert](/generators/zod#which-columns-appear-on-insert).
+
+## Connect
+
+**Supabase.** Per the
+[Supabase connection docs](https://supabase.com/docs/guides/database/connecting-to-postgres):
+the direct connection and Supavisor session mode listen on port 5432 and suit persistent
+servers; Supavisor transaction mode listens on port 6543 and is the one for serverless and edge
+functions, and "transaction mode does not support prepared statements". postgres.js sends
+prepared statements unless told otherwise, so the
+[Drizzle Supabase guide](https://orm.drizzle.team/docs/connect-supabase) disables them:
+
+```ts
+// src/db/client.ts
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+
+// Supavisor transaction mode (port 6543) does not support prepared statements,
+// so postgres.js must be told not to send them.
+const client = postgres(process.env.DATABASE_URL!, { prepare: false });
+export const db = drizzle({ client });
+```
+
+On a long-running server using the direct connection or session mode, drop `prepare: false` and
+keep prepared statements.
+
+**Neon.** The HTTP driver is one line:
+
+```ts
+// src/db/client.ts
+import { drizzle } from 'drizzle-orm/neon-http';
+
+export const db = drizzle(process.env.DATABASE_URL!);
+```
+
+Per the [Neon pooling docs](https://neon.com/docs/connect/connection-pooling), a pooled
+connection string carries `-pooler` in the hostname and runs through PgBouncer in transaction
+mode (up to 10,000 client connections); use the direct, unpooled string for migrations and
+`pg_dump`, which rely on session state. Keep both in your environment: pooled for the app,
+direct for `drizzle-kit push`.
+
+These two modules typecheck against the emitted tree; they are the one class of snippet on this
+page that was **not executed**, since both need a hosted endpoint. Everything below ran.
+
+## Mount the router
+
+The generated router expects `context.db`; the `dbMiddleware` inside it refuses to run without
+one. Wiring it to a fetch handler is the same shape the
+[oRPC + Service template page](/templates/orpc-service) shows for Cloudflare D1:
+
+```ts
+// src/server.ts
+import { RPCHandler } from '@orpc/server/fetch';
+import { router } from './api/index.js';
+import { db } from './db/client.js';
+
+const handler = new RPCHandler(router);
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const { response } = await handler.handle(request, { prefix: '/api', context: { db } });
+    return response ?? new Response('Not Found', { status: 404 });
+  },
+};
+```
+
+## The measured end to end
+
+The whole stack ran headless against PGlite: `call` from `@orpc/server` invokes a procedure the
+way the fetch handler would, middleware and both schemas included.
+
+```ts
+import { call } from '@orpc/server';
+import { users as usersRouter } from './api/users.js';
+
+const created = await call(
+  usersRouter.create,
+  { email: 'ada@example.com', name: 'Ada', bornOn: 'January 8, 1999' },
+  { context: { db } }
+);
+```
+
+What the run printed, quoted:
+
+```
+bad row: name: at most 40 characters
+router.create: {"id":1,"email":"ada@example.com","name":"Ada","bornOn":"1999-01-08",...}
+40-emoji name: schema accepts + database accepts
+```
+
+Three claims, each measured:
+
+- A 41-character `name` was refused by the input schema before any connection was used.
+- `bornOn: 'January 8, 1999'` sailed through the plain-string schema and **Postgres stored it**
+  as `1999-01-08`: the permissive date parser from the
+  [format-check grid](/generators/zod#why-numeric-is-the-only-format-checked), demonstrated in
+  one row.
+- A 40-emoji `name` passed the schema and the `varchar(40)` column both. An `n`-UTF-16-unit cap
+  would have refused it at 40 code points; the database would not have.
+
+For seeding and bulk inserts against either provider, the [seed page](/examples/seed) is
+written for exactly this dialect, including the measured 65,535 bind-parameter wire ceiling and
+the stricter PGlite ceiling its chunk arithmetic derives from.
+
+## Provider notes
+
+- **Pooling changes validation not at all.** Schemas run in your process; the pooler only sees
+  the resulting SQL. The one interaction that exists is the prepared-statements rule above.
+- **Auth tables.** If an auth library writes credential tables into the schema file DRZL reads,
+  exclude them before generating CRUD over them. The
+  [configuration page](/guide/configuration#auth-tables-in-particular) shows the exclusion and
+  why DRZL refuses to guess it for you.
+- **Migrations use the direct connection.** The Neon pooling docs say so outright, and the
+  Supabase connection docs list migrations under the direct connection's use cases. `drzl`
+  itself never connects to anything: it reads schema files.
+
+## Without drizzle-kit
+
+No drizzle-kit config to read? Name the schema in `drzl.config.ts` instead; everything else on
+this page is unchanged:
+
+```ts
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  schema: 'src/db/schema.ts',
+  outDir: 'src/api',
+  generators: [
+    { kind: 'zod', path: 'src/validators/zod' },
+    {
+      kind: 'service',
+      path: 'src/services',
+      dataAccess: 'drizzle',
+      schemaImportPath: 'src/db/schema',
+    },
+    {
+      kind: 'orpc',
+      template: '@drzl/template-orpc-service',
+      validation: { useShared: true, library: 'zod', importPath: '../validators/zod/index.js' },
+      databaseInjection: {
+        enabled: true,
+        databaseType: "import('drizzle-orm/postgres-js').PostgresJsDatabase",
+      },
+    },
+  ],
+});
+```
+
+::: tip Need something else?
+If this quickstart doesn't cover what you need, DM me on X (https://x.com/omardulaimidev) and we can scope it together.
+:::


### PR DESCRIPTION
Plan items 60, 61, 62: three provider quickstart pages under `docs/quickstarts/` with a sidebar group, in the measured-claims register of the RHF/TanStack/seed pages. The honesty rule is structural: every claim is measured on a faithful local stand-in, sourced from current provider docs with an inline citation, or absent; the not-executed set (hosted endpoints, `@planetscale/database` HTTP driver, the FK settings toggle, deployed Workers) is labeled exactly where each claim appears.

## The three pages

- **Supabase/Neon** (zod + service + oRPC with database injection): measured end to end on PGlite (bad rows refused before any connection; `bornOn: 'January 8, 1999'` stored as `1999-01-08`, tying to the zod format grid; 40 emoji through `varchar(40)` accepted by schema and database alike). Sourced with citations: Supabase 5432/6543 and "transaction mode does not support prepared statements" (hence `prepare: false`), Neon `-pooler` vs direct-for-migrations, the HTTP-vs-WebSocket serverless-driver split.
- **PlanetScale** (valibot with duplicateFinder + constraints, plus tRPC): measured on real MySQL 8.4.11 pushed through the same kit config with `drizzle-kit push`: 100 emoji in `tinytext` refused by the emitted byte cap ("at most 255 bytes") and by the server (ER_DATA_TOO_LONG) alike; `$returningId()` shown; orphan inserts failing 1452 with FKs on; the tRPC boundary refusal quoted. **PlanetScale FK truth per current docs: supported, opt-in per database via a settings toggle, unsharded environments only**, with the historical operating-without-FKs doc linked.
- **Cloudflare D1** (arktype + Hono, Worker mount with a filled create handler): SQLite semantics measured on better-sqlite3; the D1 API measured on miniflare's workerd (what `wrangler dev` runs): `db.transaction()` fails because drizzle's d1 session emits a raw `begin` (read from the installed dist), `db.batch` is atomic with rollback proven (0 rows after sabotage), the 100-parameter cap enforced at the exact 100/101 boundary and at 50/51 rows on the insert path, chunk+batch executed over 250 rows. Even `sqlite_version()` is refused by workerd, which the page uses to explain why it claims no D1 SQLite version.

All three pages showcase item 59's interop as the primary setup (`drizzleKit: true`, schema named once, the CLI's announce line quoted), each with a "Without drizzle-kit" alternative that the doc extractor lifts and runs.

## Gates

Extractor: 29 configs before, 32 after; `pnpm verify:packed` run twice, both exit 0, all three quickstart configs individually ok. Docs build green with dead-link check; full test suite green; every snippet ran or typechecked in scratch projects under strict/nodenext, Worker files against @cloudflare/workers-types. Docs-only, no changeset.

## Two master defects found while building (filed as addenda, deliberately not written around silently)

- **BN (Tier B)**: `@drzl/generator-service` emits `.returning()` unconditionally; drizzle's MySQL builders have none, so service output fails tsc against any MySQL schema. The PlanetScale page uses valibot+tRPC and states only measured facts meanwhile.
- **BO (Tier A)**: `int('x', { unsigned: true })` emits the signed int4 range, so select schemas refuse stored values in [2^31, 2^32-1]: the established read-path rejection class on a common column shape. The page schema avoids `unsigned` rather than documenting the gap as intended behavior.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
