### PR TITLE
fix: unsigned integer ranges across both majors (addendum BO, Tier A)

### DIFF
--- a/.changeset/bigint-in-literals.md
+++ b/.changeset/bigint-in-literals.md
@@ -1,0 +1,44 @@
+---
+'@drzl/analyzer': patch
+'@drzl/generator-zod': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-arktype': patch
+'@drzl/generator-typebox': patch
+'@drzl/generator-effect': patch
+'@drzl/generator-json-schema': patch
+---
+
+Unsigned integer columns get the range they actually hold
+
+`int('x', { unsigned: true })` emitted the signed range, `gte(-2147483648).lte(2147483647)`,
+so the select schema refused every stored value in [2^31, 2^32-1] on a column shape MySQL
+users reach for constantly. The whole family had the same defect, differently per major. On
+drizzle-orm 0.4x the flag lives only in `config.unsigned` and no range table read it, so every
+width kept its signed bounds and `serial`, unsigned by its own definition, had no bounds at
+all: an auto-increment column accepted -1. On drizzle v1 the `uint16`/`uint24`/`uint32`
+semantics had no arm and fell to the implicit-decimal path, `integer: false` with
++/-9999999999, and `uint64` fell back to the class table's signed int64 range, so
+`bigint({ mode: 'bigint', unsigned: true })` refused 18446744073709551615n, a value the driver
+really returns.
+
+The analyzer now answers every unsigned width on both majors with the type's own range:
+tinyint [0, 255], smallint [0, 65535], mediumint [0, 16777215], int [0, 4294967295], bigint in
+number mode [0, 9007199254740991], the safe-integer ceiling the number wire imposes, and
+bigint in bigint mode [0, 18446744073709551615], representable because the value is a bigint,
+which is how 18446744073709551615n lands in emitted literals. `serial` takes the number-mode
+answer with a BIGINT label on both majors. `bigint({ mode: 'string', unsigned: true })` stays
+the string the driver returns: v1 spells it `string uint64` and the string-mode arm keyed on
+`int64` alone. SingleStore ships the same builders and takes the same table, which also closes
+a signed gap: its tinyint and mediumint carried no range on 0.4x while v1 stated `int8` and
+`int24` for the same columns. Postgres and SQLite have no unsigned spelling and are untouched,
+asserted by test.
+
+Measured against a live MySQL 8.4.11 in STRICT_TRANS_TABLES: every ceiling stores and comes
+back, value for value, through mysql2 under both majors, and -1 and each ceiling plus one are
+refused with ER_WARN_DATA_OUT_OF_RANGE. A CHECK on an unsigned column still folds into the
+bound in its wire's spelling: `.gte(10).lte(4294967295)` on the number wire, `.gte(10n)` on
+the bigint wire. Official drizzle-zod, drizzle-valibot, drizzle-arktype and drizzle-typebox
+answer the same probes identically on both majors, so the fixed schemas agree with first-party
+behavior on every unsigned width, including the safe-integer ceiling for number mode and for
+serial. The JSON Schema generator also narrows its bigint pattern on unsigned columns, from
+`^-?\d+$` to `^\d+$`: the sign is the one half of the range a pattern can state exactly.

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -182,8 +182,10 @@ The same rules apply, with each dialect's own widths:
 | --------------------------------------- | ---------------------------------------------------------------- |
 | MySQL `tinyint()`                       | `z.number().int().gte(-128).lte(127)`                            |
 | MySQL `mediumint()`                     | `z.number().int().gte(-8388608).lte(8388607)`                    |
+| MySQL `int({ unsigned: true })`         | `z.number().int().gte(0).lte(4294967295)`, and every other width takes its own unsigned range the same way |
+| MySQL `bigint({ mode: 'bigint', unsigned: true })` | `z.bigint().gte(0n).lte(18446744073709551615n)`, the column's own ceiling, exactly |
 | MySQL `year()`                          | `z.number().int().gte(1901).lte(2155)`                           |
-| MySQL `serial()`                        | `z.number().int().gte(0)`, since it is unsigned                  |
+| MySQL `serial()`                        | `z.number().int().gte(0).lte(9007199254740991)`: `bigint unsigned` read as a number, so the safe-integer ceiling |
 | MySQL `text()`                          | a string capped at 65535 **bytes**, the width the type implies   |
 | MySQL `binary(4)`                       | a string, capped at 4 characters on select and 4 bytes on insert |
 | SQLite `blob({ mode: 'json' })`         | `z.json()`                                                       |

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -718,11 +718,15 @@ export function describeV1Column(column: any): Partial<Column> | null {
     case 'int8':
     case 'uint8':
     case 'int16':
+    case 'uint16':
     case 'int24':
+    case 'uint24':
     case 'int32':
+    case 'uint32':
     case 'int53':
     case 'uint53':
-    case 'int64': {
+    case 'int64':
+    case 'uint64': {
       // `numeric({ mode: 'bigint' })` is not an int64 column and v1 says it is: all four
       // dialects' bigint-mode classes carry `dataType: 'bigint int64'`, so a `numeric(20,0)` took
       // the range below and was labelled BIGINT with it. It is a NUMERIC column whose width is its
@@ -761,7 +765,11 @@ export function describeV1Column(column: any): Partial<Column> | null {
       // only on `mode === "number"`, so 0.4x has no string mode and a type-invalid
       // `mode: 'string'` silently builds the `PgBigInt64` bigint mode, which really does return
       // a bigint and keeps its class-map answer.
-      if (semantic === 'int64' && js === 'string') {
+      // `uint64` beside it because the flag moves the semantic too: `bigint({ mode: 'string',
+      // unsigned: true })` states `string uint64` on rc.4, measured off the real column, and
+      // keying the guard on `int64` alone sent the unsigned spelling into the integer arm below,
+      // which typed it `number` with the uint64 range: a wire the driver never uses in this mode.
+      if ((semantic === 'int64' || semantic === 'uint64') && js === 'string') {
         out.tsType = 'string';
         out.dbType = 'BIGINT';
         break;
@@ -781,33 +789,60 @@ export function describeV1Column(column: any): Partial<Column> | null {
       //
       // Unsigned, which is the whole difference from `int8` beside it: SQL Server's `tinyint`
       // holds 0 to 255 where MySQL's holds -128 to 127, and drizzle names the two accordingly.
-      // The only builder on any of the six v1 cores stating `uint8` is mssql's `tinyint`, swept
-      // over every builder each core exports.
+      // With every builder at its default config, the only one on any of the six v1 cores stating
+      // `uint8` is mssql's `tinyint`; `{ unsigned: true }` on a MySQL or SingleStore `tinyint`
+      // states it too, measured off real rc.4 columns.
+      //
+      // The other uint widths are `{ unsigned: true }` on MySQL and SingleStore, which moves the
+      // semantic half exactly as it moves the SQL type: `int32` becomes `uint32` the way `int`
+      // becomes `int unsigned`. Unhandled, they fell to the bare-number arm below, which treats a
+      // MySQL number with no declared precision as the implicit decimal(10,0): NUMERIC,
+      // `integer: false`, and a +/-9999999999 bound that takes -1, 1.5 and 4294967296 on a column
+      // that stores none of them. `uint64` fell further, all the way back to the class-name
+      // table's signed int64 range, so the select schema refused 18446744073709551615n on a row
+      // the driver returns.
+      //
+      // The unsigned ceilings are the type's, verified against a live MySQL 8.4.11: a `tinyint
+      // unsigned` stores 255 and refuses -1 and 256, an `int unsigned` stores 4294967295, and a
+      // `bigint unsigned` stores 18446744073709551615 and hands it back, as 18446744073709551615n
+      // in bigint mode. The two bigint modes keep different ceilings for the same reason the
+      // signed pair does: `uint53` arrives through `Number`, so the truthful ceiling is the
+      // safe-integer bound rather than the column's 2^64-1, which no double holds and bounding at
+      // would promise a precision that cannot survive the round trip. `uint64` is a bigint and
+      // the column's own edge is representable, so it is stated.
       const range = {
         int8: ['-128', '127'],
         uint8: ['0', '255'],
         int16: ['-32768', '32767'],
+        uint16: ['0', '65535'],
         int24: ['-8388608', '8388607'],
+        uint24: ['0', '16777215'],
         int32: ['-2147483648', '2147483647'],
+        uint32: ['0', '4294967295'],
         int53: ['-9007199254740991', '9007199254740991'],
         // MySQL `serial` is `bigint unsigned auto_increment`, so it starts at 0 rather than
-        // spanning the signed range.
+        // spanning the signed range. An explicit `bigint({ mode: 'number', unsigned: true })`
+        // states the same semantic and takes the same answer.
         uint53: ['0', '9007199254740991'],
         int64: ['-9223372036854775808', '9223372036854775807'],
+        uint64: ['0', '18446744073709551615'],
       }[semantic]!;
       [out.min, out.max] = range;
       out.integer = true;
       out.tsType = js === 'bigint' ? 'bigint' : 'number';
       out.dbType =
-        semantic === 'int8' || semantic === 'uint8'
-          ? 'TINYINT'
-          : semantic === 'int16'
-            ? 'SMALLINT'
-            : semantic === 'int24'
-              ? 'MEDIUMINT'
-              : semantic === 'int32'
-                ? 'INTEGER'
-                : 'BIGINT';
+        (
+          {
+            int8: 'TINYINT',
+            uint8: 'TINYINT',
+            int16: 'SMALLINT',
+            uint16: 'SMALLINT',
+            int24: 'MEDIUMINT',
+            uint24: 'MEDIUMINT',
+            int32: 'INTEGER',
+            uint32: 'INTEGER',
+          } as Record<string, string>
+        )[semantic] ?? 'BIGINT';
       break;
     }
     case 'year':
@@ -1701,6 +1736,12 @@ export class SchemaAnalyzer {
   private static readonly INT_RANGES: Record<string, [string, string]> = {
     // 8 bit
     MySqlTinyInt: ['-128', '127'],
+    // Absent until the unsigned fix swept the family: v1 states `number int8` for the same
+    // column, so the majors disagreed about every SingleStore tinyint. That is the shape the
+    // cross-major diff in `scripts/verify-packed.sh` exists to catch, and its fixture carries no
+    // SingleStore table, so unsigned-int-ranges.spec.ts holds these two classes across both
+    // majors instead. The width is the type's, the one `MySqlTinyInt` beside it already carries.
+    SingleStoreTinyInt: ['-128', '127'],
     SQLiteInteger: ['-9223372036854775808', '9223372036854775807'],
     // 16 bit
     PgSmallInt: ['-32768', '32767'],
@@ -1713,6 +1754,8 @@ export class SchemaAnalyzer {
     SingleStoreSmallInt: ['-32768', '32767'],
     // 24 bit
     MySqlMediumInt: ['-8388608', '8388607'],
+    // As SingleStoreTinyInt above: v1 states `number int24` and this table said nothing.
+    SingleStoreMediumInt: ['-8388608', '8388607'],
     // 32 bit
     PgInteger: ['-2147483648', '2147483647'],
     PgSerial: ['-2147483648', '2147483647'],
@@ -1728,6 +1771,61 @@ export class SchemaAnalyzer {
     PgBigSerial64: ['-9223372036854775808', '9223372036854775807'],
     MySqlBigInt64: ['-9223372036854775808', '9223372036854775807'],
     SingleStoreBigInt64: ['-9223372036854775808', '9223372036854775807'],
+    // MySQL and SingleStore `serial`, which is `bigint unsigned auto_increment`: unsigned by the
+    // builder's own definition, with no `config.unsigned` stating it, so the flag-keyed table
+    // below cannot answer and the range lives here. The mode is number, so the safe-integer
+    // ceiling rather than the column's, exactly as the 53 bit block above. The Postgres serials
+    // stay signed on purpose: a Postgres serial is a plain integer defaulting from a sequence,
+    // and the negative backfill note above applies to them and not to these. Before this entry
+    // the class was in no table at all, so an auto-increment column accepted -1 and the majors
+    // disagreed: v1 states `number uint53` for the same column and was already bounded.
+    MySqlSerial: ['0', '9007199254740991'],
+    SingleStoreSerial: ['0', '9007199254740991'],
+  };
+
+  /**
+   * The same widths with `{ unsigned: true }` set, which is the half the table above cannot see.
+   *
+   * On 0.4x the flag moves no class name: `int('x', { unsigned: true })` still builds a
+   * `MySqlInt`, and only `config.unsigned` and the ` unsigned` suffix on `getSQLType()` record
+   * the difference, measured off real 0.45.2 columns. So the table above answered every unsigned
+   * width with its signed range, and the emitted select schema refused every stored value in the
+   * upper half of the column: an `int unsigned` holding 4294967295 failed validation on a row the
+   * database returned, and the same one width up meant `bigint unsigned` refused
+   * 18446744073709551615n.
+   *
+   * The ceilings are the type's, verified against a live MySQL 8.4.11: 255, 65535, 16777215 and
+   * 4294967295 store and return, -1 and each ceiling plus one are refused with
+   * ER_WARN_DATA_OUT_OF_RANGE. The bigint pair keeps the two modes apart for the reason the
+   * signed pair above does: number mode tops out at the safe-integer bound the wire imposes,
+   * bigint mode at the column's own 2^64-1, which a bigint can spell. SingleStore is MySQL wire
+   * compatible, ships the same builders with the same `config.unsigned`, and v1 states the same
+   * `uintN` semantics for it, measured off real rc.4 columns; the entries keep the majors in
+   * agreement, which is what the cross-major diff in `scripts/verify-packed.sh` holds together.
+   *
+   * Keyed by class exactly like `INT_RANGES`, and consulted only when `config.unsigned` is
+   * `true`, so no Postgres or SQLite column can ever reach it: neither dialect has an unsigned
+   * spelling, neither builder accepts the flag, and no class of theirs is named here.
+   */
+  private static readonly UNSIGNED_INT_RANGES: Record<string, [string, string]> = {
+    // 8 bit
+    MySqlTinyInt: ['0', '255'],
+    SingleStoreTinyInt: ['0', '255'],
+    // 16 bit
+    MySqlSmallInt: ['0', '65535'],
+    SingleStoreSmallInt: ['0', '65535'],
+    // 24 bit
+    MySqlMediumInt: ['0', '16777215'],
+    SingleStoreMediumInt: ['0', '16777215'],
+    // 32 bit
+    MySqlInt: ['0', '4294967295'],
+    SingleStoreInt: ['0', '4294967295'],
+    // 53 bit, the JS safe-integer ceiling rather than the column's
+    MySqlBigInt53: ['0', '9007199254740991'],
+    SingleStoreBigInt53: ['0', '9007199254740991'],
+    // 64 bit, representable because the value is a bigint
+    MySqlBigInt64: ['0', '18446744073709551615'],
+    SingleStoreBigInt64: ['0', '18446744073709551615'],
   };
 
   /**
@@ -1858,7 +1956,15 @@ export class SchemaAnalyzer {
       out.maxLength = length;
     }
 
-    const range = SchemaAnalyzer.INT_RANGES[ctor];
+    // The unsigned table is asked first, because on 0.4x the flag moves no class name: a
+    // `MySqlInt` is the column either way and `config.unsigned` is the only thing that says
+    // which range it holds, measured off real 0.45.2 columns. v1 columns carry the same config,
+    // so this fires for them too, and it states the same range the `uintN` arm of
+    // `describeV1Column` computes from the semantic; unsigned-int-ranges.spec.ts runs both
+    // majors through the real analyzer to hold the two paths together.
+    const unsignedRange =
+      column?.config?.unsigned === true ? SchemaAnalyzer.UNSIGNED_INT_RANGES[ctor] : undefined;
+    const range = unsignedRange ?? SchemaAnalyzer.INT_RANGES[ctor];
     if (range) {
       [out.min, out.max] = range;
       out.integer = true;
@@ -2198,8 +2304,14 @@ export class SchemaAnalyzer {
           if (/Numeric|Float|Double|Real/i.test(ctor))
             return { tsType: 'number', dbType: 'NUMERIC' };
 
+          // `serial` is `bigint unsigned auto_increment`, so its label is BIGINT: the answer the
+          // v1 path already gives the same column from its `number uint53`, where the INTEGER arm
+          // below was the two majors disagreeing about a label. The range and the integer flag
+          // come from `INT_RANGES`, which names this class now.
+          if (/Serial/i.test(ctor)) return { tsType: 'number', dbType: 'BIGINT' };
+
           // Integer family
-          if (/Int|Serial|TinyInt|SmallInt|MediumInt/i.test(ctor))
+          if (/Int|TinyInt|SmallInt|MediumInt/i.test(ctor))
             return { tsType: 'number', dbType: 'INTEGER' };
 
           // Boolean
@@ -2244,8 +2356,12 @@ export class SchemaAnalyzer {
           if (/Numeric|Float|Double|Real/i.test(ctor))
             return { tsType: 'number', dbType: 'NUMERIC' };
 
+          // As the MySQL serial arm above: BIGINT is what its `bigint unsigned auto_increment`
+          // is, and what the v1 path answers for the same column.
+          if (/Serial/i.test(ctor)) return { tsType: 'number', dbType: 'BIGINT' };
+
           // Integer family
-          if (/Int|Serial|TinyInt|SmallInt|MediumInt/i.test(ctor))
+          if (/Int|TinyInt|SmallInt|MediumInt/i.test(ctor))
             return { tsType: 'number', dbType: 'INTEGER' };
 
           // Boolean

--- a/packages/analyzer/test/uncovered-dialects.spec.ts
+++ b/packages/analyzer/test/uncovered-dialects.spec.ts
@@ -192,18 +192,17 @@ describe('SingleStore, against a real singlestoreTable', () => {
     expect(warned).toEqual([]);
   });
 
-  it('DEFECT: leaves tinyint and mediumint unbounded, where MySQL bounds them', async () => {
-    // `INT_RANGES` carries `MySqlTinyInt` and `MySqlMediumInt` but has no SingleStore entry for
-    // either, so the identical column is bounded on one dialect and open on the other. Measured
-    // side by side in this same suite run: a MySQL `tinyint` comes back min '-128' max '127',
-    // and this one comes back with no bounds at all.
-    //
-    // Correct values are the same as MySQL's, since SingleStore's integer widths match.
+  it('bounds tinyint and mediumint by their width, exactly as MySQL is bounded', async () => {
+    // This was a pinned DEFECT: `INT_RANGES` carried `MySqlTinyInt` and `MySqlMediumInt` but had
+    // no SingleStore entry for either, so the identical column was bounded on one dialect and
+    // open on the other, and this test asserted the open bounds so the fix would report itself.
+    // It did: the unsigned-range fix swept the whole integer family and added the two entries,
+    // with the widths MySQL's identical columns already carried and v1 already stated as
+    // `number int8` and `number int24` for these same builders. unsigned-int-ranges.spec.ts
+    // holds the unsigned halves of the same classes.
     const { byName } = await columnsOf('real-singlestore', SINGLESTORE_SOURCE);
-    expect(byName.get('ti')?.min).toBeUndefined();
-    expect(byName.get('ti')?.max).toBeUndefined();
-    expect(byName.get('mi')?.min).toBeUndefined();
-    expect(byName.get('mi')?.max).toBeUndefined();
+    expect(byName.get('ti')).toMatchObject({ integer: true, min: '-128', max: '127' });
+    expect(byName.get('mi')).toMatchObject({ integer: true, min: '-8388608', max: '8388607' });
   });
 
   it('DEFECT: puts no cap on the text family, where MySQL caps it in bytes', async () => {

--- a/packages/analyzer/test/unsigned-int-ranges.spec.ts
+++ b/packages/analyzer/test/unsigned-int-ranges.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * `{ unsigned: true }` across the MySQL and SingleStore integer family, on both drizzle majors.
+ *
+ * The columns are built by the real builders rather than hand-modelled, because the defect this
+ * spec pins was invisible to every fixture that spelled its own column: no fixture in the repo
+ * carried an unsigned column at all, so the signed ranges looked universally correct.
+ *
+ * What each major actually states for an unsigned column, measured off real column objects:
+ *
+ *   0.45.2   the class name does not move (`MySqlInt` either way) and the flag lives only in
+ *            `config.unsigned`, plus `getSQLType()` growing an ` unsigned` suffix.
+ *   rc.4     the `dataType` semantic half moves: `int32` becomes `uint32`, `int64` becomes
+ *            `uint64`, and `bigint({ mode: 'string', unsigned: true })` states `string uint64`.
+ *            `serial` states `number uint53` with no `config.unsigned` at all, on both dialects.
+ *
+ * Before the fix, the class-name path answered every unsigned width with its signed range, so a
+ * select schema refused every stored value in the upper half of the column: an `int unsigned`
+ * holding 4294967295 failed validation on a row the database returned. On v1, `uint16`, `uint24`
+ * and `uint32` had no arm and fell to the bare-number arm, which treats a MySQL number with no
+ * declared precision as the implicit decimal(10,0): NUMERIC, `integer: false`, and a bound of
+ * +/-9999999999 that takes -1, 1.5 and 4294967296 alike. `uint64` had no arm either and fell all
+ * the way back to the class table's signed int64 range, which rejects 18446744073709551615n.
+ *
+ * The ranges below are the type's, from the MySQL manual and verified against a live MySQL 8.4.11
+ * (see the transcript in the fix's changeset review): tinyint unsigned stores 255 and refuses -1
+ * and 256, int unsigned stores 4294967295, bigint unsigned stores 18446744073709551615.
+ * SingleStore is MySQL wire compatible and its builders state the same widths.
+ *
+ * The two bigint modes stay apart on purpose, exactly as the signed ranges already do: in
+ * `{ mode: 'number' }` the value arrives through `Number`, so the truthful ceiling is the JS
+ * safe-integer bound rather than the column's 2^64-1, which no double can hold. In
+ * `{ mode: 'bigint' }` the value is a bigint and the column's own edge is representable.
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SchemaAnalyzer, type Column } from '../src/index';
+
+const dir = path.resolve(__dirname, 'fixtures');
+
+async function columnsOf(name: string, source: string): Promise<Map<string, Column>> {
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${name}.mjs`);
+  await fs.writeFile(file, source, 'utf8');
+  const analysis = await new SchemaAnalyzer(file).analyze({});
+  const table = analysis.tables[0];
+  expect(table, `no table analyzed: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  return new Map(table.columns.map((c) => [c.name, c]));
+}
+
+/** The integer family, unsigned and signed side by side, in one dialect's spelling. */
+const INT_FAMILY = (core: string, tableFn: string) => `
+  import { ${tableFn}, tinyint, smallint, mediumint, int, bigint, serial } from '${core}';
+  export const t = ${tableFn}('t', {
+    ti_u: tinyint('ti_u', { unsigned: true }),
+    si_u: smallint('si_u', { unsigned: true }),
+    mi_u: mediumint('mi_u', { unsigned: true }),
+    i_u: int('i_u', { unsigned: true }),
+    b53_u: bigint('b53_u', { mode: 'number', unsigned: true }),
+    b64_u: bigint('b64_u', { mode: 'bigint', unsigned: true }),
+    ser: serial('ser'),
+    ti_s: tinyint('ti_s'),
+    mi_s: mediumint('mi_s'),
+    i_s: int('i_s'),
+    b64_s: bigint('b64_s', { mode: 'bigint' }),
+  });
+`;
+
+const UNSIGNED: Record<string, [string, string]> = {
+  ti_u: ['0', '255'],
+  si_u: ['0', '65535'],
+  mi_u: ['0', '16777215'],
+  i_u: ['0', '4294967295'],
+  b53_u: ['0', '9007199254740991'],
+  b64_u: ['0', '18446744073709551615'],
+};
+
+function expectUnsignedFamily(cols: Map<string, Column>) {
+  for (const [name, [min, max]] of Object.entries(UNSIGNED)) {
+    expect(cols.get(name), name).toMatchObject({ integer: true, min, max });
+  }
+  expect(cols.get('b64_u')).toMatchObject({ tsType: 'bigint' });
+  // `serial` is `bigint unsigned auto_increment`: no `config.unsigned` states it, the builder
+  // itself does. Safe-integer ceiling, because the mode is number.
+  expect(cols.get('ser')).toMatchObject({
+    integer: true,
+    min: '0',
+    max: '9007199254740991',
+    dbType: 'BIGINT',
+  });
+  // The signed siblings hold their signed ranges, so the flag narrows only the column it is on.
+  expect(cols.get('ti_s')).toMatchObject({ min: '-128', max: '127' });
+  expect(cols.get('mi_s')).toMatchObject({ min: '-8388608', max: '8388607' });
+  expect(cols.get('i_s')).toMatchObject({ min: '-2147483648', max: '2147483647' });
+  expect(cols.get('b64_s')).toMatchObject({
+    min: '-9223372036854775808',
+    max: '9223372036854775807',
+  });
+}
+
+describe('MySQL unsigned integers on drizzle-orm 0.45.2, where only config.unsigned says so', () => {
+  it('bounds every width at the unsigned range the type holds', async () => {
+    expectUnsignedFamily(
+      await columnsOf('unsigned-mysql-045', INT_FAMILY('drizzle-orm/mysql-core', 'mysqlTable'))
+    );
+  });
+});
+
+describe('MySQL unsigned integers on drizzle v1, which states uintN outright', () => {
+  it('bounds every width at the unsigned range the type holds', async () => {
+    expectUnsignedFamily(
+      await columnsOf('unsigned-mysql-v1', INT_FAMILY('drizzle-orm-v1/mysql-core', 'mysqlTable'))
+    );
+  });
+
+  it('keeps the string mode a string when it is unsigned, as it already is signed', async () => {
+    // `bigint({ mode: 'string', unsigned: true })` states `string uint64`, measured on rc.4. The
+    // string-mode arm keyed on `int64` alone, so the unsigned spelling fell through to the
+    // integer arm and came back a number, which the driver never returns in this mode.
+    const cols = await columnsOf(
+      'unsigned-mysql-v1-str',
+      `
+        import { mysqlTable, bigint } from 'drizzle-orm-v1/mysql-core';
+        export const t = mysqlTable('t', {
+          bs_u: bigint('bs_u', { mode: 'string', unsigned: true }),
+        });
+      `
+    );
+    expect(cols.get('bs_u')).toMatchObject({ tsType: 'string', dbType: 'BIGINT' });
+    expect(cols.get('bs_u')?.min).toBeUndefined();
+    expect(cols.get('bs_u')?.max).toBeUndefined();
+  });
+});
+
+describe('SingleStore, whose builders state the same widths on both majors', () => {
+  it('bounds the unsigned family on 0.45.2', async () => {
+    expectUnsignedFamily(
+      await columnsOf(
+        'unsigned-ss-045',
+        INT_FAMILY('drizzle-orm/singlestore-core', 'singlestoreTable')
+      )
+    );
+  });
+
+  it('bounds the unsigned family on v1', async () => {
+    expectUnsignedFamily(
+      await columnsOf(
+        'unsigned-ss-v1',
+        INT_FAMILY('drizzle-orm-v1/singlestore-core', 'singlestoreTable')
+      )
+    );
+  });
+
+  it('gives the signed tinyint and mediumint the ranges v1 already states for them', async () => {
+    // These two classes were in no range table at all on 0.4x: v1 states `number int8` and
+    // `number int24` for the same columns, so the majors disagreed about every such column. The
+    // widths are the type's, the same ones `MySqlTinyInt` and `MySqlMediumInt` already carry.
+    const cols = await columnsOf(
+      'unsigned-ss-signed-045',
+      `
+        import { singlestoreTable, tinyint, mediumint } from 'drizzle-orm/singlestore-core';
+        export const t = singlestoreTable('t', {
+          ti_s: tinyint('ti_s'),
+          mi_s: mediumint('mi_s'),
+        });
+      `
+    );
+    expect(cols.get('ti_s')).toMatchObject({ integer: true, min: '-128', max: '127' });
+    expect(cols.get('mi_s')).toMatchObject({ integer: true, min: '-8388608', max: '8388607' });
+  });
+});
+
+describe('dialects with no unsigned keep their signed ranges', () => {
+  // Postgres and SQLite accept no `{ unsigned: true }` and state no `uintN`: nothing here may
+  // move. The serial is the column most at risk, since MySQL's serial fix keys on the class name.
+  const PG = (core: string) => `
+    import { pgTable, integer, smallint, bigint, serial } from '${core}';
+    export const t = pgTable('t', {
+      i: integer('i'),
+      si: smallint('si'),
+      b64: bigint('b64', { mode: 'bigint' }),
+      ser: serial('ser'),
+    });
+  `;
+
+  for (const [label, core] of [
+    ['0.45.2', 'drizzle-orm/pg-core'],
+    ['v1', 'drizzle-orm-v1/pg-core'],
+  ] as const) {
+    it(`leaves Postgres alone on ${label}`, async () => {
+      const cols = await columnsOf(`unsigned-pg-leak-${label.replace(/\./g, '')}`, PG(core));
+      expect(cols.get('i')).toMatchObject({ min: '-2147483648', max: '2147483647' });
+      expect(cols.get('si')).toMatchObject({ min: '-32768', max: '32767' });
+      expect(cols.get('b64')).toMatchObject({
+        min: '-9223372036854775808',
+        max: '9223372036854775807',
+      });
+      // A Postgres serial is a plain integer defaulting from a sequence, and negative values
+      // insert fine; only MySQL's serial is unsigned by definition.
+      expect(cols.get('ser')).toMatchObject({ min: '-2147483648', max: '2147483647' });
+    });
+  }
+
+  it('leaves SQLite alone on v1', async () => {
+    const cols = await columnsOf(
+      'unsigned-sqlite-leak-v1',
+      `
+        import { sqliteTable, integer } from 'drizzle-orm-v1/sqlite-core';
+        export const t = sqliteTable('t', { i: integer('i') });
+      `
+    );
+    expect(cols.get('i')).toMatchObject({ min: '-9007199254740991', max: '9007199254740991' });
+  });
+});

--- a/packages/generator-arktype/test/unsigned-int-ranges.spec.ts
+++ b/packages/generator-arktype/test/unsigned-int-ranges.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Unsigned MySQL integers on drizzle-orm 0.45.2, the major this package depends on and the one
+ * most users have installed: a real 0.4x table through the real analyzer and the real ArkType
+ * generator, with the emitted module imported and run.
+ *
+ * This is the read-path defect as the quickstarts hit it. On 0.4x the column class does not move
+ * when `{ unsigned: true }` is set, only `config.unsigned` does, and the class-name range table
+ * never read it, so `int('x', { unsigned: true })` emitted the signed int32 range and the select
+ * schema refused every stored value in [2^31, 2^32-1]. MySQL 8.4.11 stores 4294967295 in that
+ * column and hands it back; the schema called the row invalid. `serial` was worse: its class was
+ * in no range table at all, so an auto-increment column accepted -1.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { type } from 'arktype';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ArkTypeGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-unsigned-int-ranges');
+
+const SCHEMA = `
+  import { mysqlTable, tinyint, int, bigint, serial } from 'drizzle-orm/mysql-core';
+  export const t = mysqlTable('t', {
+    ti_u: tinyint('ti_u', { unsigned: true }).notNull(),
+    i_u: int('i_u', { unsigned: true }).notNull(),
+    b64_u: bigint('b64_u', { mode: 'bigint', unsigned: true }).notNull(),
+    ser: serial('ser'),
+  });
+`;
+
+let mod: Record<string, any>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  const schema = path.join(DIR, 'schema.mjs');
+  await fs.writeFile(schema, SCHEMA, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  expect(analysis.tables[0], `no table analyzed: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  await new ArkTypeGenerator(analysis).generate({ outDir: DIR } as never);
+  const emitted = path.join(DIR, `t-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 't.arktype.ts'), emitted);
+  mod = await import(emitted);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const ok = (schema: any, field: string, value: unknown) =>
+  !(schema.get(field)(value) instanceof type.errors);
+
+describe('the stored maximum comes back through the select schema', () => {
+  it('tinyint unsigned takes 255', () => {
+    expect(ok(mod.SelecttSchema, 'ti_u', 255)).toBe(true);
+    expect(ok(mod.SelecttSchema, 'ti_u', 256)).toBe(false);
+    expect(ok(mod.SelecttSchema, 'ti_u', -1)).toBe(false);
+  });
+
+  it('int unsigned takes 4294967295, the value the defect report stored', () => {
+    expect(ok(mod.SelecttSchema, 'i_u', 4294967295)).toBe(true);
+    expect(ok(mod.SelecttSchema, 'i_u', 0)).toBe(true);
+    expect(ok(mod.SelecttSchema, 'i_u', -1)).toBe(false);
+    expect(ok(mod.SelecttSchema, 'i_u', 4294967296)).toBe(false);
+  });
+
+  it('bigint unsigned in bigint mode takes 2^64-1 exactly', () => {
+    expect(ok(mod.SelecttSchema, 'b64_u', 18446744073709551615n)).toBe(true);
+    expect(ok(mod.SelecttSchema, 'b64_u', -1n)).toBe(false);
+    expect(ok(mod.SelecttSchema, 'b64_u', 18446744073709551616n)).toBe(false);
+  });
+
+  it('serial is bounded at last: zero up to the safe-integer ceiling', () => {
+    expect(ok(mod.SelecttSchema, 'ser', 1)).toBe(true);
+    expect(ok(mod.SelecttSchema, 'ser', 9007199254740991)).toBe(true);
+    expect(ok(mod.SelecttSchema, 'ser', -1)).toBe(false);
+  });
+});
+
+describe('the write direction of the same fact', () => {
+  it('the insert schema refuses -1 and takes the stored maximum', () => {
+    expect(ok(mod.InserttSchema, 'i_u', -1)).toBe(false);
+    expect(ok(mod.InserttSchema, 'i_u', 4294967295)).toBe(true);
+  });
+});

--- a/packages/generator-effect/test/unsigned-int-ranges.spec.ts
+++ b/packages/generator-effect/test/unsigned-int-ranges.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Unsigned MySQL integers, end to end: a real drizzle v1 table through the real analyzer and the
+ * real Effect generator, with the emitted module imported and whole rows pushed through it.
+ *
+ * The defect this pins, measured before the fix: the analyzer answered `int unsigned` with the
+ * implicit decimal(10,0), `integer: false` and +/-9999999999, so the emitted select schema took
+ * -1, 1.5 and 4294967296 on a column that stores none of them, and it answered
+ * `bigint({ mode: 'bigint', unsigned: true })` with the signed int64 range, so the select schema
+ * refused 18446744073709551615n, which MySQL 8.4.11 stores in a `bigint unsigned` and mysql2
+ * really returns.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { EffectGenerator } from '../src/index';
+import { accepts } from './fixtures';
+
+const DIR = path.join(__dirname, '.tmp-unsigned-int-ranges');
+
+const SCHEMA = `
+  import { mysqlTable, int, bigint, serial } from 'drizzle-orm-v1/mysql-core';
+  export const t = mysqlTable('t', {
+    i_u: int('i_u', { unsigned: true }).notNull(),
+    b64_u: bigint('b64_u', { mode: 'bigint', unsigned: true }).notNull(),
+    ser: serial('ser').notNull(),
+  });
+`;
+
+let mod: Record<string, any>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  const schema = path.join(DIR, 'schema.mjs');
+  await fs.writeFile(schema, SCHEMA, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  expect(analysis.tables[0], `no table analyzed: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  await new EffectGenerator(analysis).generate({ outDir: DIR } as never);
+  const emitted = path.join(DIR, `t-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 't.effect.ts'), emitted);
+  mod = await import(emitted);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+/** A row the fixed schema must accept whole: every column at its stored maximum. */
+const TOP = { i_u: 4294967295, b64_u: 18446744073709551615n, ser: 9007199254740991 };
+
+const selects = (over: Record<string, unknown>) => accepts(mod.SelecttSchema, { ...TOP, ...over });
+
+describe('the select schema, against what the column really stores', () => {
+  it('takes the row of stored maxima whole', () => {
+    expect(selects({})).toBe(true);
+    expect(selects({ i_u: 0, b64_u: 0n, ser: 0 })).toBe(true);
+  });
+
+  it('refuses what int unsigned cannot hold', () => {
+    expect(selects({ i_u: -1 }), 'below the unsigned floor').toBe(false);
+    expect(selects({ i_u: 4294967296 }), 'above the unsigned ceiling').toBe(false);
+    expect(selects({ i_u: 1.5 }), 'an integer column').toBe(false);
+  });
+
+  it('refuses what bigint unsigned cannot hold, in either direction', () => {
+    expect(selects({ b64_u: -1n })).toBe(false);
+    expect(selects({ b64_u: 18446744073709551616n })).toBe(false);
+    expect(selects({ b64_u: 4 }), 'a number never arrives on this wire').toBe(false);
+  });
+
+  it('starts the serial at zero', () => {
+    expect(selects({ ser: -1 })).toBe(false);
+  });
+});
+
+describe('the insert schema, which is the write half of the same fact', () => {
+  it('refuses -1 and takes the stored maximum', () => {
+    const withSer = (v: Record<string, unknown>) => ({ i_u: 1, b64_u: 1n, ...v });
+    expect(accepts(mod.InserttSchema, withSer({ i_u: -1 }))).toBe(false);
+    expect(accepts(mod.InserttSchema, withSer({ i_u: 4294967295 }))).toBe(true);
+  });
+});

--- a/packages/generator-json-schema/package.json
+++ b/packages/generator-json-schema/package.json
@@ -36,6 +36,7 @@
     "@seriousme/openapi-schema-validator": "^2.9.1",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
+    "drizzle-orm-v1": "npm:drizzle-orm@1.0.0-rc.4",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/packages/generator-json-schema/src/schemas.ts
+++ b/packages/generator-json-schema/src/schemas.ts
@@ -253,7 +253,16 @@ function baseSchema(
     case 'bigint':
       // `JSON.stringify` throws on a bigint, so in a JSON document this column is a string. The
       // pattern is what makes that string still mean an integer.
-      return { type: 'string', pattern: '^-?\\d+$' };
+      //
+      // The sign follows the column's floor: a `bigint unsigned` (min '0' from the analyzer)
+      // never holds a negative, and the sign is the one half of its range a pattern can state
+      // exactly, so '-1' stops validating there. Magnitude stays unstated in both spellings:
+      // neither 2^63-1 nor 2^64-1 survives a JSON number, which is why the column is a string in
+      // the first place.
+      return {
+        type: 'string',
+        pattern: typeof c.min === 'string' && !c.min.startsWith('-') ? '^\\d+$' : '^-?\\d+$',
+      };
     case 'boolean':
       return { type: 'boolean' };
     case 'Date':

--- a/packages/generator-json-schema/test/unsigned-int-ranges.spec.ts
+++ b/packages/generator-json-schema/test/unsigned-int-ranges.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Unsigned MySQL integers: a real drizzle v1 table through the real analyzer, the resulting
+ * documents compiled by ajv in strict mode and run against values.
+ *
+ * The defect this pins, measured before the fix: the analyzer answered `int unsigned` with the
+ * implicit decimal(10,0), `integer: false` and +/-9999999999, so the select document said
+ * `number` with those bounds and took -1, 1.5 and 4294967296 on a column that stores none of
+ * them.
+ *
+ * The bigint half is this format's own: a bigint column is a string in a JSON document, held to
+ * an integer by its pattern, and the pattern used to spell an optional minus sign whatever the
+ * column said. On an unsigned column the sign is the one thing the pattern can state exactly, so
+ * `^-?\d+$` narrows to `^\d+$` and '-1' stops validating. Magnitude stays unstated either way:
+ * neither 2^63-1 nor 2^64-1 survives a JSON number, which is why these columns are strings in
+ * the first place.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import { SchemaAnalyzer, type Table } from '@drzl/analyzer';
+import { tableSchemas } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-unsigned-int-ranges');
+
+const SCHEMA = `
+  import { mysqlTable, int, bigint, serial } from 'drizzle-orm-v1/mysql-core';
+  export const t = mysqlTable('t', {
+    i_u: int('i_u', { unsigned: true }).notNull(),
+    b64_u: bigint('b64_u', { mode: 'bigint', unsigned: true }).notNull(),
+    ser: serial('ser').notNull(),
+  });
+`;
+
+let table: Table;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  const schema = path.join(DIR, 'schema.mjs');
+  await fs.writeFile(schema, SCHEMA, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  expect(analysis.tables[0], `no table analyzed: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  table = analysis.tables[0];
+  await fs.rm(DIR, { recursive: true, force: true });
+}, 120_000);
+
+function compile(schema: unknown) {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  addFormats(ajv as never);
+  return ajv.compile(schema as never);
+}
+
+/** A row of stored maxima, spelled as JSON: the bigint arrives as a decimal string. */
+const TOP = { i_u: 4294967295, b64_u: '18446744073709551615', ser: 1 };
+
+describe('the select document, against what the column really stores', () => {
+  it('takes the row of stored maxima whole, under ajv strict mode', () => {
+    const ok = compile(tableSchemas(table).select);
+    expect(ok(TOP), JSON.stringify(ok.errors)).toBe(true);
+    expect(ok({ ...TOP, i_u: 0, b64_u: '0' })).toBe(true);
+  });
+
+  it('refuses what int unsigned cannot hold', () => {
+    const ok = compile(tableSchemas(table).select);
+    expect(ok({ ...TOP, i_u: -1 }), 'below the unsigned floor').toBe(false);
+    expect(ok({ ...TOP, i_u: 4294967296 }), 'above the unsigned ceiling').toBe(false);
+    expect(ok({ ...TOP, i_u: 1.5 }), 'an integer column').toBe(false);
+  });
+
+  it('drops the minus sign from the bigint pattern on an unsigned column', () => {
+    const ok = compile(tableSchemas(table).select);
+    expect(ok({ ...TOP, b64_u: '-1' })).toBe(false);
+    expect(ok({ ...TOP, b64_u: 'x' })).toBe(false);
+  });
+
+  it('starts the serial at zero', () => {
+    const ok = compile(tableSchemas(table).select);
+    expect(ok({ ...TOP, ser: -1 })).toBe(false);
+  });
+});
+
+describe('the insert document, which is the write half of the same fact', () => {
+  it('refuses -1 and takes the stored maximum', () => {
+    const ok = compile(tableSchemas(table).insert);
+    expect(ok({ i_u: -1, b64_u: '1' })).toBe(false);
+    expect(ok({ i_u: 4294967295, b64_u: '1' })).toBe(true);
+  });
+});

--- a/packages/generator-typebox/test/unsigned-int-ranges.spec.ts
+++ b/packages/generator-typebox/test/unsigned-int-ranges.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * Unsigned MySQL integers, end to end: a real drizzle v1 table through the real analyzer and the
+ * real TypeBox generator, with the emitted module imported and both checkers run: `Value.Check`
+ * and the compiler, whose preflight refuses schemas `Value.Check` would let slide.
+ *
+ * The defect this pins, measured before the fix: the analyzer answered `int unsigned` with the
+ * implicit decimal(10,0), `integer: false` and +/-9999999999, so the emitted select schema took
+ * -1, 1.5 and 4294967296 on a column that stores none of them, and it answered
+ * `bigint({ mode: 'bigint', unsigned: true })` with the signed int64 range, so the select schema
+ * refused 18446744073709551615n, which MySQL 8.4.11 stores in a `bigint unsigned` and mysql2
+ * really returns.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { TypeBoxGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-unsigned-int-ranges');
+
+const SCHEMA = `
+  import { mysqlTable, int, bigint, serial } from 'drizzle-orm-v1/mysql-core';
+  export const t = mysqlTable('t', {
+    i_u: int('i_u', { unsigned: true }).notNull(),
+    b64_u: bigint('b64_u', { mode: 'bigint', unsigned: true }).notNull(),
+    ser: serial('ser'),
+  });
+`;
+
+let mod: Record<string, any>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  const schema = path.join(DIR, 'schema.mjs');
+  await fs.writeFile(schema, SCHEMA, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  expect(analysis.tables[0], `no table analyzed: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  await new TypeBoxGenerator(analysis).generate({ outDir: DIR } as never);
+  const emitted = path.join(DIR, `t-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 't.typebox.ts'), emitted);
+  mod = await import(emitted);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+/** Both checkers must agree, so a bound the compiler preflight rejects cannot hide. */
+const ok = (schema: any, value: unknown) => {
+  const plain = Value.Check(schema, value);
+  const compiled = TypeCompiler.Compile(schema).Check(value);
+  expect(compiled, 'Value.Check and TypeCompiler disagree').toBe(plain);
+  return plain;
+};
+
+describe('int unsigned, on the select path', () => {
+  it('takes every value the column stores, to the top', () => {
+    const s = mod.SelecttSchema.properties.i_u;
+    expect(ok(s, 0)).toBe(true);
+    expect(ok(s, 4294967295), 'the stored maximum of an int unsigned').toBe(true);
+  });
+
+  it('refuses what the column cannot hold', () => {
+    const s = mod.SelecttSchema.properties.i_u;
+    expect(ok(s, -1), 'below the unsigned floor').toBe(false);
+    expect(ok(s, 4294967296), 'above the unsigned ceiling').toBe(false);
+    expect(ok(s, 1.5), 'an integer column').toBe(false);
+  });
+
+  it('refuses -1 on insert too, which is the write half of the same fact', () => {
+    const s = mod.InserttSchema.properties.i_u;
+    expect(ok(s, -1)).toBe(false);
+    expect(ok(s, 4294967295)).toBe(true);
+  });
+});
+
+describe('bigint unsigned in bigint mode, whose ceiling a bigint can spell exactly', () => {
+  it('takes the stored maximum back and refuses beyond either edge', () => {
+    const s = mod.SelecttSchema.properties.b64_u;
+    expect(ok(s, 0n)).toBe(true);
+    expect(ok(s, 18446744073709551615n), 'the stored maximum, 2^64-1').toBe(true);
+    expect(ok(s, -1n)).toBe(false);
+    expect(Value.Check(s, 18446744073709551616n)).toBe(false);
+    expect(ok(s, 4), 'a number never arrives on this wire').toBe(false);
+  });
+
+  it('pins the one probe the two checkers split on, so a TypeBox fix reports itself', () => {
+    // TypeCompiler 0.34.52 renders a bigint bound as `BigInt(<number literal>)`, measured with
+    // `TypeCompiler.Code`: the ceiling here compiles to `value <= BigInt(18446744073709551615)`,
+    // and that number literal is a double that rounds up to 2^64, so the compiled checker takes
+    // 18446744073709551616n where `Value.Check`, comparing against the schema's own bigint,
+    // refuses it. Not this generator's emission and not new with unsigned: the signed ceiling
+    // compiles to `BigInt(9223372036854775807)` and rounds to 2^63 the same way, measured on the
+    // same installed TypeBox before this fix existed. When a TypeBox release makes this
+    // expectation fail, the pin has done its job: delete it and fold the probe into `ok` above.
+    const s = mod.SelecttSchema.properties.b64_u;
+    expect(Value.Check(s, 18446744073709551616n)).toBe(false);
+    expect(TypeCompiler.Compile(s).Check(18446744073709551616n)).toBe(true);
+  });
+});
+
+describe('serial, which is bigint unsigned auto_increment under a shorter name', () => {
+  it('starts at zero and stops at the safe-integer ceiling its number mode imposes', () => {
+    const s = mod.SelecttSchema.properties.ser;
+    expect(ok(s, 1)).toBe(true);
+    expect(ok(s, 9007199254740991)).toBe(true);
+    expect(ok(s, -1)).toBe(false);
+  });
+});

--- a/packages/generator-valibot/package.json
+++ b/packages/generator-valibot/package.json
@@ -33,6 +33,7 @@
     "@drzl/validation-core": "workspace:^"
   },
   "devDependencies": {
+    "drizzle-orm-v1": "npm:drizzle-orm@1.0.0-rc.4",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "valibot": "^1.1.0"

--- a/packages/generator-valibot/test/unsigned-int-ranges.spec.ts
+++ b/packages/generator-valibot/test/unsigned-int-ranges.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Unsigned MySQL integers, end to end: a real drizzle v1 table through the real analyzer and the
+ * real valibot generator, with the emitted module imported and run.
+ *
+ * The defect this pins, measured before the fix: the analyzer answered `int unsigned` with the
+ * implicit decimal(10,0), `integer: false` and +/-9999999999, so the emitted select schema took
+ * -1, 1.5 and 4294967296 on a column that stores none of them, and it answered
+ * `bigint({ mode: 'bigint', unsigned: true })` with the signed int64 range, so the select schema
+ * refused 18446744073709551615n, which MySQL 8.4.11 stores in a `bigint unsigned` and mysql2
+ * really returns.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import * as v from 'valibot';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ValibotGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-unsigned-int-ranges');
+
+const SCHEMA = `
+  import { mysqlTable, int, bigint, serial } from 'drizzle-orm-v1/mysql-core';
+  export const t = mysqlTable('t', {
+    i_u: int('i_u', { unsigned: true }).notNull(),
+    b64_u: bigint('b64_u', { mode: 'bigint', unsigned: true }).notNull(),
+    ser: serial('ser'),
+  });
+`;
+
+let mod: Record<string, any>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  const schema = path.join(DIR, 'schema.mjs');
+  await fs.writeFile(schema, SCHEMA, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  expect(analysis.tables[0], `no table analyzed: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  await new ValibotGenerator(analysis).generate({ outDir: DIR } as never);
+  const emitted = path.join(DIR, `t-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 't.valibot.ts'), emitted);
+  mod = await import(emitted);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const ok = (schema: any, value: unknown) => v.safeParse(schema, value).success;
+
+describe('int unsigned, on the select path', () => {
+  it('takes every value the column stores, to the top', () => {
+    const s = mod.SelecttSchema.entries.i_u;
+    expect(ok(s, 0)).toBe(true);
+    expect(ok(s, 4294967295), 'the stored maximum of an int unsigned').toBe(true);
+  });
+
+  it('refuses what the column cannot hold', () => {
+    const s = mod.SelecttSchema.entries.i_u;
+    expect(ok(s, -1), 'below the unsigned floor').toBe(false);
+    expect(ok(s, 4294967296), 'above the unsigned ceiling').toBe(false);
+    expect(ok(s, 1.5), 'an integer column').toBe(false);
+  });
+
+  it('refuses -1 on insert too, which is the write half of the same fact', () => {
+    const s = mod.InserttSchema.entries.i_u;
+    expect(ok(s, -1)).toBe(false);
+    expect(ok(s, 4294967295)).toBe(true);
+  });
+});
+
+describe('bigint unsigned in bigint mode, whose ceiling a bigint can spell exactly', () => {
+  it('takes the stored maximum back and refuses beyond either edge', () => {
+    const s = mod.SelecttSchema.entries.b64_u;
+    expect(ok(s, 0n)).toBe(true);
+    expect(ok(s, 18446744073709551615n), 'the stored maximum, 2^64-1').toBe(true);
+    expect(ok(s, -1n)).toBe(false);
+    expect(ok(s, 18446744073709551616n)).toBe(false);
+    expect(ok(s, 4), 'a number never arrives on this wire').toBe(false);
+  });
+});
+
+describe('serial, which is bigint unsigned auto_increment under a shorter name', () => {
+  it('starts at zero and stops at the safe-integer ceiling its number mode imposes', () => {
+    const s = mod.SelecttSchema.entries.ser;
+    expect(ok(s, 1)).toBe(true);
+    expect(ok(s, 9007199254740991)).toBe(true);
+    expect(ok(s, -1)).toBe(false);
+  });
+});

--- a/packages/generator-zod/test/unsigned-int-ranges.spec.ts
+++ b/packages/generator-zod/test/unsigned-int-ranges.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Unsigned MySQL integers, end to end: a real drizzle v1 table through the real analyzer and the
+ * real zod generator, with the emitted module imported and run.
+ *
+ * The read-path defect this pins: `int('x', { unsigned: true })` used to come back from the
+ * analyzer as the implicit decimal(10,0), `integer: false` with a +/-9999999999 bound, so the
+ * select schema took -1, 1.5 and 4294967296 on a column that stores none of them. And
+ * `bigint({ mode: 'bigint', unsigned: true })` fell back to the signed int64 range, so the select
+ * schema refused 18446744073709551615n, a value the driver really returns: MySQL 8.4.11 stores
+ * 2^64-1 in a `bigint unsigned` and mysql2 hands it back, `1.8446744073709551615e19` only to a
+ * schema that rejects it.
+ *
+ * The CHECK columns prove the wire machinery is unmoved by unsignedness: an unsigned int is still
+ * a number wire and an unsigned bigint in bigint mode is still a bigint wire, so a CHECK literal
+ * folds into the bound in the wire's own spelling, `10` on the one and `10n` on the other, with
+ * the unsigned ceiling standing beside it.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ZodGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-unsigned-int-ranges');
+
+const SCHEMA = `
+  import { mysqlTable, int, bigint, serial, check } from 'drizzle-orm-v1/mysql-core';
+  import { sql } from 'drizzle-orm-v1';
+  export const t = mysqlTable('t', {
+    i_u: int('i_u', { unsigned: true }).notNull(),
+    b64_u: bigint('b64_u', { mode: 'bigint', unsigned: true }).notNull(),
+    ser: serial('ser'),
+    i_c: int('i_c', { unsigned: true }).notNull(),
+    b64_c: bigint('b64_c', { mode: 'bigint', unsigned: true }).notNull(),
+  }, (t) => [
+    check('i_c_floor', sql\`\${t.i_c} >= 10\`),
+    check('b64_c_floor', sql\`\${t.b64_c} >= 10\`),
+  ]);
+`;
+
+let mod: Record<string, any>;
+let text: string;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  const schema = path.join(DIR, 'schema.mjs');
+  await fs.writeFile(schema, SCHEMA, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  expect(analysis.tables[0], `no table analyzed: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
+  await new ZodGenerator(analysis).generate({ outDir: DIR } as never);
+  text = await fs.readFile(path.join(DIR, 't.zod.ts'), 'utf8');
+  const emitted = path.join(DIR, `t-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 't.zod.ts'), emitted);
+  mod = await import(emitted);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const accepts = (schema: any, v: unknown) => schema.safeParse(v).success;
+
+describe('int unsigned, on the select path', () => {
+  it('takes every value the column stores, to the top', () => {
+    const s = mod.SelecttSchema.shape.i_u;
+    expect(accepts(s, 0)).toBe(true);
+    expect(accepts(s, 4294967295), 'the stored maximum of an int unsigned').toBe(true);
+  });
+
+  it('refuses what the column cannot hold', () => {
+    const s = mod.SelecttSchema.shape.i_u;
+    expect(accepts(s, -1), 'below the unsigned floor').toBe(false);
+    expect(accepts(s, 4294967296), 'above the unsigned ceiling').toBe(false);
+    expect(accepts(s, 1.5), 'an integer column').toBe(false);
+  });
+
+  it('refuses -1 on insert too, which is the write half of the same fact', () => {
+    const s = mod.InserttSchema.shape.i_u;
+    expect(accepts(s, -1)).toBe(false);
+    expect(accepts(s, 4294967295)).toBe(true);
+  });
+});
+
+describe('bigint unsigned in bigint mode, whose ceiling a bigint can spell exactly', () => {
+  it('takes the stored maximum back', () => {
+    const s = mod.SelecttSchema.shape.b64_u;
+    expect(accepts(s, 0n)).toBe(true);
+    expect(accepts(s, 18446744073709551615n), 'the stored maximum, 2^64-1').toBe(true);
+  });
+
+  it('refuses beyond either edge, and the wrong wire type', () => {
+    const s = mod.SelecttSchema.shape.b64_u;
+    expect(accepts(s, -1n)).toBe(false);
+    expect(accepts(s, 18446744073709551616n)).toBe(false);
+    expect(accepts(s, 4), 'a number never arrives on this wire').toBe(false);
+  });
+});
+
+describe('serial, which is bigint unsigned auto_increment under a shorter name', () => {
+  it('starts at zero and stops at the safe-integer ceiling its number mode imposes', () => {
+    const s = mod.SelecttSchema.shape.ser;
+    expect(accepts(s, 1)).toBe(true);
+    expect(accepts(s, 9007199254740991)).toBe(true);
+    expect(accepts(s, -1)).toBe(false);
+  });
+});
+
+describe('a CHECK on an unsigned column still lands on its wire', () => {
+  it('folds the number literal into the bound beside the unsigned ceiling', () => {
+    expect(text).toContain('.gte(10).lte(4294967295)');
+    const s = mod.SelecttSchema.shape.i_c;
+    expect(accepts(s, 10)).toBe(true);
+    expect(accepts(s, 9), 'the CHECK floor replaced the type floor').toBe(false);
+    expect(accepts(s, 4294967296)).toBe(false);
+  });
+
+  it('spells the literal 10n on the bigint wire, with the unsigned ceiling beside it', () => {
+    expect(text).toContain('.gte(10n).lte(18446744073709551615n)');
+    const s = mod.SelecttSchema.shape.b64_c;
+    expect(accepts(s, 10n)).toBe(true);
+    expect(accepts(s, 9n)).toBe(false);
+    expect(accepts(s, 18446744073709551615n)).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,9 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.20.0)
+      drizzle-orm-v1:
+        specifier: npm:drizzle-orm@1.0.0-rc.4
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(effect@3.22.1)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -505,6 +508,9 @@ importers:
         specifier: workspace:^
         version: link:../validation-core
     devDependencies:
+      drizzle-orm-v1:
+        specifier: npm:drizzle-orm@1.0.0-rc.4
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(effect@3.22.1)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.6)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0)

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -7801,17 +7801,6 @@ const DEFECTS: Record<string, Entry> = {
   // zod's `.int()` refuses a number outside the safe-integer range on its own, so zod reaches
   // official's answer for 9007199254740993 without the bound DRZL failed to emit. The other three
   // have no such rule and take it.
-  'mysql/m_serial': {
-    libs: LIB_NAMES,
-    modes: MODE_NAMES,
-    divergence: {
-      '*/zod': `L: -1 | T: `,
-      '*/valibot,arktype,typebox': `L: -1, 9007199254740993, 3.4028235e38 | T: `,
-    },
-    drzl: 'an unbounded integer, so it takes -1 for an auto-increment column',
-    official: 'an integer within 0..9007199254740991',
-    filed: 'new',
-  },
   'mysql/m_year': {
     libs: LIB_NAMES,
     modes: MODE_NAMES,


### PR DESCRIPTION
Fixes plan addendum BO (Tier A): `int({ unsigned: true })` emitted the signed int4 range, so select schemas refused stored values in [2^31, 2^32-1]. The measured surface was wider than the filing on both majors: 0.4x gave **every** unsigned width its signed range and `serial` no range at all (the gate's pinned `mysql/m_serial` defect), while v1's `uint16/24/32` fell into the bare-number arm as implicit decimal(10,0) (NUMERIC, non-integer, +/-9999999999 bounds) and `uint64` returned null, so `bigint({ mode: 'bigint', unsigned: true })` refused its own stored maximum `18446744073709551615n`.

## What landed

- Ranges per width on MySQL and SingleStore, both majors: tinyint [0,255], smallint [0,65535], mediumint [0,16777215], int [0,4294967295], bigint mode bigint [0,2^64-1], serial and bigint mode number [0,9007199254740991]. SingleStore's tinyint/mediumint were additionally missing **signed** ranges on 0.4x; fixed in the same pass. Postgres and SQLite leak nothing (asserted by tests).
- **The bigint-mode-number decision, database as tiebreak**: a stored 2^64-1 read in number mode returns `18446744073709552000` (a rounded double) through mysql2 under BOTH majors, so above 2^53 the wire does not carry the stored value and no bound can make it honest. All seven measurable official validators bound this mode to the safe-integer ceiling; DRZL now matches, and the small-value round trip proves the ceiling refuses only what the wire already corrupts.
- json-schema: bigint pattern tightens to `^\d+$` when the minimum is non-negative.

## Verification

- Red-first: 29 failing tests across 7 new spec files (analyzer + all six validator generators, v1 end-to-end through real tables and executed emitted modules; arktype covers the 0.4x headline surface). All 20 packages green after.
- MySQL 8.4.11 ground truth: every ceiling stored via exact decimal literals and read back exact; all ten refusal probes (-1 and ceiling+1 per width) fail ER_WARN_DATA_OUT_OF_RANGE; the fixed select schema accepts every returned row, the insert schema refuses -1. Pre-existing symmetric caveat recorded: 0.45.2 over a default mysql2 connection rounds both bigint maxima; rc.4 is exact.
- Officials (four 0.4x packages + three importable rc.4 modules) answer every probe identically to fixed DRZL: **no new ALLOWED lines**.
- CHECK interaction: wire classification unchanged; a CHECK literal on unsigned columns lands per wire (`.gte(10).lte(4294967295)` and `.gte(10n).lte(18446744073709551615n)`, evaluated).
- Fixture sweep: no unsigned column existed anywhere (total-absence blind spot); one pinned DEFECT test (`uncovered-dialects.spec.ts` SingleStore unbounded tinyint/mediumint) died as designed and was converted to assert the fixed bounds.

## The ledger working as designed (controller edit in this PR)

The fix made DRZL's `m_serial` emission byte-identical to official drizzle-zod, so the gate failed with `DEFECTS[mysql/m_serial] suppressed nothing on this run`: the fix reported itself. This PR deletes that 11-line entry; the agent validated the exact deletion on a scratch copy running the FULL gate with MYSQL_URL to exit 0 ("rows MySQL rejects and DRZL accepts: 0", 0.4x defect count 7 to 6).

## Filed for the gate-extension batch (BM)

Zero unsigned columns exist in any gate fixture and the value pools carry no unsigned edges; suggested additions with predicted-parity measurements are in the agent report (an `int unsigned` and a `bigint unsigned` column plus pool values 4294967295/4294967296 and the 2^64 boundary bigints). Also pinned: TypeBox 0.34.52's compiled checker renders bigint bounds via `BigInt(<number literal>)` and accepts 2^64 against a 2^64-1 ceiling (`Value.Check` is exact), so an upstream TypeBox fix reports itself.

Changeset: patch for analyzer and all six validator generators.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
