### PR TITLE
fix: dialect-aware service emission for MySQL and SingleStore (addendum BN)

### DIFF
--- a/.changeset/service-mysql-returning.md
+++ b/.changeset/service-mysql-returning.md
@@ -1,0 +1,23 @@
+---
+'@drzl/generator-service': patch
+---
+
+MySQL and SingleStore services stop calling RETURNING the dialect does not have
+
+`dataAccess: 'drizzle'` emitted `.returning()` unconditionally, and drizzle's MySQL and
+SingleStore insert/update builders have no such method on either major (0.45.2 and 1.0.0-rc.4,
+measured), so the emitted service failed tsc against every schema of these dialects: the whole
+dialect was unusable. The emission now keys on the dialect the analyzer already records and
+emits what the dialect really offers, measured on MySQL 8.4.11 through mysql2 identically on
+both majors: create inserts through `$returningId()`, which reports AUTO_INCREMENT and
+`$defaultFn` keys as `[{ id }]` and nothing for a caller-supplied key, where the input already
+carries the value, then reads the created row back by that key; update writes and reads the row
+back (awaiting the builder yields `[ResultSetHeader, ...]`, never rows); delete never used
+RETURNING and is unchanged. Method signatures are identical across dialects, so routers built
+on these services do not change. A `generatedAlwaysAs` primary key is the one shape the dialect
+cannot round-trip, and create for such a table throws with an explanation instead of returning
+undefined. Postgres, SQLite, stub and unknown-dialect output is byte-identical to before,
+proved by generating both from the same analyses and diffing. Red-first: 12 failing tests (tsc
+red on both majors plus a runtime TypeError through the emitted service), green after, with the
+runtime contract asserted against a real MySQL 8.4.11 and the sqlite emission proved healthy
+against a real better-sqlite3 on both majors.

--- a/docs/generators/service.md
+++ b/docs/generators/service.md
@@ -79,6 +79,35 @@ export default defineConfig({
 
 Stubs return sample values for quick prototyping.
 
+## MySQL and SingleStore
+
+These dialects have no `RETURNING`, and drizzle's MySQL and SingleStore builders have no
+`.returning()` method, so `dataAccess: 'drizzle'` emits a different body for them. The dialect
+comes from the analyzed schema; you configure nothing. Method signatures are identical to every
+other dialect. The behavior is measured on MySQL 8.4.11 through mysql2, identically on
+drizzle-orm 0.45.x and 1.0.0 rc:
+
+- `create` inserts through drizzle's `$returningId()`, which reports an `AUTO_INCREMENT` or
+  `$defaultFn` primary key as `[{ id }]`; a caller-supplied key it reports nothing for, and the
+  input already carries the value. Either way the created row is then read back by that key and
+  returned, so `create` still resolves to the full row.
+- `update` writes, then reads the row back by its key and returns it.
+- `delete` is unchanged; it never used `RETURNING` on any dialect.
+
+Two divergences from the `RETURNING` dialects are worth knowing:
+
+- `create` and `update` are two statements here (write, then read back) with no transaction
+  around them, where Postgres and SQLite do one atomic statement. If another writer can race you
+  on the same key, wrap the call in `db.transaction`.
+- A `generatedAlwaysAs(...)` primary key cannot be round-tripped at all: the database computes
+  the key and reports nothing back. `create` for such a table throws with an explanation; every
+  other method works.
+
+One corner degrades quietly: a primary key whose default is computed in SQL, such as
+``.default(sql`(uuid())`)``, is reported by neither `$returningId()` nor the input, so `create`
+inserts the row and resolves to `undefined`. Use `$defaultFn` when a generated key must come
+back from `create`.
+
 ## Generated Output License
 
 - You own the generated output. DRZL grants you a worldwide, royalty‑free, irrevocable license to use, copy, modify, and distribute the generated files under your project’s license.

--- a/packages/generator-service/package.json
+++ b/packages/generator-service/package.json
@@ -33,6 +33,11 @@
     "@drzl/validation-core": "workspace:^"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^12.2.0",
+    "drizzle-orm": "^0.45.2",
+    "drizzle-orm-v1": "npm:drizzle-orm@1.0.0-rc.4",
+    "mysql2": "^3.23.2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/packages/generator-service/src/index.ts
+++ b/packages/generator-service/src/index.ts
@@ -107,13 +107,110 @@ function renderTypes(table: Table) {
   return `export interface Insert${T} {\n${insertFields}\n}\nexport interface Update${T} {\n${updateFields}\n}\nexport interface Select${T} {\n${selectFields}\n}`;
 }
 
+/**
+ * The drizzle-mode service for a dialect with no RETURNING: MySQL and SingleStore, whose
+ * insert/update/delete builders have no `.returning()` on either drizzle major, so the pg
+ * emission fails tsc against every schema of these dialects.
+ *
+ * What replaces it is measured on MySQL 8.4.11 through mysql2, identically on drizzle-orm
+ * 0.45.2 and 1.0.0-rc.4:
+ *
+ * - `insert(...).$returningId()` runs the same single INSERT and reports the primary key as
+ *   `[{ <pk>: value }]` per row when drizzle can know the value: an AUTO_INCREMENT key
+ *   (derived from the result packet's insertId) or a `$defaultFn` key (generated client
+ *   side). For a caller-supplied key, a SQL-side `.default(...)` key and a composite key it
+ *   reports `[]`, and its declared result type omits those columns, which is why create
+ *   falls back to the key already in the input rather than reading it off the result.
+ * - awaiting `update(...)` or `delete(...)` yields `[ResultSetHeader, ...]` (affectedRows and
+ *   friends), never rows, so update writes and then reads the row back by its key. delete
+ *   never used RETURNING on any dialect and keeps its shape.
+ *
+ * The method signatures are exactly the ones every other dialect gets. The divergence is
+ * behavioral: create and update are two statements here (write, then read back) with no
+ * transaction around them, where RETURNING dialects do one atomic statement.
+ *
+ * A database-generated primary key (`generatedAlwaysAs`) is the one shape this dialect cannot
+ * round-trip: the database computes the key and reports nothing, and the input does not carry
+ * it, so create throws with an explanation instead of emitting a lookup that quietly returns
+ * undefined.
+ */
+function renderNoReturningDrizzleService(args: {
+  table: Table;
+  dialect: Analysis['dialect'];
+  Service: string;
+  pk: string;
+  schemaImportPath: string;
+  dbImportPath?: string;
+  typeImport: string;
+  dbType: string;
+  injection: boolean;
+}) {
+  const { table, dialect, Service, pk, schemaImportPath, dbImportPath, typeImport, dbType } =
+    args;
+  const T = table.tsName;
+  const pkCol = table.columns.find((c: Column) => c.name === pk);
+  const dbParam = args.injection ? `db: ${dbType}, ` : '';
+  const dbParamOnly = args.injection ? `db: ${dbType}` : '';
+  const head = args.injection
+    ? `import { ${T} } from '${schemaImportPath}';\nimport { eq } from 'drizzle-orm';\n${typeImport}\n`
+    : `import { db } from '${dbImportPath}';\nimport { ${T} } from '${schemaImportPath}';\nimport { eq } from 'drizzle-orm';\n`;
+
+  const create = pkCol?.isGenerated
+    ? `  static async create(${dbParam}input: Insert${T}): Promise<Select${T}> {
+    // ${pk} is database-generated and ${dialect} has no RETURNING, so the created row cannot
+    // be read back by its key. Insert directly and select by a column you know.
+    ${args.injection ? 'void db;\n    void input;' : 'void input;'}
+    throw new Error(
+      '${Service}.create is not supported on ${dialect}: primary key ${T}.${pk} is database-generated and cannot be read back without RETURNING'
+    );
+  }`
+    : `  static async create(${dbParam}input: Insert${T}): Promise<Select${T}> {
+    // No RETURNING on ${dialect}. $returningId() reports AUTO_INCREMENT and $defaultFn keys as
+    // [{ ${pk} }]; for a caller-supplied key it reports nothing and the input already carries
+    // the value. Either way the created row is then read back by that key.
+    const ids = (await db.insert(${T}).values(input).$returningId()) as Array<{ ${pk}: Select${T}['${pk}'] }>;
+    const key = ids[0] ? ids[0].${pk} : (input as Select${T}).${pk};
+    const rows = await db.select().from(${T}).where(eq(${T}.${pk}, key)).limit(1);
+    return rows[0];
+  }`;
+
+  return `${head}
+type Select${T} = typeof ${T}.$inferSelect;
+type Insert${T} = typeof ${T}.$inferInsert;
+type Update${T} = Partial<Omit<typeof ${T}.$inferInsert, '${pk}'>>;
+
+export class ${Service} {
+  static async getAll(${dbParamOnly}): Promise<Select${T}[]> {
+    const rows = await db.select().from(${T});
+    return rows;
+  }
+  static async getById(${dbParam}id: number): Promise<Select${T} | null> {
+    const rows = await db.select().from(${T}).where(eq(${T}.${pk}, id)).limit(1);
+    return rows[0] ?? null;
+  }
+${create}
+  static async update(${dbParam}id: number, data: Update${T}): Promise<Select${T}> {
+    // No RETURNING on updates either: write, then read the row back by its key.
+    await db.update(${T}).set(data).where(eq(${T}.${pk}, id));
+    const rows = await db.select().from(${T}).where(eq(${T}.${pk}, id)).limit(1);
+    return rows[0];
+  }
+  static async delete(${dbParam}id: number): Promise<boolean> {
+    await db.delete(${T}).where(eq(${T}.${pk}, id));
+    return true;
+  }
+}
+`;
+}
+
 function renderService(
   table: Table,
   mode: 'stub' | 'drizzle',
   dbImportPath?: string,
   schemaImportPath?: string,
   databaseInjection?: ServiceGenerateOptions['databaseInjection'],
-  importExtension?: ImportExtension
+  importExtension?: ImportExtension,
+  dialect?: Analysis['dialect']
 ) {
   const T = table.tsName;
   const singular = singularize(T);
@@ -125,8 +222,25 @@ function renderService(
     const typeImport = databaseInjection?.databaseTypeImport
       ? `\nimport type { ${databaseInjection.databaseTypeImport.name} } from '${databaseInjection.databaseTypeImport.from}';\n`
       : '';
+    // From the analysis, which records the dialect off drizzle's own entityKind marks; never
+    // from class-name sniffing here. `unknown` keeps the RETURNING emission, matching what
+    // every schema got before the dialect reached this function, and the analyzer has already
+    // warned DRZL_ANL_DIALECT for it.
+    const noReturning = dialect === 'mysql' || dialect === 'singlestore';
 
     if (isInjectionMode) {
+      if (noReturning) {
+        return renderNoReturningDrizzleService({
+          table,
+          dialect,
+          Service,
+          pk,
+          schemaImportPath,
+          typeImport,
+          dbType,
+          injection: true,
+        });
+      }
       // Database injection mode - services accept database as parameter
       return `import { ${T} } from '${schemaImportPath}';
 import { eq } from 'drizzle-orm';
@@ -160,6 +274,19 @@ export class ${Service} {
 }
 `;
     } else if (dbImportPath) {
+      if (noReturning) {
+        return renderNoReturningDrizzleService({
+          table,
+          dialect,
+          Service,
+          pk,
+          schemaImportPath,
+          dbImportPath,
+          typeImport,
+          dbType,
+          injection: false,
+        });
+      }
       // Traditional mode - global database import (backward compatibility)
       return `import { db } from '${dbImportPath}';
 import { ${T} } from '${schemaImportPath}';
@@ -235,7 +362,10 @@ export class ServiceGenerator {
           ? resolveConfiguredImport(opts.schemaImportPath, out, process.cwd(), opts.importExtension)
           : undefined,
         opts.databaseInjection,
-        opts.importExtension
+        opts.importExtension,
+        // The dialect decides whether RETURNING exists. It is a fact about the schema the
+        // analyzer already recorded; MySQL and SingleStore get the $returningId emission.
+        this.analysis.dialect
       );
       const formattedTypes = await formatCode(
         buildHeader(opts.outputHeader) + typesCode,

--- a/packages/generator-service/test/mysql-dialect.spec.ts
+++ b/packages/generator-service/test/mysql-dialect.spec.ts
@@ -1,0 +1,415 @@
+/**
+ * The MySQL emission, end to end: a real drizzle mysql schema through the real analyzer and the
+ * real service generator, with the emitted tree compiled by a real tsc against both drizzle
+ * majors and, when MYSQL_URL names a server, run against a real MySQL.
+ *
+ * The defect this pins (plan addendum BN): `dataAccess: 'drizzle'` emitted `.returning()`
+ * unconditionally, and drizzle's MySQL insert/update/delete builders have no such method on
+ * either major (measured: `typeof builder.returning === 'undefined'` on 0.45.2 and 1.0.0-rc.4),
+ * so the emitted service failed tsc against every MySQL schema. The whole dialect was unusable.
+ *
+ * The dialect comes from the analysis, which records it from drizzle's own entityKind marks.
+ * Nothing here sniffs class names.
+ *
+ * What replaces `.returning()` is what the dialect really offers, measured on MySQL 8.4.11
+ * through mysql2 on both majors:
+ *
+ *   - insert:  `$returningId()` reports `[{ <pk>: v }]` per row for an AUTO_INCREMENT pk and
+ *     for a `$defaultFn` pk. For a caller-supplied pk and for a composite pk it reports `[]`,
+ *     and the input already carries the key, so the emitted create falls back to it. Either
+ *     way the created row is then read back by that key.
+ *   - update:  awaiting the builder yields `[ResultSetHeader, undefined]` (affectedRows and
+ *     friends), never the row, so the emitted update writes and then reads the row back.
+ *   - delete:  unchanged; the service never used RETURNING on delete for any dialect.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, promises as fs } from 'node:fs';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import type { Analysis } from '@drzl/analyzer';
+import { ServiceGenerator } from '../src';
+
+const pkgRoot = path.resolve(import.meta.dirname, '..');
+const ROOT = path.join(pkgRoot, 'test', '.tmp-mysql-dialect');
+const tsc = path.join(pkgRoot, 'node_modules', '.bin', 'tsc');
+const MYSQL_URL = process.env.MYSQL_URL;
+
+if (!MYSQL_URL) {
+  console.warn(
+    '[mysql-dialect.spec] MYSQL_URL is not set: the runtime stage is SKIPPED. ' +
+      'The emit and compile stages still ran. CI provides a server; locally: ' +
+      'docker run -d --rm -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=d -p 33061:3306 mysql:8.4 ' +
+      'and export MYSQL_URL=mysql://root:root@127.0.0.1:33061/d'
+  );
+}
+
+/**
+ * Every pk flavor the emission branches on. Table names are prefixed so the CI database,
+ * which other stages share, cannot collide; the ts names stay plain so the emitted service
+ * names read naturally (users -> UserService).
+ */
+const MYSQL_SCHEMA = `import { mysqlTable, int, varchar, primaryKey } from 'drizzle-orm/mysql-core';
+import { sql } from 'drizzle-orm';
+
+export const users = mysqlTable('svc_users', {
+  id: int('id').autoincrement().primaryKey(),
+  email: varchar('email', { length: 190 }).notNull(),
+  nickname: varchar('nickname', { length: 50 }),
+});
+
+export const codes = mysqlTable('svc_codes', {
+  code: int('code').primaryKey(),
+  label: varchar('label', { length: 50 }).notNull(),
+});
+
+export const widgets = mysqlTable('svc_widgets', {
+  id: int('id').primaryKey().$defaultFn(() => Math.trunc(Math.random() * 1e9)),
+  name: varchar('name', { length: 50 }).notNull(),
+});
+
+export const pairs = mysqlTable(
+  'svc_pairs',
+  {
+    a: int('a').notNull(),
+    b: int('b').notNull(),
+    note: varchar('note', { length: 20 }),
+  },
+  (t) => [primaryKey({ columns: [t.a, t.b] })]
+);
+
+export const gen = mysqlTable('svc_gen', {
+  a: int('a').notNull(),
+  b: int('b').generatedAlwaysAs(sql\`a * 2\`, { mode: 'stored' }).primaryKey(),
+});
+`;
+
+const PG_SCHEMA = `import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+  nickname: text('nickname'),
+});
+`;
+
+interface Tree {
+  dir: string;
+  analysis: Analysis;
+  compileOut: string;
+  /** emitted text by relative path, e.g. 'services-injection/userService.ts' */
+  texts: Record<string, string>;
+}
+
+const rel = (p: string) => path.relative(process.cwd(), p);
+
+async function readTexts(dir: string, sub: string, out: Record<string, string>) {
+  for (const f of await fs.readdir(path.join(dir, sub))) {
+    if (!f.endsWith('.ts')) continue;
+    out[`${sub}/${f}`] = await fs.readFile(path.join(dir, sub, f), 'utf8');
+  }
+}
+
+/**
+ * A tree whose bare `drizzle-orm` is one specific major, the way a consumer's project has one:
+ * a node_modules with a single `drizzle-orm` entry, symlinked to this package's copy of that
+ * major. tsc, the analyzer and vitest all resolve upward from the file, so schema, emitted
+ * services and the compiler agree on the major without any import rewriting.
+ */
+async function buildTree(name: string, majorPkg: string): Promise<Tree> {
+  const dir = path.join(ROOT, name);
+  await fs.mkdir(path.join(dir, 'node_modules'), { recursive: true });
+  const link = path.join(dir, 'node_modules', 'drizzle-orm');
+  await fs.rm(link, { recursive: true, force: true });
+  await fs.symlink(path.join(pkgRoot, 'node_modules', majorPkg), link, 'dir');
+  await fs.writeFile(path.join(dir, 'package.json'), '{"name":"probe","private":true,"type":"module"}');
+  await fs.writeFile(path.join(dir, 'schema.ts'), MYSQL_SCHEMA);
+  // Traditional mode imports a project db module; a typed one, so the compile stage actually
+  // checks the builder calls instead of collapsing everything to any.
+  await fs.writeFile(
+    path.join(dir, 'db.ts'),
+    "import type { MySql2Database } from 'drizzle-orm/mysql2';\nexport const db = null as unknown as MySql2Database;\n"
+  );
+
+  const analysis = await new SchemaAnalyzer(rel(path.join(dir, 'schema.ts'))).analyze({});
+  expect(analysis.tables.length, `no tables analyzed: ${JSON.stringify(analysis.issues)}`).toBe(5);
+
+  const gen = new ServiceGenerator(analysis);
+  await gen.generate({
+    outDir: rel(path.join(dir, 'services')),
+    dataAccess: 'drizzle',
+    dbImportPath: rel(path.join(dir, 'db')),
+    schemaImportPath: rel(path.join(dir, 'schema')),
+    importExtension: 'js',
+  });
+  const injection = {
+    enabled: true,
+    databaseType: 'MySql2Database',
+    databaseTypeImport: { name: 'MySql2Database', from: 'drizzle-orm/mysql2' },
+  };
+  await gen.generate({
+    outDir: rel(path.join(dir, 'services-injection')),
+    dataAccess: 'drizzle',
+    schemaImportPath: rel(path.join(dir, 'schema')),
+    databaseInjection: injection,
+    importExtension: 'js',
+  });
+  // The tree the runtime stage imports: same emission, extensionless specifiers, because the
+  // compile tree's `.js` specifiers name files that only exist as `.ts` here.
+  await gen.generate({
+    outDir: rel(path.join(dir, 'services-run')),
+    dataAccess: 'drizzle',
+    schemaImportPath: rel(path.join(dir, 'schema')),
+    databaseInjection: injection,
+    importExtension: 'none',
+  });
+
+  const texts: Record<string, string> = {};
+  await readTexts(dir, 'services', texts);
+  await readTexts(dir, 'services-injection', texts);
+
+  await fs.writeFile(
+    path.join(dir, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          target: 'es2022',
+          module: 'nodenext',
+          moduleResolution: 'nodenext',
+          skipLibCheck: true,
+        },
+        include: ['schema.ts', 'db.ts', 'services/**/*.ts', 'services-injection/**/*.ts'],
+      },
+      null,
+      2
+    )
+  );
+
+  let compileOut = '';
+  try {
+    execFileSync(tsc, ['-p', path.join(dir, 'tsconfig.json')], { cwd: dir, stdio: 'pipe' });
+  } catch (e) {
+    const err = e as { stdout?: Buffer; stderr?: Buffer };
+    compileOut = `${err.stdout?.toString() ?? ''}${err.stderr?.toString() ?? ''}`;
+  }
+  return { dir, analysis, compileOut, texts };
+}
+
+let v045: Tree;
+let v1: Tree;
+let pgTexts: Record<string, string> = {};
+
+beforeAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+  v045 = await buildTree('v045', 'drizzle-orm');
+  v1 = await buildTree('v1', 'drizzle-orm-v1');
+
+  // The pg control, generated in the same run: the fix must not move a byte of it. Text-level
+  // here; the packed gate compiles pg emission against a real consumer install.
+  const pgDir = path.join(v045.dir, 'pg');
+  await fs.mkdir(pgDir, { recursive: true });
+  await fs.writeFile(path.join(pgDir, 'schema.ts'), PG_SCHEMA);
+  const pgAnalysis = await new SchemaAnalyzer(rel(path.join(pgDir, 'schema.ts'))).analyze({});
+  expect(pgAnalysis.dialect).toBe('postgres');
+  await new ServiceGenerator(pgAnalysis).generate({
+    outDir: rel(path.join(pgDir, 'services')),
+    dataAccess: 'drizzle',
+    dbImportPath: rel(path.join(pgDir, 'db')),
+    schemaImportPath: rel(path.join(pgDir, 'schema')),
+    importExtension: 'js',
+  });
+  pgTexts = {};
+  await readTexts(pgDir, 'services', pgTexts);
+}, 300_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe('the analysis carries the dialect the emission keys on', () => {
+  it('has a tsc to run', () => {
+    expect(existsSync(tsc), `no tsc at ${tsc}; run pnpm install`).toBe(true);
+  });
+
+  it('records mysql for a mysql schema, on both majors', () => {
+    expect(v045.analysis.dialect).toBe('mysql');
+    expect(v1.analysis.dialect).toBe('mysql');
+  });
+});
+
+describe.each([
+  ['0.45.2', () => v045],
+  ['1.0.0-rc.4', () => v1],
+])('emitted mysql services on drizzle-orm %s', (_label, tree) => {
+  it('compiles under the tsconfig the packed gate constructs for documented configs', () => {
+    expect(tree().compileOut).toBe('');
+  });
+
+  it('never calls .returning(), which this dialect does not have', () => {
+    for (const [file, text] of Object.entries(tree().texts)) {
+      expect(text.includes('.returning('), `${file} still calls .returning()`).toBe(false);
+    }
+  });
+
+  it('reads the created row back via $returningId with the input key as fallback', () => {
+    for (const sub of ['services', 'services-injection']) {
+      const create = tree().texts[`${sub}/userService.ts`];
+      expect(create).toContain('$returningId()');
+      expect(create).toContain('ids[0] ? ids[0].id : (input as Selectusers).id');
+    }
+  });
+
+  it('update writes and then reads the row back by its key', () => {
+    const text = tree().texts['services-injection/userService.ts'];
+    expect(text).toMatch(/update\(users\)\s*\.set\(data\)/);
+    // the re-select that replaces RETURNING on this dialect
+    const updateBody = text.slice(text.indexOf('static async update'));
+    expect(updateBody).toContain('.select().from(users)');
+  });
+
+  it('create on a database-generated pk says so instead of emitting a lie', () => {
+    const text = tree().texts['services-injection/genService.ts'];
+    expect(text).toContain('database-generated');
+    expect(text).not.toContain('$returningId');
+  });
+});
+
+describe('the compiler would have said so', () => {
+  it('reports the exact defect class when .returning() is planted back in', async () => {
+    const dir = v045.dir;
+    await fs.writeFile(
+      path.join(dir, 'canary.ts'),
+      `import { users } from './schema.js';
+import type { MySql2Database } from 'drizzle-orm/mysql2';
+declare const db: MySql2Database;
+export const bad = () => db.insert(users).values({ email: 'x' }).returning();
+`
+    );
+    await fs.writeFile(
+      path.join(dir, 'tsconfig.canary.json'),
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          target: 'es2022',
+          module: 'nodenext',
+          moduleResolution: 'nodenext',
+          skipLibCheck: true,
+        },
+        include: ['schema.ts', 'canary.ts'],
+      })
+    );
+    let out = '';
+    try {
+      execFileSync(tsc, ['-p', path.join(dir, 'tsconfig.canary.json')], { cwd: dir, stdio: 'pipe' });
+    } catch (e) {
+      const err = e as { stdout?: Buffer; stderr?: Buffer };
+      out = `${err.stdout?.toString() ?? ''}${err.stderr?.toString() ?? ''}`;
+    }
+    expect(out).toContain('returning');
+    // TS2551 when the checker can suggest $returningId, TS2339 when it cannot.
+    expect(out).toMatch(/TS2551|TS2339/);
+  }, 120_000);
+});
+
+describe('the pg emission is not touched by any of this', () => {
+  it('still returns rows through RETURNING and never mentions $returningId', () => {
+    const text = pgTexts['services/userService.ts'];
+    expect(text).toBeTruthy();
+    expect(text.match(/\.returning\(\)/g)?.length).toBe(2);
+    expect(text).not.toContain('$returningId');
+  });
+});
+
+describe.skipIf(!MYSQL_URL)('runtime against a real MySQL', () => {
+  it(
+    'create returns the created row, update the updated one, delete true; both majors',
+    async () => {
+      const mysql = await import('mysql2/promise');
+      const raw = await mysql.createConnection(MYSQL_URL!);
+      const [[ver]] = (await raw.query('SELECT VERSION() AS v')) as unknown as [[{ v: string }]];
+      console.log(`[mysql-dialect.spec] runtime stage against MySQL ${ver.v}`);
+
+      const cleanups: Array<() => Promise<void> | void> = [() => raw.end()];
+      try {
+        for (const [label, tree] of [
+          ['0.45.2', v045],
+          ['1.0.0-rc.4', v1],
+        ] as const) {
+          for (const t of ['svc_users', 'svc_codes', 'svc_widgets', 'svc_pairs']) {
+            await raw.query(`DROP TABLE IF EXISTS ${t}`);
+          }
+          await raw.query(
+            'CREATE TABLE svc_users (id int NOT NULL AUTO_INCREMENT PRIMARY KEY, email varchar(190) NOT NULL, nickname varchar(50) NULL)'
+          );
+          await raw.query('CREATE TABLE svc_codes (code int NOT NULL PRIMARY KEY, label varchar(50) NOT NULL)');
+          await raw.query('CREATE TABLE svc_widgets (id int NOT NULL PRIMARY KEY, name varchar(50) NOT NULL)');
+          await raw.query(
+            'CREATE TABLE svc_pairs (a int NOT NULL, b int NOT NULL, note varchar(20) NULL, PRIMARY KEY (a, b))'
+          );
+
+          let db: unknown;
+          if (label === '0.45.2') {
+            const { drizzle } = await import('drizzle-orm/mysql2');
+            db = drizzle(raw);
+          } else {
+            const { createPool } = await import('mysql2');
+            const pool = createPool(MYSQL_URL!);
+            cleanups.push(() => new Promise<void>((res) => pool.end(() => res())));
+            const { drizzle } = await import('drizzle-orm-v1/mysql2');
+            db = drizzle({ client: pool });
+          }
+
+          const svc = (name: string) => import(path.join(tree.dir, 'services-run', name));
+          const { UserService } = await svc('userService.ts');
+          const { CodeService } = await svc('codeService.ts');
+          const { WidgetService } = await svc('widgetService.ts');
+          const { PairService } = await svc('pairService.ts');
+
+          // AUTO_INCREMENT pk: the database supplies the key and create hands the row back.
+          const created = await UserService.create(db, { email: 'ada@x.io' });
+          expect(created, label).toEqual({ id: 1, email: 'ada@x.io', nickname: null });
+          const second = await UserService.create(db, { email: 'lin@x.io', nickname: 'Lin' });
+          expect(second, label).toEqual({ id: 2, email: 'lin@x.io', nickname: 'Lin' });
+
+          const updated = await UserService.update(db, 1, { nickname: 'Ada' });
+          expect(updated, label).toEqual({ id: 1, email: 'ada@x.io', nickname: 'Ada' });
+          // A missing id updates nothing and reads nothing back: the same undefined the pg
+          // emission produces from rows[0] of an empty RETURNING.
+          expect(await UserService.update(db, 9999, { nickname: 'X' }), label).toBeUndefined();
+
+          expect(await UserService.getById(db, 1), label).toEqual({
+            id: 1,
+            email: 'ada@x.io',
+            nickname: 'Ada',
+          });
+          expect(await UserService.getById(db, 9999), label).toBeNull();
+          expect(await UserService.getAll(db), label).toHaveLength(2);
+
+          expect(await UserService.delete(db, 2), label).toBe(true);
+          expect(await UserService.getById(db, 2), label).toBeNull();
+          expect(await UserService.delete(db, 9999), label).toBe(true);
+
+          // Caller-supplied pk: $returningId reports nothing and the input key addresses the row.
+          const code = await CodeService.create(db, { code: 7, label: 'seven' });
+          expect(code, label).toEqual({ code: 7, label: 'seven' });
+
+          // $defaultFn pk: drizzle generates the key client-side and reports it.
+          const widget = await WidgetService.create(db, { name: 'sprocket' });
+          expect(widget.name, label).toBe('sprocket');
+          expect(typeof widget.id, label).toBe('number');
+          expect(await WidgetService.getById(db, widget.id), label).toEqual(widget);
+
+          // Composite pk: addressed by its first column, the generator's single-key model.
+          const pair = await PairService.create(db, { a: 1, b: 2, note: 'n' });
+          expect(pair, label).toEqual({ a: 1, b: 2, note: 'n' });
+        }
+      } finally {
+        for (const c of cleanups.reverse()) await c();
+      }
+    },
+    120_000
+  );
+});

--- a/packages/generator-service/test/sqlite-runtime.spec.ts
+++ b/packages/generator-service/test/sqlite-runtime.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * The SQLite half of the dialect split: SQLite has RETURNING and drizzle's sqlite builders
+ * expose `.returning()` on both majors (measured through better-sqlite3), so the service
+ * emission for sqlite keeps the single-statement shape the pg emission uses. This spec pins
+ * that: the emitted tree compiles against both majors and runs against a real database, so a
+ * change that routed sqlite through the MySQL branch, or broke the RETURNING branch, fails
+ * here rather than in a consumer's project.
+ */
+import { execFileSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ServiceGenerator } from '../src';
+
+const pkgRoot = path.resolve(import.meta.dirname, '..');
+const ROOT = path.join(pkgRoot, 'test', '.tmp-sqlite-runtime');
+const tsc = path.join(pkgRoot, 'node_modules', '.bin', 'tsc');
+
+const SCHEMA = `import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  email: text('email').notNull(),
+  nickname: text('nickname'),
+});
+`;
+
+interface Tree {
+  dir: string;
+  compileOut: string;
+  text: string;
+}
+
+const rel = (p: string) => path.relative(process.cwd(), p);
+
+async function buildTree(name: string, majorPkg: string): Promise<Tree> {
+  const dir = path.join(ROOT, name);
+  await fs.mkdir(path.join(dir, 'node_modules'), { recursive: true });
+  const link = path.join(dir, 'node_modules', 'drizzle-orm');
+  await fs.rm(link, { recursive: true, force: true });
+  await fs.symlink(path.join(pkgRoot, 'node_modules', majorPkg), link, 'dir');
+  await fs.writeFile(path.join(dir, 'package.json'), '{"name":"probe","private":true,"type":"module"}');
+  await fs.writeFile(path.join(dir, 'schema.ts'), SCHEMA);
+
+  const analysis = await new SchemaAnalyzer(rel(path.join(dir, 'schema.ts'))).analyze({});
+  expect(analysis.dialect).toBe('sqlite');
+
+  const injection = {
+    enabled: true,
+    databaseType: 'BetterSQLite3Database',
+    databaseTypeImport: { name: 'BetterSQLite3Database', from: 'drizzle-orm/better-sqlite3' },
+  };
+  const gen = new ServiceGenerator(analysis);
+  await gen.generate({
+    outDir: rel(path.join(dir, 'services')),
+    dataAccess: 'drizzle',
+    schemaImportPath: rel(path.join(dir, 'schema')),
+    databaseInjection: injection,
+    importExtension: 'js',
+  });
+  await gen.generate({
+    outDir: rel(path.join(dir, 'services-run')),
+    dataAccess: 'drizzle',
+    schemaImportPath: rel(path.join(dir, 'schema')),
+    databaseInjection: injection,
+    importExtension: 'none',
+  });
+
+  await fs.writeFile(
+    path.join(dir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        noEmit: true,
+        target: 'es2022',
+        module: 'nodenext',
+        moduleResolution: 'nodenext',
+        skipLibCheck: true,
+      },
+      include: ['schema.ts', 'services/**/*.ts'],
+    })
+  );
+  let compileOut = '';
+  try {
+    execFileSync(tsc, ['-p', path.join(dir, 'tsconfig.json')], { cwd: dir, stdio: 'pipe' });
+  } catch (e) {
+    const err = e as { stdout?: Buffer; stderr?: Buffer };
+    compileOut = `${err.stdout?.toString() ?? ''}${err.stderr?.toString() ?? ''}`;
+  }
+  const text = await fs.readFile(path.join(dir, 'services', 'userService.ts'), 'utf8');
+  return { dir, compileOut, text };
+}
+
+let v045: Tree;
+let v1: Tree;
+
+beforeAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+  v045 = await buildTree('v045', 'drizzle-orm');
+  v1 = await buildTree('v1', 'drizzle-orm-v1');
+}, 300_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe.each([
+  ['0.45.2', () => v045],
+  ['1.0.0-rc.4', () => v1],
+])('emitted sqlite services on drizzle-orm %s', (label, tree) => {
+  it('keeps the RETURNING shape and compiles', () => {
+    expect(tree().compileOut).toBe('');
+    expect(tree().text.match(/\.returning\(\)/g)?.length).toBe(2);
+    expect(tree().text).not.toContain('$returningId');
+  });
+
+  it('create and update hand the row back through a real better-sqlite3', async () => {
+    const { default: Database } = await import('better-sqlite3');
+    const sqlite = new Database(':memory:');
+    sqlite.exec(
+      'CREATE TABLE users (id integer PRIMARY KEY AUTOINCREMENT, email text NOT NULL, nickname text NULL)'
+    );
+    let db: unknown;
+    if (label === '0.45.2') {
+      const { drizzle } = await import('drizzle-orm/better-sqlite3');
+      db = drizzle(sqlite);
+    } else {
+      const { drizzle } = await import('drizzle-orm-v1/better-sqlite3');
+      db = drizzle({ client: sqlite });
+    }
+    try {
+      const { UserService } = await import(path.join(tree().dir, 'services-run', 'userService.ts'));
+      const created = await UserService.create(db, { email: 'ada@x.io' });
+      expect(created).toEqual({ id: 1, email: 'ada@x.io', nickname: null });
+      const updated = await UserService.update(db, 1, { nickname: 'Ada' });
+      expect(updated).toEqual({ id: 1, email: 'ada@x.io', nickname: 'Ada' });
+      expect(await UserService.update(db, 9999, { nickname: 'X' })).toBeUndefined();
+      expect(await UserService.delete(db, 1)).toBe(true);
+      expect(await UserService.getById(db, 1)).toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  }, 60_000);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
     dependencies:
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(mysql2@3.23.2(@types/node@26.1.2))
       next:
         specifier: ^16.3.0
         version: 16.3.0(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -90,10 +90,10 @@ importers:
     devDependencies:
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(mysql2@3.23.2(@types/node@26.1.2))
       drizzle-orm-v1:
         specifier: npm:drizzle-orm@1.0.0-rc.4
-        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(effect@3.22.1)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(@types/better-sqlite3@7.6.13)(arktype@2.2.3)(better-sqlite3@12.11.1)(effect@3.22.1)(mysql2@3.23.2(@types/node@26.1.2))(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.6)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -151,7 +151,7 @@ importers:
     devDependencies:
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(mysql2@3.23.2(@types/node@26.1.2))
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@26.1.2)(typescript@5.9.3)
@@ -201,7 +201,7 @@ importers:
         version: 2.2.3
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(mysql2@3.23.2(@types/node@26.1.2))
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.6)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -220,7 +220,7 @@ importers:
     devDependencies:
       drizzle-orm-v1:
         specifier: npm:drizzle-orm@1.0.0-rc.4
-        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(effect@3.22.1)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(@types/better-sqlite3@7.6.13)(arktype@2.2.3)(better-sqlite3@12.11.1)(effect@3.22.1)(mysql2@3.23.2(@types/node@26.1.2))(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       effect:
         specifier: ^3.22.1
         version: 3.22.1
@@ -363,7 +363,7 @@ importers:
         version: 3.0.1(ajv@8.20.0)
       drizzle-orm-v1:
         specifier: npm:drizzle-orm@1.0.0-rc.4
-        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(effect@3.22.1)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(@types/better-sqlite3@7.6.13)(arktype@2.2.3)(better-sqlite3@12.11.1)(effect@3.22.1)(mysql2@3.23.2(@types/node@26.1.2))(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -442,6 +442,21 @@ importers:
         specifier: workspace:^
         version: link:../validation-core
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      better-sqlite3:
+        specifier: ^12.2.0
+        version: 12.11.1
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(mysql2@3.23.2(@types/node@26.1.2))
+      drizzle-orm-v1:
+        specifier: npm:drizzle-orm@1.0.0-rc.4
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(@types/better-sqlite3@7.6.13)(arktype@2.2.3)(better-sqlite3@12.11.1)(effect@3.22.1)(mysql2@3.23.2(@types/node@26.1.2))(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
+      mysql2:
+        specifier: ^3.23.2
+        version: 3.23.2(@types/node@26.1.2)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.6)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -491,7 +506,7 @@ importers:
         version: 0.34.52
       drizzle-orm-v1:
         specifier: npm:drizzle-orm@1.0.0-rc.4
-        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(effect@3.22.1)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(@types/better-sqlite3@7.6.13)(arktype@2.2.3)(better-sqlite3@12.11.1)(effect@3.22.1)(mysql2@3.23.2(@types/node@26.1.2))(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -510,7 +525,7 @@ importers:
     devDependencies:
       drizzle-orm-v1:
         specifier: npm:drizzle-orm@1.0.0-rc.4
-        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(effect@3.22.1)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(@types/better-sqlite3@7.6.13)(arktype@2.2.3)(better-sqlite3@12.11.1)(effect@3.22.1)(mysql2@3.23.2(@types/node@26.1.2))(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.6)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -532,7 +547,7 @@ importers:
     devDependencies:
       drizzle-orm-v1:
         specifier: npm:drizzle-orm@1.0.0-rc.4
-        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(effect@3.22.1)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
+        version: drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(@types/better-sqlite3@7.6.13)(arktype@2.2.3)(better-sqlite3@12.11.1)(effect@3.22.1)(mysql2@3.23.2(@types/node@26.1.2))(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.6)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -1798,6 +1813,9 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -2282,9 +2300,16 @@ packages:
   avvio@9.3.0:
     resolution: {integrity: sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==}
 
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.11.12:
     resolution: {integrity: sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==}
@@ -2295,8 +2320,18 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   birpc@2.5.0:
     resolution: {integrity: sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
@@ -2312,6 +2347,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -2373,6 +2411,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -2472,8 +2513,20 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2760,6 +2813,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
@@ -2857,6 +2913,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -2926,6 +2986,9 @@ packages:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -2967,6 +3030,9 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -2983,6 +3049,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -2994,6 +3063,9 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -3080,6 +3152,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -3110,6 +3185,9 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -3282,6 +3360,13 @@ packages:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru.min@1.1.4:
+    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3353,15 +3438,25 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minisearch@7.1.2:
     resolution: {integrity: sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==}
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -3377,8 +3472,18 @@ packages:
     resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
 
+  mysql2@3.23.2:
+    resolution: {integrity: sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==}
+    engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3389,6 +3494,9 @@ packages:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -3417,6 +3525,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-abi@3.94.0:
+    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
+    engines: {node: '>=10'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3576,6 +3688,12 @@ packages:
   preact@10.27.1:
     resolution: {integrity: sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -3602,6 +3720,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3630,6 +3751,10 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -3803,6 +3928,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3834,6 +3965,10 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sql-escaper@1.5.1:
+    resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3879,6 +4014,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
@@ -3911,6 +4050,13 @@ packages:
 
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -4012,6 +4158,9 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -5301,6 +5450,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 26.1.2
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -5782,7 +5935,11 @@ snapshots:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
 
+  aws-ssl-profiles@1.1.2: {}
+
   balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.11.12: {}
 
@@ -5790,7 +5947,22 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@12.11.1:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   birpc@2.5.0: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   body-parser@2.3.0(supports-color@7.2.0):
     dependencies:
@@ -5815,6 +5987,11 @@ snapshots:
       fill-range: 7.1.1
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
@@ -5862,6 +6039,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -5937,7 +6116,15 @@ snapshots:
     optionalDependencies:
       supports-color: 7.2.0
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -5957,13 +6144,20 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  drizzle-orm@0.45.2: {}
+  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(mysql2@3.23.2(@types/node@26.1.2)):
+    optionalDependencies:
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 12.11.1
+      mysql2: 3.23.2(@types/node@26.1.2)
 
-  drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(arktype@2.2.3)(effect@3.22.1)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4(@sinclair/typebox@0.34.52)(@types/better-sqlite3@7.6.13)(arktype@2.2.3)(better-sqlite3@12.11.1)(effect@3.22.1)(mysql2@3.23.2(@types/node@26.1.2))(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3):
     optionalDependencies:
       '@sinclair/typebox': 0.34.52
+      '@types/better-sqlite3': 7.6.13
       arktype: 2.2.3
+      better-sqlite3: 12.11.1
       effect: 3.22.1
+      mysql2: 3.23.2(@types/node@26.1.2)
       valibot: 1.4.2(typescript@5.9.3)
       zod: 4.4.3
 
@@ -5985,6 +6179,10 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enquirer@2.4.1:
     dependencies:
@@ -6138,6 +6336,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  expand-template@2.0.3: {}
+
   expect-type@1.4.0: {}
 
   express@5.2.1(supports-color@7.2.0):
@@ -6253,6 +6453,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -6305,6 +6507,8 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-constants@1.0.0: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -6321,6 +6525,10 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
 
   get-east-asian-width@1.6.0: {}
 
@@ -6341,6 +6549,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -6424,6 +6634,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ini@1.3.8: {}
+
   ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.5.0: {}
@@ -6441,6 +6653,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-promise@4.0.0: {}
+
+  is-property@1.0.2: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -6572,6 +6786,10 @@ snapshots:
       is-unicode-supported: 2.1.0
       yoctocolors: 2.2.0
 
+  long@5.3.2: {}
+
+  lru.min@1.1.4: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6638,13 +6856,19 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.8
 
+  minimist@1.2.8: {}
+
   minisearch@7.1.2: {}
 
   mitt@3.0.1: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
     dependencies:
@@ -6664,15 +6888,33 @@ snapshots:
       concat-stream: 2.0.0
       type-is: 1.6.18
 
+  mysql2@3.23.2(@types/node@26.1.2):
+    dependencies:
+      '@types/node': 26.1.2
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.3
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      sql-escaper: 1.5.1
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.4
+
   nanoid@3.3.11: {}
 
   nanoid@3.3.16: {}
+
+  napi-build-utils@2.0.0: {}
 
   natural-compare@1.4.0: {}
 
@@ -6702,6 +6944,10 @@ snapshots:
       - '@babel/core'
       - '@types/node'
       - babel-plugin-macros
+
+  node-abi@3.94.0:
+    dependencies:
+      semver: 7.8.5
 
   object-assign@4.1.1: {}
 
@@ -6859,6 +7105,21 @@ snapshots:
 
   preact@10.27.1: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.94.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -6875,6 +7136,11 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -6899,6 +7165,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -7154,6 +7427,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   slash@3.0.0: {}
 
   sonic-boom@4.2.1:
@@ -7176,6 +7457,8 @@ snapshots:
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
+
+  sql-escaper@1.5.1: {}
 
   stackback@0.0.2: {}
 
@@ -7217,6 +7500,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -7246,6 +7531,21 @@ snapshots:
     optional: true
 
   tabbable@6.2.0: {}
+
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 
@@ -7373,6 +7673,10 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,3 +27,7 @@ packages:
 allowBuilds:
   esbuild: true
   sharp: false
+  # better-sqlite3 is a generator-service devDependency: its tests run emitted sqlite services
+  # against a real database. The install script fetches a prebuilt binding via prebuild-install
+  # and compiles only where none exists; without `true` here the module cannot load at all.
+  better-sqlite3: true


### PR DESCRIPTION
Fixes plan addendum BN (Tier B): `@drzl/generator-service` with `dataAccess: 'drizzle'` emitted `.returning()` unconditionally; drizzle's MySQL builders have none, so the emitted service failed tsc against any MySQL schema.

## The design, from the measured surface

- **Contract held constant**: same method signatures on every dialect (`create(input): Promise<Select>`, `update(id, data): Promise<Select>`, `delete(id): Promise<boolean>`), so `template-orpc-service` and generator-trpc's service template ride along unchanged; both suites passed untouched.
- **`$returningId()` measured on both majors** (declared types read from insert.d.ts, runtime proven on MySQL 8.4.11): ids arrive for autoincrement and `$defaultFn` keys, `[]` for caller-supplied, composite and SQL-default keys. So `create` inserts, takes the id from `$returningId` when present, falls back to the input's key otherwise, and reads the row back. `update` writes then reads back by key. A `generatedAlwaysAs` pk cannot round-trip (the db computes the key and reports nothing): `create` throws with an explanation rather than quietly resolving undefined. The two-statement create/update (no transaction) is documented. SingleStore mirrors MySQL exactly (measured, both majors) and shares the emission.
- **SQLite verified, not assumed**: drizzle has `.returning()` there on both majors; the new sqlite runtime spec was green before the fix, the correct control.
- **Dialect keyed on the analysis** (`analysis.dialect`, recorded from drizzle's entityKind symbols); `unknown` keeps the old emission behind the analyzer's existing warning.

## Proofs

- **pg byte-identity**: master's generator extracted from cf19c30 and run beside the new one over identical real analyses: 20 file pairs byte-identical (pg traditional/injection, sqlite both, stub, unknown-dialect, types files included).
- **Red-first**: 12 failing before the fix (tsc TS2551 "Did you mean '$returningId'?" on every service file on both majors; runtime `TypeError: ....returning is not a function` through the real emitted service against MySQL 8.4.11); 19/19 after, package 45/45, with a planted-`.returning()` must-fire canary. Without MYSQL_URL the runtime leg skips loudly; compile legs still run.
- **MySQL runtime transcript** (both majors, identical): create returns the full row for autoincrement, supplied, `$defaultFn` and composite keys; update returns the updated row and pg-parity undefined on a missing id; delete returns true with the row gone.
- Full gates green including `pnpm verify:packed` unmodified **with MYSQL_URL** (MySQL stages confirmed run).

## Filed, not silently fixed

- **BP (Tier B, new)**: every service method types its key as `id: number`, so a varchar pk (`books.isbn`) is TS2769 on every dialect including byte-identical pg. Invisible today because the gate's documented-configs pg fixture uses `export const db = {} as any`, collapsing every builder call.
- **BM update**: the gate never strictly compiles drizzle-mode service output anywhere; a per-dialect stage shape with typed driverless db objects (`MySqlDatabase<any, any>`, `PgDatabase<any, any, any>`) was scratch-validated end to end (strict nodenext tsc exit 0 post-fix) and filed, gated on BP for the natural-pk fixture.
- MSSQL (v1-only) uses `.output()` and would fail the same way; unmeasurable without a server, left on the default emission and named.
- The PlanetScale quickstart's service omission is now stale and can be lifted in a follow-up.

Changeset: patch (nothing pg/sqlite/stub-facing moved a byte, proven; the MySQL emission never compiled so no consumer could depend on it; BL/BO precedent ships measured-surface corrections as patch).

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
