### PR TITLE
fix: service keys at their real types (addendum BP)

### DIFF
--- a/.changeset/service-key-typing.md
+++ b/.changeset/service-key-typing.md
@@ -1,0 +1,28 @@
+---
+'@drzl/generator-service': patch
+---
+
+Service key parameters are typed from the primary key instead of a hardcoded `id: number`
+
+Every emitted `getById`/`update`/`delete` spelled its key parameter as `id: number` whatever
+the primary key's type, so a varchar key made `eq(books.isbn, id)` TS2769 on every dialect
+including Postgres: the generator was unusable on natural-key tables, invisible only because
+the packed gate's fixture collapses builders through `db = {} as any`. The key is now read the
+way every route generator reads it: every column of `primaryKey`, at its real type. A single
+column keeps the parameter name `id` at the column's type (`string`, `bigint`, `Date`, an
+enum's literal union; a column DRZL cannot type falls back to `Select<T>['col']`, exact by
+construction). A composite key becomes one parameter per key column in key order, addressed
+with `and(eq(...), eq(...))`, where it previously matched, updated and deleted by the FIRST
+key column alone, touching every row that shared it, and `Update<T>` now omits every key
+column rather than the first. A keyless table loses the methods that need a key rather than
+addressing a fictional `id`, on MySQL its create throws with an explanation (nothing can read
+the row back without RETURNING), and a composite create on MySQL skips `$returningId()`, which
+reports nothing for one, and reads the row back by the input's key columns. Integer-key
+emissions are byte-identical to before, proved by running the previous generator beside this
+one over the same analyses (96 file pairs, the 18 that differ are exactly the natural,
+composite and keyless ones). Stub-mode signatures follow the same policy, so an oRPC router
+from `@drzl/template-orpc-service` over a stub service now fails tsc on non-integer keys
+instead of compiling against a fictional `id: number` that addressed nothing; the oRPC
+surface's own hardcoded key inputs are filed as their own defect. Red-first: 29 failing tests
+including a live MySQL run where composite create returned the sibling row; green after
+against real typed database objects on both drizzle majors, better-sqlite3 and MySQL 8.4.11.

--- a/.changeset/trpc-service-keys.md
+++ b/.changeset/trpc-service-keys.md
@@ -1,0 +1,15 @@
+---
+'@drzl/generator-trpc': patch
+---
+
+Service-mode routers reach the service for natural and composite keys
+
+`template: 'service'` stubbed byId/update/delete for any table whose key was not exactly one
+`number`, because `@drzl/generator-service` could not receive anything else. That generator now
+types its key parameters from the primary key itself, so the guard follows it: the call is
+wired whenever every key column has a type the input schema can spell (number, string,
+boolean, Date, or an enum's literals), composing a composite key as one argument per key
+column in key order (`Service.getById(input.orgId, input.userId)`). The throwing stub remains
+only for a key column DRZL cannot type, where the input carries `z.unknown()` and the call
+would not compile, and the emitted note now states that reason instead of the old single
+number limitation.

--- a/docs/generators/service.md
+++ b/docs/generators/service.md
@@ -48,6 +48,32 @@ export class UserService {
 
 This aligns with Cloudflare Workers/Astro patterns where a db is created per request/context.
 
+## Methods and key typing
+
+Every key parameter is typed from the table's primary key, read column by column at each
+column's real TypeScript type. `id: number` is what an integer key produces, not a fixed
+spelling: a `varchar` key makes the same parameter a `string`, and `eq(table.key, id)` then
+compiles against the real column. A composite key becomes one parameter per key column, in key
+order, named after the columns (the function-signature analogue of a router's
+`/:orgId/:userId`), and every method addresses the row with `and(eq(...), eq(...))` over the
+whole key. A table with no primary key cannot address a row at all, so it loses the methods
+that would have needed one, exactly as the route generators drop those routes.
+
+| Primary key                    | Emitted methods beside `getAll(...)` and `create(input)`                                            |
+| ------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `integer` / `serial`           | `getById(id: number)`, `update(id: number, data)`, `delete(id: number)`                              |
+| `varchar` / `text` / `uuid`    | `getById(id: string)`, `update(id: string, data)`, `delete(id: string)`                              |
+| `bigint({ mode: 'bigint' })`   | `getById(id: bigint)`, `update(id: bigint, data)`, `delete(id: bigint)`                              |
+| enum                           | `getById(id: 'draft' \| 'live')`, and the same union on `update`/`delete`                            |
+| `timestamp({ mode: 'date' })`  | `getById(id: Date)`, `update(id: Date, data)`, `delete(id: Date)`                                    |
+| composite `(orgId, userId)`    | `getById(orgId: number, userId: string)`, `update(orgId, userId, data)`, `delete(orgId, userId)`     |
+| column DRZL cannot type        | drizzle mode types it `Select<T>['col']` (exact by construction); the stub spells `unknown`          |
+| none                           | nothing else: `getById`/`update`/`delete` are not emitted, and no `eq` import is left behind         |
+
+`Update<T>` omits every primary-key column, so a patch cannot move a row to another key: for a
+composite key that is `Omit<..., 'orgId' | 'userId'>`, not just the first column. In
+`databaseInjection` mode the `db` parameter stays first, ahead of the key columns.
+
 ## Examples
 
 ### Drizzle mode
@@ -91,8 +117,13 @@ drizzle-orm 0.45.x and 1.0.0 rc:
   `$defaultFn` primary key as `[{ id }]`; a caller-supplied key it reports nothing for, and the
   input already carries the value. Either way the created row is then read back by that key and
   returned, so `create` still resolves to the full row.
+- A composite key never goes through `$returningId()` (it reports nothing for one): `create`
+  inserts, then reads the row back by every key column the input carries.
 - `update` writes, then reads the row back by its key and returns it.
 - `delete` is unchanged; it never used `RETURNING` on any dialect.
+- A table with no primary key has nothing to read a created row back by, so its `create`
+  throws with an explanation, the same way a `generatedAlwaysAs(...)` key's does. On dialects
+  with `RETURNING`, keyless `create` works and returns the row.
 
 Two divergences from the `RETURNING` dialects are worth knowing:
 
@@ -105,8 +136,10 @@ Two divergences from the `RETURNING` dialects are worth knowing:
 
 One corner degrades quietly: a primary key whose default is computed in SQL, such as
 ``.default(sql`(uuid())`)``, is reported by neither `$returningId()` nor the input, so `create`
-inserts the row and resolves to `undefined`. Use `$defaultFn` when a generated key must come
-back from `create`.
+inserts the row and resolves to `undefined`. A defaulted member of a composite key that the
+caller omitted degrades the same way, because a composite key is read back from the input
+alone. Use `$defaultFn` when a generated single-column key must come back from `create`; for a
+composite key, supply every key column in the input.
 
 ## Generated Output License
 

--- a/packages/generator-service/README.md
+++ b/packages/generator-service/README.md
@@ -50,5 +50,6 @@ generators: [
 ## Notes
 
 - In drizzle mode, uses `$inferSelect` / `$inferInsert` for end‑to‑end types.
-- `Update<T>` is derived from `Insert<T>` with PKs omitted and fields partial.
+- `Update<T>` is derived from `Insert<T>` with every primary‑key column omitted and fields partial.
+- Key parameters are typed from the primary key itself: `getById(id: string)` for a varchar key, `getById(orgId: number, userId: string)` for a composite one (one parameter per key column, in key order). A table with no primary key emits `getAll` and `create` only.
 - `databaseInjection` makes services accept `db: Database` (or your chosen type) instead of importing a global singleton, which is ideal for serverless runtimes.

--- a/packages/generator-service/src/index.ts
+++ b/packages/generator-service/src/index.ts
@@ -83,6 +83,70 @@ function fieldType(c: Column): string {
   return c.nullable ? `${tsTypeOf(c)} | null` : tsTypeOf(c);
 }
 
+/**
+ * The columns that address one row, or `null` when nothing does.
+ *
+ * The same reading of `primaryKey` as every route generator (hono, express, fastify, nestjs and
+ * the tRPC procedures): every column of the key, at its real type, and a table without one loses
+ * the methods that would have needed it rather than gaining a fictional `id`. This module used to
+ * fall back to a literal `'id'` and type every key parameter as `number`, which made
+ * `eq(books.isbn, id)` TS2769 for a varchar key on every dialect including Postgres, addressed a
+ * composite key by its first column alone, so update and delete hit every row sharing that
+ * value, and emitted addressing methods for keyless tables against a column that may not exist.
+ */
+function keyColumns(table: Table): Column[] | null {
+  const names = table.primaryKey?.columns ?? [];
+  if (!names.length) return null;
+  const cols = names.map((n) => table.columns.find((c) => c.name === n));
+  if (cols.some((c) => !c)) return null;
+  return cols as Column[];
+}
+
+/**
+ * The type a key parameter is declared at: the key column's own type through `tsTypeOf`, so an
+ * integer key keeps its historical `id: number` byte for byte and an enum key becomes the same
+ * literal union the row types carry. A column the analyzer could not type falls back, in drizzle
+ * mode, to `Select<T>['col']`: exact by construction, because `Select<T>` is
+ * `typeof table.$inferSelect`, so the parameter has whatever type drizzle infers for the column
+ * and `eq` accepts it where a literal `unknown` would not. The stub has no select type standing
+ * on a real table, and its interface field is `unknown` there anyway, so `unknown` stays.
+ */
+function keyParamType(c: Column, T: string, mode: 'drizzle' | 'stub'): string {
+  const t = tsTypeOf(c);
+  return t === 'unknown' && mode === 'drizzle' ? `Select${T}['${c.name}']` : t;
+}
+
+/**
+ * A composite key becomes one parameter per key column, in key order, named after the columns:
+ * the function-signature analogue of the route generators' `/:orgId/:userId`, and the spelling a
+ * caller holding `input.orgId, input.userId` composes without an object type nothing exports.
+ * The column names are already required to be identifiers by everything this module emits
+ * (`eq(table.column, ...)` member access, unquoted interface fields), so they can serve as
+ * parameter names.
+ * A single-column key keeps the parameter name `id` whatever the column is called: the name was
+ * never the defect, and integer-key emissions must not move a byte.
+ */
+function keyParams(key: Column[], T: string, mode: 'drizzle' | 'stub'): string {
+  if (key.length === 1) return `id: ${keyParamType(key[0], T, mode)}`;
+  return key.map((c) => `${c.name}: ${keyParamType(c, T, mode)}`).join(', ');
+}
+
+/** The WHERE that addresses exactly one row: every key column, `and`ed where there are several. */
+function keyWhere(key: Column[], T: string): string {
+  if (key.length === 1) return `eq(${T}.${key[0].name}, id)`;
+  return `and(${key.map((c) => `eq(${T}.${c.name}, ${c.name})`).join(', ')})`;
+}
+
+/** Every key column, quoted, for the update patch's Omit: a patch must not move a row's key. */
+function keyOmit(key: Column[]): string {
+  return key.map((c) => `'${c.name}'`).join(' | ');
+}
+
+/** The drizzle-orm import for the finished body: absent when no method addresses a row. */
+function ormImport(key: Column[] | null): string {
+  return key ? `import { ${key.length > 1 ? 'and, eq' : 'eq'} } from 'drizzle-orm';\n` : '';
+}
+
 function renderTypes(table: Table) {
   const cols = table.columns;
   const pk = table.primaryKey?.columns ?? [];
@@ -132,39 +196,80 @@ function renderTypes(table: Table) {
  * A database-generated primary key (`generatedAlwaysAs`) is the one shape this dialect cannot
  * round-trip: the database computes the key and reports nothing, and the input does not carry
  * it, so create throws with an explanation instead of emitting a lookup that quietly returns
- * undefined.
+ * undefined. A generated member of a composite key is the same wound, and a keyless table is
+ * its degenerate case: nothing addresses the created row at all, so its create throws too,
+ * while getAll survives and the addressing methods are not emitted (see `keyColumns`).
+ *
+ * A composite key never goes through `$returningId()`: it reports `[]` for one and its declared
+ * result type omits those columns, so create inserts and reads the row back by every key column
+ * the input carries. A `$defaultFn` or SQL-side default member the caller omitted is the same
+ * quiet corner the single-key SQL-default has: the input does not carry the value, so create
+ * resolves to undefined.
  */
 function renderNoReturningDrizzleService(args: {
   table: Table;
   dialect: Analysis['dialect'];
   Service: string;
-  pk: string;
+  key: Column[] | null;
   schemaImportPath: string;
   dbImportPath?: string;
   typeImport: string;
   dbType: string;
   injection: boolean;
 }) {
-  const { table, dialect, Service, pk, schemaImportPath, dbImportPath, typeImport, dbType } =
+  const { table, dialect, Service, key, schemaImportPath, dbImportPath, typeImport, dbType } =
     args;
   const T = table.tsName;
-  const pkCol = table.columns.find((c: Column) => c.name === pk);
   const dbParam = args.injection ? `db: ${dbType}, ` : '';
   const dbParamOnly = args.injection ? `db: ${dbType}` : '';
   const head = args.injection
-    ? `import { ${T} } from '${schemaImportPath}';\nimport { eq } from 'drizzle-orm';\n${typeImport}\n`
-    : `import { db } from '${dbImportPath}';\nimport { ${T} } from '${schemaImportPath}';\nimport { eq } from 'drizzle-orm';\n`;
+    ? `import { ${T} } from '${schemaImportPath}';\n${ormImport(key)}${typeImport}\n`
+    : `import { db } from '${dbImportPath}';\nimport { ${T} } from '${schemaImportPath}';\n${ormImport(key)}`;
+  const voids = args.injection ? 'void db;\n    void input;' : 'void input;';
+  const params = key ? keyParams(key, T, 'drizzle') : '';
+  const where = key ? keyWhere(key, T) : '';
+  const pk = key && key.length === 1 ? key[0].name : '';
+  const genCol = key?.find((c: Column) => c.isGenerated);
 
-  const create = pkCol?.isGenerated
+  const create = !key
     ? `  static async create(${dbParam}input: Insert${T}): Promise<Select${T}> {
+    // ${T} has no primary key and ${dialect} has no RETURNING, so the created row cannot be
+    // read back. Insert directly and select by a column you know.
+    ${voids}
+    throw new Error(
+      '${Service}.create is not supported on ${dialect}: ${T} has no primary key, so the created row cannot be read back without RETURNING'
+    );
+  }`
+    : genCol && key.length === 1
+      ? `  static async create(${dbParam}input: Insert${T}): Promise<Select${T}> {
     // ${pk} is database-generated and ${dialect} has no RETURNING, so the created row cannot
     // be read back by its key. Insert directly and select by a column you know.
-    ${args.injection ? 'void db;\n    void input;' : 'void input;'}
+    ${voids}
     throw new Error(
       '${Service}.create is not supported on ${dialect}: primary key ${T}.${pk} is database-generated and cannot be read back without RETURNING'
     );
   }`
-    : `  static async create(${dbParam}input: Insert${T}): Promise<Select${T}> {
+      : genCol
+        ? `  static async create(${dbParam}input: Insert${T}): Promise<Select${T}> {
+    // ${genCol.name} is database-generated and ${dialect} has no RETURNING, so the created row
+    // cannot be read back by its key. Insert directly and select by a column you know.
+    ${voids}
+    throw new Error(
+      '${Service}.create is not supported on ${dialect}: primary key column ${T}.${genCol.name} is database-generated and cannot be read back without RETURNING'
+    );
+  }`
+        : key.length > 1
+          ? `  static async create(${dbParam}input: Insert${T}): Promise<Select${T}> {
+    // No RETURNING on ${dialect}, and $returningId() reports nothing for a composite key: the
+    // input already carries every part of it. Insert, then read the row back by that key.
+    await db.insert(${T}).values(input);
+    const key = input as Select${T};
+    const rows = await db.select().from(${T}).where(and(${key
+      .map((c: Column) => `eq(${T}.${c.name}, key.${c.name})`)
+      .join(', ')})).limit(1);
+    return rows[0];
+  }`
+          : `  static async create(${dbParam}input: Insert${T}): Promise<Select${T}> {
     // No RETURNING on ${dialect}. $returningId() reports AUTO_INCREMENT and $defaultFn keys as
     // [{ ${pk} }]; for a caller-supplied key it reports nothing and the input already carries
     // the value. Either way the created row is then read back by that key.
@@ -174,31 +279,109 @@ function renderNoReturningDrizzleService(args: {
     return rows[0];
   }`;
 
-  return `${head}
-type Select${T} = typeof ${T}.$inferSelect;
-type Insert${T} = typeof ${T}.$inferInsert;
-type Update${T} = Partial<Omit<typeof ${T}.$inferInsert, '${pk}'>>;
-
-export class ${Service} {
-  static async getAll(${dbParamOnly}): Promise<Select${T}[]> {
+  const methods = [
+    `  static async getAll(${dbParamOnly}): Promise<Select${T}[]> {
     const rows = await db.select().from(${T});
     return rows;
-  }
-  static async getById(${dbParam}id: number): Promise<Select${T} | null> {
-    const rows = await db.select().from(${T}).where(eq(${T}.${pk}, id)).limit(1);
+  }`,
+    key
+      ? `  static async getById(${dbParam}${params}): Promise<Select${T} | null> {
+    const rows = await db.select().from(${T}).where(${where}).limit(1);
     return rows[0] ?? null;
-  }
-${create}
-  static async update(${dbParam}id: number, data: Update${T}): Promise<Select${T}> {
+  }`
+      : '',
+    create,
+    key
+      ? `  static async update(${dbParam}${params}, data: Update${T}): Promise<Select${T}> {
     // No RETURNING on updates either: write, then read the row back by its key.
-    await db.update(${T}).set(data).where(eq(${T}.${pk}, id));
-    const rows = await db.select().from(${T}).where(eq(${T}.${pk}, id)).limit(1);
+    await db.update(${T}).set(data).where(${where});
+    const rows = await db.select().from(${T}).where(${where}).limit(1);
     return rows[0];
-  }
-  static async delete(${dbParam}id: number): Promise<boolean> {
-    await db.delete(${T}).where(eq(${T}.${pk}, id));
+  }`
+      : '',
+    key
+      ? `  static async delete(${dbParam}${params}): Promise<boolean> {
+    await db.delete(${T}).where(${where});
     return true;
+  }`
+      : '',
+  ].filter(Boolean);
+
+  return `${head}
+type Select${T} = typeof ${T}.$inferSelect;
+type Insert${T} = typeof ${T}.$inferInsert;${
+    key ? `\ntype Update${T} = Partial<Omit<typeof ${T}.$inferInsert, ${keyOmit(key)}>>;` : ''
   }
+
+export class ${Service} {
+${methods.join('\n')}
+}
+`;
+}
+
+/**
+ * The drizzle-mode service for a dialect with RETURNING: Postgres, SQLite, Gel, and any
+ * analysis whose dialect is unknown, where RETURNING matches what every schema got before the
+ * dialect reached this module. Create and update are one atomic statement each. The keyed
+ * methods and the update patch type exist only while `keyColumns` found a key to address by.
+ */
+function renderReturningDrizzleService(args: {
+  table: Table;
+  Service: string;
+  key: Column[] | null;
+  schemaImportPath: string;
+  dbImportPath?: string;
+  typeImport: string;
+  dbType: string;
+  injection: boolean;
+}) {
+  const { table, Service, key, schemaImportPath, dbImportPath, typeImport, dbType } = args;
+  const T = table.tsName;
+  const dbParam = args.injection ? `db: ${dbType}, ` : '';
+  const dbParamOnly = args.injection ? `db: ${dbType}` : '';
+  const head = args.injection
+    ? `import { ${T} } from '${schemaImportPath}';\n${ormImport(key)}${typeImport}\n`
+    : `import { db } from '${dbImportPath}';\nimport { ${T} } from '${schemaImportPath}';\n${ormImport(key)}`;
+  const params = key ? keyParams(key, T, 'drizzle') : '';
+  const where = key ? keyWhere(key, T) : '';
+
+  const methods = [
+    `  static async getAll(${dbParamOnly}): Promise<Select${T}[]> {
+    const rows = await db.select().from(${T});
+    return rows;
+  }`,
+    key
+      ? `  static async getById(${dbParam}${params}): Promise<Select${T} | null> {
+    const rows = await db.select().from(${T}).where(${where}).limit(1);
+    return rows[0] ?? null;
+  }`
+      : '',
+    `  static async create(${dbParam}input: Insert${T}): Promise<Select${T}> {
+    const rows = await db.insert(${T}).values(input).returning();
+    return rows[0];
+  }`,
+    key
+      ? `  static async update(${dbParam}${params}, data: Update${T}): Promise<Select${T}> {
+    const rows = await db.update(${T}).set(data).where(${where}).returning();
+    return rows[0];
+  }`
+      : '',
+    key
+      ? `  static async delete(${dbParam}${params}): Promise<boolean> {
+    await db.delete(${T}).where(${where});
+    return true;
+  }`
+      : '',
+  ].filter(Boolean);
+
+  return `${head}
+type Select${T} = typeof ${T}.$inferSelect;
+type Insert${T} = typeof ${T}.$inferInsert;${
+    key ? `\ntype Update${T} = Partial<Omit<typeof ${T}.$inferInsert, ${keyOmit(key)}>>;` : ''
+  }
+
+export class ${Service} {
+${methods.join('\n')}
 }
 `;
 }
@@ -215,7 +398,7 @@ function renderService(
   const T = table.tsName;
   const singular = singularize(T);
   const Service = `${cap(singular)}Service`;
-  const pk = (table.primaryKey?.columns ?? ['id'])[0];
+  const key = keyColumns(table);
   if (mode === 'drizzle' && schemaImportPath) {
     const isInjectionMode = databaseInjection?.enabled === true;
     const dbType = databaseInjection?.databaseType ?? 'unknown';
@@ -229,106 +412,69 @@ function renderService(
     const noReturning = dialect === 'mysql' || dialect === 'singlestore';
 
     if (isInjectionMode) {
-      if (noReturning) {
-        return renderNoReturningDrizzleService({
-          table,
-          dialect,
-          Service,
-          pk,
-          schemaImportPath,
-          typeImport,
-          dbType,
-          injection: true,
-        });
-      }
-      // Database injection mode - services accept database as parameter
-      return `import { ${T} } from '${schemaImportPath}';
-import { eq } from 'drizzle-orm';
-${typeImport}
-
-type Select${T} = typeof ${T}.$inferSelect;
-type Insert${T} = typeof ${T}.$inferInsert;
-type Update${T} = Partial<Omit<typeof ${T}.$inferInsert, '${pk}'>>;
-
-export class ${Service} {
-  static async getAll(db: ${dbType}): Promise<Select${T}[]> {
-    const rows = await db.select().from(${T});
-    return rows;
-  }
-  static async getById(db: ${dbType}, id: number): Promise<Select${T} | null> {
-    const rows = await db.select().from(${T}).where(eq(${T}.${pk}, id)).limit(1);
-    return rows[0] ?? null;
-  }
-  static async create(db: ${dbType}, input: Insert${T}): Promise<Select${T}> {
-    const rows = await db.insert(${T}).values(input).returning();
-    return rows[0];
-  }
-  static async update(db: ${dbType}, id: number, data: Update${T}): Promise<Select${T}> {
-    const rows = await db.update(${T}).set(data).where(eq(${T}.${pk}, id)).returning();
-    return rows[0];
-  }
-  static async delete(db: ${dbType}, id: number): Promise<boolean> {
-    await db.delete(${T}).where(eq(${T}.${pk}, id));
-    return true;
-  }
-}
-`;
+      return noReturning
+        ? renderNoReturningDrizzleService({
+            table,
+            dialect,
+            Service,
+            key,
+            schemaImportPath,
+            typeImport,
+            dbType,
+            injection: true,
+          })
+        : renderReturningDrizzleService({
+            table,
+            Service,
+            key,
+            schemaImportPath,
+            typeImport,
+            dbType,
+            injection: true,
+          });
     } else if (dbImportPath) {
-      if (noReturning) {
-        return renderNoReturningDrizzleService({
-          table,
-          dialect,
-          Service,
-          pk,
-          schemaImportPath,
-          dbImportPath,
-          typeImport,
-          dbType,
-          injection: false,
-        });
-      }
-      // Traditional mode - global database import (backward compatibility)
-      return `import { db } from '${dbImportPath}';
-import { ${T} } from '${schemaImportPath}';
-import { eq } from 'drizzle-orm';
-
-type Select${T} = typeof ${T}.$inferSelect;
-type Insert${T} = typeof ${T}.$inferInsert;
-type Update${T} = Partial<Omit<typeof ${T}.$inferInsert, '${pk}'>>;
-
-export class ${Service} {
-  static async getAll(): Promise<Select${T}[]> {
-    const rows = await db.select().from(${T});
-    return rows;
-  }
-  static async getById(id: number): Promise<Select${T} | null> {
-    const rows = await db.select().from(${T}).where(eq(${T}.${pk}, id)).limit(1);
-    return rows[0] ?? null;
-  }
-  static async create(input: Insert${T}): Promise<Select${T}> {
-    const rows = await db.insert(${T}).values(input).returning();
-    return rows[0];
-  }
-  static async update(id: number, data: Update${T}): Promise<Select${T}> {
-    const rows = await db.update(${T}).set(data).where(eq(${T}.${pk}, id)).returning();
-    return rows[0];
-  }
-  static async delete(id: number): Promise<boolean> {
-    await db.delete(${T}).where(eq(${T}.${pk}, id));
-    return true;
-  }
-}
-`;
+      return noReturning
+        ? renderNoReturningDrizzleService({
+            table,
+            dialect,
+            Service,
+            key,
+            schemaImportPath,
+            dbImportPath,
+            typeImport,
+            dbType,
+            injection: false,
+          })
+        : renderReturningDrizzleService({
+            table,
+            Service,
+            key,
+            schemaImportPath,
+            dbImportPath,
+            typeImport,
+            dbType,
+            injection: false,
+          });
     }
   }
-  return `import type { Insert${T}, Update${T}, Select${T} } from '${importSpecifier(`./types/${T}.ts`, importExtension)}';
+  // Stub mode. The same key policy as the drizzle emissions: typed key parameters, and a
+  // keyless table loses the methods that would have needed one, together with the type imports
+  // only those methods used, so `noUnusedLocals` consumers stay clean.
+  const stubParams = key ? keyParams(key, T, 'stub') : '';
+  const typeNames = key ? `Insert${T}, Update${T}, Select${T}` : `Insert${T}, Select${T}`;
+  const stubMethods = [
+    `  static async getAll(): Promise<Select${T}[]> { return [] as any }`,
+    key ? `  static async getById(${stubParams}): Promise<Select${T} | null> { return null }` : '',
+    `  static async create(input: Insert${T}): Promise<Select${T}> { return input as any }`,
+    key
+      ? `  static async update(${stubParams}, data: Update${T}): Promise<Select${T}> { return data as any }`
+      : '',
+    key ? `  static async delete(${stubParams}): Promise<boolean> { return true }` : '',
+  ].filter(Boolean);
+  return `import type { ${typeNames} } from '${importSpecifier(`./types/${T}.ts`, importExtension)}';
 
 export class ${Service} {
-  static async getAll(): Promise<Select${T}[]> { return [] as any }
-  static async getById(id: number): Promise<Select${T} | null> { return null }
-  static async create(input: Insert${T}): Promise<Select${T}> { return input as any }
-  static async update(id: number, data: Update${T}): Promise<Select${T}> { return data as any }
-  static async delete(id: number): Promise<boolean> { return true }
+${stubMethods.join('\n')}
 }
 `;
 }

--- a/packages/generator-service/test/key-typing.spec.ts
+++ b/packages/generator-service/test/key-typing.spec.ts
@@ -1,0 +1,522 @@
+/**
+ * The key parameter of every emitted service method, typed from the primary key itself.
+ *
+ * The defect this pins (plan addendum BP): getById/update/delete spelled their key parameter
+ * as `id: number` whatever the primary key's type, so a varchar key made `eq(books.isbn, id)`
+ * TS2769 on every dialect including Postgres (measured: 3 errors per emitted module per mode
+ * on pg/sqlite, 4 on mysql where update re-selects). A composite key was worse for compiling:
+ * every method addressed the row by the FIRST key column alone, so `update` and `delete` hit
+ * every row sharing that column's value, and the update patch type omitted only that first
+ * column. A table with no primary key emitted the methods anyway against a fictional `id`
+ * column, which is TS2339 against any real schema.
+ *
+ * The policy here is the route generators' settled one (hono/express/fastify/nestjs, and the
+ * tRPC procedures): the key is read off `primaryKey`, every column of it, at its real type,
+ * and a table without one loses the methods that would have needed it rather than gaining a
+ * fictional `id`. Spelled for a function signature, a composite key becomes one parameter per
+ * key column, in key order, named after the columns: the signature analogue of the routers'
+ * `/:orgId/:userId`. A single-column key keeps its historical parameter name `id`, because for
+ * an integer key `id: number` was always correct and int-pk emissions must not move a byte.
+ */
+import { execFileSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import type { Analysis, Column, Table } from '@drzl/analyzer';
+import { ServiceGenerator } from '../src';
+
+const pkgRoot = path.resolve(import.meta.dirname, '..');
+const ROOT = path.join(pkgRoot, 'test', '.tmp-key-typing');
+const tsc = path.join(pkgRoot, 'node_modules', '.bin', 'tsc');
+const rel = (p: string) => path.relative(process.cwd(), p);
+
+// ---------------------------------------------------------------------------------------------
+// In-memory fixtures for the emission shapes, same helpers as the tRPC generator's tests.
+// ---------------------------------------------------------------------------------------------
+
+function col(name: string, tsType: string, over: Partial<Column> = {}): Column {
+  return {
+    name,
+    tsType,
+    dbType: tsType.toUpperCase(),
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  } as Column;
+}
+
+function table(name: string, over: Partial<Table> & { columns: Column[] }): Table {
+  return { name, tsName: name, unique: [], indexes: [], ...over } as Table;
+}
+
+function analysis(tables: Table[], dialect: Analysis['dialect'] = 'postgres'): Analysis {
+  return { dialect, tables, enums: [], relations: [], issues: [] };
+}
+
+const users = table('users', {
+  columns: [col('id', 'number', { hasDefault: true, isGenerated: true }), col('email', 'string')],
+  primaryKey: { columns: ['id'] },
+});
+const books = table('books', {
+  columns: [col('isbn', 'string'), col('title', 'string')],
+  primaryKey: { columns: ['isbn'] },
+});
+const counters = table('counters', {
+  columns: [col('id', 'bigint'), col('n', 'number')],
+  primaryKey: { columns: ['id'] },
+});
+const snapshots = table('snapshots', {
+  columns: [col('at', 'Date'), col('state', 'string')],
+  primaryKey: { columns: ['at'] },
+});
+const states = table('states', {
+  columns: [col('kind', 'string', { enumValues: ['draft', 'live'] }), col('note', 'string')],
+  primaryKey: { columns: ['kind'] },
+});
+/** A key column the analyzer could not type: `tsType` is not a name `tsTypeOf` passes through. */
+const things = table('things', {
+  columns: [col('ref', 'CustomRef'), col('note', 'string')],
+  primaryKey: { columns: ['ref'] },
+});
+const memberships = table('memberships', {
+  columns: [col('orgId', 'number'), col('userId', 'string'), col('role', 'string')],
+  primaryKey: { columns: ['orgId', 'userId'] },
+});
+const auditLog = table('audit_log', {
+  tsName: 'auditLog',
+  columns: [col('at', 'Date'), col('what', 'string')],
+});
+/** A composite key with a database-generated member, for the mysql throw branch. */
+const genPair = table('gen_pair', {
+  tsName: 'genPair',
+  columns: [col('a', 'number'), col('b', 'number', { isGenerated: true })],
+  primaryKey: { columns: ['a', 'b'] },
+});
+
+async function emit(
+  t: Table,
+  opts: {
+    dialect?: Analysis['dialect'];
+    mode?: 'stub' | 'drizzle';
+    injection?: boolean;
+  } = {}
+): Promise<string> {
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-svc-key-'));
+  try {
+    const gen = new ServiceGenerator(analysis([t], opts.dialect ?? 'postgres'));
+    await gen.generate({
+      outDir,
+      dataAccess: opts.mode ?? 'drizzle',
+      ...(opts.mode === 'stub'
+        ? {}
+        : opts.injection
+          ? {
+              schemaImportPath: 'src/db/schema',
+              databaseInjection: { enabled: true, databaseType: 'Database' },
+            }
+          : { dbImportPath: 'src/db/connection', schemaImportPath: 'src/db/schema' }),
+      format: { enabled: false },
+    });
+    const file = (await fs.readdir(outDir)).find((f) => f.endsWith('Service.ts'))!;
+    return await fs.readFile(path.join(outDir, file), 'utf8');
+  } finally {
+    await fs.rm(outDir, { recursive: true, force: true });
+  }
+}
+
+describe('single-column keys are typed from the key column', () => {
+  it('keeps id: number for an integer key, byte for byte', async () => {
+    const text = await emit(users);
+    expect(text).toContain('static async getById(id: number): Promise<Selectusers | null> {');
+    expect(text).toContain('static async update(id: number, data: Updateusers): Promise<Selectusers> {');
+    expect(text).toContain('static async delete(id: number): Promise<boolean> {');
+    expect(text).toContain("import { eq } from 'drizzle-orm';");
+    expect(text).toContain("Partial<Omit<typeof users.$inferInsert, 'id'>>");
+  });
+
+  it('types a varchar key as string, against the real key column', async () => {
+    const text = await emit(books);
+    expect(text).toContain('static async getById(id: string): Promise<Selectbooks | null> {');
+    expect(text).toContain('static async update(id: string, data: Updatebooks): Promise<Selectbooks> {');
+    expect(text).toContain('static async delete(id: string): Promise<boolean> {');
+    expect(text).toContain('eq(books.isbn, id)');
+  });
+
+  it('types bigint, Date and enum keys at their real types', async () => {
+    expect(await emit(counters)).toContain('static async getById(id: bigint)');
+    expect(await emit(snapshots)).toContain('static async getById(id: Date)');
+    expect(await emit(states)).toContain("static async getById(id: 'draft' | 'live')");
+  });
+
+  it('falls back to the indexed select type when the analyzer could not type the column', async () => {
+    // `Selectthings['ref']` is exact by construction: `Selectthings` is `$inferSelect`, so the
+    // parameter has whatever type drizzle infers for the column, and `eq` accepts it.
+    const text = await emit(things);
+    expect(text).toContain("static async getById(id: Selectthings['ref'])");
+    expect(text).toContain('eq(things.ref, id)');
+  });
+
+  it('types the stub signatures from the same key column', async () => {
+    const text = await emit(books, { mode: 'stub' });
+    expect(text).toContain('static async getById(id: string)');
+    expect(text).toContain('static async update(id: string, data: Updatebooks)');
+    expect(text).toContain('static async delete(id: string)');
+    // No select type to index into in stub mode: the honest spelling is unknown.
+    expect(await emit(things, { mode: 'stub' })).toContain('static async getById(id: unknown)');
+  });
+});
+
+describe('a composite key becomes one parameter per key column, in key order', () => {
+  it('addresses the row by every key column, not the first one', async () => {
+    const text = await emit(memberships);
+    expect(text).toContain(
+      'static async getById(orgId: number, userId: string): Promise<Selectmemberships | null> {'
+    );
+    expect(text).toContain(
+      'static async update(orgId: number, userId: string, data: Updatememberships): Promise<Selectmemberships> {'
+    );
+    expect(text).toContain('static async delete(orgId: number, userId: string): Promise<boolean> {');
+    expect(text).toContain('and(eq(memberships.orgId, orgId), eq(memberships.userId, userId))');
+    expect(text).toContain("import { and, eq } from 'drizzle-orm';");
+  });
+
+  it('omits every key column from the update patch, not the first one', async () => {
+    const text = await emit(memberships);
+    expect(text).toContain("Partial<Omit<typeof memberships.$inferInsert, 'orgId' | 'userId'>>");
+  });
+
+  it('keeps the database parameter first in injection mode', async () => {
+    const text = await emit(memberships, { injection: true });
+    expect(text).toContain('static async getById(db: Database, orgId: number, userId: string)');
+    expect(text).toContain('static async update(db: Database, orgId: number, userId: string, data: Updatememberships)');
+  });
+
+  it('does the same in stub mode', async () => {
+    const text = await emit(memberships, { mode: 'stub' });
+    expect(text).toContain('static async getById(orgId: number, userId: string)');
+  });
+});
+
+describe('a table with no primary key loses the methods that need one', () => {
+  it('emits getAll and create only, and no eq import, in drizzle mode', async () => {
+    const text = await emit(auditLog);
+    expect(text).toContain('static async getAll(');
+    expect(text).toContain('static async create(');
+    expect(text).not.toContain('getById');
+    expect(text).not.toContain('static async update');
+    expect(text).not.toContain('static async delete');
+    // Nothing addresses a row, so nothing needs eq, and the patch type has no method left to use it.
+    expect(text).not.toContain("from 'drizzle-orm'");
+    expect(text).not.toContain('type UpdateauditLog');
+  });
+
+  it('prunes the stub the same way, including its type imports', async () => {
+    const text = await emit(auditLog, { mode: 'stub' });
+    expect(text).not.toContain('getById');
+    expect(text).not.toContain('UpdateauditLog');
+    expect(text).toContain("import type { InsertauditLog, SelectauditLog } from './types/auditLog.js';");
+  });
+});
+
+describe('the mysql read-back paths carry the same typing', () => {
+  it('keeps the single-key $returningId shape, typed from the key', async () => {
+    const text = await emit(books, { dialect: 'mysql' });
+    expect(text).toContain('static async getById(id: string)');
+    expect(text).toContain('$returningId()');
+    expect(text).toContain('ids[0] ? ids[0].isbn : (input as Selectbooks).isbn');
+  });
+
+  it('reads a composite-keyed row back by every key column from the input', async () => {
+    // $returningId() reports nothing for a composite key (measured by the BN change), so the
+    // emitted create does not call it: the input already carries every part of the key. The
+    // emitted comment may still name it, so the assertion is on the call.
+    const text = await emit(memberships, { dialect: 'mysql' });
+    expect(text).not.toContain('.$returningId()');
+    expect(text).toContain('await db.insert(memberships).values(input);');
+    expect(text).toContain('const key = input as Selectmemberships;');
+    expect(text).toContain('and(eq(memberships.orgId, key.orgId), eq(memberships.userId, key.userId))');
+    expect(text).toContain('static async update(orgId: number, userId: string, data: Updatememberships)');
+  });
+
+  it('throws from create when a composite member is database-generated', async () => {
+    const text = await emit(genPair, { dialect: 'mysql' });
+    expect(text).toContain('database-generated');
+    expect(text).toContain('genPair.b');
+    expect(text).not.toContain('$returningId');
+  });
+
+  it('throws from create for a keyless table instead of inventing a read-back', async () => {
+    const text = await emit(auditLog, { dialect: 'mysql' });
+    expect(text).not.toContain('getById');
+    expect(text).not.toContain('$returningId');
+    expect(text).toContain('has no primary key');
+    expect(text).toContain('throw new Error');
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// End to end: a real schema through the real analyzer, compiled against a REAL typed database
+// object with strict nodenext tsc, on both drizzle majors. This is the leg the packed gate's
+// `db = {} as any` fixture could never exercise, which is how BP stayed invisible.
+// ---------------------------------------------------------------------------------------------
+
+const PG_SCHEMA = `import { pgTable, serial, integer, text, primaryKey } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+export const books = pgTable('books', {
+  isbn: text('isbn').primaryKey(),
+  title: text('title').notNull(),
+});
+export const memberships = pgTable(
+  'memberships',
+  {
+    orgId: integer('org_id').notNull(),
+    userId: text('user_id').notNull(),
+    role: text('role').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.orgId, t.userId] })]
+);
+export const logs = pgTable('logs', {
+  at: integer('at').notNull(),
+  what: text('what').notNull(),
+});
+`;
+
+const SQLITE_SCHEMA = `import { sqliteTable, integer, text, primaryKey } from 'drizzle-orm/sqlite-core';
+
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  email: text('email').notNull(),
+});
+export const books = sqliteTable('books', {
+  isbn: text('isbn').primaryKey(),
+  title: text('title').notNull(),
+});
+export const memberships = sqliteTable(
+  'memberships',
+  {
+    orgId: integer('org_id').notNull(),
+    userId: text('user_id').notNull(),
+    role: text('role').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.orgId, t.userId] })]
+);
+export const logs = sqliteTable('logs', {
+  at: integer('at').notNull(),
+  what: text('what').notNull(),
+});
+`;
+
+/**
+ * A driverless typed database object per dialect, the BM gate-stage shape. The two majors
+ * disagree about the pg type's name and arity: 0.45.x exports `PgDatabase<HKT, Schema, Rels>`
+ * and 1.0.0-rc.4 renamed the async side to `PgAsyncDatabase<HKT, Rels?>`, so the module is
+ * chosen per major. `BetterSQLite3Database` exists on both.
+ */
+const DB_MODULES: Record<string, string> = {
+  'pg-drizzle-orm':
+    "import type { PgDatabase } from 'drizzle-orm/pg-core';\nexport const db = null as unknown as PgDatabase<any, any, any>;\n",
+  'pg-drizzle-orm-v1':
+    "import type { PgAsyncDatabase } from 'drizzle-orm/pg-core';\nexport const db = null as unknown as PgAsyncDatabase<any>;\n",
+  'sqlite-drizzle-orm':
+    "import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';\nexport const db = null as unknown as BetterSQLite3Database;\n",
+  'sqlite-drizzle-orm-v1':
+    "import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';\nexport const db = null as unknown as BetterSQLite3Database;\n",
+};
+const INJECTION: Record<string, { databaseType: string; databaseTypeImport: { name: string; from: string } }> = {
+  'pg-drizzle-orm': {
+    databaseType: 'PgDatabase<any, any, any>',
+    databaseTypeImport: { name: 'PgDatabase', from: 'drizzle-orm/pg-core' },
+  },
+  'pg-drizzle-orm-v1': {
+    databaseType: 'PgAsyncDatabase<any>',
+    databaseTypeImport: { name: 'PgAsyncDatabase', from: 'drizzle-orm/pg-core' },
+  },
+  'sqlite-drizzle-orm': {
+    databaseType: 'BetterSQLite3Database',
+    databaseTypeImport: { name: 'BetterSQLite3Database', from: 'drizzle-orm/better-sqlite3' },
+  },
+  'sqlite-drizzle-orm-v1': {
+    databaseType: 'BetterSQLite3Database',
+    databaseTypeImport: { name: 'BetterSQLite3Database', from: 'drizzle-orm/better-sqlite3' },
+  },
+};
+
+interface Tree {
+  dir: string;
+  compileOut: string;
+}
+
+async function buildTree(
+  name: string,
+  majorPkg: string,
+  kind: 'pg' | 'sqlite',
+  schemaText: string
+): Promise<Tree> {
+  const dir = path.join(ROOT, name);
+  await fs.mkdir(path.join(dir, 'node_modules'), { recursive: true });
+  const link = path.join(dir, 'node_modules', 'drizzle-orm');
+  await fs.rm(link, { recursive: true, force: true });
+  await fs.symlink(path.join(pkgRoot, 'node_modules', majorPkg), link, 'dir');
+  await fs.writeFile(path.join(dir, 'package.json'), '{"name":"probe","private":true,"type":"module"}');
+  await fs.writeFile(path.join(dir, 'schema.ts'), schemaText);
+  await fs.writeFile(path.join(dir, 'db.ts'), DB_MODULES[`${kind}-${majorPkg}`]);
+
+  const a = await new SchemaAnalyzer(rel(path.join(dir, 'schema.ts'))).analyze({});
+  expect(a.tables.length, `no tables analyzed: ${JSON.stringify(a.issues)}`).toBe(4);
+
+  const flavor = `${kind}-${majorPkg}`;
+  const gen = new ServiceGenerator(a);
+  await gen.generate({
+    outDir: rel(path.join(dir, 'services')),
+    dataAccess: 'drizzle',
+    dbImportPath: rel(path.join(dir, 'db')),
+    schemaImportPath: rel(path.join(dir, 'schema')),
+    importExtension: 'js',
+  });
+  await gen.generate({
+    outDir: rel(path.join(dir, 'services-injection')),
+    dataAccess: 'drizzle',
+    schemaImportPath: rel(path.join(dir, 'schema')),
+    databaseInjection: { enabled: true, ...INJECTION[flavor] },
+    importExtension: 'js',
+  });
+  await gen.generate({
+    outDir: rel(path.join(dir, 'services-run')),
+    dataAccess: 'drizzle',
+    schemaImportPath: rel(path.join(dir, 'schema')),
+    databaseInjection: { enabled: true, ...INJECTION[flavor] },
+    importExtension: 'none',
+  });
+
+  await fs.writeFile(
+    path.join(dir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        noEmit: true,
+        target: 'es2022',
+        module: 'nodenext',
+        moduleResolution: 'nodenext',
+        skipLibCheck: true,
+      },
+      include: ['schema.ts', 'db.ts', 'services/**/*.ts', 'services-injection/**/*.ts'],
+    })
+  );
+  let compileOut = '';
+  try {
+    execFileSync(tsc, ['-p', path.join(dir, 'tsconfig.json')], { cwd: dir, stdio: 'pipe' });
+  } catch (e) {
+    const err = e as { stdout?: Buffer; stderr?: Buffer };
+    compileOut = `${err.stdout?.toString() ?? ''}${err.stderr?.toString() ?? ''}`;
+  }
+  return { dir, compileOut };
+}
+
+let pg045: Tree;
+let pg1: Tree;
+let sq045: Tree;
+let sq1: Tree;
+
+beforeAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+  pg045 = await buildTree('pg-v045', 'drizzle-orm', 'pg', PG_SCHEMA);
+  pg1 = await buildTree('pg-v1', 'drizzle-orm-v1', 'pg', PG_SCHEMA);
+  sq045 = await buildTree('sqlite-v045', 'drizzle-orm', 'sqlite', SQLITE_SCHEMA);
+  sq1 = await buildTree('sqlite-v1', 'drizzle-orm-v1', 'sqlite', SQLITE_SCHEMA);
+}, 300_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe.each([
+  ['pg on drizzle-orm 0.45.2', () => pg045],
+  ['pg on drizzle-orm 1.0.0-rc.4', () => pg1],
+  ['sqlite on drizzle-orm 0.45.2', () => sq045],
+  ['sqlite on drizzle-orm 1.0.0-rc.4', () => sq1],
+])('%s', (_label, tree) => {
+  it('compiles natural, composite and keyless tables against a real typed db', () => {
+    expect(tree().compileOut).toBe('');
+  });
+});
+
+describe('runtime against a real better-sqlite3', () => {
+  it.each([
+    ['0.45.2', () => sq045],
+    ['1.0.0-rc.4', () => sq1],
+  ])(
+    'addresses rows by their real keys on drizzle-orm %s',
+    async (label, tree) => {
+      const { default: Database } = await import('better-sqlite3');
+      const sqlite = new Database(':memory:');
+      sqlite.exec('CREATE TABLE books (isbn text PRIMARY KEY, title text NOT NULL)');
+      sqlite.exec(
+        'CREATE TABLE memberships (org_id integer NOT NULL, user_id text NOT NULL, role text NOT NULL, PRIMARY KEY (org_id, user_id))'
+      );
+      sqlite.exec('CREATE TABLE logs (at integer NOT NULL, what text NOT NULL)');
+      let db: unknown;
+      if (label === '0.45.2') {
+        const { drizzle } = await import('drizzle-orm/better-sqlite3');
+        db = drizzle(sqlite);
+      } else {
+        const { drizzle } = await import('drizzle-orm-v1/better-sqlite3');
+        db = drizzle({ client: sqlite });
+      }
+      try {
+        const svc = (name: string) => import(path.join(tree().dir, 'services-run', name));
+        const { BookService } = await svc('bookService.ts');
+        const { MembershipService } = await svc('membershipService.ts');
+        const { LogService } = await svc('logService.ts');
+
+        // A supplied string key: create returns the row, and the row is addressable by it.
+        const created = await BookService.create(db, { isbn: '978-3', title: 'SICP' });
+        expect(created, label).toEqual({ isbn: '978-3', title: 'SICP' });
+        expect(await BookService.getById(db, '978-3'), label).toEqual(created);
+        const renamed = await BookService.update(db, '978-3', { title: 'SICP 2e' });
+        expect(renamed, label).toEqual({ isbn: '978-3', title: 'SICP 2e' });
+        expect(await BookService.delete(db, '978-3'), label).toBe(true);
+        expect(await BookService.getById(db, '978-3'), label).toBeNull();
+
+        // Two rows sharing the first key column: the full key must tell them apart. Under the
+        // defect every method addressed by orgId alone, so getById returned an arbitrary
+        // sibling and update/delete hit both rows.
+        await MembershipService.create(db, { orgId: 1, userId: 'a', role: 'admin' });
+        await MembershipService.create(db, { orgId: 1, userId: 'b', role: 'viewer' });
+        expect(await MembershipService.getById(db, 1, 'b'), label).toEqual({
+          orgId: 1,
+          userId: 'b',
+          role: 'viewer',
+        });
+        const promoted = await MembershipService.update(db, 1, 'b', { role: 'editor' });
+        expect(promoted, label).toEqual({ orgId: 1, userId: 'b', role: 'editor' });
+        expect(await MembershipService.getById(db, 1, 'a'), label).toEqual({
+          orgId: 1,
+          userId: 'a',
+          role: 'admin',
+        });
+        expect(await MembershipService.delete(db, 1, 'a'), label).toBe(true);
+        expect(await MembershipService.getById(db, 1, 'a'), label).toBeNull();
+        expect(await MembershipService.getById(db, 1, 'b'), label).not.toBeNull();
+
+        // Keyless: the class carries no addressing methods at all, and create still returns
+        // the created row because sqlite has RETURNING.
+        expect(LogService.getById, label).toBeUndefined();
+        expect(LogService.update, label).toBeUndefined();
+        expect(LogService.delete, label).toBeUndefined();
+        const logged = await LogService.create(db, { at: 7, what: 'boot' });
+        expect(logged, label).toEqual({ at: 7, what: 'boot' });
+        expect(await LogService.getAll(db), label).toHaveLength(1);
+      } finally {
+        sqlite.close();
+      }
+    },
+    60_000
+  );
+});

--- a/packages/generator-service/test/mysql-dialect.spec.ts
+++ b/packages/generator-service/test/mysql-dialect.spec.ts
@@ -21,6 +21,12 @@
  *   - update:  awaiting the builder yields `[ResultSetHeader, undefined]` (affectedRows and
  *     friends), never the row, so the emitted update writes and then reads the row back.
  *   - delete:  unchanged; the service never used RETURNING on delete for any dialect.
+ *
+ * Plan addendum BP extended this file's schema with a varchar key, a keyless table and the
+ * composite disambiguation checks: the read-back paths above must carry the key at its real
+ * type (a supplied string key comes back by that string), a composite key must address by
+ * every column, and a keyless table has nothing to read a created row back by, so its create
+ * throws with an explanation the same way a database-generated key's does.
  */
 import { execFileSync } from 'node:child_process';
 import { existsSync, promises as fs } from 'node:fs';
@@ -82,6 +88,16 @@ export const gen = mysqlTable('svc_gen', {
   a: int('a').notNull(),
   b: int('b').generatedAlwaysAs(sql\`a * 2\`, { mode: 'stored' }).primaryKey(),
 });
+
+export const books = mysqlTable('svc_books', {
+  isbn: varchar('isbn', { length: 20 }).primaryKey(),
+  title: varchar('title', { length: 100 }).notNull(),
+});
+
+export const logs = mysqlTable('svc_logs', {
+  at: int('at').notNull(),
+  what: varchar('what', { length: 50 }).notNull(),
+});
 `;
 
 const PG_SCHEMA = `import { pgTable, serial, text } from 'drizzle-orm/pg-core';
@@ -132,7 +148,7 @@ async function buildTree(name: string, majorPkg: string): Promise<Tree> {
   );
 
   const analysis = await new SchemaAnalyzer(rel(path.join(dir, 'schema.ts'))).analyze({});
-  expect(analysis.tables.length, `no tables analyzed: ${JSON.stringify(analysis.issues)}`).toBe(5);
+  expect(analysis.tables.length, `no tables analyzed: ${JSON.stringify(analysis.issues)}`).toBe(7);
 
   const gen = new ServiceGenerator(analysis);
   await gen.generate({
@@ -274,6 +290,36 @@ describe.each([
     expect(text).toContain('database-generated');
     expect(text).not.toContain('$returningId');
   });
+
+  it('types a varchar key as string on every method, including the read-back fallback', () => {
+    for (const sub of ['services', 'services-injection']) {
+      const text = tree().texts[`${sub}/bookService.ts`];
+      expect(text).toContain('id: string');
+      expect(text).not.toContain('id: number');
+      expect(text).toContain('ids[0] ? ids[0].isbn : (input as Selectbooks).isbn');
+    }
+  });
+
+  it('addresses a composite key by every column and reads create back from the input key', () => {
+    const text = tree().texts['services-injection/pairService.ts'];
+    expect(text).toContain('static async getById(db: MySql2Database, a: number, b: number)');
+    expect(text).toContain('and(eq(pairs.a, a), eq(pairs.b, b))');
+    // $returningId() reports nothing for a composite key (measured above), so create does not
+    // call it: the input already carries every part of the key. The emitted comment may still
+    // name it, so the assertion is on the call.
+    expect(text).not.toContain('.$returningId()');
+    expect(text).toContain('and(eq(pairs.a, key.a), eq(pairs.b, key.b))');
+    expect(text).toContain("Partial<Omit<typeof pairs.$inferInsert, 'a' | 'b'>>");
+  });
+
+  it('drops the addressing methods for a keyless table and throws from its create', () => {
+    const text = tree().texts['services-injection/logService.ts'];
+    expect(text).not.toContain('getById');
+    expect(text).not.toContain('static async update');
+    expect(text).not.toContain('static async delete');
+    expect(text).toContain('has no primary key');
+    expect(text).not.toContain("from 'drizzle-orm'");
+  });
 });
 
 describe('the compiler would have said so', () => {
@@ -338,7 +384,7 @@ describe.skipIf(!MYSQL_URL)('runtime against a real MySQL', () => {
           ['0.45.2', v045],
           ['1.0.0-rc.4', v1],
         ] as const) {
-          for (const t of ['svc_users', 'svc_codes', 'svc_widgets', 'svc_pairs']) {
+          for (const t of ['svc_users', 'svc_codes', 'svc_widgets', 'svc_pairs', 'svc_books', 'svc_logs']) {
             await raw.query(`DROP TABLE IF EXISTS ${t}`);
           }
           await raw.query(
@@ -349,6 +395,10 @@ describe.skipIf(!MYSQL_URL)('runtime against a real MySQL', () => {
           await raw.query(
             'CREATE TABLE svc_pairs (a int NOT NULL, b int NOT NULL, note varchar(20) NULL, PRIMARY KEY (a, b))'
           );
+          await raw.query(
+            'CREATE TABLE svc_books (isbn varchar(20) NOT NULL PRIMARY KEY, title varchar(100) NOT NULL)'
+          );
+          await raw.query('CREATE TABLE svc_logs (at int NOT NULL, what varchar(50) NOT NULL)');
 
           let db: unknown;
           if (label === '0.45.2') {
@@ -367,6 +417,8 @@ describe.skipIf(!MYSQL_URL)('runtime against a real MySQL', () => {
           const { CodeService } = await svc('codeService.ts');
           const { WidgetService } = await svc('widgetService.ts');
           const { PairService } = await svc('pairService.ts');
+          const { BookService } = await svc('bookService.ts');
+          const { LogService } = await svc('logService.ts');
 
           // AUTO_INCREMENT pk: the database supplies the key and create hands the row back.
           const created = await UserService.create(db, { email: 'ada@x.io' });
@@ -402,9 +454,37 @@ describe.skipIf(!MYSQL_URL)('runtime against a real MySQL', () => {
           expect(typeof widget.id, label).toBe('number');
           expect(await WidgetService.getById(db, widget.id), label).toEqual(widget);
 
-          // Composite pk: addressed by its first column, the generator's single-key model.
+          // Composite pk: create reads the row back by every key column from the input, and the
+          // full key is what tells two rows sharing a first column apart. Under the BP defect all
+          // of these addressed by `a` alone, so getById returned an arbitrary sibling and
+          // update hit both rows.
           const pair = await PairService.create(db, { a: 1, b: 2, note: 'n' });
           expect(pair, label).toEqual({ a: 1, b: 2, note: 'n' });
+          const sibling = await PairService.create(db, { a: 1, b: 3, note: 'm' });
+          expect(sibling, label).toEqual({ a: 1, b: 3, note: 'm' });
+          expect(await PairService.getById(db, 1, 3), label).toEqual(sibling);
+          const patched = await PairService.update(db, 1, 3, { note: 'z' });
+          expect(patched, label).toEqual({ a: 1, b: 3, note: 'z' });
+          expect(await PairService.getById(db, 1, 2), label).toEqual({ a: 1, b: 2, note: 'n' });
+          expect(await PairService.delete(db, 1, 2), label).toBe(true);
+          expect(await PairService.getById(db, 1, 2), label).toBeNull();
+          expect(await PairService.getById(db, 1, 3), label).not.toBeNull();
+
+          // A supplied string key: create returns the row by that key, typed as the string it is.
+          const book = await BookService.create(db, { isbn: '978-3', title: 'SICP' });
+          expect(book, label).toEqual({ isbn: '978-3', title: 'SICP' });
+          expect(await BookService.getById(db, '978-3'), label).toEqual(book);
+          const retitled = await BookService.update(db, '978-3', { title: 'SICP 2e' });
+          expect(retitled, label).toEqual({ isbn: '978-3', title: 'SICP 2e' });
+          expect(await BookService.delete(db, '978-3'), label).toBe(true);
+          expect(await BookService.getById(db, '978-3'), label).toBeNull();
+
+          // Keyless: nothing addresses a row and mysql cannot read a created one back, so the
+          // class has no addressing methods and its create says why it cannot resolve.
+          expect(LogService.getById, label).toBeUndefined();
+          await expect(LogService.create(db, { at: 7, what: 'boot' }), label).rejects.toThrow(
+            /no primary key/
+          );
         }
       } finally {
         for (const c of cleanups.reverse()) await c();

--- a/packages/generator-trpc/src/index.ts
+++ b/packages/generator-trpc/src/index.ts
@@ -490,12 +490,16 @@ function renderRouter(table: Table, opts: GenerateOptions, ctx: RenderContext): 
   const key = keyColumns(table);
 
   const Service = `${cap(singularize(table.tsName))}Service`;
-  // `@drzl/generator-service` types its key parameter as exactly one `number`
-  // (`getById(id: number)`, `update(id, data)`), so a call built from any other key does not
-  // typecheck against it. Rather than emit that call, or drop the procedures and give every table
-  // a differently shaped client, those fall back to the throwing stub the standard template uses.
-  const serviceKeyable = !!key && key.length === 1 && key[0].tsType === 'number';
-  const keyArg = key && key.length === 1 ? `input.${key[0].name}` : '';
+  // `@drzl/generator-service` types its key parameters from the primary key itself: one
+  // parameter per key column, in key order, at the column's real type. A call composed from the
+  // input object therefore typechecks whenever every key column has a type the input schema can
+  // spell (`field()` above: number, string, boolean, Date, or an enum's literals). A column the
+  // analyzer could not type arrives in the input as `unknown`, which the service's typed
+  // parameter does not accept, so rather than emit a call that does not compile, or drop the
+  // procedures and give every table a differently shaped client, those fall back to the
+  // throwing stub the standard template uses.
+  const serviceKeyable = !!key && key.every(serviceKeyExpressible);
+  const keyArg = key ? key.map((c) => `input.${c.name}`).join(', ') : '';
   const dbArg = injection ? 'ctx.db, ' : '';
   const wiredParams = injection ? '{ ctx, input }' : '{ input }';
 
@@ -824,16 +828,30 @@ export type AppRouter = typeof appRouter;
 ${reExports}`;
 }
 
+/**
+ * Whether the generated input schema can type this key column, which is exactly when the
+ * emitted service call typechecks: `field()` spells number, string, boolean, Date and enum
+ * literals, and everything else becomes `z.unknown()`, which the service's typed key parameter
+ * does not accept.
+ */
+function serviceKeyExpressible(c: Column): boolean {
+  if (c.enumValues && c.enumValues.length) return true;
+  return ['number', 'string', 'boolean', 'Date'].includes(c.tsType);
+}
+
 /** Why a service-backed procedure is a stub, stated in the file rather than only in the docs. */
 function serviceKeyNote(table: Table): string {
   const cols = table.primaryKey?.columns ?? [];
-  const shape =
-    cols.length > 1
-      ? `has a composite primary key (${cols.join(', ')})`
-      : `has a non-numeric primary key (${cols[0]})`;
+  const untyped = cols.filter((n) => {
+    const c = table.columns.find((x) => x.name === n);
+    return !c || !serviceKeyExpressible(c);
+  });
+  const what =
+    untyped.length === 1 ? `its column ${untyped[0]}` : `its columns ${untyped.join(', ')}`;
   return (
-    `// ${table.name} ${shape}, and @drzl/generator-service types its key parameter as one ` +
-    `number.\n// Wire this to your own lookup.`
+    `// ${table.name} is keyed on (${cols.join(', ')}) and DRZL cannot type ${what}: the input\n` +
+    `// schema carries unknown there, which the service's typed key parameter does not accept.\n` +
+    `// Wire this to your own lookup.`
   );
 }
 

--- a/packages/generator-trpc/test/fixtures.ts
+++ b/packages/generator-trpc/test/fixtures.ts
@@ -65,6 +65,15 @@ export const auditLog = table('audit_log', {
   columns: [col('at', 'Date'), col('what', 'string')],
 });
 
+/**
+ * A key column the input schemas cannot type: `bigint` has no JSON transport, so `field()`
+ * emits `z.unknown()` for it, and `unknown` is not assignable to the service's `id: bigint`.
+ */
+export const ledgers = table('ledgers', {
+  columns: [col('seq', 'bigint'), col('entry', 'string')],
+  primaryKey: { columns: ['seq'] },
+});
+
 /** A materialized view: readable, and refuses every write. */
 export const activeUsers = table('active_users', {
   tsName: 'activeUsers',

--- a/packages/generator-trpc/test/service-template.spec.ts
+++ b/packages/generator-trpc/test/service-template.spec.ts
@@ -1,18 +1,20 @@
 /**
  * `template: 'service'`, which wires the routers to the classes `@drzl/generator-service` writes.
  *
- * That generator types its key parameter as exactly one `number`, in both of its modes:
- * `getById(id: number)`, `update(id, data)`, `delete(id)`. So a call built from a composite key,
- * or from a `varchar` primary key, does not typecheck against it. Emitting that call anyway is
- * how a generator ships output that reads correctly and does not compile, which is the failure
- * this repository keeps finding after release.
+ * That generator types every key parameter from the primary key itself (plan addendum BP): one
+ * parameter per key column, at the column's real type, so `getById(input.isbn)` and
+ * `getById(input.orgId, input.userId)` both typecheck against it. The one key it cannot receive
+ * is a column DRZL could not type: the input schema carries `z.unknown()` there, `unknown` is
+ * not assignable to the service's typed parameter, and emitting the call anyway is how a
+ * generator ships output that reads correctly and does not compile. Those fall back to the
+ * throwing stub, with the reason stated in the file.
  */
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { TRPCGenerator } from '../src';
-import { analysis, books, memberships, posts, users } from './fixtures';
+import { analysis, books, ledgers, memberships, posts, users } from './fixtures';
 
 async function router(t = users, opts: Record<string, unknown> = {}) {
   const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-trpc-svc-'));
@@ -108,24 +110,24 @@ describe('database injection', () => {
   });
 });
 
-describe('a key the service layer cannot express', () => {
-  it('falls back to a throwing stub for a composite key, and says why', async () => {
+describe('keys the service layer now expresses', () => {
+  it('wires a composite key through as one argument per key column, in key order', async () => {
     const source = await router(memberships);
-    // list and create still reach the service: neither needs a key.
     expect(source).toContain('return await MembershipService.getAll();');
     expect(source).toContain('return await MembershipService.create(input);');
-    for (const method of ['getById', 'update(', 'delete(']) {
-      expect(source, method).not.toContain(`MembershipService.${method}`);
-    }
-    expect(source).toContain('has a composite primary key (orgId, userId)');
-    expect(source).toMatch(/throw new Error\('Not implemented: byId memberships\.'\)/);
+    expect(source).toContain('return await MembershipService.getById(input.orgId, input.userId);');
+    expect(source).toContain(
+      'return await MembershipService.update(input.orgId, input.userId, input.data);'
+    );
+    expect(source).toContain('return await MembershipService.delete(input.orgId, input.userId);');
+    expect(source).not.toContain('Not implemented: byId');
   });
 
-  it('does the same for a non-numeric key', async () => {
+  it('wires a non-numeric key through at its real type', async () => {
     const source = await router(books);
-    expect(source).toContain('has a non-numeric primary key (isbn)');
-    expect(source).not.toContain('BookService.getById');
-    expect(source).toContain('return await BookService.getAll();');
+    expect(source).toContain('return await BookService.getById(input.isbn);');
+    expect(source).toContain('return await BookService.update(input.isbn, input.data);');
+    expect(source).not.toContain('Not implemented: byId');
   });
 
   it('keeps the client surface the same shape either way', async () => {
@@ -134,6 +136,30 @@ describe('a key the service layer cannot express', () => {
     const source = await router(books);
     expect(source).toContain('.input(z.object({ isbn: z.string() }))');
     expect(source).toContain('.output(SelectbooksSchema.nullable())');
+  });
+
+  it('passes the injected handle ahead of a composite key', async () => {
+    const source = await router(memberships, {
+      databaseInjection: { enabled: true, databaseType: 'Database' },
+    });
+    expect(source).toContain(
+      'return await MembershipService.getById(ctx.db, input.orgId, input.userId);'
+    );
+  });
+});
+
+describe('a key the service layer cannot receive', () => {
+  it('falls back to a throwing stub when a key column has no typed transport, and says why', async () => {
+    // `bigint` over JSON arrives as z.unknown() in the input schema, and `unknown` is not
+    // assignable to the service's `id: bigint`, so the call would not typecheck.
+    const source = await router(ledgers);
+    expect(source).toContain('return await LedgerService.getAll();');
+    expect(source).toContain('return await LedgerService.create(input);');
+    for (const method of ['getById', 'update(', 'delete(']) {
+      expect(source, method).not.toContain(`LedgerService.${method}`);
+    }
+    expect(source).toContain('DRZL cannot type its column seq');
+    expect(source).toMatch(/throw new Error\('Not implemented: byId ledgers\.'\)/);
   });
 });
 


### PR DESCRIPTION
Fixes plan addendum BP (Tier B): every emitted service method typed its key parameter as `id: number`. Natural pks (varchar/uuid/bigint/Date) failed tsc on every dialect; **composite pks were worse than mistyped**: every method addressed rows by the first key column alone, proven live on MySQL 8.4.11 where `PairService.create(db, {a:1,b:3})` returned the sibling row `{a:1,b:2}`, and update/delete would hit every row sharing that column. Keyless tables emitted addressing methods around a fictional `T.id`. Invisible to the gate because the docs-probe db module is `export const db = {} as any`.

## The design (route-generator precedent applied)

- `keyColumns(table)` is verbatim the settled helper from hono/express/fastify/nestjs/trpc: every `primaryKey` column at its real type, null when none resolve.
- Single keys keep the `id` name (byte-identity proves the name was never the defect), typed from `tsTypeOf` (number, string, bigint, Date, boolean, enum literal unions), `Select<T>['col']` as the drizzle-mode fallback for untypeable columns (exact by construction, `eq` accepts it).
- Composite keys: one parameter per key column in key order, the function-signature analogue of `/:orgId/:userId` (a typed object would invent an anonymous type nothing exports); WHERE becomes `and(eq(...), eq(...))`; `Update<T>` omits every key column.
- Keyless tables drop getById/update/delete in every mode, imports pruned noUnusedLocals-clean. Keyless creates on MySQL throw with an explanation (the BN generatedAlwaysAs precedent: nothing can read the row back), as do composites with a database-generated member; composite create on MySQL skips `$returningId()` entirely (BN measured `[]` there) and reads back via the input's key columns.

## Proofs

- **Byte identity** (BN extraction method, master's dist snapshotted pre-edit): 96 file pairs, 78 byte-identical, and the 18 differing are exactly the natural/composite/keyless emissions; every int-pk table is byte-identical across traditional, injection and stub modes, types files included.
- **Red-first: 33 failing** (29 generator-service incl. tsc red on every dialect with the books fixture and the live wrong-row composite; 4 generator-trpc), all green after; full suites 72/72 and 82/82 with MYSQL_URL runtime legs run.
- **Consumers measured**: the trpc service template's inputs were already key-typed; its `number`-only guard existed only because of BP and is widened (composite composes `getById(input.orgId, input.userId)`), proven by a regenerated tree compiling clean against a real typed PgDatabase. express/fastify/nestjs/hono/graphql/effect consume nothing from the service generator (verified).

## Filed, not half-fixed here

- **BQ (Tier B)**: generator-orpc rewrites every template's get/update/delete inputs with hardcoded `z.object({ id: z.number() })` (src/index.ts:677-688) and template-orpc-service's bodies call `Service.getById(input.id)` through a too-narrow local Table type. Post-fix probe: 9 tsc errors confined to the routers; int-pk trees green before and after; the one true green-to-red (stub-mode services under oRPC on natural keys, previously compiling-but-fictional) is named in the changeset. Fix shape mirrors generator-trpc; linked changeset group.
- **BR (Tier C)**: stub-mode `Insert<T>` excludes natural pk columns (a books stub create cannot carry its isbn); distinct mechanism, needs byte-identity discipline of its own.
- **BM service stage unblocked**: the stage text is re-validated end to end WITH the books fixture (negative control fails pg 3 / mysql 4 against master); final text is in the plan file for the controller batch, including the rc.4 `PgAsyncDatabase` note for a future v1 leg.

## Gates

Full suite green at the final tree (build, tests with MYSQL_URL, typecheck, lint, docs, `pnpm verify:packed` unmodified exit 0). Changesets: `@drzl/generator-service` patch (changed signatures previously failed tsc in drizzle mode; the stub/oRPC caveat stated inside), `@drzl/generator-trpc` patch. Docs: the service page gains a "Methods and key typing" table plus the MySQL composite/keyless bullets.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
