### PR TITLE
ci: compile services against typed dbs, wire the fuzz gate (BM batch 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       # how it came to be failing unnoticed.
       - run: pnpm typecheck
       - run: pnpm -r test
+      # The analyzer fuzz baseline (test/fuzz/expected.json) was wired into neither CI nor
+      # verify-packed, so it rotted silently: two entries kept "reproducing" months after their
+      # columns were fixed, and nobody saw the gate's own delete-these message. Cheap to run,
+      # and a baseline that fails the build cannot rot.
+      - run: pnpm -C packages/analyzer fuzz:gate
       - run: pnpm lint
 
   # Everything above imports from source. This job is the only one that exercises what a

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -691,6 +691,13 @@ export const books = pgTable('books', {
   authorId: integer('author_id').references(() => authors.id),
 });
 SCHEMA
+      # A typed, driverless db object. The docs-probe stage's `{} as any` collapses every builder
+      # call, which is how the BN (.returning() on MySQL) and BP (id: number on a varchar key)
+      # classes stayed invisible; a real PgDatabase type makes tsc see the builders.
+      cat > "src/dia-$dialect/db.ts" <<'DB'
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+export const db = null as unknown as PgDatabase<any, any, any>;
+DB
       ;;
     mysql)
       cat > "src/dia-$dialect/schema.ts" <<'SCHEMA'
@@ -704,6 +711,10 @@ export const books = mysqlTable('books', {
   authorId: int('author_id').references(() => authors.id),
 });
 SCHEMA
+      cat > "src/dia-$dialect/db.ts" <<'DB'
+import type { MySqlDatabase } from 'drizzle-orm/mysql-core';
+export const db = null as unknown as MySqlDatabase<any, any>;
+DB
       ;;
   esac
 
@@ -714,6 +725,7 @@ export default {
   generators: [
     { kind: 'zod', path: './src/dia-$dialect/zod' },
     { kind: 'orpc', includeRelations: true },
+    { kind: 'service', path: './src/dia-$dialect/services', dataAccess: 'drizzle', dbImportPath: 'src/dia-$dialect/db', schemaImportPath: 'src/dia-$dialect/schema' },
   ],
 };
 CONFIG
@@ -738,6 +750,13 @@ CONFIG
       exit 1
     }
   fi
+  # The drizzle-mode service against the typed db, keyed by the varchar it is. The tsc below is
+  # what actually catches the BN and BP classes; this grep names the defect when the emission
+  # regresses to id: number without breaking compilation some other way.
+  grep -q 'id: string' "src/dia-$dialect/services/bookService.ts" || {
+    echo "FAIL [$dialect]: the books service does not type its key as the varchar it is." >&2
+    exit 1
+  }
 
   cat > "tsconfig.$dialect.json" <<EOF
 {


### PR DESCRIPTION
First batch of the BM gate-extension addendum: two blind spots closed as controller edits, both scratch-validated end to end by the agents that found them (BN and BP for the service stage, BK for the fuzz wiring).

## Service output now compiles against typed dbs

The per-dialect loop gains a drizzle-mode service target per dialect with a typed, driverless db module (`PgDatabase<any, any, any>` / `MySqlDatabase<any, any>` casts; nothing to install). The documented-configs stage compiles services only against `export const db = {} as any`, which collapses every builder call; that is precisely how two whole defect classes stayed invisible to a green gate: BN (unconditional `.returning()`, MySQL locked out of the generator entirely) and BP (`id: number` on varchar keys, composite methods addressing rows by the first key column alone). The loop's existing strict nodenext tsc now sees the builders. Validated: post-fix trees compile exit 0 on both dialects; negative controls against the pre-fix generator fail pg 3 / mysql 4 (BP) and TS2551 on every service file (BN). A `id: string` grep on the books service names the key-typing defect directly if the emission regresses without breaking compilation.

## The fuzz baseline can no longer rot

`packages/analyzer` `fuzz:gate` was wired into neither ci.yml nor verify-packed, so `test/fuzz/expected.json` rotted silently: two entries (sqlite blob, int timestamp_ms) kept "reproducing" on paper months after their columns were fixed, and the gate's own delete-these instruction had no audience until the BK agent tripped over it. It is now a build-test-lint step.

## Deliberately deferred to a measuring agent

The remaining BM items (unsigned probe columns with the 2^32/2^64 boundary pool values from BO; the mode-string bigint probe column from BK) change parity comparisons against the official validators, and their ALLOWED entries must be written from measured mechanisms across all four libraries, not predicted. They follow as their own PR after measurement; this PR stays mechanical.

Gate note: this PR's own CI run is the integration proof, since verify-packed executes the modified script end to end (the ship gate ran it locally green first, including the new stage against the freshly fixed BP emission).

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
