### PR TITLE
fix: state the input syntax for mode-string bigint wires (addendum BS)

### DIFF
--- a/.changeset/bigint-string-format.md
+++ b/.changeset/bigint-string-format.md
@@ -1,0 +1,57 @@
+---
+'@drzl/analyzer': patch
+'@drzl/validation-core': patch
+---
+
+Bound a `bigint({ mode: 'string' })` column by the input syntax its own server parses, per dialect
+
+The arm that typed this column a string (addendum BK) stated nothing else, so every generator
+emitted a bare string. Graded against a real Postgres through PGlite with the parity gate's own
+36-value probe pool, that schema disagreed with the server on **14** of them, and on every one
+of the 14 `drizzle-orm`'s own validator agreed with the server: `''`, `'hello'`, a 300-character
+run, three and five emoji, `'12.5'`, a uuid, `'not-a-uuid'`, `'happy'`, `'zzz'`, `'2020-01-01'`,
+`'12:00:00'`, `'10.0.0.1'` and `'999.999.999.999'` all validated and then failed at the INSERT,
+which is the outcome an insert schema exists to prevent.
+
+The column now carries a `format`, which is the vehicle all six validation generators already
+route through `COLUMN_FORMATS`, so nothing in any generator changed. There are **two** patterns,
+because the two servers disagree in both directions, measured on PGlite and on a live MySQL
+8.4.11: Postgres stores `'0x1f'` as 31 and `'1_000'` as 1000 and refuses `'12.5'`, while MySQL
+refuses the first two as "Data truncated" and stores `'12.5'` as 13, rounded. A single pattern
+would have to be their union, which readmits `'12.5'` on Postgres and leaves the defect standing,
+or their intersection, which turns away rows each server really stores. So Postgres gets an
+integer-literal grammar (sign, surrounding whitespace, underscore separators, decimal or
+`0x`/`0o`/`0b`, leading zeros, and the `_` Postgres allows directly after a base prefix) and
+MySQL gets a decimal-number grammar with an optional fraction and exponent. SingleStore takes
+MySQL's, as every other MySQL-shaped answer in the analyzer does; SQL Server takes neither,
+because no SQL Server was measured for its conversion rules, and Cockroach never reaches the arm
+at all.
+
+Verified against the servers rather than reasoned about. Postgres: 16160 probes, boundary sweeps
+in all four bases and random shapes, **zero** values the server takes and the pattern refuses.
+MySQL: 3319 probes against each of a signed and an unsigned column, **zero** again. The read path
+is covered too, since the `bigint:string` codec casts to text and registers no normalize, so a row
+written `'0x1f'` reads back `'31'`: every value either server hands back validates.
+
+Neither pattern states the magnitude, and that is deliberate. On MySQL it is not expressible: the
+range applies to the **rounded** value, so `'9223372036854775807.4'` is a row and
+`'9223372036854775807.6'` is not, and `'92233720368547758070e-1'` is the int64 maximum. On
+Postgres it is expressible, and the exact ladder was built and agreed with the server 16160/16160,
+but leading zeros and separators make it a per-digit ladder of about 1200 characters, and the
+ArkType generator states a format as a regex literal inside the type expression: the emitted
+module then fails to compile with TS2589, measured on the real emitted output, where the 101
+character pattern that ships compiles clean. Emitting a module that does not typecheck is a worse
+failure than the bound it buys, and every value the pattern admits that Postgres refuses is
+exactly an out-of-range magnitude, so the syntax half is complete on its own. The tests assert
+that remainder in both directions, so stating it later reports itself.
+
+The unsigned spelling shares the MySQL pattern, and that is what makes it agree with the database:
+`drizzle-orm` at 1.0.0-rc.4 caps `bigint({ mode: 'string', unsigned: true })` at the signed int64
+maximum and so refuses `'18446744073709551615'`, which MySQL 8.4.11 stores in a `bigint unsigned`
+and hands straight back. DRZL accepts it.
+
+Every other column shape is untouched, proved rather than asserted: master's dists and this
+branch's were run side by side over the parity gate's three fixtures, and all 90 emitted files are
+byte identical. With a mode-string bigint column added to the Postgres and MySQL fixtures, 78 of
+90 stay identical and the 12 that differ are exactly the two `matrix` modules in each of the six
+generators, each diverging first at the new column's own line.

--- a/docs/generators/json-schema.md
+++ b/docs/generators/json-schema.md
@@ -238,14 +238,15 @@ A schema with nothing shared is byte-for-byte what it was.
 The schema describes the value **after** `JSON.stringify`, which is not always what the TypeScript
 type says:
 
-| Column                  | Schema                                                                                                                                       |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `bigint`                | `{ type: 'string', pattern: '^-?\\d+$' }`, because `JSON.stringify` throws on a bigint                                                       |
-| `bytea`, `blob`         | `{ type: 'string', contentEncoding: 'base64' }`                                                                                              |
-| `timestamp`             | `{ type: 'string', format: 'date-time' }`                                                                                                    |
-| `json`, `jsonb`         | `{}`, which is how the format spells "any JSON value"                                                                                        |
-| `point`                 | `prefixItems` of two numbers, with `minItems` and `maxItems`                                                                                 |
-| `point({ mode: 'xy' })` | `{ type: 'object', properties: { x, y }, required: ['x', 'y'] }`, with no `additionalProperties`, because the column ignores an unlisted key |
+| Column                       | Schema                                                                                                                                       |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bigint`                     | `{ type: 'string', pattern: '^-?\\d+$' }`, because `JSON.stringify` throws on a bigint                                                       |
+| `bigint({ mode: 'string' })` | `{ type: 'string', pattern }` for the input syntax that dialect's server parses, which is not the same pattern as the row above              |
+| `bytea`, `blob`              | `{ type: 'string', contentEncoding: 'base64' }`                                                                                              |
+| `timestamp`                  | `{ type: 'string', format: 'date-time' }`                                                                                                    |
+| `json`, `jsonb`              | `{}`, which is how the format spells "any JSON value"                                                                                        |
+| `point`                      | `prefixItems` of two numbers, with `minItems` and `maxItems`                                                                                 |
+| `point({ mode: 'xy' })`      | `{ type: 'object', properties: { x, y }, required: ['x', 'y'] }`, with no `additionalProperties`, because the column ignores an unlisted key |
 
 `contentEncoding` is worth one warning. In draft 2020-12 and in OpenAPI 3.1 it is an **annotation**,
 not an assertion: a conforming validator records that the string is meant to be base64 and does not

--- a/docs/generators/zod.md
+++ b/docs/generators/zod.md
@@ -559,7 +559,35 @@ underscore digit separators and `0x`/`0o`/`0b` literals, so `1_000` and `0xDEAD_
 
 It is not applied on SQLite, whose NUMERIC affinity stores whatever text it is given.
 
-### Why numeric is the only format checked
+## `bigint({ mode: 'string' })` columns
+
+Drizzle v1 can hand a 64 bit column back as a string, and that string also goes to the server as
+text, so the same reasoning applies: a bare `z.string()` accepts `'hello'` for a column the server
+will refuse. Against a real Postgres it took 14 of the 36 values in DRZL's own probe pool that
+Postgres rejects, `drizzle-orm/zod` agreeing with Postgres on every one.
+
+The pattern here is **per dialect**, because the two servers disagree in both directions:
+
+| Value     | Postgres                        | MySQL                      |
+| --------- | ------------------------------- | -------------------------- |
+| `'0x1f'`  | stores 31                       | refused, "Data truncated"  |
+| `'1_000'` | stores 1000                     | refused, "Data truncated"  |
+| `'12.5'`  | refused, invalid input syntax   | stores 13, rounded         |
+| `'1e3'`   | refused                         | stores 1000                |
+
+So Postgres gets an integer-literal grammar (sign, whitespace, underscore separators, decimal or
+`0x`/`0o`/`0b`, leading zeros) and MySQL gets a decimal-number grammar, since MySQL parses the text
+as a number and rounds it. SingleStore takes MySQL's, and SQL Server takes neither, because no SQL
+Server was measured for it.
+
+Neither pattern states the magnitude. On MySQL it cannot: the range applies to the **rounded**
+value, so `'9223372036854775807.4'` is a row and `'9223372036854775807.6'` is not, and no regex
+does that arithmetic. On Postgres it can, and the exact bound was built and verified, but leading
+zeros and separators make it a per-digit ladder around 1200 characters long, which exhausts
+ArkType's type-level budget and emits a module that does not compile. A schema that fails to
+typecheck is a worse trade than the bound, so the syntax is stated and the magnitude is not.
+
+### Why so few formats are checked
 
 `date`, `timestamp`, `time`, `interval`, `inet`, `cidr` and `macaddr` were all attempted and all
 dropped. Each candidate pattern was run against a real Postgres, and each turned away input the

--- a/docs/quickstarts/supabase-neon.md
+++ b/docs/quickstarts/supabase-neon.md
@@ -138,7 +138,7 @@ repeated:
   counts: [character limits count characters](/generators/zod#character-limits-count-characters).
 - `bornOn` stays a plain string on purpose. Postgres accepts `today`, `January 8, 1999` and
   `20200101` for a `date`, so any regex DRZL could emit would refuse values the database takes:
-  [why numeric is the only format checked](/generators/zod#why-numeric-is-the-only-format-checked).
+  [why so few formats are checked](/generators/zod#why-so-few-formats-are-checked).
   The measured insert below feeds it one of exactly those strings.
 - `serial` stays optional on insert rather than omitted, because the database accepts an
   explicit id: [which columns appear on insert](/generators/zod#which-columns-appear-on-insert).
@@ -236,7 +236,7 @@ Three claims, each measured:
 - A 41-character `name` was refused by the input schema before any connection was used.
 - `bornOn: 'January 8, 1999'` sailed through the plain-string schema and **Postgres stored it**
   as `1999-01-08`: the permissive date parser from the
-  [format-check grid](/generators/zod#why-numeric-is-the-only-format-checked), demonstrated in
+  [format-check grid](/generators/zod#why-so-few-formats-are-checked), demonstrated in
   one row.
 - A 40-emoji `name` passed the schema and the `varchar(40)` column both. An `n`-UTF-16-unit cap
   would have refused it at 40 code points; the database would not have.

--- a/packages/analyzer/README.md
+++ b/packages/analyzer/README.md
@@ -53,6 +53,12 @@ budget, which is a different measurement on the same kind of column), `min`/`max
 `arrayDimensions`, `format`, and `shape` for values that are not scalars (json, buffer, tuple,
 numberObject, vector, bitstring, customType).
 
+`format` names a pattern in `COLUMN_FORMATS`, and two of its values name a dialect: a
+`bigint({ mode: 'string' })` column is `pgBigint` on Postgres and `mysqlBigint` on MySQL and
+SingleStore, because the two servers really do parse that text differently (`'0x1f'` is 31 on one
+and an error on the other, `'12.5'` is 13 on one and an error on the other). SQL Server carries no
+format for it, since none was measured.
+
 `DRZL_ANL_UNKNOWN_COLUMN` is reported for any column whose validator would accept anything, which
 is the shape a missing type mapping takes: nothing throws, and every row passes.
 

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -185,13 +185,18 @@ export interface Column {
   /**
    * A string column whose contents have a shape the database enforces.
    *
-   * Only formats checked against Postgres itself appear here, and the list is short because most
+   * Only formats checked against a real server appear here, and the list is short because most
    * candidates failed: Postgres reads `'today'` and `'January 8, 1999'` as dates, pads
    * `'2020-01-01'` into a macaddr, and accepts `'10.1/16'` as an inet. A check for any of those
    * would reject input the database accepts, and turning away valid data is worse than not
    * checking at all. See `COLUMN_FORMATS` in `@drzl/validation-core`.
+   *
+   * Two of the keys name a dialect, because the same column has two different answers: a
+   * `bigint({ mode: 'string' })` is parsed by Postgres as an integer literal, `'0x1f'` and
+   * `'1_000'` included, and by MySQL as a decimal number it then rounds, so `'12.5'` is a row on
+   * one server and an error on the other.
    */
-  format?: 'uuid' | 'numeric';
+  format?: 'uuid' | 'numeric' | 'pgBigint' | 'mysqlBigint';
 
   /**
    * The column's default, when it is a literal a schema can reproduce.
@@ -756,10 +761,29 @@ export function describeV1Column(column: any): Partial<Column> | null {
       // the column returns. The js half is the reliable key: two of the four dialects state no
       // codec for it.
       //
-      // No numeric facts on the string shape, mirroring the `numeric` arm below:
+      // Still no numeric facts on the string shape, mirroring the `numeric` arm below:
       // `isIntegerColumn` in validation-core reads "min and max both present" as an integer
-      // column, and the generators' string arms state no numeric facts to begin with. Bounding
-      // the string by pattern and range is a recorded follow-up, not this shape.
+      // column, and the generators' string arms state no numeric facts to begin with. What the
+      // string carries instead is a `format`, which is the vehicle every generator already routes
+      // through `COLUMN_FORMATS`.
+      //
+      // Bare, this column was a `z.string()` and its siblings, and against a real Postgres with
+      // the parity gate's own probe pool it took fourteen of the thirty-six values on an INSERT
+      // the server refuses, `drizzle-orm`'s own validator agreeing with the server on every one.
+      //
+      // The format is per dialect because the two servers disagree in both directions, measured
+      // on PGlite and on MySQL 8.4.11: Postgres stores `'0x1f'` as 31 and `'1_000'` as 1000 and
+      // refuses `'12.5'`; MySQL refuses the first two as "Data truncated" and stores `'12.5'` as
+      // 13, rounded. One pattern for both would have to be their union, which admits `'12.5'` on
+      // Postgres and so leaves the defect in place, or their intersection, which turns away rows
+      // each server really stores. See `COLUMN_FORMATS` for what each one states and what it
+      // deliberately does not.
+      //
+      // SingleStore takes MySQL's, as every other MySQL-shaped answer in this file does (see
+      // `decimalModeRange`), and it is wire-compatible with it. mssql takes neither: `MsSqlBigInt`
+      // states `string int64` too, and no SQL Server was measured for its conversion rules, so it
+      // keeps the bare string rather than a guessed pattern. Cockroach never reaches this arm at
+      // all, because `bigint({ mode: 'string' })` there builds `CockroachBigInt64`, a bigint wire.
       //
       // v1-only: drizzle-orm 0.45.2 spells `PgBigIntConfig<'number' | 'bigint'>` and branches
       // only on `mode === "number"`, so 0.4x has no string mode and a type-invalid
@@ -769,9 +793,16 @@ export function describeV1Column(column: any): Partial<Column> | null {
       // unsigned: true })` states `string uint64` on rc.4, measured off the real column, and
       // keying the guard on `int64` alone sent the unsigned spelling into the integer arm below,
       // which typed it `number` with the uint64 range: a wire the driver never uses in this mode.
+      // Both spellings take the same MySQL pattern, since the unsigned ceiling is a fact about
+      // the rounded value and not about the text; the ceiling itself is what `drizzle-orm` gets
+      // wrong, capping the unsigned column at the signed maximum and refusing 18446744073709551615
+      // on a row MySQL stores and returns.
       if ((semantic === 'int64' || semantic === 'uint64') && js === 'string') {
         out.tsType = 'string';
         out.dbType = 'BIGINT';
+        if (entityKind.startsWith('Pg')) out.format = 'pgBigint';
+        else if (entityKind.startsWith('MySql') || entityKind.startsWith('SingleStore'))
+          out.format = 'mysqlBigint';
         break;
       }
       // Every width Drizzle names. Missing `int8` and `int24` did not leave MySQL's `tinyint` and

--- a/packages/analyzer/test/bigint-string-format.spec.ts
+++ b/packages/analyzer/test/bigint-string-format.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * The input syntax a `bigint({ mode: 'string' })` column really accepts, as a `format` the
+ * generators can state, and the dialect split that decides which one.
+ *
+ * The defect: the arm PR #172 added types this column `string`/`BIGINT` and states nothing else,
+ * so every generator emitted a bare string. Run against a real Postgres through PGlite with the
+ * parity gate's own MATRIX_POOL, that schema disagreed with the server on 14 of the 36 values
+ * (`''`, `'hello'`, a 300-character run, three and five emoji, `'12.5'`, a uuid, `'not-a-uuid'`,
+ * `'happy'`, `'zzz'`, `'2020-01-01'`, `'12:00:00'`, `'10.0.0.1'`, `'999.999.999.999'`), on every
+ * one of which Postgres refuses the insert and `drizzle-orm/zod` agrees with Postgres. A schema
+ * that takes what the server will not is the thing an Insert schema exists to prevent.
+ *
+ * **Two patterns, because the two servers disagree in both directions.** Measured, Postgres 17
+ * through PGlite and MySQL 8.4.11 in Docker, on a `bigint` column of each:
+ *
+ *   value      Postgres                     MySQL
+ *   '0x1f'     stores 31                    refused, "Data truncated"
+ *   '1_000'    stores 1000                  refused, "Data truncated"
+ *   '12.5'     refused, "invalid input"     stores 13, rounded
+ *   '1e3'      refused                      stores 1000
+ *   '.5'       refused                      stores 1
+ *
+ * So no single pattern is right for both. The union of the two admits `'12.5'` on Postgres, which
+ * is one of the 14 above, and the intersection turns away values each server stores, which is the
+ * failure this file's sibling entries in `COLUMN_FORMATS` were built to avoid. The dialect split
+ * is the same one the analyzer already carries for `varchar` characters against TEXT bytes.
+ *
+ * SingleStore takes MySQL's, which is where every other MySQL-shaped answer in the analyzer goes
+ * (see `decimalModeRange`), and mssql takes neither: `MsSqlBigInt` states `string int64` too, and
+ * there is no SQL Server here to read a row back from, so it keeps the bare string it had.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer, type Column } from '@drzl/analyzer';
+
+const DIR = path.join(__dirname, '.tmp-bigint-string-format');
+
+const SCHEMAS = {
+  pg: `
+    import { pgTable, bigint } from 'drizzle-orm-v1/pg-core';
+    export const t = pgTable('t', {
+      b: bigint('b', { mode: 'string' }).notNull(),
+      b_num: bigint('b_num', { mode: 'number' }).notNull(),
+      b_big: bigint('b_big', { mode: 'bigint' }).notNull(),
+    });
+  `,
+  mysql: `
+    import { mysqlTable, bigint } from 'drizzle-orm-v1/mysql-core';
+    export const t = mysqlTable('t', {
+      b: bigint('b', { mode: 'string' }).notNull(),
+      u: bigint('u', { mode: 'string', unsigned: true }).notNull(),
+    });
+  `,
+  singlestore: `
+    import { singlestoreTable, bigint } from 'drizzle-orm-v1/singlestore-core';
+    export const t = singlestoreTable('t', {
+      b: bigint('b', { mode: 'string' }).notNull(),
+      u: bigint('u', { mode: 'string', unsigned: true }).notNull(),
+    });
+  `,
+  mssql: `
+    import { mssqlTable, bigint } from 'drizzle-orm-v1/mssql-core';
+    export const t = mssqlTable('t', {
+      b: bigint('b', { mode: 'string' }).notNull(),
+    });
+  `,
+};
+
+const columns: Record<string, Map<string, Column>> = {};
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  for (const [dialect, source] of Object.entries(SCHEMAS)) {
+    const file = path.join(DIR, `${dialect}.mjs`);
+    await fs.writeFile(file, source, 'utf8');
+    const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+    expect(
+      analysis.tables[0],
+      `${dialect}: no table analyzed: ${JSON.stringify(analysis.issues)}`
+    ).toBeTruthy();
+    columns[dialect] = new Map(analysis.tables[0].columns.map((c) => [c.name, c]));
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+describe('the format the string mode carries', () => {
+  it('states the Postgres input syntax on a Postgres column', () => {
+    expect(columns.pg.get('b')).toMatchObject({
+      tsType: 'string',
+      dbType: 'BIGINT',
+      format: 'pgBigint',
+    });
+  });
+
+  it('states the MySQL one on MySQL, in both the signed and the unsigned spelling', () => {
+    expect(columns.mysql.get('b')).toMatchObject({ tsType: 'string', format: 'mysqlBigint' });
+    expect(columns.mysql.get('u')).toMatchObject({ tsType: 'string', format: 'mysqlBigint' });
+  });
+
+  it("gives SingleStore MySQL's answer, which is where its every other answer comes from", () => {
+    expect(columns.singlestore.get('b')).toMatchObject({ tsType: 'string', format: 'mysqlBigint' });
+    expect(columns.singlestore.get('u')).toMatchObject({ tsType: 'string', format: 'mysqlBigint' });
+  });
+
+  it('leaves mssql bare, because no SQL Server was measured for it', () => {
+    expect(columns.mssql.get('b')).toMatchObject({ tsType: 'string', dbType: 'BIGINT' });
+    expect(columns.mssql.get('b')?.format).toBeUndefined();
+  });
+
+  it('leaves the sibling modes untouched: a format is a fact about a string', () => {
+    expect(columns.pg.get('b_num')).toMatchObject({ tsType: 'number', dbType: 'BIGINT' });
+    expect(columns.pg.get('b_num')?.format).toBeUndefined();
+    expect(columns.pg.get('b_big')).toMatchObject({ tsType: 'bigint', dbType: 'BIGINT' });
+    expect(columns.pg.get('b_big')?.format).toBeUndefined();
+  });
+
+  it('states no numeric facts, which would make it read as an integer column', () => {
+    for (const c of [columns.pg.get('b'), columns.mysql.get('b'), columns.mysql.get('u')]) {
+      expect(c?.min, 'min and max together are how isIntegerColumn reads a number column').toBe(
+        undefined
+      );
+      expect(c?.max).toBe(undefined);
+      expect(c?.integer).toBe(undefined);
+    }
+  });
+});

--- a/packages/generator-arktype/test/bigint-string-format.spec.ts
+++ b/packages/generator-arktype/test/bigint-string-format.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * `bigint({ mode: 'string' })` bounded by the input syntax its server really accepts, end to end:
+ * real drizzle v1 tables through the real analyzer and the real ArkType generator, with the emitted
+ * output run against values.
+ *
+ * The defect, measured against a real Postgres through PGlite with the parity gate's own
+ * MATRIX_POOL: the emitted schema was a bare string, and on 14 of the 36 values it accepted an
+ * insert Postgres refuses, with `drizzle-orm` agreeing with Postgres on every one of them. The 14
+ * are the whole of `PG_REFUSES` below.
+ *
+ * The two servers disagree in both directions, so there are two patterns and not one. Postgres
+ * stores `'0x1f'` as 31 and `'1_000'` as 1000 and refuses `'12.5'`; MySQL 8.4.11 refuses both of
+ * the first two and stores `'12.5'` as 13, rounded. Each list below is what that server answered.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { type } from 'arktype';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ArkTypeGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-bigint-string-format');
+
+const PG_SCHEMA = `
+  import { pgTable, bigint } from 'drizzle-orm-v1/pg-core';
+  export const pgt = pgTable('pgt', { b: bigint('b', { mode: 'string' }).notNull() });
+`;
+const MY_SCHEMA = `
+  import { mysqlTable, bigint } from 'drizzle-orm-v1/mysql-core';
+  export const myt = mysqlTable('myt', {
+    b: bigint('b', { mode: 'string' }).notNull(),
+    u: bigint('u', { mode: 'string', unsigned: true }).notNull(),
+  });
+`;
+
+/** Values a real Postgres stores in a `bigint` column, so the schema must take every one. */
+const PG_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '1_000',
+  '0x1f',
+  '0X1F',
+  '0xdead_beef',
+  '0o17',
+  '0b1010',
+  '0101',
+  '010',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** The 14 values Postgres refuses that the bare string accepted. */
+const PG_REFUSES = [
+  '',
+  'hello',
+  'x'.repeat(300),
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+  '\u{1F44D}'.repeat(5),
+  '12.5',
+  '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  'not-a-uuid',
+  'happy',
+  'zzz',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+];
+/** Values MySQL 8.4.11 stores in a `bigint` column, rounding the fractional ones. */
+const MY_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '12.5',
+  '1.5',
+  '1e3',
+  '.5',
+  '1.',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** Values MySQL refuses outright, by "Incorrect integer value" or "Data truncated". */
+const MY_REFUSES = [
+  '',
+  'hello',
+  '1_000',
+  '0x1f',
+  '0b1010',
+  'NaN',
+  'Infinity',
+  'not-a-uuid',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+];
+/** What the read path hands back: the codec casts to text, so a stored row is plain digits. */
+const RETURNED = ['1', '-1', '0', '31', '7', '1000', '9223372036854775807', '-9223372036854775808'];
+
+const show = (v: string) => (v.length > 20 ? `${v.length} chars` : JSON.stringify(v));
+
+let pg: Record<string, any>;
+let my: Record<string, any>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  for (const source of [PG_SCHEMA, MY_SCHEMA]) {
+    const file = path.join(DIR, `${source.includes('pgTable') ? 'pg' : 'my'}.mjs`);
+    await fs.writeFile(file, source, 'utf8');
+    const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+    expect(
+      analysis.tables[0],
+      `no table analyzed: ${JSON.stringify(analysis.issues)}`
+    ).toBeTruthy();
+    await new ArkTypeGenerator(analysis).generate({ outDir: DIR } as never);
+  }
+  const pgFile = path.join(DIR, `pgt-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 'pgt.arktype.ts'), pgFile);
+  pg = await import(pgFile);
+  const myFile = path.join(DIR, `myt-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 'myt.arktype.ts'), myFile);
+  my = await import(myFile);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const ok = (schema: any, field: string, value: unknown) =>
+  !(schema.get(field)(value) instanceof type.errors);
+const pgSelect = (x: string) => ok(pg.SelectpgtSchema, 'b', x);
+const pgInsert = (x: string) => ok(pg.InsertpgtSchema, 'b', x);
+const mySelect = (x: string) => ok(my.SelectmytSchema, 'b', x);
+const myInsert = (x: string) => ok(my.InsertmytSchema, 'b', x);
+const myUnsigned = (x: string) => ok(my.SelectmytSchema, 'u', x);
+
+describe('the Postgres column, against what PGlite answered', () => {
+  it('takes every value the server stores', () => {
+    for (const v of PG_ADMITS) expect(pgSelect(v), `Postgres stores ${show(v)}`).toBe(true);
+  });
+
+  it('refuses all 14 the server rejects, on the insert schema the gate grades', () => {
+    for (const v of PG_REFUSES) expect(pgInsert(v), `Postgres refuses ${show(v)}`).toBe(false);
+  });
+
+  it('refuses them on select too, since none is a value the column can return', () => {
+    for (const v of PG_REFUSES) expect(pgSelect(v)).toBe(false);
+  });
+
+  it('takes every value the read path hands back, which is plain digits', () => {
+    // The `bigint:string` codec casts to text and registers no normalize, so a row written as
+    // '0x1f' comes back '31' and one written as '007' comes back '7'. Measured through
+    // drizzle-orm 1.0.0-rc.4 on PGlite.
+    for (const v of RETURNED) expect(pgSelect(v)).toBe(true);
+  });
+
+  it('leaves the magnitude unstated, which is the one half of the fact this does not carry', () => {
+    // Asserted rather than left implicit, so stating it later reports itself here rather than
+    // going in silently. Postgres refuses both of these and this schema takes them: the exact
+    // bound is a per-digit ladder whose branch count exhausts ArkType's type-level budget, so
+    // carrying it would emit an arktype module that does not compile. See COLUMN_FORMATS.
+    expect(pgSelect('9223372036854775808')).toBe(true);
+    expect(pgSelect('-9223372036854775809')).toBe(true);
+  });
+});
+
+describe('the MySQL column, against what MySQL 8.4.11 answered', () => {
+  it('takes every value the server stores, fractions included, because MySQL rounds them', () => {
+    for (const v of MY_ADMITS) expect(mySelect(v), `MySQL stores ${show(v)}`).toBe(true);
+  });
+
+  it('refuses what MySQL refuses, including the two spellings Postgres accepts', () => {
+    for (const v of MY_REFUSES) expect(myInsert(v), `MySQL refuses ${show(v)}`).toBe(false);
+  });
+
+  it('takes the unsigned ceiling MySQL really stores, where drizzle-orm refuses it', () => {
+    // Measured: a `bigint unsigned` stores 18446744073709551615 and hands it back, and
+    // `drizzle-orm` at 1.0.0-rc.4 caps the same column at the signed int64 maximum, so its select
+    // schema rejects a row the driver returns. That is an intended divergence.
+    expect(myUnsigned('18446744073709551615')).toBe(true);
+    expect(myUnsigned('9223372036854775808')).toBe(true);
+  });
+});

--- a/packages/generator-effect/test/bigint-string-format.spec.ts
+++ b/packages/generator-effect/test/bigint-string-format.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * `bigint({ mode: 'string' })` bounded by the input syntax its server really accepts, end to end:
+ * real drizzle v1 tables through the real analyzer and the real Effect generator, with the emitted
+ * output run against values.
+ *
+ * The defect, measured against a real Postgres through PGlite with the parity gate's own
+ * MATRIX_POOL: the emitted schema was a bare string, and on 14 of the 36 values it accepted an
+ * insert Postgres refuses, with `drizzle-orm` agreeing with Postgres on every one of them. The 14
+ * are the whole of `PG_REFUSES` below.
+ *
+ * The two servers disagree in both directions, so there are two patterns and not one. Postgres
+ * stores `'0x1f'` as 31 and `'1_000'` as 1000 and refuses `'12.5'`; MySQL 8.4.11 refuses both of
+ * the first two and stores `'12.5'` as 13, rounded. Each list below is what that server answered.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { EffectGenerator } from '../src/index';
+import { accepts } from './fixtures';
+
+const DIR = path.join(__dirname, '.tmp-bigint-string-format');
+
+const PG_SCHEMA = `
+  import { pgTable, bigint } from 'drizzle-orm-v1/pg-core';
+  export const pgt = pgTable('pgt', { b: bigint('b', { mode: 'string' }).notNull() });
+`;
+const MY_SCHEMA = `
+  import { mysqlTable, bigint } from 'drizzle-orm-v1/mysql-core';
+  export const myt = mysqlTable('myt', {
+    b: bigint('b', { mode: 'string' }).notNull(),
+    u: bigint('u', { mode: 'string', unsigned: true }).notNull(),
+  });
+`;
+
+/** Values a real Postgres stores in a `bigint` column, so the schema must take every one. */
+const PG_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '1_000',
+  '0x1f',
+  '0X1F',
+  '0xdead_beef',
+  '0o17',
+  '0b1010',
+  '0101',
+  '010',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** The 14 values Postgres refuses that the bare string accepted. */
+const PG_REFUSES = [
+  '',
+  'hello',
+  'x'.repeat(300),
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+  '\u{1F44D}'.repeat(5),
+  '12.5',
+  '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  'not-a-uuid',
+  'happy',
+  'zzz',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+];
+/** Values MySQL 8.4.11 stores in a `bigint` column, rounding the fractional ones. */
+const MY_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '12.5',
+  '1.5',
+  '1e3',
+  '.5',
+  '1.',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** Values MySQL refuses outright, by "Incorrect integer value" or "Data truncated". */
+const MY_REFUSES = [
+  '',
+  'hello',
+  '1_000',
+  '0x1f',
+  '0b1010',
+  'NaN',
+  'Infinity',
+  'not-a-uuid',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+];
+/** What the read path hands back: the codec casts to text, so a stored row is plain digits. */
+const RETURNED = ['1', '-1', '0', '31', '7', '1000', '9223372036854775807', '-9223372036854775808'];
+
+const show = (v: string) => (v.length > 20 ? `${v.length} chars` : JSON.stringify(v));
+
+let pg: Record<string, any>;
+let my: Record<string, any>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  for (const source of [PG_SCHEMA, MY_SCHEMA]) {
+    const file = path.join(DIR, `${source.includes('pgTable') ? 'pg' : 'my'}.mjs`);
+    await fs.writeFile(file, source, 'utf8');
+    const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+    expect(
+      analysis.tables[0],
+      `no table analyzed: ${JSON.stringify(analysis.issues)}`
+    ).toBeTruthy();
+    await new EffectGenerator(analysis).generate({ outDir: DIR } as never);
+  }
+  const pgFile = path.join(DIR, `pgt-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 'pgt.effect.ts'), pgFile);
+  pg = await import(pgFile);
+  const myFile = path.join(DIR, `myt-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 'myt.effect.ts'), myFile);
+  my = await import(myFile);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+// Effect states a struct, so the probe is a whole row with the one column under test set.
+const pgSelect = (x: string) => accepts(pg.SelectpgtSchema, { b: x });
+const pgInsert = (x: string) => accepts(pg.InsertpgtSchema, { b: x });
+const mySelect = (x: string) => accepts(my.SelectmytSchema, { b: x, u: '1' });
+const myInsert = (x: string) => accepts(my.InsertmytSchema, { b: x, u: '1' });
+const myUnsigned = (x: string) => accepts(my.SelectmytSchema, { b: '1', u: x });
+
+describe('the Postgres column, against what PGlite answered', () => {
+  it('takes every value the server stores', () => {
+    for (const v of PG_ADMITS) expect(pgSelect(v), `Postgres stores ${show(v)}`).toBe(true);
+  });
+
+  it('refuses all 14 the server rejects, on the insert schema the gate grades', () => {
+    for (const v of PG_REFUSES) expect(pgInsert(v), `Postgres refuses ${show(v)}`).toBe(false);
+  });
+
+  it('refuses them on select too, since none is a value the column can return', () => {
+    for (const v of PG_REFUSES) expect(pgSelect(v)).toBe(false);
+  });
+
+  it('takes every value the read path hands back, which is plain digits', () => {
+    // The `bigint:string` codec casts to text and registers no normalize, so a row written as
+    // '0x1f' comes back '31' and one written as '007' comes back '7'. Measured through
+    // drizzle-orm 1.0.0-rc.4 on PGlite.
+    for (const v of RETURNED) expect(pgSelect(v)).toBe(true);
+  });
+
+  it('leaves the magnitude unstated, which is the one half of the fact this does not carry', () => {
+    // Asserted rather than left implicit, so stating it later reports itself here rather than
+    // going in silently. Postgres refuses both of these and this schema takes them: the exact
+    // bound is a per-digit ladder whose branch count exhausts ArkType's type-level budget, so
+    // carrying it would emit an arktype module that does not compile. See COLUMN_FORMATS.
+    expect(pgSelect('9223372036854775808')).toBe(true);
+    expect(pgSelect('-9223372036854775809')).toBe(true);
+  });
+});
+
+describe('the MySQL column, against what MySQL 8.4.11 answered', () => {
+  it('takes every value the server stores, fractions included, because MySQL rounds them', () => {
+    for (const v of MY_ADMITS) expect(mySelect(v), `MySQL stores ${show(v)}`).toBe(true);
+  });
+
+  it('refuses what MySQL refuses, including the two spellings Postgres accepts', () => {
+    for (const v of MY_REFUSES) expect(myInsert(v), `MySQL refuses ${show(v)}`).toBe(false);
+  });
+
+  it('takes the unsigned ceiling MySQL really stores, where drizzle-orm refuses it', () => {
+    // Measured: a `bigint unsigned` stores 18446744073709551615 and hands it back, and
+    // `drizzle-orm` at 1.0.0-rc.4 caps the same column at the signed int64 maximum, so its select
+    // schema rejects a row the driver returns. That is an intended divergence.
+    expect(myUnsigned('18446744073709551615')).toBe(true);
+    expect(myUnsigned('9223372036854775808')).toBe(true);
+  });
+});

--- a/packages/generator-json-schema/test/bigint-string-format.spec.ts
+++ b/packages/generator-json-schema/test/bigint-string-format.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * `bigint({ mode: 'string' })` bounded by the input syntax its server really accepts: real drizzle
+ * v1 tables through the real analyzer, the resulting documents compiled by ajv in strict mode and
+ * run against values.
+ *
+ * The defect, measured against a real Postgres through PGlite with the parity gate's own
+ * MATRIX_POOL: the document said `{"type":"string"}` and nothing else, so on 14 of the 36 values
+ * it accepted an insert Postgres refuses, with `drizzle-orm` agreeing with Postgres on every one
+ * of them. The 14 are the whole of `PG_REFUSES` below.
+ *
+ * This is the format that carries the fact natively: `pattern` is a keyword every draft has, so
+ * the statement here is the same string the four validation generators compile to a RegExp,
+ * rather than an approximation of it. Not to be confused with the `bigint`-wire arm beside it,
+ * which is a *bigint*-typed column serialised as a digit string; this one is a column whose
+ * TypeScript type is already `string`, and the pattern is what the server will parse.
+ *
+ * The two servers disagree in both directions, so there are two patterns and not one. Postgres
+ * stores `'0x1f'` as 31 and `'1_000'` as 1000 and refuses `'12.5'`; MySQL 8.4.11 refuses both of
+ * the first two and stores `'12.5'` as 13, rounded.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import { SchemaAnalyzer, type Table } from '@drzl/analyzer';
+import { tableSchemas } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-bigint-string-format');
+
+const PG_SCHEMA = `
+  import { pgTable, bigint } from 'drizzle-orm-v1/pg-core';
+  export const pgt = pgTable('pgt', { b: bigint('b', { mode: 'string' }).notNull() });
+`;
+const MY_SCHEMA = `
+  import { mysqlTable, bigint } from 'drizzle-orm-v1/mysql-core';
+  export const myt = mysqlTable('myt', {
+    b: bigint('b', { mode: 'string' }).notNull(),
+    u: bigint('u', { mode: 'string', unsigned: true }).notNull(),
+  });
+`;
+
+/** Values a real Postgres stores in a `bigint` column, so the document must take every one. */
+const PG_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '1_000',
+  '0x1f',
+  '0X1F',
+  '0xdead_beef',
+  '0o17',
+  '0b1010',
+  '0101',
+  '010',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** The 14 values Postgres refuses that the bare string accepted. */
+const PG_REFUSES = [
+  '',
+  'hello',
+  'x'.repeat(300),
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+  '\u{1F44D}'.repeat(5),
+  '12.5',
+  '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  'not-a-uuid',
+  'happy',
+  'zzz',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+];
+/** Values MySQL 8.4.11 stores in a `bigint` column, rounding the fractional ones. */
+const MY_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '12.5',
+  '1.5',
+  '1e3',
+  '.5',
+  '1.',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** Values MySQL refuses outright, by "Incorrect integer value" or "Data truncated". */
+const MY_REFUSES = [
+  '',
+  'hello',
+  '1_000',
+  '0x1f',
+  '0b1010',
+  'NaN',
+  'Infinity',
+  'not-a-uuid',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+];
+/** What the read path hands back: the codec casts to text, so a stored row is plain digits. */
+const RETURNED = ['1', '-1', '0', '31', '7', '1000', '9223372036854775807', '-9223372036854775808'];
+
+let pgTable_: Table;
+let myTable: Table;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  const analysed: Table[] = [];
+  for (const [name, source] of [
+    ['pg', PG_SCHEMA],
+    ['my', MY_SCHEMA],
+  ] as const) {
+    const file = path.join(DIR, `${name}.mjs`);
+    await fs.writeFile(file, source, 'utf8');
+    const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+    expect(
+      analysis.tables[0],
+      `no table analyzed: ${JSON.stringify(analysis.issues)}`
+    ).toBeTruthy();
+    analysed.push(analysis.tables[0]);
+  }
+  [pgTable_, myTable] = analysed;
+  await fs.rm(DIR, { recursive: true, force: true });
+}, 120_000);
+
+function compile(schema: unknown) {
+  const ajv = new Ajv2020({ strict: true, allErrors: true });
+  addFormats(ajv as never);
+  return ajv.compile(schema as never);
+}
+
+const show = (v: string) => (v.length > 20 ? `${v.length} chars` : JSON.stringify(v));
+
+describe('the Postgres document, against what PGlite answered', () => {
+  it('states the syntax as a pattern rather than leaving the string bare', () => {
+    const s = tableSchemas(pgTable_).select as any;
+    expect(s.properties.b.type).toBe('string');
+    expect(typeof s.properties.b.pattern, 'a bare string is the defect').toBe('string');
+  });
+
+  it('takes every value the server stores, under ajv strict mode', () => {
+    const ok = compile(tableSchemas(pgTable_).select);
+    for (const v of [...PG_ADMITS, ...RETURNED]) {
+      expect(ok({ b: v }), `Postgres stores ${show(v)}`).toBe(true);
+    }
+  });
+
+  it('refuses all 14 the server rejects, on the insert document the gate grades', () => {
+    const ok = compile(tableSchemas(pgTable_).insert);
+    for (const v of PG_REFUSES) expect(ok({ b: v }), `Postgres refuses ${show(v)}`).toBe(false);
+  });
+
+  it('leaves the magnitude unstated, which is the one half of the fact this does not carry', () => {
+    // Asserted rather than left implicit, so stating it later reports itself here rather than
+    // going in silently. Postgres refuses both of these and this document takes them: the exact
+    // bound is a per-digit ladder whose branch count exhausts ArkType's type-level budget, so
+    // carrying it would emit an arktype module that does not compile. See COLUMN_FORMATS.
+    const ok = compile(tableSchemas(pgTable_).select);
+    expect(ok({ b: '9223372036854775808' })).toBe(true);
+    expect(ok({ b: '-9223372036854775809' })).toBe(true);
+  });
+});
+
+describe('the MySQL document, against what MySQL 8.4.11 answered', () => {
+  it('takes every value the server stores, fractions included, because MySQL rounds them', () => {
+    const ok = compile(tableSchemas(myTable).select);
+    for (const v of MY_ADMITS) expect(ok({ b: v, u: '1' }), `MySQL stores ${show(v)}`).toBe(true);
+  });
+
+  it('refuses what MySQL refuses, including the two spellings Postgres accepts', () => {
+    const ok = compile(tableSchemas(myTable).insert);
+    for (const v of MY_REFUSES)
+      expect(ok({ b: v, u: '1' }), `MySQL refuses ${show(v)}`).toBe(false);
+  });
+
+  it('takes the unsigned ceiling MySQL really stores, where drizzle-orm refuses it', () => {
+    // Measured: a `bigint unsigned` stores 18446744073709551615 and hands it back, and
+    // `drizzle-orm` at 1.0.0-rc.4 caps the same column at the signed int64 maximum, so its select
+    // schema rejects a row the driver returns. That is an intended divergence.
+    const ok = compile(tableSchemas(myTable).select);
+    expect(ok({ b: '1', u: '18446744073709551615' })).toBe(true);
+    expect(ok({ b: '1', u: '9223372036854775808' })).toBe(true);
+  });
+});

--- a/packages/generator-typebox/test/bigint-string-format.spec.ts
+++ b/packages/generator-typebox/test/bigint-string-format.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * `bigint({ mode: 'string' })` bounded by the input syntax its server really accepts, end to end:
+ * real drizzle v1 tables through the real analyzer and the real TypeBox generator, with the emitted
+ * output run against values.
+ *
+ * The defect, measured against a real Postgres through PGlite with the parity gate's own
+ * MATRIX_POOL: the emitted schema was a bare string, and on 14 of the 36 values it accepted an
+ * insert Postgres refuses, with `drizzle-orm` agreeing with Postgres on every one of them. The 14
+ * are the whole of `PG_REFUSES` below.
+ *
+ * The two servers disagree in both directions, so there are two patterns and not one. Postgres
+ * stores `'0x1f'` as 31 and `'1_000'` as 1000 and refuses `'12.5'`; MySQL 8.4.11 refuses both of
+ * the first two and stores `'12.5'` as 13, rounded. Each list below is what that server answered.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { TypeBoxGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-bigint-string-format');
+
+const PG_SCHEMA = `
+  import { pgTable, bigint } from 'drizzle-orm-v1/pg-core';
+  export const pgt = pgTable('pgt', { b: bigint('b', { mode: 'string' }).notNull() });
+`;
+const MY_SCHEMA = `
+  import { mysqlTable, bigint } from 'drizzle-orm-v1/mysql-core';
+  export const myt = mysqlTable('myt', {
+    b: bigint('b', { mode: 'string' }).notNull(),
+    u: bigint('u', { mode: 'string', unsigned: true }).notNull(),
+  });
+`;
+
+/** Values a real Postgres stores in a `bigint` column, so the schema must take every one. */
+const PG_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '1_000',
+  '0x1f',
+  '0X1F',
+  '0xdead_beef',
+  '0o17',
+  '0b1010',
+  '0101',
+  '010',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** The 14 values Postgres refuses that the bare string accepted. */
+const PG_REFUSES = [
+  '',
+  'hello',
+  'x'.repeat(300),
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+  '\u{1F44D}'.repeat(5),
+  '12.5',
+  '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  'not-a-uuid',
+  'happy',
+  'zzz',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+];
+/** Values MySQL 8.4.11 stores in a `bigint` column, rounding the fractional ones. */
+const MY_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '12.5',
+  '1.5',
+  '1e3',
+  '.5',
+  '1.',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** Values MySQL refuses outright, by "Incorrect integer value" or "Data truncated". */
+const MY_REFUSES = [
+  '',
+  'hello',
+  '1_000',
+  '0x1f',
+  '0b1010',
+  'NaN',
+  'Infinity',
+  'not-a-uuid',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+];
+/** What the read path hands back: the codec casts to text, so a stored row is plain digits. */
+const RETURNED = ['1', '-1', '0', '31', '7', '1000', '9223372036854775807', '-9223372036854775808'];
+
+const show = (v: string) => (v.length > 20 ? `${v.length} chars` : JSON.stringify(v));
+
+let pg: Record<string, any>;
+let my: Record<string, any>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  for (const source of [PG_SCHEMA, MY_SCHEMA]) {
+    const file = path.join(DIR, `${source.includes('pgTable') ? 'pg' : 'my'}.mjs`);
+    await fs.writeFile(file, source, 'utf8');
+    const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+    expect(
+      analysis.tables[0],
+      `no table analyzed: ${JSON.stringify(analysis.issues)}`
+    ).toBeTruthy();
+    await new TypeBoxGenerator(analysis).generate({ outDir: DIR } as never);
+  }
+  const pgFile = path.join(DIR, `pgt-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 'pgt.typebox.ts'), pgFile);
+  pg = await import(pgFile);
+  const myFile = path.join(DIR, `myt-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 'myt.typebox.ts'), myFile);
+  my = await import(myFile);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+/** Both checkers must agree, so a pattern the compiler preflight rejects cannot hide. */
+const ok = (schema: any, value: unknown) => {
+  const plain = Value.Check(schema, value);
+  const compiled = TypeCompiler.Compile(schema).Check(value);
+  expect(compiled, 'Value.Check and TypeCompiler disagree').toBe(plain);
+  return plain;
+};
+const pgSelect = (x: string) => ok(pg.SelectpgtSchema.properties.b, x);
+const pgInsert = (x: string) => ok(pg.InsertpgtSchema.properties.b, x);
+const mySelect = (x: string) => ok(my.SelectmytSchema.properties.b, x);
+const myInsert = (x: string) => ok(my.InsertmytSchema.properties.b, x);
+const myUnsigned = (x: string) => ok(my.SelectmytSchema.properties.u, x);
+
+describe('the Postgres column, against what PGlite answered', () => {
+  it('takes every value the server stores', () => {
+    for (const v of PG_ADMITS) expect(pgSelect(v), `Postgres stores ${show(v)}`).toBe(true);
+  });
+
+  it('refuses all 14 the server rejects, on the insert schema the gate grades', () => {
+    for (const v of PG_REFUSES) expect(pgInsert(v), `Postgres refuses ${show(v)}`).toBe(false);
+  });
+
+  it('refuses them on select too, since none is a value the column can return', () => {
+    for (const v of PG_REFUSES) expect(pgSelect(v)).toBe(false);
+  });
+
+  it('takes every value the read path hands back, which is plain digits', () => {
+    // The `bigint:string` codec casts to text and registers no normalize, so a row written as
+    // '0x1f' comes back '31' and one written as '007' comes back '7'. Measured through
+    // drizzle-orm 1.0.0-rc.4 on PGlite.
+    for (const v of RETURNED) expect(pgSelect(v)).toBe(true);
+  });
+
+  it('leaves the magnitude unstated, which is the one half of the fact this does not carry', () => {
+    // Asserted rather than left implicit, so stating it later reports itself here rather than
+    // going in silently. Postgres refuses both of these and this schema takes them: the exact
+    // bound is a per-digit ladder whose branch count exhausts ArkType's type-level budget, so
+    // carrying it would emit an arktype module that does not compile. See COLUMN_FORMATS.
+    expect(pgSelect('9223372036854775808')).toBe(true);
+    expect(pgSelect('-9223372036854775809')).toBe(true);
+  });
+});
+
+describe('the MySQL column, against what MySQL 8.4.11 answered', () => {
+  it('takes every value the server stores, fractions included, because MySQL rounds them', () => {
+    for (const v of MY_ADMITS) expect(mySelect(v), `MySQL stores ${show(v)}`).toBe(true);
+  });
+
+  it('refuses what MySQL refuses, including the two spellings Postgres accepts', () => {
+    for (const v of MY_REFUSES) expect(myInsert(v), `MySQL refuses ${show(v)}`).toBe(false);
+  });
+
+  it('takes the unsigned ceiling MySQL really stores, where drizzle-orm refuses it', () => {
+    // Measured: a `bigint unsigned` stores 18446744073709551615 and hands it back, and
+    // `drizzle-orm` at 1.0.0-rc.4 caps the same column at the signed int64 maximum, so its select
+    // schema rejects a row the driver returns. That is an intended divergence.
+    expect(myUnsigned('18446744073709551615')).toBe(true);
+    expect(myUnsigned('9223372036854775808')).toBe(true);
+  });
+});

--- a/packages/generator-valibot/test/bigint-string-format.spec.ts
+++ b/packages/generator-valibot/test/bigint-string-format.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * `bigint({ mode: 'string' })` bounded by the input syntax its server really accepts, end to end:
+ * real drizzle v1 tables through the real analyzer and the real valibot generator, with the emitted
+ * output run against values.
+ *
+ * The defect, measured against a real Postgres through PGlite with the parity gate's own
+ * MATRIX_POOL: the emitted schema was a bare string, and on 14 of the 36 values it accepted an
+ * insert Postgres refuses, with `drizzle-orm` agreeing with Postgres on every one of them. The 14
+ * are the whole of `PG_REFUSES` below.
+ *
+ * The two servers disagree in both directions, so there are two patterns and not one. Postgres
+ * stores `'0x1f'` as 31 and `'1_000'` as 1000 and refuses `'12.5'`; MySQL 8.4.11 refuses both of
+ * the first two and stores `'12.5'` as 13, rounded. Each list below is what that server answered.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import * as v from 'valibot';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ValibotGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-bigint-string-format');
+
+const PG_SCHEMA = `
+  import { pgTable, bigint } from 'drizzle-orm-v1/pg-core';
+  export const pgt = pgTable('pgt', { b: bigint('b', { mode: 'string' }).notNull() });
+`;
+const MY_SCHEMA = `
+  import { mysqlTable, bigint } from 'drizzle-orm-v1/mysql-core';
+  export const myt = mysqlTable('myt', {
+    b: bigint('b', { mode: 'string' }).notNull(),
+    u: bigint('u', { mode: 'string', unsigned: true }).notNull(),
+  });
+`;
+
+/** Values a real Postgres stores in a `bigint` column, so the schema must take every one. */
+const PG_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '1_000',
+  '0x1f',
+  '0X1F',
+  '0xdead_beef',
+  '0o17',
+  '0b1010',
+  '0101',
+  '010',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** The 14 values Postgres refuses that the bare string accepted. */
+const PG_REFUSES = [
+  '',
+  'hello',
+  'x'.repeat(300),
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+  '\u{1F44D}'.repeat(5),
+  '12.5',
+  '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  'not-a-uuid',
+  'happy',
+  'zzz',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+];
+/** Values MySQL 8.4.11 stores in a `bigint` column, rounding the fractional ones. */
+const MY_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '12.5',
+  '1.5',
+  '1e3',
+  '.5',
+  '1.',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** Values MySQL refuses outright, by "Incorrect integer value" or "Data truncated". */
+const MY_REFUSES = [
+  '',
+  'hello',
+  '1_000',
+  '0x1f',
+  '0b1010',
+  'NaN',
+  'Infinity',
+  'not-a-uuid',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+];
+/** What the read path hands back: the codec casts to text, so a stored row is plain digits. */
+const RETURNED = ['1', '-1', '0', '31', '7', '1000', '9223372036854775807', '-9223372036854775808'];
+
+const show = (v: string) => (v.length > 20 ? `${v.length} chars` : JSON.stringify(v));
+
+let pg: Record<string, any>;
+let my: Record<string, any>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  for (const source of [PG_SCHEMA, MY_SCHEMA]) {
+    const file = path.join(DIR, `${source.includes('pgTable') ? 'pg' : 'my'}.mjs`);
+    await fs.writeFile(file, source, 'utf8');
+    const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+    expect(
+      analysis.tables[0],
+      `no table analyzed: ${JSON.stringify(analysis.issues)}`
+    ).toBeTruthy();
+    await new ValibotGenerator(analysis).generate({ outDir: DIR } as never);
+  }
+  const pgFile = path.join(DIR, `pgt-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 'pgt.valibot.ts'), pgFile);
+  pg = await import(pgFile);
+  const myFile = path.join(DIR, `myt-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 'myt.valibot.ts'), myFile);
+  my = await import(myFile);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const ok = (schema: any, value: unknown) => v.safeParse(schema, value).success;
+const pgSelect = (x: string) => ok(pg.SelectpgtSchema.entries.b, x);
+const pgInsert = (x: string) => ok(pg.InsertpgtSchema.entries.b, x);
+const mySelect = (x: string) => ok(my.SelectmytSchema.entries.b, x);
+const myInsert = (x: string) => ok(my.InsertmytSchema.entries.b, x);
+const myUnsigned = (x: string) => ok(my.SelectmytSchema.entries.u, x);
+
+describe('the Postgres column, against what PGlite answered', () => {
+  it('takes every value the server stores', () => {
+    for (const v of PG_ADMITS) expect(pgSelect(v), `Postgres stores ${show(v)}`).toBe(true);
+  });
+
+  it('refuses all 14 the server rejects, on the insert schema the gate grades', () => {
+    for (const v of PG_REFUSES) expect(pgInsert(v), `Postgres refuses ${show(v)}`).toBe(false);
+  });
+
+  it('refuses them on select too, since none is a value the column can return', () => {
+    for (const v of PG_REFUSES) expect(pgSelect(v)).toBe(false);
+  });
+
+  it('takes every value the read path hands back, which is plain digits', () => {
+    // The `bigint:string` codec casts to text and registers no normalize, so a row written as
+    // '0x1f' comes back '31' and one written as '007' comes back '7'. Measured through
+    // drizzle-orm 1.0.0-rc.4 on PGlite.
+    for (const v of RETURNED) expect(pgSelect(v)).toBe(true);
+  });
+
+  it('leaves the magnitude unstated, which is the one half of the fact this does not carry', () => {
+    // Asserted rather than left implicit, so stating it later reports itself here rather than
+    // going in silently. Postgres refuses both of these and this schema takes them: the exact
+    // bound is a per-digit ladder whose branch count exhausts ArkType's type-level budget, so
+    // carrying it would emit an arktype module that does not compile. See COLUMN_FORMATS.
+    expect(pgSelect('9223372036854775808')).toBe(true);
+    expect(pgSelect('-9223372036854775809')).toBe(true);
+  });
+});
+
+describe('the MySQL column, against what MySQL 8.4.11 answered', () => {
+  it('takes every value the server stores, fractions included, because MySQL rounds them', () => {
+    for (const v of MY_ADMITS) expect(mySelect(v), `MySQL stores ${show(v)}`).toBe(true);
+  });
+
+  it('refuses what MySQL refuses, including the two spellings Postgres accepts', () => {
+    for (const v of MY_REFUSES) expect(myInsert(v), `MySQL refuses ${show(v)}`).toBe(false);
+  });
+
+  it('takes the unsigned ceiling MySQL really stores, where drizzle-orm refuses it', () => {
+    // Measured: a `bigint unsigned` stores 18446744073709551615 and hands it back, and
+    // `drizzle-orm` at 1.0.0-rc.4 caps the same column at the signed int64 maximum, so its select
+    // schema rejects a row the driver returns. That is an intended divergence.
+    expect(myUnsigned('18446744073709551615')).toBe(true);
+    expect(myUnsigned('9223372036854775808')).toBe(true);
+  });
+});

--- a/packages/generator-zod/test/bigint-string-format.spec.ts
+++ b/packages/generator-zod/test/bigint-string-format.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * `bigint({ mode: 'string' })` bounded by the input syntax its server really accepts, end to end:
+ * real drizzle v1 tables through the real analyzer and the real zod generator, with the emitted
+ * modules imported and run.
+ *
+ * The defect, measured against a real Postgres through PGlite with the parity gate's own
+ * MATRIX_POOL: the emitted schema was a bare `z.string()`, and on 14 of the 36 values it accepted
+ * an insert Postgres refuses, with `drizzle-orm/zod` agreeing with Postgres on every one of them.
+ * The 14 are the whole of `PG_REFUSES` below.
+ *
+ * The two servers disagree in both directions, so there are two patterns and not one. Postgres
+ * stores `'0x1f'` as 31 and `'1_000'` as 1000 and refuses `'12.5'`; MySQL 8.4.11 refuses both of
+ * the first two and stores `'12.5'` as 13, rounded. Each list below is what that server answered.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ZodGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-bigint-string-format');
+
+const PG_SCHEMA = `
+  import { pgTable, bigint } from 'drizzle-orm-v1/pg-core';
+  export const pgt = pgTable('pgt', { b: bigint('b', { mode: 'string' }).notNull() });
+`;
+const MY_SCHEMA = `
+  import { mysqlTable, bigint } from 'drizzle-orm-v1/mysql-core';
+  export const myt = mysqlTable('myt', {
+    b: bigint('b', { mode: 'string' }).notNull(),
+    u: bigint('u', { mode: 'string', unsigned: true }).notNull(),
+  });
+`;
+
+/** Values a real Postgres stores in a `bigint` column, so the schema must take every one. */
+const PG_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '1_000',
+  '0x1f',
+  '0X1F',
+  '0xdead_beef',
+  '0o17',
+  '0b1010',
+  '0101',
+  '010',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** The 14 values Postgres refuses that the bare string accepted. */
+const PG_REFUSES = [
+  '',
+  'hello',
+  'x'.repeat(300),
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+  '\u{1F44D}'.repeat(5),
+  '12.5',
+  '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  'not-a-uuid',
+  'happy',
+  'zzz',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+];
+/** Values MySQL 8.4.11 stores in a `bigint` column, rounding the fractional ones. */
+const MY_ADMITS = [
+  '1',
+  '-1',
+  '0',
+  '007',
+  '+1',
+  '  1  ',
+  '12.5',
+  '1.5',
+  '1e3',
+  '.5',
+  '1.',
+  '9223372036854775807',
+  '-9223372036854775808',
+];
+/** Values MySQL refuses outright, by "Incorrect integer value" or "Data truncated". */
+const MY_REFUSES = [
+  '',
+  'hello',
+  '1_000',
+  '0x1f',
+  '0b1010',
+  'NaN',
+  'Infinity',
+  'not-a-uuid',
+  '2020-01-01',
+  '12:00:00',
+  '10.0.0.1',
+  '999.999.999.999',
+  '\u{1F44D}\u{1F44D}\u{1F44D}',
+];
+
+let pg: Record<string, any>;
+let my: Record<string, any>;
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  await fs.mkdir(DIR, { recursive: true });
+  for (const [name, source] of [
+    ['pg', PG_SCHEMA],
+    ['my', MY_SCHEMA],
+  ] as const) {
+    const file = path.join(DIR, `${name}.mjs`);
+    await fs.writeFile(file, source, 'utf8');
+    const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
+    expect(
+      analysis.tables[0],
+      `no table analyzed: ${JSON.stringify(analysis.issues)}`
+    ).toBeTruthy();
+    await new ZodGenerator(analysis).generate({ outDir: DIR } as never);
+  }
+  const pgFile = path.join(DIR, `pgt-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 'pgt.zod.ts'), pgFile);
+  pg = await import(pgFile);
+  const myFile = path.join(DIR, `myt-${process.pid}.ts`);
+  await fs.rename(path.join(DIR, 'myt.zod.ts'), myFile);
+  my = await import(myFile);
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const ok = (schema: any, v: unknown) => schema.safeParse(v).success;
+const show = (v: string) => (v.length > 20 ? `${v.length} chars` : JSON.stringify(v));
+
+describe('the Postgres column, against what PGlite answered', () => {
+  it('takes every value the server stores', () => {
+    for (const v of PG_ADMITS) {
+      expect(ok(pg.SelectpgtSchema.shape.b, v), `Postgres stores ${show(v)}`).toBe(true);
+    }
+  });
+
+  it('refuses all 14 the server rejects, on the insert schema the gate grades', () => {
+    for (const v of PG_REFUSES) {
+      expect(ok(pg.InsertpgtSchema.shape.b, v), `Postgres refuses ${show(v)}`).toBe(false);
+    }
+  });
+
+  it('refuses them on select too, since neither is a value the column can return', () => {
+    for (const v of PG_REFUSES) expect(ok(pg.SelectpgtSchema.shape.b, v)).toBe(false);
+  });
+
+  it('takes every value the read path hands back, which is plain digits', () => {
+    // The `bigint:string` codec casts to text and registers no normalize, so a row written as
+    // '0x1f' comes back '31' and one written as '007' comes back '7'. Measured through
+    // drizzle-orm 1.0.0-rc.4 on PGlite.
+    for (const v of [
+      '1',
+      '-1',
+      '0',
+      '31',
+      '7',
+      '1000',
+      '9223372036854775807',
+      '-9223372036854775808',
+    ]) {
+      expect(ok(pg.SelectpgtSchema.shape.b, v)).toBe(true);
+    }
+  });
+
+  it('still refuses the wire types this column never carries', () => {
+    expect(ok(pg.SelectpgtSchema.shape.b, 123n)).toBe(false);
+    expect(ok(pg.SelectpgtSchema.shape.b, 123)).toBe(false);
+  });
+
+  it('leaves the magnitude unstated, which is the one half of the fact this does not carry', () => {
+    // Asserted rather than left implicit, so stating it later reports itself here rather than
+    // going in silently. Postgres refuses both of these and this schema takes them: the exact
+    // bound is a per-digit ladder whose branch count exhausts ArkType's type-level budget, so
+    // carrying it would emit an arktype module that does not compile. See COLUMN_FORMATS.
+    expect(ok(pg.SelectpgtSchema.shape.b, '9223372036854775808')).toBe(true);
+    expect(ok(pg.SelectpgtSchema.shape.b, '-9223372036854775809')).toBe(true);
+  });
+});
+
+describe('the MySQL column, against what MySQL 8.4.11 answered', () => {
+  it('takes every value the server stores, fractions included, because MySQL rounds them', () => {
+    for (const v of MY_ADMITS) {
+      expect(ok(my.SelectmytSchema.shape.b, v), `MySQL stores ${show(v)}`).toBe(true);
+    }
+  });
+
+  it('refuses what MySQL refuses, including the two spellings Postgres accepts', () => {
+    for (const v of MY_REFUSES) {
+      expect(ok(my.InsertmytSchema.shape.b, v), `MySQL refuses ${show(v)}`).toBe(false);
+    }
+  });
+
+  it('takes the unsigned ceiling MySQL really stores, where drizzle-orm/zod refuses it', () => {
+    // Measured: a `bigint unsigned` stores 18446744073709551615 and hands it back, and
+    // `drizzle-orm/zod` at 1.0.0-rc.4 caps the same column at the signed int64 maximum, so its
+    // select schema rejects a row the driver returns. That is an intended divergence.
+    expect(ok(my.SelectmytSchema.shape.u, '18446744073709551615')).toBe(true);
+    expect(ok(my.SelectmytSchema.shape.u, '9223372036854775808')).toBe(true);
+  });
+});

--- a/packages/generator-zod/test/numeric-format.spec.ts
+++ b/packages/generator-zod/test/numeric-format.spec.ts
@@ -93,9 +93,11 @@ describe('scope', () => {
     expect(m.SelecttSchema.shape.name.safeParse('hello').success).toBe(true);
   });
 
-  it('carries only the one format, since the rest could not be verified', async () => {
+  it('carries only the formats a server was asked about, since the rest could not be verified', async () => {
     // Postgres reads 'today' as a date and pads '2020-01-01' into a macaddr, so patterns for
-    // those turned away valid input and were dropped rather than shipped.
-    expect(Object.keys(COLUMN_FORMATS)).toEqual(['numeric']);
+    // those turned away valid input and were dropped rather than shipped. The two `bigint` keys
+    // are the same rule applied twice over: each was measured against its own server, and there
+    // is no third key for mssql because no SQL Server was there to measure.
+    expect(Object.keys(COLUMN_FORMATS)).toEqual(['numeric', 'pgBigint', 'mysqlBigint']);
   });
 });

--- a/packages/validation-core/README.md
+++ b/packages/validation-core/README.md
@@ -62,9 +62,13 @@ Shared interfaces and helpers used by validation generators.
     `length()` is the character count on a `text` and the byte count on a `bytea`, and
     `char_length(bytea)` is not a function that exists. `measureExpression(measure, variable)`
     renders it and `lengthCheckLabel(check)` renders the message the ledger keys on.
-  - `COLUMN_FORMATS` -> patterns for the column formats that are expressible. Only `numeric` is:
-    Postgres accepts `today`, `January 8, 1999` and `allballs`, so a date or time pattern would
-    reject rows the database takes.
+  - `COLUMN_FORMATS` -> patterns for the column formats that are expressible, which is a short
+    list: Postgres accepts `today`, `January 8, 1999` and `allballs`, so a date or time pattern
+    would reject rows the database takes. `numeric` is Postgres's numeric input grammar, and
+    `pgBigint`/`mysqlBigint` are the two answers a `bigint({ mode: 'string' })` column has, since
+    Postgres parses that text as an integer literal (`0x1f` and `1_000` included) and MySQL parses
+    it as a decimal number it then rounds (`12.5` becomes 13). Each was measured against its own
+    server; neither states the magnitude, and the entry says why.
   - `CODEPOINT_LENGTH` -> `[...v].length`, since `varchar(n)` counts characters and JavaScript's
     `.length` counts UTF-16 units. All four generators use it.
   - `isIntegerColumn(c)`

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -220,7 +220,7 @@ export function isGeneratedColumn(c: Column, _primaryKeyColumns: string[] = []):
  * the real hazard is over-rejection. A check that turns away something Postgres accepts breaks
  * working code, which is worse than the bare `string` it replaces.
  *
- * That is why there is exactly one entry. Candidates for `date`, `timestamp`, `time`, `interval`,
+ * The list is short for that reason. Candidates for `date`, `timestamp`, `time`, `interval`,
  * `inet`, `cidr` and `macaddr` were all built and all rejected, each by a value Postgres accepts
  * and the pattern did not:
  *
@@ -229,6 +229,11 @@ export function isGeneratedColumn(c: Column, _primaryKeyColumns: string[] = []):
  *   macaddr   `2020-01-01`, which Postgres pads into `20:20:00:01:00:01`
  *   inet      `10.1/16`, `::ffff:1.2.3.4`
  *   cidr      parses as `inet` and then demands zero host bits, which no regex can state
+ *
+ * **One key per dialect where the servers disagree.** `numeric` is Postgres's alone, and the
+ * analyzer withholds it from SQLite for that reason. The two `bigint` entries are the case where
+ * withholding is not enough, because both dialects have a real answer and the answers contradict
+ * each other in both directions. See them below.
  */
 export const COLUMN_FORMATS: Record<string, string> = {
   // Sign, decimals, exponents, NaN/Infinity, surrounding whitespace, and the underscore digit
@@ -238,6 +243,51 @@ export const COLUMN_FORMATS: Record<string, string> = {
     '^\\s*([+-]?(0[xX][0-9a-fA-F](_?[0-9a-fA-F])*|0[oO][0-7](_?[0-7])*|0[bB][01](_?[01])*)' +
     '|[+-]?(\\d(_?\\d)*(\\.(\\d(_?\\d)*)?)?|\\.\\d(_?\\d)*)([eE][+-]?\\d(_?\\d)*)?' +
     '|[+-]?(NaN|Infinity))\\s*$',
+
+  // What Postgres itself parses into a `bigint`, for a `bigint({ mode: 'string' })` column whose
+  // value goes to the server as text. `int8in` is a pure integer parser: an optional sign against
+  // the digits, decimal or a `0x`/`0o`/`0b` literal, single `_` separators between digits and one
+  // permitted directly after the base prefix, leading zeros, and surrounding whitespace. Measured
+  // against a real Postgres through PGlite over 16160 probes, boundary sweeps and random shapes:
+  // **zero** values the server takes and this refuses.
+  //
+  // Two things it deliberately does not say.
+  //
+  // **The magnitude.** Every one of the 4474 probes this admits and the server refuses is a value
+  // outside the signed 64 bit range, and nothing else: the syntax half is complete. The exact
+  // bound is expressible, since leading zeros and separators make it a per-digit ladder rather
+  // than a digit count, and it was built and verified at 16160/16160 against the server. It is
+  // not shipped, because at 1237 characters and around twenty alternation branches it exhausts
+  // ArkType's type-level instantiation budget: that generator states a format as a regex literal
+  // inside the type expression, and the emitted module then fails to compile with TS2589.
+  // Measured on arktype 2.2.3, this 101-character pattern compiles and the ladder does not, as
+  // `COLUMN_FORMATS.numeric` at 176 characters already does not. Emitting a module that does not
+  // typecheck is a worse failure than the bound it would buy, and the bound is unreachable by any
+  // value the probe pools carry. The ArkType defect is already reported and carved out of the
+  // parity gate's typecheck stage; when it is fixed, the ladder is what goes here.
+  //
+  // **Whitespace exactly.** Postgres pads with C `isspace`, which is the six ASCII characters, and
+  // JS `\s` also admits NBSP and the Unicode spaces. That admits a handful of strings the server
+  // refuses, which is the safe direction, and it is what `numeric` above already does.
+  pgBigint:
+    '^\\s*[+-]?(\\d(_?\\d)*|0[xX]_?[\\da-fA-F](_?[\\da-fA-F])*' +
+    '|0[oO]_?[0-7](_?[0-7])*|0[bB]_?[01](_?[01])*)\\s*$',
+
+  // The same column on MySQL, which parses it as a *decimal number* and then rounds. Measured
+  // against MySQL 8.4.11: `'12.5'` stores 13, `'1.5'` stores 2, `'.5'` stores 1, `'1e3'` stores
+  // 1000, and `'92233720368547758070e-1'` stores the int64 maximum. It refuses the two spellings
+  // Postgres takes, `'0x1f'` and `'1_000'`, both as "Data truncated". So no single pattern serves
+  // both servers: their union admits `'12.5'` on Postgres, which is one of the fourteen values
+  // that made this a defect, and their intersection turns away values each server really stores.
+  //
+  // Shared by the signed and the unsigned spelling, and this is why neither magnitude nor sign is
+  // stated here: the value the range applies to is the *rounded* one, so the text does not
+  // determine whether it fits. `'9223372036854775807.4'` is stored and `'9223372036854775807.6'`
+  // is refused; on a `bigint unsigned`, `'-0.4'` and `'-1e-1'` are both stored as 0 while `'-0.5'`
+  // is refused. A pattern cannot do that arithmetic, and guessing at it turns away working rows.
+  // Over 3319 probes against each of a signed and an unsigned column: zero values the server takes
+  // and this refuses.
+  mysqlBigint: '^\\s*[+-]?(\\d+(\\.\\d*)?|\\.\\d+)([eE][+-]?\\d*)?\\s*$',
 };
 
 /**


### PR DESCRIPTION
Fixes plan addendum BS (Tier B): `bigint({ mode: 'string' })` emitted a bare string schema, accepting **14 values the gate's own ground-truth predicate (`drzl !== db && off === db`) marks as defects**, each one a string Postgres rejects with official agreeing against DRZL. The column now states a `format` from the analyzer's int64 arm, resolved through `COLUMN_FORMATS`; **no generator source changed**, because all six already route `c.format` (verified at each call site, then relied on).

## Decision 1: per-dialect patterns, forced by measurement

The servers disagree in both directions, so neither a union nor an intersection is honest:

| value | Postgres | MySQL 8.4.11 |
|---|---|---|
| `'0x1f'` | stores 31 | refused |
| `'1_000'` | stores 1000 | refused |
| `'12.5'` | refused | stores 13, rounded |
| `'1e3'` | refused | stores 1000 |

A union must admit `'12.5'`, leaving the pg ground-truth stage red, which is the stage this fix exists to clear; an intersection over-rejects on both, the failure mode `COLUMN_FORMATS` was built to avoid. SingleStore takes MySQL's pattern (existing dialect precedent), mssql gets none (no server to measure), Cockroach never reaches the arm.

## Decision 2: the unsigned range, and why the magnitude stays unstated

Official v1 caps unsigned mode-string at int64 max and thereby refuses `'18446744073709551615'`, which MySQL stores in a `bigint unsigned` and hands back; DRZL agrees with the database instead of borrowing that bug. The magnitude itself is deliberately not stated: the exact int64 ladder was built and agreed with Postgres **16160/16160**, but leading zeros and `_` separators make it per-digit rather than a digit count, and at 1237 characters it exhausts ArkType's type-level budget. Measured on the real emitted module, same column, same generator: the shipped 101-char pattern typechecks clean, the ladder is `TS2589 Type instantiation is excessively deep`. Emitting a module that does not compile is the worse trade, the syntax half is provably complete (0 over-rejections across 16160 probes; every one of its 4474 under-checks is a magnitude nothing else would catch), and the gap is pinned in both directions in every spec so stating it later reports itself. A dedicated string-range refinement was the alternative and is worse: it needs all six generators changed and JSON Schema cannot express a numeric bound on a string at all, so that generator would silently drop it.

## Proofs

- **Ground truth both dialects**, including the read path: the `bigint:string` codec casts to text with no normalize, so returned values are plain digits (`'0x1f'` comes back `'31'`); the shipped patterns refuse **zero** returned rows. Postgres verification 16160 probes with 0 over-rejections; MySQL 3319 probes against signed and unsigned columns, 0 over-rejections on both.
- **Byte identity**: master's dists built at 27c388b and run beside the fix over the gate's fixtures, **90/90 emitted files identical**; with a mode-string column present, the 12 that differ are exactly the pg and MySQL matrix modules in each of the six generators, each diverging first at the new column's own line.
- Red-first: 21 failing before across 7 new spec files, 54 passing after.
- `pnpm verify:packed` on the **unmodified** gate reproduces master's numbers exactly (1440 probes, DRZL 1069, budgets 277/352/275/446), confirming this moves nothing already covered.

## The probe follows next

The gate probe for this column is fully validated (RC=0 on a scratch copy with this fix in place) and lands as its own controller PR, since it also moves per-column byte budgets, the ground-truth DDL, the 0.4x `sed` derivation with addendum BT's positive check, and four numbers in the benchmarks page that the gate compares literally. Two probe findings recorded: the arktype typecheck stage passes with the new column, so no carve-out is needed, and the CHECKed column really does mask the missing format (confirmed on emitted zod), which is why it must land after this fix.

Full gates green: 3199 tests across 286 files, typecheck, lint, docs, and the unmodified verify-packed. Changeset: patch for analyzer and validation-core, matching PR #172's changeset for the same column shape.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
