### PR TITLE
fix: refuse the infinities where MySQL refuses them (addendum BU)

### DIFF
--- a/.changeset/mysql-infinity-refused.md
+++ b/.changeset/mysql-infinity-refused.md
@@ -1,0 +1,53 @@
+---
+'@drzl/analyzer': patch
+'@drzl/validation-core': patch
+'@drzl/generator-valibot': patch
+'@drzl/generator-arktype': patch
+---
+
+The valibot and ArkType generators refuse `Infinity` and `-Infinity` on a MySQL or SingleStore
+`float`, `double` and `real`, which the server refuses too.
+
+An infinity is a value the schema has to answer for per dialect rather than once, and until now the
+analyzer only ever said yes. Postgres genuinely stores both in a `real` and a `double precision` and
+hands them back on SELECT, so all four generators accept them there and that does not change. A real
+MySQL 8.4.11 in `STRICT_TRANS_TABLES` stores neither, in any of the three columns: measured on the
+binary prepared path, which is the one that puts the real IEEE double on the wire, `float`, `double`
+and `real` all answer `ER_WARN_DATA_OUT_OF_RANGE` for `Infinity`, `-Infinity` and `NaN` alike, while
+`double` and `real` take 1e300 and 3.4028235e38 unchanged. The column carried no flag at all for
+that, and an absent flag reads the same as an unmeasured one.
+
+**The mechanism is the magnitude bound, doing this by accident.** Measured on the installed
+libraries: `z.number()` and `Type.Number()` refuse a non-finite number with no bound at all, so zod
+and TypeBox were never affected. `v.number()` and ArkType's `number` take both infinities, and only
+a range holds them back, one end each, so `v.maxValue(n)` refuses `+Infinity` whatever `n` is and
+`number >= 0` still accepts it. MySQL's `float` carries the float32 range and was therefore already
+right; its `double` and `real` carry no finite bound, because every finite JS number fits in an
+8 byte float and no finite bound on one is truthful, and those are what leaked. Unlike the `NaN`
+leak this repeats, no union arm was needed: a bare `number` takes an infinity wherever it stands, so
+the two libraries leaked in `select`, `insert` and `update`, on the object and through a field
+pulled out of the schema.
+
+**What changes.** `@drzl/analyzer` now states the refusal outright, as `allowsNaN: false` and
+`allowsInfinity: false` on the MySQL and SingleStore `float`, `double` and `real` columns, on both
+the drizzle 0.4x class-name path and the v1 codec path. That is a third state rather than the
+absence of the first, and `@drzl/validation-core` gains `nonFiniteRefused` to read it: `true` is
+stored and returned, `false` is offered and refused, absent is unstated. The valibot generator emits
+`v.check((val) => Number.isFinite(val), 'a finite number')` and the ArkType generator a `.narrow`
+with the same predicate, in both cases only where no bound already refuses both ends. On ArkType
+that replaces the narrower `NaN` narrow on the same columns rather than joining it, since
+`Number.isFinite` is false for `NaN` too.
+
+**Postgres does not move, and neither does SQLite.** A Postgres `real` and `double precision` still
+accept `NaN` and both infinities in every mode, nullable or not. SQLite is deliberately untouched
+and is a third answer rather than MySQL's: a real SQLite 3.53.4 stores both infinities in a `real`
+and hands them back, and silently turns `NaN` into NULL, so its column still states neither flag and
+its emitted output is unchanged. MySQL's `decimal` is untouched for a similar reason: on the same
+prepared path the server silently stored `0.00` for all three where the text path answers `Incorrect
+decimal value`, and "refuses" is only half true of a column that accepted the row.
+
+The zod, TypeBox, Effect and JSON Schema generators do not change. The first two already refused
+both infinities everywhere, Effect builds on `Schema.Finite` unconditionally, and JSON has neither
+value to express. Generated output is byte identical everywhere else: master's analyzer and
+generators run beside these over the same schemas produced 80 emitted file pairs, of which the 8
+that differ are exactly valibot and ArkType on MySQL and SingleStore, on both drizzle majors.

--- a/docs/generators/arktype.md
+++ b/docs/generators/arktype.md
@@ -119,8 +119,23 @@ branches on its own.
 
 A `numeric` in number mode takes `NaN` and keeps refusing both infinities, because Postgres refuses
 an infinity in any `numeric` carrying a precision and nothing in the analysis reads one. Integer
-columns are unchanged, and so are MySQL and SQLite. A declared default is still restricted to a
-finite number: the literal is written through `JSON.stringify`, which renders all three as `null`.
+columns are unchanged, and so is SQLite, which stores both infinities in a `real` and hands them
+back. A declared default is still restricted to a finite number: the literal is written through
+`JSON.stringify`, which renders all three as `null`.
+
+MySQL and SingleStore run the other way, and that is the same question answered by a different
+server: measured on MySQL 8.4.11, a `float`, a `double` and a `real` refuse `Infinity`, `-Infinity`
+and `NaN` alike. ArkType's bare `number` takes both infinities wherever it stands, and a range
+refuses them, so a column with no range carries a narrow and the bounded `float` keeps its DSL
+string. `Number.isFinite` is false for `NaN` too, so one narrow states the whole answer:
+
+```ts
+c_float:  "-3402... <= number <= 3402...",                        // float()
+c_double: type("number").narrow(                                  // double()
+  (v, ctx) => v == null || Number.isFinite(v) || ctx.mustBe("a finite number")
+),
+```
+
 See
 [Zod → `NaN` and the infinities](/generators/zod#nan-and-the-infinities-are-values-not-out-of-range-numbers).
 

--- a/docs/generators/valibot.md
+++ b/docs/generators/valibot.md
@@ -114,7 +114,20 @@ c_num:    v.union([v.pipe(v.number(), v.minValue(-9007199254740991),
 
 A `numeric` in number mode takes `NaN` and keeps refusing both infinities, because Postgres refuses
 an infinity in any `numeric` carrying a precision and nothing in the analysis reads one. Integer
-columns are unchanged, and so are MySQL and SQLite. See
+columns are unchanged, and so is SQLite, which stores both infinities in a `real` and hands them
+back.
+
+MySQL and SingleStore run the other way, and that is the same question answered by a different
+server: measured on MySQL 8.4.11, a `float`, a `double` and a `real` refuse `Infinity`, `-Infinity`
+and `NaN` alike. `v.number()` takes both infinities and `v.maxValue(n)` refuses only `+Infinity`, so
+the columns with no range gain a finite check and the bounded `float` needs nothing:
+
+```ts
+c_float:  v.pipe(v.number(), v.minValue(-3402...), v.maxValue(3402...)),   // float()
+c_double: v.pipe(v.number(), v.check((val) => Number.isFinite(val), 'a finite number')), // double()
+```
+
+See
 [Zod → `NaN` and the infinities](/generators/zod#nan-and-the-infinities-are-values-not-out-of-range-numbers).
 
 Valibot has no `json()` built-in, so a json column emits a recursive declaration at the top of the

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -929,6 +929,27 @@ export function describeV1Column(column: any): Partial<Column> | null {
         out.allowsNaN = true;
         out.allowsInfinity = true;
       }
+      // The other direction, and a third state rather than the absence of the first: MySQL and
+      // SingleStore refuse all three here, which `false` says and an absent flag does not. Leaving
+      // it absent is what let an unbounded `double` accept an `Infinity` the server answers
+      // `ER_WARN_DATA_OUT_OF_RANGE` for, in the two libraries whose bare number takes one.
+      //
+      // MySQL by codec, for the reason the bound above uses one: `float`, `double` and `real` are
+      // MySQL's own spellings and no other dialect states them, all swept off real 1.0.0-rc.4
+      // columns. SingleStore states no codec at all on that release, so it is read off the class
+      // name instead, which is the third marker this function already uses for mssql and cockroach.
+      // Neither of those two joins here and neither does SQLite: mssql and cockroach were never
+      // asked, and SQLite really does store both infinities while turning `NaN` into NULL, which is
+      // a third answer that has to arrive whole. See `NON_FINITE_BY_CLASS`.
+      if (
+        codec === 'float' ||
+        codec === 'double' ||
+        codec === 'real' ||
+        entityKind.startsWith('SingleStore')
+      ) {
+        out.allowsNaN = false;
+        out.allowsInfinity = false;
+      }
       break;
     }
     case 'uuid':
@@ -1933,35 +1954,63 @@ export class SchemaAnalyzer {
   // which no table keyed on a class name can hold; see `declaredDecimalRange`.
 
   /**
-   * The Postgres number columns that hold a non-finite double, and which of the three each holds.
+   * The number columns whose server has an answer about a non-finite double, and what it is.
+   *
+   * Three states rather than two, and the third is the reason this table has a `false` half at all.
+   * A column present here with `true` stores the value and hands it back, so a schema refusing it
+   * refuses rows the column returns. A column present with `false` is one the server was asked
+   * about and refused, so a schema accepting it promises what the server will not take. A column
+   * *absent* is one nobody has measured, and the generators leave whatever their library does alone
+   * rather than guessing; `nonFiniteAccepted` and `nonFiniteRefused` in `@drzl/validation-core` are
+   * the two readings of that.
    *
    * The class-name half of what `describeV1Column` reads off the codec, and the two must agree: a
    * fact stated on one path and not the other is a schema that changes when the user upgrades
-   * drizzle, which the cross-major diff in `verify-packed.sh` fails on. These three class names are
-   * the same on both majors, read off real `pgTable` columns on 0.45.2 and on 1.0.0-rc.4, so this
-   * table also answers for a v1 column and the two answers are identical rather than merely
-   * compatible. non-finite-numbers.spec.ts asserts that agreement through the real analyzer.
+   * drizzle, which the cross-major diff in `verify-packed.sh` fails on. Every class name here is the
+   * same on both majors, read off real columns on 0.45.2 and on 1.0.0-rc.4, so this table also
+   * answers for a v1 column and the two answers are identical rather than merely compatible.
+   * non-finite-numbers.spec.ts asserts that agreement through the real analyzer.
    *
-   * No MySQL, SingleStore or SQLite class belongs here: MySQL refuses all three on a `float`/
-   * `double` and stores `0.00` for a `decimal`, and SQLite returns both infinities while silently
-   * turning `NaN` into NULL, which is a different answer that has to arrive whole.
+   * Postgres and Gel store all three. Gel joined on a measurement of its own rather than on being
+   * Postgres-backed: a live Gel 7.1 stored `nan`, `inf` and `-inf` in both `std::float32` and
+   * `std::float64` and handed all three back, through a cast and again through a stored property.
+   * Without them every row of such a column failed validation.
    *
-   * Gel does belong, and is the fourth and fifth entries. Measured on a live Gel 7.1 rather than
-   * inferred from it being Postgres-backed: both `std::float32` and `std::float64` stored `nan`,
-   * `inf` and `-inf` and handed all three back as `NaN`, `Infinity` and `-Infinity`, through a cast
-   * and again through a stored property. Without them every row of such a column failed validation.
+   * MySQL and SingleStore refuse all three, and that used to be left unstated on the reasoning that
+   * a column stating nothing costs nothing. It cost two libraries: `v.number()` and ArkType's
+   * `number` take both infinities where `z.number()` and `Type.Number()` refuse them, so an
+   * unbounded `double` or `real` accepted a value the server answers `ER_WARN_DATA_OUT_OF_RANGE`
+   * for. Measured on MySQL 8.4.11 in `STRICT_TRANS_TABLES`, on the binary prepared path, which is
+   * the one that puts the real IEEE double on the wire: `float`, `double` and `real` refuse
+   * `Infinity`, `-Infinity` and `NaN` alike, while `double` and `real` store 1e300 and
+   * 3.4028235e38 unchanged. SingleStore is MySQL wire-compatible and unmeasured, and takes MySQL's
+   * answer here exactly as it already takes MySQL's float32 bound in `INEXACT_RANGES`.
    *
-   * `PgNumeric` is absent because its value is a string, and its pattern already accepts `NaN` and
-   * `Infinity`. `PgNumericNumber` is absent because its answer is no longer flat: it takes `NaN` at
-   * any width and an infinity only where no precision is declared, which is a per-column question
-   * this table cannot ask. `columnConstraints` answers it beside the bound that decides it.
+   * No SQLite class belongs here in either direction. A real SQLite 3.53.4 stores both infinities in
+   * a `real` and hands them back, and silently turns `NaN` into NULL, so it is neither the Postgres
+   * answer nor the MySQL one; it is filed on its own and a column needs both halves of it or none.
+   *
+   * The decimal families are absent too. `PgNumeric` is a string whose pattern already accepts `NaN`
+   * and `Infinity`. `PgNumericNumber` is a per-column question this table cannot ask: it takes `NaN`
+   * at any width and an infinity only where no precision is declared, and `columnConstraints`
+   * answers it beside the bound that decides it. MySQL's `decimal` is absent because the two client
+   * paths disagree: on the binary prepared path MySQL 8.4.11 silently stored `0.00` for all three,
+   * where the text path answers `Incorrect decimal value`, and "refuses" is only half true of a
+   * column that accepted the row.
    */
-  private static readonly PG_NON_FINITE: Record<string, { nan: boolean; infinity: boolean }> = {
-    PgReal: { nan: true, infinity: true },
-    PgDoublePrecision: { nan: true, infinity: true },
-    GelReal: { nan: true, infinity: true },
-    GelDoublePrecision: { nan: true, infinity: true },
-  };
+  private static readonly NON_FINITE_BY_CLASS: Record<string, { nan: boolean; infinity: boolean }> =
+    {
+      PgReal: { nan: true, infinity: true },
+      PgDoublePrecision: { nan: true, infinity: true },
+      GelReal: { nan: true, infinity: true },
+      GelDoublePrecision: { nan: true, infinity: true },
+      MySqlFloat: { nan: false, infinity: false },
+      MySqlDouble: { nan: false, infinity: false },
+      MySqlReal: { nan: false, infinity: false },
+      SingleStoreFloat: { nan: false, infinity: false },
+      SingleStoreDouble: { nan: false, infinity: false },
+      SingleStoreReal: { nan: false, infinity: false },
+    };
 
   /**
    * Constraints the column definition already carries, which the analysis used to throw away.
@@ -2020,7 +2069,7 @@ export class SchemaAnalyzer {
     // Beside the range rather than inside it, because no range can hold either fact: `>=`/`<=`
     // refuses `Infinity` whatever the bounds are and `NaN` compares false against both ends. The
     // range describes the finite values of the column and these two describe the rest.
-    const nonFinite = SchemaAnalyzer.PG_NON_FINITE[ctor];
+    const nonFinite = SchemaAnalyzer.NON_FINITE_BY_CLASS[ctor];
     if (nonFinite) {
       out.allowsNaN = nonFinite.nan;
       out.allowsInfinity = nonFinite.infinity;

--- a/packages/analyzer/test/non-finite-numbers.spec.ts
+++ b/packages/analyzer/test/non-finite-numbers.spec.ts
@@ -36,14 +36,30 @@ const dir = path.resolve(__dirname, 'fixtures');
 /** A column as drizzle v1 presents one, which is what the codec path reads. */
 const v1col = (dataType: string, codec?: string) => ({ dataType, codec, dimensions: 0 });
 
-async function columnsOf(name: string, source: string) {
+/**
+ * A stand-in constructor carrying only drizzle's entity kind, for the dialects that state no codec.
+ *
+ * Read off real 1.0.0-rc.4 columns: `singlestoreTable({ d: double() })` stamps
+ * `dataType: 'number double'` with no codec at all and `drizzle:entityKind` of `SingleStoreDouble`,
+ * where the MySQL column beside it states codec `double`.
+ */
+const entityKind = (kind: string) => ({ [Symbol.for('drizzle:entityKind')]: kind }) as never;
+
+async function analysisOf(name: string, source: string) {
   await fs.mkdir(dir, { recursive: true });
   const file = path.join(dir, `${name}.mjs`);
   await fs.writeFile(file, source, 'utf8');
   const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), file)).analyze({});
-  const t = analysis.tables[0];
-  expect(t, `no table was analyzed; issues: ${JSON.stringify(analysis.issues)}`).toBeTruthy();
-  return Object.fromEntries(t!.columns.map((c) => [c.name, c]));
+  expect(
+    analysis.tables[0],
+    `no table was analyzed; issues: ${JSON.stringify(analysis.issues)}`
+  ).toBeTruthy();
+  return analysis;
+}
+
+async function columnsOf(name: string, source: string) {
+  const analysis = await analysisOf(name, source);
+  return Object.fromEntries(analysis.tables[0]!.columns.map((c) => [c.name, c]));
 }
 
 /** The same Postgres table, written against each major. */
@@ -98,29 +114,55 @@ describe('the codec path, which drizzle v1 takes', () => {
     });
   });
 
-  it('says nothing about a mysql float, double or decimal', () => {
-    // MySQL refuses NaN and both infinities on a `float`/`double`, and silently stores 0.00 in a
-    // `decimal`, so none of the three is a value the column hands back.
+  it('states the refusal on a mysql float, double and real, and says nothing about a decimal', () => {
+    // `false` rather than absent, and the difference is the whole of this: absent means nobody
+    // asked, and the two libraries whose bare number takes an infinity then took one on a column
+    // the server refuses it on. Measured on MySQL 8.4.11 in STRICT_TRANS_TABLES on the binary
+    // prepared path, which is the one that puts the real IEEE double on the wire: all three columns
+    // answer ER_WARN_DATA_OUT_OF_RANGE for Infinity, -Infinity and NaN alike.
     for (const c of [
       v1col('number float', 'float'),
       v1col('number double', 'double'),
       v1col('number double', 'real'),
-      v1col('number', 'decimal:number'),
     ]) {
-      const out = describeV1Column(c)!;
-      expect(out.allowsNaN, JSON.stringify(c)).toBeUndefined();
-      expect(out.allowsInfinity, JSON.stringify(c)).toBeUndefined();
+      expect(describeV1Column(c), JSON.stringify(c)).toMatchObject({
+        allowsNaN: false,
+        allowsInfinity: false,
+      });
+    }
+    // The decimal families stay out of it. On the same prepared path MySQL silently stored 0.00 for
+    // all three, where the text path answers `Incorrect decimal value`, and "refuses" is only half
+    // true of a column that accepted the row.
+    const dec = describeV1Column(v1col('number', 'decimal:number'))!;
+    expect(dec.allowsNaN).toBeUndefined();
+    expect(dec.allowsInfinity).toBeUndefined();
+  });
+
+  it('states it for singlestore too, off the class name, since it declares no codec', () => {
+    // SingleStore is MySQL wire-compatible and unmeasured, and takes MySQL's answer here exactly as
+    // it already takes MySQL's float32 bound. It states no codec at all on 1.0.0-rc.4, so the class
+    // name is the marker, which is the third marker this function already uses for mssql and
+    // cockroach.
+    for (const kind of ['SingleStoreFloat', 'SingleStoreDouble', 'SingleStoreReal']) {
+      const c = { ...v1col('number double'), constructor: entityKind(kind) };
+      expect(describeV1Column(c), kind).toMatchObject({ allowsNaN: false, allowsInfinity: false });
     }
   });
 
-  it('says nothing about sqlite, singlestore, cockroach or mssql, which state no codec', () => {
+  it('says nothing about sqlite, cockroach or mssql, which state no codec either', () => {
     // Every one of these reaches the float/double arm with no codec at all on 1.0.0-rc.4. SQLite is
     // the one that really does store an infinity, and it turns NaN into NULL, so it needs its own
-    // answer rather than Postgres's.
+    // answer rather than Postgres's or MySQL's; cockroach and mssql were never asked.
     for (const c of [v1col('number float'), v1col('number double')]) {
       const out = describeV1Column(c)!;
       expect(out.allowsNaN, JSON.stringify(c)).toBeUndefined();
       expect(out.allowsInfinity, JSON.stringify(c)).toBeUndefined();
+    }
+    for (const kind of ['SQLiteReal', 'CockroachDoublePrecision', 'MsSqlFloat']) {
+      const c = { ...v1col('number double'), constructor: entityKind(kind) };
+      const out = describeV1Column(c)!;
+      expect(out.allowsNaN, kind).toBeUndefined();
+      expect(out.allowsInfinity, kind).toBeUndefined();
     }
     // A bare `number` with no codec is what a 0.4x column looks like, so this path declines it
     // outright and the class-name table answers instead. SQLite's `numeric({ mode: 'number' })` is
@@ -168,7 +210,7 @@ describe('the class-name path, which drizzle 0.4x takes', () => {
     }
   });
 
-  it('leaves mysql and sqlite alone', async () => {
+  it('states the mysql and singlestore refusal, and leaves their decimal alone', async () => {
     const my = await columnsOf(
       'mysql-non-finite-0.4x',
       `
@@ -179,10 +221,25 @@ describe('the class-name path, which drizzle 0.4x takes', () => {
       });
       `
     );
-    for (const name of ['f', 'd', 'r', 'n']) {
-      expect(my[name].allowsNaN, name).toBeUndefined();
-      expect(my[name].allowsInfinity, name).toBeUndefined();
+    for (const name of ['f', 'd', 'r']) {
+      expect(my[name], name).toMatchObject({ allowsNaN: false, allowsInfinity: false });
     }
+    expect(my.n.allowsNaN, 'decimal').toBeUndefined();
+    expect(my.n.allowsInfinity, 'decimal').toBeUndefined();
+
+    const ss = await columnsOf(
+      'singlestore-non-finite-0.4x',
+      `
+      import { singlestoreTable, float, double, real } from 'drizzle-orm/singlestore-core';
+      export const t = singlestoreTable('t', { f: float(), d: double(), r: real() });
+      `
+    );
+    for (const name of ['f', 'd', 'r']) {
+      expect(ss[name], name).toMatchObject({ allowsNaN: false, allowsInfinity: false });
+    }
+  });
+
+  it('leaves sqlite alone', async () => {
     const sq = await columnsOf(
       'sqlite-non-finite-0.4x',
       `
@@ -216,5 +273,31 @@ describe('the two majors', () => {
     expect(Object.keys(next), 'the v1 fixture analysed').toEqual(Object.keys(old));
     expect(flags(next).r, 'v1 reached the real column').toEqual([true, true]);
     expect(flags(next)).toEqual(flags(old));
+  });
+
+  it('give the same answer for the same mysql and singlestore tables', async () => {
+    // The same trap on the other side of the fact. The two paths reach it differently here: 0.4x by
+    // the class name, v1 by MySQL's own `float`/`double`/`real` codec, and SingleStore by its class
+    // name on both majors because it declares no codec at all.
+    const SOURCE = (pkg: string) => `
+      import { mysqlTable, float, double, real, decimal } from '${pkg}/mysql-core';
+      import { singlestoreTable, double as ssDouble } from '${pkg}/singlestore-core';
+      export const t = mysqlTable('t', {
+        f: float(), d: double(), r: real(),
+        n: decimal({ precision: 10, scale: 2, mode: 'number' }),
+      });
+      export const u = singlestoreTable('u', { d: ssDouble() });
+    `;
+    const flags = (a: any) =>
+      Object.fromEntries(
+        a.tables.flatMap((t: any) =>
+          t.columns.map((c: any) => [`${t.name}.${c.name}`, [c.allowsNaN, c.allowsInfinity]])
+        )
+      );
+    const old = flags(await analysisOf('mysql-non-finite-cross-0.4x', SOURCE('drizzle-orm')));
+    const next = flags(await analysisOf('mysql-non-finite-cross-v1', SOURCE('drizzle-orm-v1')));
+    expect(old['t.d'], '0.4x reached the double column').toEqual([false, false]);
+    expect(next['u.d'], 'v1 reached the singlestore column').toEqual([false, false]);
+    expect(next).toEqual(old);
   });
 });

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -33,6 +33,7 @@ import {
   measureExpression,
   needsNumericCanon,
   nonFiniteAccepted,
+  nonFiniteRefused,
   NUMERIC_CANON_NAME,
   NUMERIC_CANON_SOURCE,
   parseCheck,
@@ -627,8 +628,8 @@ function renderObjectShape(
         atNumericCanonNarrows(c, checks, sets) +
         atNonFiniteNarrow(c, checks) +
         // Mutually exclusive with the one above it: that one is reached only where the column
-        // admits `NaN` and this one only where it does not.
-        atNanNarrow(c, mode, checks, sets, !!dflt) +
+        // admits `NaN` and this one only where the server refuses one of the three.
+        atNonFiniteRefusedNarrow(c, mode, checks, sets, !!dflt) +
         atDateNarrow(c, mode, coerceDates);
       // A defaultable definition is only valid as an object *property*: `type("bigint = 7")`
       // throws "Defaultable definitions like 'number = 0' are only valid as properties in an
@@ -885,28 +886,45 @@ function atUnionArm(c: Column, mode: Mode, defaulted: boolean): boolean {
 }
 
 /**
- * `NaN` refused on a column that stores none, in the two places the string DSL stops refusing it.
+ * The non-finite doubles a column stores none of, refused where the string DSL stops refusing them.
  *
- * The mirror image of `atNonFiniteNarrow`, and the dialect is the whole of the difference. Postgres
- * really does store `NaN` in a float, so `allowsNaN` is true there and the schema must take it; a
- * real MySQL 8.4 refuses it on `float` and on `double` and silently writes `0.00` for a
- * `decimal(10,2)`, so `allowsNaN` is false and the schema must not. One flag, set by the analyzer,
- * decides which, and nothing here reads the dialect.
+ * The mirror image of `atNonFiniteNarrow`, and the dialect is the whole of the difference, read off
+ * the flags the analyzer sets rather than off the dialect itself. Postgres really does store `NaN`
+ * and both infinities in a float and hand them back, so a schema there must take them; a real MySQL
+ * 8.4.11 answers `ER_WARN_DATA_OUT_OF_RANGE` for all three on a `float`, a `double` and a `real`,
+ * measured on the binary prepared path, so a schema there must not. SQLite states neither, because
+ * it stores both infinities and turns `NaN` into NULL, and it keeps whatever ArkType does.
  *
- * The mechanism is ArkType's, measured on the installed version and asserted in this package's
- * `nan-union-arm` spec rather than remembered:
+ * Two leaks with two different shapes, and one narrow answers whichever is present:
  *
- *   `min <= number <= max`            refuses NaN
- *   `(min <= number <= max | null)`   ACCEPTS NaN, and still refuses an infinity and 1e300
+ * `NaN` needs a union arm. A bounded ArkType number stops refusing it the moment it becomes one
+ * branch beside a unit, because `NaN` is the one value that compares false against both ends of a
+ * range. Both arms this file writes are such a union: `| null` for a nullable column, visible on the
+ * object itself, and the `?` on an optional key, visible through `schema.get(key)`.
+ *
+ * An infinity needs no arm at all. A bare `number` takes both wherever it stands, and only a range
+ * holds them back, one end each: `number >= 0` still takes `Infinity`. So the leak is every mode
+ * and both paths on a column with no range, which is what MySQL's `double` and `real` are, since
+ * every finite JS number fits in an 8 byte float and no finite bound on one is truthful. MySQL's
+ * `float` carries the float32 range and was never affected.
+ *
+ * Measured on the installed ArkType, asserted in this package's `nan-union-arm` and
+ * `mysql-infinity` specs rather than remembered:
+ *
+ *   `min <= number <= max`            refuses NaN,  refuses both infinities
+ *   `(min <= number <= max | null)`   ACCEPTS NaN,  refuses both infinities and 1e300
  *   `{ "x?": "min <= number <= max" }`  the object refuses NaN, `.get("x")` ACCEPTS it
- *   `number`                          refuses NaN
- *   `(number | null)`                 ACCEPTS NaN
- *   `(number.integer | null)`         refuses NaN
+ *   `number`                          refuses NaN,  ACCEPTS both infinities, everywhere
+ *   `(number | null)`                 ACCEPTS NaN,  ACCEPTS both infinities
+ *   `number >= 0`                     refuses NaN,  ACCEPTS `Infinity`, refuses `-Infinity`
+ *   `(number.integer | null)`         refuses NaN,  refuses both infinities
  *
- * It is `NaN` alone, because `NaN` is the one value that compares false against both ends of a
- * range: an infinity fails a bound inside a union exactly as it does outside one. And it spares the
- * integers, because integrality is a predicate rather than a comparison and `NaN` fails it, so no
- * integer column pays for this.
+ * `Number.isFinite` is false for `NaN` too, so where the column refuses all three one narrow states
+ * the whole answer and the `NaN` one would be bytes in the consumer's bundle for a verdict already
+ * reached. Where a range already holds the infinities back, `NaN` is what is left.
+ *
+ * The integers are spared either way, because integrality is a predicate rather than a comparison
+ * and every non-finite number fails it, so no integer column pays for this.
  *
  * A narrow rather than a union branch or a keyword, because there is no keyword for it. Every
  * number keyword ArkType has was tried inside a `| null`: `number.integer` and `number.epoch`
@@ -914,10 +932,10 @@ function atUnionArm(c: Column, mode: Mode, defaulted: boolean): boolean {
  * three unit keywords intersect with a range to an unsatisfiable type that throws at import.
  *
  * The guards below mirror the arms of `atTypeForColumn` that render something other than a bare or
- * ranged `number`. A set, an enum and an equality all render as literals, which `NaN` is not, so a
- * narrow beside them would be bytes in the consumer's bundle for a verdict already reached.
+ * ranged `number`. A set, an enum and an equality all render as literals, which none of the three
+ * is, so a narrow beside them would again be bytes for a verdict already reached.
  */
-function atNanNarrow(
+function atNonFiniteRefusedNarrow(
   c: Column,
   mode: Mode,
   checks: ColumnCheck[],
@@ -925,14 +943,24 @@ function atNanNarrow(
   defaulted: boolean
 ): string {
   if (c.tsType !== 'number' || c.shape) return '';
-  // The column stores `NaN` and the schema has to take it. `atNonFiniteNarrow` holds that side.
-  if (nonFiniteAccepted(c).nan) return '';
-  if (!atUnionArm(c, mode, defaulted)) return '';
   if (c.enumValues && c.enumValues.length) return '';
   if (sets.some((s) => s.column === c.name)) return '';
   // The same discard `atTypeForColumn` makes: a scalar check describes an element, never the list.
-  if (atNarrowRange(c, c.arrayDimensions ? [] : checks).equals !== undefined) return '';
+  const { lower, upper, equals } = atNarrowRange(c, c.arrayDimensions ? [] : checks);
+  if (equals !== undefined) return '';
   if (isIntegerColumn(c)) return '';
+
+  // Both ends declared is what refuses both infinities; one end refuses one of them and none
+  // refuses neither. The analyzer sets the two flags as a pair, so the column reaching this is one
+  // the server refuses every non-finite value on and `Number.isFinite` is exactly its answer.
+  const refused = nonFiniteRefused(c);
+  if (refused.infinity && refused.nan && !(lower && upper)) {
+    return atNarrow(c, (v) => `Number.isFinite(${v})`, 'a finite number');
+  }
+
+  // The column stores `NaN` and the schema has to take it. `atNonFiniteNarrow` holds that side.
+  if (nonFiniteAccepted(c).nan) return '';
+  if (!atUnionArm(c, mode, defaulted)) return '';
   return atNarrow(c, (v) => `!Number.isNaN(${v})`, 'a number, not NaN');
 }
 

--- a/packages/generator-arktype/test/mysql-infinity.spec.ts
+++ b/packages/generator-arktype/test/mysql-infinity.spec.ts
@@ -1,0 +1,274 @@
+/**
+ * `Infinity` and `-Infinity` on a MySQL `float`, `double` and `real`, in ArkType output.
+ *
+ * The other half of `nan-union-arm.spec.ts`, which refused `NaN` on the same columns. `NaN` needed
+ * a union arm to leak; an infinity needs none, because ArkType's bare `number` takes both wherever
+ * it stands. Measured on the installed ArkType and asserted below rather than remembered:
+ *
+ *   `number`                          takes both infinities, refuses NaN
+ *   `-F <= number <= F`               refuses both
+ *   `number >= 0`                     takes `Infinity`, refuses `-Infinity`
+ *   `(number | null)`, `{ "x?": ... }`  take both, on the object and through `.get`
+ *
+ * So the magnitude bound was doing this by accident and only where the column has one. MySQL's
+ * `float` carries the float32 range and already refused them; `double` and `real` carry no finite
+ * bound, because every finite JS number fits in an 8 byte float, and took both.
+ *
+ * The arbiter is the server. Measured on a real MySQL 8.4.11 in `STRICT_TRANS_TABLES`, on the
+ * binary prepared path, which is the one that puts the real IEEE double on the wire: `float`,
+ * `double` and `real` all answer `ER_WARN_DATA_OUT_OF_RANGE` for `Infinity`, `-Infinity` and `NaN`
+ * alike, and `double`/`real` store 1e300 and 3.4028235e38 unchanged.
+ *
+ * This runs the 0.4x class-name path of the analyzer, since that is the major this package depends
+ * on. The valibot, zod and TypeBox siblings run the v1 codec path, and the two have to agree.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { type } from 'arktype';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ArkTypeGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-mysql-infinity');
+
+const MYSQL = `
+  import { mysqlTable, float, double, real } from 'drizzle-orm/mysql-core';
+  export const t = mysqlTable('t', {
+    c_float: float('c_float').notNull(),
+    c_double: double('c_double').notNull(),
+    c_real: real('c_real').notNull(),
+    n_float: float('n_float'),
+    n_double: double('n_double'),
+    n_real: real('n_real'),
+  });
+`;
+
+const SINGLESTORE = `
+  import { singlestoreTable, float, double, real } from 'drizzle-orm/singlestore-core';
+  export const t = singlestoreTable('t', {
+    c_float: float('c_float').notNull(),
+    c_double: double('c_double').notNull(),
+    c_real: real('c_real').notNull(),
+    n_double: double('n_double'),
+  });
+`;
+
+const SQLITE = `
+  import { sqliteTable, real } from 'drizzle-orm/sqlite-core';
+  export const t = sqliteTable('t', {
+    c_real: real('c_real').notNull(),
+    n_real: real('n_real'),
+  });
+`;
+
+const POSTGRES = `
+  import { pgTable, real, doublePrecision } from 'drizzle-orm/pg-core';
+  export const t = pgTable('t', {
+    c_real: real('c_real').notNull(),
+    c_double: doublePrecision('c_double').notNull(),
+    n_double: doublePrecision('n_double'),
+  });
+`;
+
+/** `dense` is the source with every space removed, so an assertion cannot depend on line breaks. */
+type Emitted = { source: string; dense: string; module: Record<string, any> };
+const built: Record<string, Emitted> = {};
+
+async function build(label: string, source: string): Promise<Emitted> {
+  const dir = path.join(DIR, label);
+  await fs.mkdir(dir, { recursive: true });
+  const schema = path.join(dir, 'schema.mjs');
+  await fs.writeFile(schema, source, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  expect(analysis.tables[0], `${label}: no table analyzed`).toBeTruthy();
+  await new ArkTypeGenerator(analysis).generate({ outDir: dir } as never);
+  const emitted = path.join(dir, `t-${process.pid}.ts`);
+  await fs.rename(path.join(dir, 't.arktype.ts'), emitted);
+  const text = await fs.readFile(emitted, 'utf8');
+  return {
+    source: text.replace(/\s+/g, ' '),
+    dense: text.replace(/\s+/g, ''),
+    module: await import(emitted),
+  };
+}
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  for (const [label, source] of [
+    ['mysql', MYSQL],
+    ['singlestore', SINGLESTORE],
+    ['sqlite', SQLITE],
+    ['postgres', POSTGRES],
+  ] as const) {
+    built[label] = await build(label, source);
+  }
+}, 180_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const MODES = ['Select', 'Insert', 'Update'] as const;
+
+/** One column pulled out of the schema, which is how the packed gate takes a schema apart. */
+const field = (schema: any, key: string, x: unknown) =>
+  !(schema.get(key)(x) instanceof type.errors);
+
+/** The same column through the whole object, which is the path the nullable arm leaks on. */
+const rowOf =
+  (base: Record<string, unknown>) =>
+  (schema: any, key: string, x: unknown): boolean =>
+    !(schema({ ...base, [key]: x }) instanceof type.errors);
+
+const INF = [
+  ['Infinity', Infinity],
+  ['-Infinity', -Infinity],
+] as const;
+
+describe('what ArkType does on its own', () => {
+  it('takes both infinities wherever a bare number stands, and refuses them under a range', () => {
+    const bare = type('number');
+    for (const [label, value] of INF) {
+      expect(bare(value) instanceof type.errors, `bare number, ${label}`).toBe(false);
+    }
+    const ranged = type('-10 <= number <= 10');
+    for (const [label, value] of INF) {
+      expect(ranged(value) instanceof type.errors, `ranged, ${label}`).toBe(true);
+    }
+    // A lone bound holds one end only, which is why the repair cannot key on "has a bound".
+    expect(type('number >= 0')(Infinity) instanceof type.errors, 'lone lower bound').toBe(false);
+    expect(type('number >= 0')(-Infinity) instanceof type.errors, 'lone lower bound').toBe(true);
+
+    // Both arms this generator emits, on the object and through the field, unlike NaN.
+    const nullable = type({ x: '(number | null)' });
+    const optional = type({ 'x?': 'number' });
+    expect(nullable({ x: Infinity }) instanceof type.errors, 'nullable, on the object').toBe(false);
+    expect(optional.get('x')(Infinity) instanceof type.errors, 'optional, on the field').toBe(
+      false
+    );
+    expect(optional({ x: Infinity }) instanceof type.errors, 'optional, on the object').toBe(false);
+
+    // The repair, and that it survives both arms.
+    const finite = type('number').narrow((v, ctx) => Number.isFinite(v) || ctx.mustBe('finite'));
+    expect(type({ 'x?': finite }).get('x')(Infinity) instanceof type.errors).toBe(true);
+    expect(type({ x: finite.or('null') })({ x: Infinity }) instanceof type.errors).toBe(true);
+    expect(finite(1.5) instanceof type.errors, 'an ordinary number').toBe(false);
+  });
+});
+
+describe('a mysql float, double and real column', () => {
+  const COLS = ['c_float', 'c_double', 'c_real', 'n_float', 'n_double', 'n_real'];
+  const row = rowOf({
+    c_float: 1.5,
+    c_double: 1.5,
+    c_real: 1.5,
+    n_float: 1.5,
+    n_double: 1.5,
+    n_real: 1.5,
+  });
+
+  it('refuses both infinities in every mode, on the field and on the row', () => {
+    const leaks: string[] = [];
+    for (const mode of MODES) {
+      const s = built.mysql.module[`${mode}tSchema`];
+      expect(row(s, 'c_double', 1.5), `${mode} the baseline row is accepted`).toBe(true);
+      for (const name of COLS) {
+        for (const [label, value] of INF) {
+          if (field(s, name, value)) leaks.push(`${mode} ${name} ${label} field`);
+          if (row(s, name, value)) leaks.push(`${mode} ${name} ${label} row`);
+        }
+      }
+    }
+    expect(leaks).toEqual([]);
+  });
+
+  it('still refuses NaN, which the same server refuses on the same columns', () => {
+    for (const mode of MODES) {
+      const s = built.mysql.module[`${mode}tSchema`];
+      for (const name of COLS) expect(field(s, name, NaN), `${mode} ${name}`).toBe(false);
+    }
+  });
+
+  it('still takes every finite value the column really stores', () => {
+    for (const mode of MODES) {
+      const s = built.mysql.module[`${mode}tSchema`];
+      for (const name of COLS) {
+        expect(field(s, name, 1.5), `${mode} ${name} 1.5`).toBe(true);
+        expect(field(s, name, 0), `${mode} ${name} 0`).toBe(true);
+        expect(field(s, name, 'x'), `${mode} ${name} a string`).toBe(false);
+      }
+      for (const name of ['c_double', 'c_real', 'n_double', 'n_real']) {
+        expect(field(s, name, 1e300), `${mode} ${name} 1e300`).toBe(true);
+        expect(field(s, name, 3.4028235e38), `${mode} ${name} 3.4028235e38`).toBe(true);
+      }
+      expect(field(s, 'c_float', 1e300), `${mode} c_float 1e300`).toBe(false);
+      expect(field(s, 'n_float', null), `${mode} n_float null`).toBe(true);
+      expect(field(s, 'c_float', null), `${mode} c_float null on NOT NULL`).toBe(false);
+      expect(row(s, 'n_double', null), `${mode} n_double null, row`).toBe(true);
+    }
+  });
+
+  it('carries one narrow per column and picks the wider of the two predicates', () => {
+    const { dense } = built.mysql;
+    const F = '340282346638528859811704183484516925440';
+    // The bounded 4 byte column keeps its plain DSL string wherever it is not a union arm: the
+    // range already refuses both infinities, so only NaN is left to state and only where NaN leaks.
+    expect(dense, 'select keeps the bare range').toContain(`c_float:'-${F}<=number<=${F}'`);
+    // `Number.isFinite` is false for NaN too, so a column carrying it needs no second narrow.
+    // Four unbounded columns, once in each of the three schemas the file exports.
+    expect(dense.match(/Number\.isFinite/g)?.length ?? 0, 'double and real, not float').toBe(12);
+    // NaN alone is left where a bound already holds the infinities back: `c_float` is a union arm
+    // in update only, and `n_float` in all three modes.
+    expect(dense.match(/Number\.isNaN/g)?.length ?? 0, 'float only, and only where it leaks').toBe(
+      4
+    );
+  });
+});
+
+describe('a singlestore column, which mirrors mysql', () => {
+  it('refuses both infinities on double and real', () => {
+    for (const mode of MODES) {
+      const s = built.singlestore.module[`${mode}tSchema`];
+      for (const name of ['c_double', 'c_real', 'n_double']) {
+        for (const [label, value] of INF) {
+          expect(field(s, name, value), `${mode} ${name} ${label}`).toBe(false);
+        }
+        expect(field(s, name, 1e300), `${mode} ${name} 1e300`).toBe(true);
+      }
+      expect(field(s, 'c_float', Infinity), `${mode} c_float`).toBe(false);
+    }
+  });
+});
+
+describe('sqlite, which is a different answer and must not move', () => {
+  it('keeps accepting both infinities, which the engine really stores and returns', () => {
+    for (const mode of MODES) {
+      const s = built.sqlite.module[`${mode}tSchema`];
+      for (const name of ['c_real', 'n_real']) {
+        for (const [label, value] of INF) {
+          expect(field(s, name, value), `${mode} ${name} ${label}`).toBe(true);
+        }
+      }
+    }
+    expect(built.sqlite.dense, 'nothing was added').not.toContain('Number.isFinite');
+  });
+});
+
+describe('postgres, which stores all three and hands them back', () => {
+  it('keeps accepting both infinities and NaN', () => {
+    for (const mode of MODES) {
+      const s = built.postgres.module[`${mode}tSchema`];
+      for (const name of ['c_real', 'c_double', 'n_double']) {
+        for (const [label, value] of INF) {
+          expect(field(s, name, value), `${mode} ${name} ${label}`).toBe(true);
+        }
+        expect(field(s, name, NaN), `${mode} ${name} NaN`).toBe(true);
+      }
+      expect(field(s, 'c_real', 1e300), `${mode} c_real 1e300`).toBe(false);
+    }
+    // `!Number.isFinite` already appears here, on the accept side: a Postgres `real` that stores
+    // all three keeps its magnitude bound in a narrow, since the DSL cannot hold four branches. So
+    // the assertion is on the refusal's own message rather than on the predicate both share.
+    expect(built.postgres.dense, 'nothing refuses one here').not.toContain("'afinitenumber'");
+  });
+});

--- a/packages/generator-typebox/test/mysql-infinity.spec.ts
+++ b/packages/generator-typebox/test/mysql-infinity.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * `Infinity` and `-Infinity` on a MySQL `float`, `double` and `real`, in TypeBox output.
+ *
+ * A pin rather than a repair, for the reason the zod sibling records: `Type.Number()` refuses a
+ * non-finite number with no options at all, measured and asserted below, so this generator already
+ * refused both infinities everywhere. What the fix changed is the analysis underneath, where a
+ * MySQL float, double and real now state `allowsInfinity: false` instead of stating nothing, and a
+ * flag turning from absent to present is exactly what would otherwise add a union branch and the
+ * registered kind that goes with it.
+ *
+ * Both `Value.Check` and `TypeCompiler` are run, because they are two different implementations of
+ * the same question and only one of them is what a consumer's hot path uses.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Type } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { TypeBoxGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-mysql-infinity');
+
+const MYSQL = `
+  import { mysqlTable, float, double, real } from 'drizzle-orm-v1/mysql-core';
+  export const t = mysqlTable('t', {
+    c_float: float().notNull(),
+    c_double: double().notNull(),
+    c_real: real().notNull(),
+    n_double: double(),
+  });
+`;
+
+const SQLITE = `
+  import { sqliteTable, real } from 'drizzle-orm-v1/sqlite-core';
+  export const t = sqliteTable('t', { c_real: real().notNull(), n_real: real() });
+`;
+
+const POSTGRES = `
+  import { pgTable, doublePrecision } from 'drizzle-orm-v1/pg-core';
+  export const t = pgTable('t', { c_double: doublePrecision().notNull() });
+`;
+
+type Emitted = { dense: string; module: Record<string, any> };
+const built: Record<string, Emitted> = {};
+
+async function build(label: string, source: string): Promise<Emitted> {
+  const dir = path.join(DIR, label);
+  await fs.mkdir(dir, { recursive: true });
+  const schema = path.join(dir, 'schema.mjs');
+  await fs.writeFile(schema, source, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  expect(analysis.tables[0], `${label}: no table analyzed`).toBeTruthy();
+  await new TypeBoxGenerator(analysis).generate({ outDir: dir } as never);
+  const emitted = path.join(dir, `t-${process.pid}.ts`);
+  await fs.rename(path.join(dir, 't.typebox.ts'), emitted);
+  const text = await fs.readFile(emitted, 'utf8');
+  return { dense: text.replace(/\s+/g, ''), module: await import(emitted) };
+}
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  for (const [label, source] of [
+    ['mysql', MYSQL],
+    ['sqlite', SQLITE],
+    ['postgres', POSTGRES],
+  ] as const) {
+    built[label] = await build(label, source);
+  }
+}, 180_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const MODES = ['Select', 'Insert', 'Update'] as const;
+const field = (schema: any, key: string, x: unknown) => Value.Check(schema.properties[key], x);
+const compiled = (schema: any, key: string, x: unknown) =>
+  TypeCompiler.Compile(schema.properties[key]).Check(x);
+const rowOf =
+  (base: Record<string, unknown>) =>
+  (schema: any, key: string, x: unknown): boolean =>
+    Value.Check(schema, { ...base, [key]: x });
+
+const INF = [
+  ['Infinity', Infinity],
+  ['-Infinity', -Infinity],
+] as const;
+
+describe('what TypeBox does on its own', () => {
+  it('refuses a non-finite number with no options at all, in every wrapper', () => {
+    for (const [label, value] of INF) {
+      expect(Value.Check(Type.Number(), value), `bare, ${label}`).toBe(false);
+      expect(
+        Value.Check(Type.Union([Type.Number(), Type.Null()]), value),
+        `nullable, ${label}`
+      ).toBe(false);
+      expect(Value.Check(Type.Optional(Type.Number()), value), `optional, ${label}`).toBe(false);
+    }
+    expect(Value.Check(Type.Number(), 1e300), 'an ordinary large number').toBe(true);
+  });
+});
+
+describe('a mysql float, double and real column', () => {
+  const COLS = ['c_float', 'c_double', 'c_real', 'n_double'];
+  const row = rowOf({ c_float: 1.5, c_double: 1.5, c_real: 1.5, n_double: 1.5 });
+
+  it('refuses both infinities in every mode, on the field, compiled and on the row', () => {
+    const leaks: string[] = [];
+    for (const mode of MODES) {
+      const s = built.mysql.module[`${mode}tSchema`];
+      expect(row(s, 'c_double', 1.5), `${mode} the baseline row is accepted`).toBe(true);
+      for (const name of COLS) {
+        for (const [label, value] of INF) {
+          if (field(s, name, value)) leaks.push(`${mode} ${name} ${label} field`);
+          if (compiled(s, name, value)) leaks.push(`${mode} ${name} ${label} compiled`);
+          if (row(s, name, value)) leaks.push(`${mode} ${name} ${label} row`);
+        }
+      }
+    }
+    expect(leaks).toEqual([]);
+  });
+
+  it('states nothing new in the emitted file, and keeps every finite value', () => {
+    expect(built.mysql.dense, 'no registered kind for a verdict already reached').not.toContain(
+      'DrzlRowCheck'
+    );
+    expect(built.mysql.dense).not.toContain('Number.isFinite');
+    expect(built.mysql.dense).toContain('c_double:Type.Number()');
+    for (const mode of MODES) {
+      const s = built.mysql.module[`${mode}tSchema`];
+      for (const name of ['c_double', 'c_real', 'n_double']) {
+        expect(field(s, name, 1e300), `${mode} ${name} 1e300`).toBe(true);
+        expect(field(s, name, 1.5), `${mode} ${name} 1.5`).toBe(true);
+        expect(field(s, name, NaN), `${mode} ${name} NaN`).toBe(false);
+      }
+      expect(field(s, 'c_float', 1e300), `${mode} c_float 1e300`).toBe(false);
+    }
+  });
+});
+
+describe('the two controls', () => {
+  it('leaves sqlite exactly as it was, refusing both for TypeBox reasons of its own', () => {
+    expect(built.sqlite.dense).not.toContain('DrzlRowCheck');
+    for (const mode of MODES) {
+      const s = built.sqlite.module[`${mode}tSchema`];
+      for (const [label, value] of INF) {
+        expect(field(s, 'c_real', value), `${mode} ${label}`).toBe(false);
+      }
+    }
+  });
+
+  it('keeps accepting all three on a postgres double, which stores them', () => {
+    for (const mode of MODES) {
+      const s = built.postgres.module[`${mode}tSchema`];
+      for (const [label, value] of INF) {
+        expect(field(s, 'c_double', value), `${mode} ${label}`).toBe(true);
+        expect(compiled(s, 'c_double', value), `${mode} ${label} compiled`).toBe(true);
+      }
+      expect(field(s, 'c_double', NaN), `${mode} NaN`).toBe(true);
+    }
+  });
+});

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -33,6 +33,7 @@ import {
   nestedSchemaName,
   nestedTypeName,
   nonFiniteAccepted,
+  nonFiniteRefused,
   parseCheck,
   parsesToADate,
   renderConstraintsModule,
@@ -109,7 +110,10 @@ function vDateExpr(
  * so they are pasted rather than parsed. `literal` spells each one, which is the only difference
  * between the number and bigint cases.
  */
-function vBounds(c: Column, literal: (v: string) => string, checks: ColumnCheck[] = []): string[] {
+function vBoundEnds(
+  c: Column,
+  checks: ColumnCheck[] = []
+): { lo?: { action: string; value: string }; hi?: { action: string; value: string } } {
   let lo = c.min !== undefined ? { action: 'minValue', value: c.min } : undefined;
   let hi = c.max !== undefined ? { action: 'maxValue', value: c.max } : undefined;
 
@@ -125,8 +129,48 @@ function vBounds(c: Column, literal: (v: string) => string, checks: ColumnCheck[
     else if (k.operator === '<=') hi = { action: 'maxValue', value: k.value };
     else if (k.operator === '<') hi = { action: 'ltValue', value: k.value };
   }
+  return { lo, hi };
+}
 
+function vBounds(c: Column, literal: (v: string) => string, checks: ColumnCheck[] = []): string[] {
+  const { lo, hi } = vBoundEnds(c, checks);
   return [lo, hi].filter(Boolean).map((x) => `v.${x!.action}(${literal(x!.value)})`);
+}
+
+/**
+ * `Infinity` and `-Infinity` refused on a column the server refuses them on, or nothing.
+ *
+ * The mirror of `vNonFiniteBranches` and the dialect is the whole of the difference, read off the
+ * one flag the analyzer sets rather than off the dialect itself. Postgres stores both in a float
+ * and hands them back, so a schema there must take them; MySQL 8.4.11 answers
+ * `ER_WARN_DATA_OUT_OF_RANGE` for either on a `float`, a `double` and a `real`, measured on the
+ * binary prepared path, so a schema there must not. SQLite states neither and is left alone, which
+ * is why `nonFiniteRefused` reads `=== false` rather than "not accepted": that engine stores both
+ * infinities too and turns `NaN` into NULL, and half of that answer is worse than none.
+ *
+ * Only where a bound is not already doing it, and one end at a time. Measured on the installed
+ * valibot: `v.number()` takes both, `v.maxValue(n)` refuses `+Infinity` whatever `n` is and
+ * `v.minValue(n)` refuses `-Infinity`, so a column with both ends declared already refuses both and
+ * a check beside them would be bytes in the consumer's bundle for a verdict already reached. That
+ * is exactly MySQL's `float`, which carries the float32 range; its `double` and `real` carry no
+ * finite bound, because every finite JS number fits in an 8 byte float, and they are what leaked.
+ *
+ * `Number.isFinite` rather than `v.finite()`, and the difference is only in what a failure says:
+ * both refuse `NaN` as well, which is right here, since the same server refuses that too.
+ *
+ * An integer column cannot reach this: only the three float classes carry the flag, and
+ * `v.integer()` refuses a non-finite number by itself. An equality check is skipped for the same
+ * reason it is in the ArkType generator, since `val === 7` has already reached the verdict.
+ */
+function vFiniteCheck(c: Column, checks: ColumnCheck[]): string[] {
+  if (!nonFiniteRefused(c).infinity) return [];
+  if (isIntegerColumn(c)) return [];
+  if (checks.some((k) => k.column === c.name && k.kind === 'number' && k.operator === '=')) {
+    return [];
+  }
+  const { lo, hi } = vBoundEnds(c, checks);
+  if (lo && hi) return [];
+  return [`v.check((val) => Number.isFinite(val), 'a finite number')`];
 }
 
 /**
@@ -445,7 +489,11 @@ function vExprForColumn(
       return piped('v.string()', caps.length ? caps : []);
     case 'number': {
       const bounds = vBounds(c, (v) => v, checks);
-      const actions = [...(isIntegerColumn(c) ? ['v.integer()'] : []), ...bounds];
+      const actions = [
+        ...(isIntegerColumn(c) ? ['v.integer()'] : []),
+        ...bounds,
+        ...vFiniteCheck(c, checks),
+      ];
       const branches = vNonFiniteBranches(c, bounds.length > 0);
       if (!branches.length) return piped('v.number()', actions);
       // The bounds stay on the number branch and the union is what `extra` then applies to, so a

--- a/packages/generator-valibot/test/mysql-infinity.spec.ts
+++ b/packages/generator-valibot/test/mysql-infinity.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * `Infinity` and `-Infinity` on a MySQL `float`, `double` and `real`, in valibot output.
+ *
+ * The sibling of `non-finite-numbers.spec.ts`, asking the opposite question of a different
+ * database. That file asks what a Postgres float must *accept*; this one asks what a MySQL one must
+ * refuse, and the arbiter is the server. Measured on a real MySQL 8.4.11 in `STRICT_TRANS_TABLES`,
+ * on the binary prepared path, which is the one that puts the real IEEE double on the wire:
+ *
+ *   float, double, real     Infinity, -Infinity and NaN all refused, ER_WARN_DATA_OUT_OF_RANGE
+ *   double, real            1e300 and 3.4028235e38 stored and returned unchanged
+ *
+ * mysql2's text protocol interpolates a JS number through `toString`, so a placeholder carrying
+ * `Infinity` reaches the server as the bare word `Infinity` and comes back "Unknown column
+ * 'Infinity' in 'field list'". That is a client artifact and says nothing about the column, which is
+ * why the measurement above is the prepared one.
+ *
+ * The mechanism is valibot's and it is a magnitude bound doing the work by accident: `v.number()`
+ * takes both infinities, `v.maxValue(n)` refuses `+Infinity` whatever `n` is and `v.minValue(n)`
+ * refuses `-Infinity`. So MySQL's `float`, which carries the float32 range, already refused them,
+ * and `double` and `real`, which carry no finite bound because every finite JS number fits, took
+ * both. The analyzer states the refusal outright now and the generator emits a finite check where
+ * no bound already holds.
+ *
+ * SQLite is the control that must not move, and it is not the same answer: a real SQLite 3.53.4
+ * stores both infinities in a `real` and hands them back, and turns `NaN` into NULL. Postgres is
+ * the other control: it stores all three and a schema refusing them refuses rows the column
+ * returns.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import * as v from 'valibot';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ValibotGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-mysql-infinity');
+
+const MYSQL = `
+  import { mysqlTable, float, double, real } from 'drizzle-orm-v1/mysql-core';
+  export const t = mysqlTable('t', {
+    c_float: float().notNull(),
+    c_double: double().notNull(),
+    c_real: real().notNull(),
+    n_float: float(),
+    n_double: double(),
+    n_real: real(),
+  });
+`;
+
+const SINGLESTORE = `
+  import { singlestoreTable, float, double, real } from 'drizzle-orm-v1/singlestore-core';
+  export const t = singlestoreTable('t', {
+    c_float: float().notNull(),
+    c_double: double().notNull(),
+    c_real: real().notNull(),
+    n_double: double(),
+  });
+`;
+
+const SQLITE = `
+  import { sqliteTable, real } from 'drizzle-orm-v1/sqlite-core';
+  export const t = sqliteTable('t', { c_real: real().notNull(), n_real: real() });
+`;
+
+const POSTGRES = `
+  import { pgTable, real, doublePrecision } from 'drizzle-orm-v1/pg-core';
+  export const t = pgTable('t', {
+    c_real: real().notNull(),
+    c_double: doublePrecision().notNull(),
+    n_double: doublePrecision(),
+  });
+`;
+
+/** `dense` is the source with every space removed, so an assertion cannot depend on line breaks. */
+type Emitted = { source: string; dense: string; module: Record<string, any> };
+const built: Record<string, Emitted> = {};
+
+async function build(label: string, source: string): Promise<Emitted> {
+  const dir = path.join(DIR, label);
+  await fs.mkdir(dir, { recursive: true });
+  const schema = path.join(dir, 'schema.mjs');
+  await fs.writeFile(schema, source, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  expect(analysis.tables[0], `${label}: no table analyzed`).toBeTruthy();
+  await new ValibotGenerator(analysis).generate({ outDir: dir } as never);
+  const emitted = path.join(dir, `t-${process.pid}.ts`);
+  await fs.rename(path.join(dir, 't.valibot.ts'), emitted);
+  const text = await fs.readFile(emitted, 'utf8');
+  return {
+    source: text.replace(/\s+/g, ' '),
+    dense: text.replace(/\s+/g, ''),
+    module: await import(emitted),
+  };
+}
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  for (const [label, source] of [
+    ['mysql', MYSQL],
+    ['singlestore', SINGLESTORE],
+    ['sqlite', SQLITE],
+    ['postgres', POSTGRES],
+  ] as const) {
+    built[label] = await build(label, source);
+  }
+}, 180_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const MODES = ['Select', 'Insert', 'Update'] as const;
+
+/** One column pulled out of the schema, which is how the packed gate takes a schema apart. */
+const field = (schema: any, key: string, x: unknown) => v.safeParse(schema.entries[key], x).success;
+
+/** The same column through the whole object, with every other key filled with a value it takes. */
+const rowOf =
+  (base: Record<string, unknown>) =>
+  (schema: any, key: string, x: unknown): boolean =>
+    v.safeParse(schema, { ...base, [key]: x }).success;
+
+const INF = [
+  ['Infinity', Infinity],
+  ['-Infinity', -Infinity],
+] as const;
+
+describe('what valibot does on its own', () => {
+  it('takes both infinities unbounded, and each bound refuses only its own end', () => {
+    expect(v.safeParse(v.number(), Infinity).success, 'bare number, Infinity').toBe(true);
+    expect(v.safeParse(v.number(), -Infinity).success, 'bare number, -Infinity').toBe(true);
+    const hi = v.pipe(v.number(), v.maxValue(10));
+    expect(v.safeParse(hi, Infinity).success, 'maxValue, Infinity').toBe(false);
+    expect(v.safeParse(hi, -Infinity).success, 'maxValue, -Infinity').toBe(true);
+    const lo = v.pipe(v.number(), v.minValue(-10));
+    expect(v.safeParse(lo, Infinity).success, 'minValue, Infinity').toBe(true);
+    expect(v.safeParse(lo, -Infinity).success, 'minValue, -Infinity').toBe(false);
+    // The repair, and that it survives the two wrappers a column gets.
+    const finite = v.pipe(
+      v.number(),
+      v.check((x) => Number.isFinite(x), 'finite')
+    );
+    for (const [, value] of INF) expect(v.safeParse(finite, value).success).toBe(false);
+    expect(v.safeParse(v.nullable(finite), Infinity).success, 'nullable').toBe(false);
+    expect(v.safeParse(v.optional(finite), Infinity).success, 'optional').toBe(false);
+    expect(v.safeParse(finite, 1.5).success, 'an ordinary number').toBe(true);
+  });
+});
+
+describe('a mysql float, double and real column', () => {
+  const COLS = ['c_float', 'c_double', 'c_real', 'n_float', 'n_double', 'n_real'];
+  const row = rowOf({
+    c_float: 1.5,
+    c_double: 1.5,
+    c_real: 1.5,
+    n_float: 1.5,
+    n_double: 1.5,
+    n_real: 1.5,
+  });
+
+  it('refuses both infinities in every mode, on the field and on the row', () => {
+    const leaks: string[] = [];
+    for (const mode of MODES) {
+      const s = built.mysql.module[`${mode}tSchema`];
+      expect(row(s, 'c_double', 1.5), `${mode} the baseline row is accepted`).toBe(true);
+      for (const name of COLS) {
+        for (const [label, value] of INF) {
+          if (field(s, name, value)) leaks.push(`${mode} ${name} ${label} field`);
+          if (row(s, name, value)) leaks.push(`${mode} ${name} ${label} row`);
+        }
+      }
+    }
+    expect(leaks).toEqual([]);
+  });
+
+  it('still takes every finite value the column really stores', () => {
+    for (const mode of MODES) {
+      const s = built.mysql.module[`${mode}tSchema`];
+      for (const name of COLS) {
+        expect(field(s, name, 1.5), `${mode} ${name} 1.5`).toBe(true);
+        expect(field(s, name, 0), `${mode} ${name} 0`).toBe(true);
+        expect(field(s, name, NaN), `${mode} ${name} NaN`).toBe(false);
+        expect(field(s, name, 'x'), `${mode} ${name} a string`).toBe(false);
+      }
+      // The 8 byte columns hold every finite JS number, and MySQL returned both of these.
+      for (const name of ['c_double', 'c_real', 'n_double', 'n_real']) {
+        expect(field(s, name, 1e300), `${mode} ${name} 1e300`).toBe(true);
+        expect(field(s, name, 3.4028235e38), `${mode} ${name} 3.4028235e38`).toBe(true);
+      }
+      // The 4 byte one keeps the float32 edge, which MySQL refuses past.
+      expect(field(s, 'c_float', 1e300), `${mode} c_float 1e300`).toBe(false);
+      expect(field(s, 'n_float', null), `${mode} n_float null`).toBe(true);
+      expect(field(s, 'c_float', null), `${mode} c_float null on NOT NULL`).toBe(false);
+    }
+  });
+
+  it('spends the check only where no bound already refuses an infinity', () => {
+    const { dense } = built.mysql;
+    const F = '340282346638528859811704183484516925440';
+    // `float` carries the float32 range, so `v.minValue`/`v.maxValue` already refuse both ends and
+    // a check beside them would be bytes in the consumer's bundle for a verdict already reached.
+    expect(dense, 'the bounded 4 byte column keeps its plain pipe').toContain(
+      `c_float:v.pipe(v.number(),v.minValue(-${F}),v.maxValue(${F}))`
+    );
+    expect(dense, 'the unbounded 8 byte one gains the check').toContain(
+      "c_double:v.pipe(v.number(),v.check((val)=>Number.isFinite(val),'afinitenumber'))"
+    );
+    // Four of the six columns, once in each of the three schemas the file exports: every mode
+    // renders every column, so a per-column repair appears three times.
+    expect(dense.match(/Number\.isFinite/g)?.length ?? 0, 'double and real, not float').toBe(12);
+  });
+});
+
+describe('a singlestore column, which mirrors mysql', () => {
+  it('refuses both infinities on double and real', () => {
+    for (const mode of MODES) {
+      const s = built.singlestore.module[`${mode}tSchema`];
+      for (const name of ['c_double', 'c_real', 'n_double']) {
+        for (const [label, value] of INF) {
+          expect(field(s, name, value), `${mode} ${name} ${label}`).toBe(false);
+        }
+        expect(field(s, name, 1e300), `${mode} ${name} 1e300`).toBe(true);
+      }
+      expect(field(s, 'c_float', Infinity), `${mode} c_float`).toBe(false);
+    }
+  });
+});
+
+describe('sqlite, which is a different answer and must not move', () => {
+  it('keeps accepting both infinities, which the engine really stores and returns', () => {
+    for (const mode of MODES) {
+      const s = built.sqlite.module[`${mode}tSchema`];
+      for (const name of ['c_real', 'n_real']) {
+        for (const [label, value] of INF) {
+          expect(field(s, name, value), `${mode} ${name} ${label}`).toBe(true);
+        }
+      }
+    }
+    expect(built.sqlite.source, 'nothing was added').not.toContain('Number.isFinite');
+  });
+});
+
+describe('postgres, which stores all three and hands them back', () => {
+  it('keeps accepting both infinities and NaN', () => {
+    for (const mode of MODES) {
+      const s = built.postgres.module[`${mode}tSchema`];
+      for (const name of ['c_real', 'c_double', 'n_double']) {
+        for (const [label, value] of INF) {
+          expect(field(s, name, value), `${mode} ${name} ${label}`).toBe(true);
+        }
+        expect(field(s, name, NaN), `${mode} ${name} NaN`).toBe(true);
+      }
+      expect(field(s, 'c_real', 1e300), `${mode} c_real 1e300`).toBe(false);
+    }
+    expect(built.postgres.source, 'nothing was added').not.toContain('Number.isFinite');
+  });
+});

--- a/packages/generator-zod/test/mysql-infinity.spec.ts
+++ b/packages/generator-zod/test/mysql-infinity.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * `Infinity` and `-Infinity` on a MySQL `float`, `double` and `real`, in zod output.
+ *
+ * A pin rather than a repair. `z.number()` is `Number.isFinite`, measured and asserted below, so
+ * this generator already refused both infinities on every column of every dialect and the fix that
+ * moved valibot and ArkType left it alone. What that fix did change is the analysis underneath:
+ * a MySQL float, double and real now state `allowsInfinity: false` where they used to state
+ * nothing, and a flag turning from absent to present is exactly the kind of change that quietly
+ * adds a union branch. This file is what says it did not.
+ *
+ * The arbiter is the server. Measured on a real MySQL 8.4.11 in `STRICT_TRANS_TABLES`, on the
+ * binary prepared path: `float`, `double` and `real` answer `ER_WARN_DATA_OUT_OF_RANGE` for
+ * `Infinity`, `-Infinity` and `NaN` alike, and `double`/`real` store 1e300 unchanged.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import { ZodGenerator } from '../src/index';
+
+const DIR = path.join(__dirname, '.tmp-mysql-infinity');
+
+const MYSQL = `
+  import { mysqlTable, float, double, real } from 'drizzle-orm-v1/mysql-core';
+  export const t = mysqlTable('t', {
+    c_float: float().notNull(),
+    c_double: double().notNull(),
+    c_real: real().notNull(),
+    n_double: double(),
+  });
+`;
+
+const SQLITE = `
+  import { sqliteTable, real } from 'drizzle-orm-v1/sqlite-core';
+  export const t = sqliteTable('t', { c_real: real().notNull(), n_real: real() });
+`;
+
+const POSTGRES = `
+  import { pgTable, doublePrecision } from 'drizzle-orm-v1/pg-core';
+  export const t = pgTable('t', { c_double: doublePrecision().notNull() });
+`;
+
+type Emitted = { dense: string; module: Record<string, any> };
+const built: Record<string, Emitted> = {};
+
+async function build(label: string, source: string): Promise<Emitted> {
+  const dir = path.join(DIR, label);
+  await fs.mkdir(dir, { recursive: true });
+  const schema = path.join(dir, 'schema.mjs');
+  await fs.writeFile(schema, source, 'utf8');
+  const analysis = await new SchemaAnalyzer(path.relative(process.cwd(), schema)).analyze({});
+  expect(analysis.tables[0], `${label}: no table analyzed`).toBeTruthy();
+  await new ZodGenerator(analysis).generate({ outDir: dir } as never);
+  const emitted = path.join(dir, `t-${process.pid}.ts`);
+  await fs.rename(path.join(dir, 't.zod.ts'), emitted);
+  const text = await fs.readFile(emitted, 'utf8');
+  return { dense: text.replace(/\s+/g, ''), module: await import(emitted) };
+}
+
+beforeAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+  for (const [label, source] of [
+    ['mysql', MYSQL],
+    ['sqlite', SQLITE],
+    ['postgres', POSTGRES],
+  ] as const) {
+    built[label] = await build(label, source);
+  }
+}, 180_000);
+
+afterAll(async () => {
+  await fs.rm(DIR, { recursive: true, force: true });
+});
+
+const MODES = ['Select', 'Insert', 'Update'] as const;
+const field = (schema: any, key: string, x: unknown) => schema.shape[key].safeParse(x).success;
+const rowOf =
+  (base: Record<string, unknown>) =>
+  (schema: any, key: string, x: unknown): boolean =>
+    schema.safeParse({ ...base, [key]: x }).success;
+
+const INF = [
+  ['Infinity', Infinity],
+  ['-Infinity', -Infinity],
+] as const;
+
+describe('what zod does on its own', () => {
+  it('refuses a non-finite number with no bound at all, in every wrapper', () => {
+    for (const [label, value] of INF) {
+      expect(z.number().safeParse(value).success, `bare, ${label}`).toBe(false);
+      expect(z.number().nullable().safeParse(value).success, `nullable, ${label}`).toBe(false);
+      expect(z.number().optional().safeParse(value).success, `optional, ${label}`).toBe(false);
+    }
+    expect(z.number().safeParse(1e300).success, 'an ordinary large number').toBe(true);
+  });
+});
+
+describe('a mysql float, double and real column', () => {
+  const COLS = ['c_float', 'c_double', 'c_real', 'n_double'];
+  const row = rowOf({ c_float: 1.5, c_double: 1.5, c_real: 1.5, n_double: 1.5 });
+
+  it('refuses both infinities in every mode, on the field and on the row', () => {
+    const leaks: string[] = [];
+    for (const mode of MODES) {
+      const s = built.mysql.module[`${mode}tSchema`];
+      expect(row(s, 'c_double', 1.5), `${mode} the baseline row is accepted`).toBe(true);
+      for (const name of COLS) {
+        for (const [label, value] of INF) {
+          if (field(s, name, value)) leaks.push(`${mode} ${name} ${label} field`);
+          if (row(s, name, value)) leaks.push(`${mode} ${name} ${label} row`);
+        }
+      }
+    }
+    expect(leaks).toEqual([]);
+  });
+
+  it('states nothing new in the emitted file, and keeps every finite value', () => {
+    // No union branch and no check: the base type already reached this verdict, and a flag turning
+    // from absent to present must not put bytes in the consumer's bundle for it.
+    expect(built.mysql.dense, 'no non-finite union').not.toContain('z.nan()');
+    expect(built.mysql.dense).not.toContain('z.literal(Infinity)');
+    expect(built.mysql.dense).not.toContain('Number.isFinite');
+    expect(built.mysql.dense).toContain('c_double:z.number()');
+    for (const mode of MODES) {
+      const s = built.mysql.module[`${mode}tSchema`];
+      for (const name of ['c_double', 'c_real', 'n_double']) {
+        expect(field(s, name, 1e300), `${mode} ${name} 1e300`).toBe(true);
+        expect(field(s, name, 1.5), `${mode} ${name} 1.5`).toBe(true);
+        expect(field(s, name, NaN), `${mode} ${name} NaN`).toBe(false);
+      }
+      expect(field(s, 'c_float', 1e300), `${mode} c_float 1e300`).toBe(false);
+    }
+  });
+});
+
+describe('the two controls', () => {
+  it('leaves sqlite exactly as it was, refusing both for zod reasons of its own', () => {
+    expect(built.sqlite.dense).not.toContain('z.literal(Infinity)');
+    for (const mode of MODES) {
+      const s = built.sqlite.module[`${mode}tSchema`];
+      for (const [label, value] of INF) {
+        expect(field(s, 'c_real', value), `${mode} ${label}`).toBe(false);
+      }
+    }
+  });
+
+  it('keeps accepting all three on a postgres double, which stores them', () => {
+    for (const mode of MODES) {
+      const s = built.postgres.module[`${mode}tSchema`];
+      for (const [label, value] of INF) {
+        expect(field(s, 'c_double', value), `${mode} ${label}`).toBe(true);
+      }
+      expect(field(s, 'c_double', NaN), `${mode} NaN`).toBe(true);
+    }
+  });
+});

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -436,6 +436,35 @@ export function nonFiniteAccepted(c: Column): { nan: boolean; infinity: boolean 
 }
 
 /**
+ * The non-finite doubles the emitted schema must *refuse*, as the analyzer stated them.
+ *
+ * The other reading of the same two flags, and not the negation of `nonFiniteAccepted`. Three
+ * states, because a column that was measured and refused the value is a different thing from a
+ * column nobody measured: `true` is stored and returned, `false` is offered and refused, absent is
+ * unstated. `nonFiniteAccepted` reads `=== true` and this reads `=== false`, so an unstated column
+ * answers no to both and every generator leaves it exactly as its library renders it.
+ *
+ * The distinction is load-bearing rather than tidy. MySQL and SQLite both leave a `real` unbounded,
+ * and MySQL answers `ER_WARN_DATA_OUT_OF_RANGE` for an infinity where SQLite stores it and hands it
+ * back. Reading "not accepted" as "refuse it" would have made one schema right and the other wrong
+ * from the same reading, and the SQLite half is filed separately because that engine also turns
+ * `NaN` into NULL and a column needs both halves of that answer or none.
+ *
+ * Guarded on `tsType` exactly as its sibling is, so a stale analysis carrying the flags on a string
+ * or a shaped column cannot put a numeric predicate beside a `z.string()`.
+ *
+ * What each generator does with a yes is its own: `z.number()` and `Type.Number()` already refuse
+ * every non-finite number with no bound at all, measured, so they emit nothing and read this only
+ * through the tests that pin that. `v.number()` and ArkType's `number` take both infinities, so
+ * those two add a finite predicate wherever no bound already holds one back. Effect builds on
+ * `Schema.Finite` unconditionally and needs nothing either.
+ */
+export function nonFiniteRefused(c: Column): { nan: boolean; infinity: boolean } {
+  if (c.tsType !== 'number' || c.shape) return { nan: false, infinity: false };
+  return { nan: c.allowsNaN === false, infinity: c.allowsInfinity === false };
+}
+
+/**
  * The columns a `CHECK (col IS NOT NULL)` on this table forbids NULL in.
  *
  * The whole constraint has to parse, not just the clause: `email IS NOT NULL OR my_fn(email) > 1`

--- a/packages/validation-core/test/non-finite-accepted.spec.ts
+++ b/packages/validation-core/test/non-finite-accepted.spec.ts
@@ -9,7 +9,7 @@
  * column would otherwise put a `z.nan()` branch beside a `z.string()`.
  */
 import { describe, it, expect } from 'vitest';
-import { nonFiniteAccepted } from '../src/index';
+import { nonFiniteAccepted, nonFiniteRefused } from '../src/index';
 import type { Column } from '@drzl/analyzer';
 
 const col = (over: Partial<Column>): Column =>
@@ -55,6 +55,45 @@ describe('nonFiniteAccepted', () => {
     expect(
       nonFiniteAccepted(
         col({ shape: { kind: 'numberVector', length: 3 }, allowsNaN: true, allowsInfinity: true })
+      )
+    ).toEqual({ nan: false, infinity: false });
+  });
+});
+
+describe('nonFiniteRefused', () => {
+  it('reads the MySQL answer, which is the flags stated as false rather than left off', () => {
+    expect(
+      nonFiniteRefused(col({ dbType: 'DOUBLE', allowsNaN: false, allowsInfinity: false }))
+    ).toEqual({ nan: true, infinity: true });
+  });
+
+  it('is not the negation of nonFiniteAccepted, which is the whole point of it', () => {
+    // The third state. A SQLite `real` states neither flag, and the engine really does store both
+    // infinities and hand them back, so "not accepted" must not become "refuse it". Both functions
+    // answer no here and every generator leaves the column exactly as its library renders it.
+    const unstated = col({ dbType: 'REAL' });
+    expect(nonFiniteAccepted(unstated)).toEqual({ nan: false, infinity: false });
+    expect(nonFiniteRefused(unstated)).toEqual({ nan: false, infinity: false });
+  });
+
+  it('separates the two halves, as a postgres numeric in number mode needs', () => {
+    // Postgres stores NaN in a `numeric` of any width and refuses either infinity in one carrying a
+    // precision, so this column answers yes to one function on one flag and yes to the other on the
+    // other. A reading that could only be all or nothing would be wrong about it either way.
+    const c = col({ dbType: 'NUMERIC', allowsNaN: true, allowsInfinity: false });
+    expect(nonFiniteAccepted(c)).toEqual({ nan: true, infinity: false });
+    expect(nonFiniteRefused(c)).toEqual({ nan: false, infinity: true });
+  });
+
+  it('refuses to answer yes for anything that is not a plain number', () => {
+    // The same guard as its sibling, with the flags set to the answering value, so a passing case
+    // here cannot be the flags being absent.
+    expect(
+      nonFiniteRefused(col({ tsType: 'string', allowsNaN: false, allowsInfinity: false }))
+    ).toEqual({ nan: false, infinity: false });
+    expect(
+      nonFiniteRefused(
+        col({ shape: { kind: 'numberVector', length: 3 }, allowsNaN: false, allowsInfinity: false })
       )
     ).toEqual({ nan: false, infinity: false });
   });

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -2400,8 +2400,16 @@ const ALLOWED: Record<string, Waiver> = {
   // that cell diverges now: official accepts the value the column refuses there too.
   'pg/c_numeric_n': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'Postgres stores NaN in a numeric column and returns it, and refuses a value past the declared precision; official reads no precision so it accepts what the column will not hold', divergence: { 'select,insert/*': `L: NaN | T: 2147483648, 4294967295, 4294967296`, 'update/zod,valibot,typebox': `L: NaN | T: 2147483648, 4294967295, 4294967296`, 'update/arktype': `L:  | T: 2147483648, 4294967295, 4294967296` } },
   'pg/c_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'no finite bound is true of an 8 byte float, which holds every finite JS number. Non-finite values were added on top: Postgres stores NaN and both infinities in a float column and returns them, and a Select schema refusing what the database hands back fails on real rows (AW).', divergence: { 'select,insert/*': `L: 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/zod,valibot,typebox': `L: 9007199254740993, 3.4028235e38, NaN, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
-  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; MySQL REAL is a synonym for DOUBLE', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
-  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
+  // Only the magnitudes now. The `Infinity` term these two carried was the entry reading "as
+  // pg/c_double" on a column whose database is not Postgres: an 8 byte float stores an infinity
+  // there and MySQL 8.4.11 answers ER_WARN_DATA_OUT_OF_RANGE for `Infinity`, `-Infinity` and `NaN`
+  // alike on `float`, `double` and `real`, measured on the binary prepared path, which is the one
+  // that puts the real IEEE double on the wire. The analyzer states that refusal now, valibot and
+  // arktype refuse it with it, and all four generators agree with official on those two values
+  // (BU). What is left is the pair of magnitudes, where DRZL is looser because no finite bound is
+  // truthful of an 8 byte float, and arktype's update-only NaN narrow.
+  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double at the magnitudes; MySQL REAL is a synonym for DOUBLE. Not as pg/c_double on the infinities, which is where the two databases part and this entry used to claim they did not', divergence: { '*/zod,valibot,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38 | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38 | T: ` } },
+  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as mysql/m_real, which is the same column under its other name', divergence: { '*/zod,valibot,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38 | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38 | T: ` } },
   'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, why: 'as pg/c_double; SQLite REAL is an 8 byte IEEE float', divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` } },
   // ---- binary and varbinary, where official refuses rows the server returns --------------------
   // Official emits `^[01]*$` capped at n for these columns on v1, which is a bit-string pattern on
@@ -2691,17 +2699,24 @@ const CROSS_ALLOWED: Record<string, CrossWaiver> = {
   'sqlite/s_text_json': { modes: ['select', 'insert', 'update'], why: 'as pg/c_json', divergence: { '*': `NaN: arktype accept, zod/valibot/typebox reject; Infinity: arktype accept, zod/valibot/typebox reject; Date: arktype accept, zod/valibot/typebox reject; Buffer: arktype accept, zod/valibot/typebox reject; Uint8Array: arktype accept, zod/valibot/typebox reject` } },
   'sqlite/s_blob_json': { modes: ['select', 'insert', 'update'], why: 'as pg/c_json', divergence: { '*': `NaN: arktype accept, zod/valibot/typebox reject; Infinity: arktype accept, zod/valibot/typebox reject; Date: arktype accept, zod/valibot/typebox reject; Buffer: arktype accept, zod/valibot/typebox reject; Uint8Array: arktype accept, zod/valibot/typebox reject` } },
   'sqlite/s_blob': { modes: ['select', 'insert', 'update'], why: 'as pg/c_json; a bare blob() is Drizzle json mode', divergence: { '*': `NaN: arktype accept, zod/valibot/typebox reject; Infinity: arktype accept, zod/valibot/typebox reject; Date: arktype accept, zod/valibot/typebox reject; Buffer: arktype accept, zod/valibot/typebox reject; Uint8Array: arktype accept, zod/valibot/typebox reject` } },
-  // The four generators split on `Infinity` for every 8 byte float column, and only since those
-  // columns stopped carrying a magnitude bound. That is not a difference in what DRZL asked for:
-  // all four are handed the same column, with `integer: false` and no range, and `z.number()` and
-  // `Type.Number()` refuse a non-finite number on their own while `v.number()` and arktype's
-  // `number` accept one. Postgres stores and returns Infinity in `real` and `double precision`
-  // alike, so valibot and arktype are the two that agree with the database here.
+  // The four generators split on `Infinity` for an 8 byte float column whose database stores one,
+  // and only since those columns stopped carrying a magnitude bound. That is not a difference in
+  // what DRZL asked for: all four are handed the same column, with `integer: false` and no range,
+  // and `z.number()` and `Type.Number()` refuse a non-finite number on their own while `v.number()`
+  // and arktype's `number` accept one. Postgres stores and returns Infinity in `real` and `double
+  // precision` alike, and a real SQLite 3.53.4 stores it in a `real` and hands it back, so valibot
+  // and arktype are the two that agree with the database on both of those.
   //
   // No `real` entry: the float4 bound refuses Infinity in all four, so they agree there for a
   // reason that has nothing to do with the libraries.
-  'mysql/m_real': { modes: ['select', 'insert', 'update'], why: 'as pg/c_double', divergence: { '*': `Infinity: valibot/arktype accept, zod/typebox reject` } },
-  'mysql/m_double': { modes: ['select', 'insert', 'update'], why: 'as pg/c_double', divergence: { '*': `Infinity: valibot/arktype accept, zod/typebox reject` } },
+  //
+  // No MySQL entry, and that is a fix rather than an omission. `mysql/m_real` and `mysql/m_double`
+  // sat here reading "as pg/c_double", which is the wrong arbiter for a MySQL column: measured on
+  // 8.4.11 on the binary prepared path, `float`, `double` and `real` answer
+  // ER_WARN_DATA_OUT_OF_RANGE for `Infinity` and `-Infinity` alike, so the two libraries that
+  // accepted them were the two disagreeing with the database rather than the two agreeing with it.
+  // The analyzer states that refusal now and valibot and arktype refuse it with it, so all four
+  // generators agree on those two columns and there is nothing left to waive (BU).
   'sqlite/s_real': { modes: ['select', 'insert', 'update'], why: 'as pg/c_double', divergence: { '*': `Infinity: valibot/arktype accept, zod/typebox reject` } },
   // The same two splits on the nullable table, which is what says the wrapper each generator puts
   // round a nullable column does not change which library can express what.
@@ -7700,8 +7715,12 @@ const ALLOWED: Record<string, Entry> = {
     official: 'a number within +/-140737488355327, which refuses an ordinary microsecond epoch',
     filed: 'not a defect: as pg/c_real',
   },
-  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
-  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  // The `Infinity` term is gone from both, on this major as on the other: MySQL 8.4.11 refuses both
+  // infinities on `float`, `double` and `real`, so DRZL refuses them too and agrees with official
+  // there. Only the magnitudes are left, plus arktype's update-only NaN narrow. See the ALLOWED
+  // entry in the v1 pass for the measurement (BU).
+  'mysql/m_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,valibot,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38 | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38 | T: ` }, drzl: 'as pg/c_double at the magnitudes, refusing both infinities as MySQL does', official: 'as pg/c_double', filed: 'as pg/c_real' },
+  'mysql/m_double': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,valibot,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38 | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38 | T: ` }, drzl: 'as mysql/m_real', official: 'as pg/c_double', filed: 'as pg/c_real' },
   'sqlite/s_real': { libs: LIB_NAMES, modes: MODE_NAMES, divergence: { '*/zod,typebox': `L: 9007199254740993, 3.4028235e38 | T: `, '*/valibot': `L: 9007199254740993, 3.4028235e38, Infinity | T: `, 'update/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: NaN`, 'select,insert/arktype': `L: 9007199254740993, 3.4028235e38, Infinity | T: ` }, drzl: 'as pg/c_double', official: 'as pg/c_double', filed: 'as pg/c_real' },
 
   // ---- the nullable table --------------------------------------------------------------------


### PR DESCRIPTION
Fixes plan addendum BU (Tier B): valibot and arktype accepted `Infinity` into MySQL `real` and `double` columns, under two ledger waivers whose `why` was the literal string `'as pg/c_double'`, pointing at a block comment arguing that Postgres stores infinities so the accepting libraries are the ones agreeing with the database. True of Postgres, **false of the MySQL columns those waivers covered**, so a write-path defect read as intended behavior. Found by the audit that was verifying whether three older addenda were still open.

## Measured, three dialects

MySQL 8.4.11 on the **binary prepared path** (the one that puts a real IEEE double on the wire): `float`, `double` and `real` all answer `ER_WARN_DATA_OUT_OF_RANGE` for `Infinity`, `-Infinity` and `NaN`; `float` additionally refuses `1e300` and `3.4028235e38` where `double`/`real` accept them. The server cannot produce an infinity either (`CAST('Infinity' AS DOUBLE)` is 0, `1e308*10` errors, `0e0/0e0` and `SQRT(-1)` are NULL). Postgres accepts and returns all three on `real`/`double precision`, unchanged. SQLite stores both infinities faithfully on every affinity and silently turns NaN into NULL (recorded for addendum AY, out of scope here).

A measurement trap worth recording: mysql2's **text** protocol interpolates a JS number through `toString`, so `Infinity` arrives as the bare word and returns `ER_BAD_FIELD_ERROR Unknown column 'Infinity'`, which says nothing about the column. The first measurement pass said exactly that for all eight columns; the prepared path is the arbiter.

## The rule

Refuse where the server refuses and no bound already does. The gate is "both bound ends declared", not "has a bound", because a lone `number >= 0` still accepts `+Infinity` (measured). The analyzer states the refusal for MySQL and SingleStore float/double/real on both majors (MySQL keyed on its codec, SingleStore on entityKind since it declares none). The new predicate reads three states and that is load-bearing: stated-true, measured-and-refused, and unstated; reading "not accepted" as "refuse it" would have moved SQLite, which is exactly where the behavior is correct. zod and TypeBox needed no change and are now pinned: `z.number()` and `Type.Number()` refuse every non-finite value in every wrapper.

## Proofs

- **Red-first**: 48 leaking combinations each in valibot and arktype (4 unbounded columns x 2 infinities x 2 lookup paths x 3 modes), zero after; each spec drives a real drizzle schema through the real analyzer and generator and runs the emitted module, with Postgres and SQLite controls that must keep accepting.
- **Byte identity**: 80 emitted file pairs against master's extracted dists, **72 identical, 8 differing**, exactly valibot and arktype on MySQL and SingleStore across both majors; the 4 differing analyses each differ by 6 hunks adding `allowsNaN: false, allowsInfinity: false` beside `integer: false`.
- `pnpm verify:packed` unmodified fails on **exactly** the four dead ledger entries and nothing else.

## Ledger, rewritten and deleted (controller edits in this PR)

The two `ALLOWED` entries still carry a real divergence after the fix (DRZL accepts `9007199254740993` and `3.4028235e38` where official refuses, because no finite bound is truthful of an 8 byte float, plus arktype's update-only NaN narrow), so they are **rewritten** in both parity passes. The two `CROSS_ALLOWED` entries carried nothing but the Infinity split and are **deleted**, with the block comment corrected to state why MySQL has no entry rather than leaving a silent gap. The measured signature came out stronger than predicted: `Infinity` does not move to the other side of the ledger, it disappears entirely, because official refuses it on these columns too. Validated on a scratch copy running the full gate with MYSQL_URL to exit 0, byte budgets unmoved (the size stage measures Postgres output, which is byte-identical).

## Filed, not fixed

**BV**: MySQL `decimal(10,2)` stores `0.00` for all three non-finite values on the prepared path instead of refusing, while the analyzer's doc comment says MySQL "refuses them outright", a sentence written from the text path. Left unstated rather than half-fixed; the gate's own mysql-truth harness uses the text path and probes no non-finite values, so it cannot arbitrate this either.

Full gates green (290 files, 3231 tests, typecheck, lint, docs). Changeset: patch for analyzer, validation-core, generator-valibot, generator-arktype. Both affected generator doc pages said "MySQL and SQLite are unchanged", which this makes false for MySQL, so each now states the MySQL answer with its measurement.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
