### PR TITLE
feat: Bun and Deno compatibility, measured, plus the formatter defect it found (item 63)

### DIFF
--- a/.changeset/bun-biome-auto-install.md
+++ b/.changeset/bun-biome-auto-install.md
@@ -1,0 +1,55 @@
+---
+'@drzl/validation-core': patch
+---
+
+Biome formatting is refused unless Biome is actually installed in the project, which makes generated
+output byte-identical under Bun and Node again
+
+Under Bun, `drzl generate` emitted differently formatted files from Node over the same schema and the
+same config, and reached the network to do it. Measured on a packed install of `@drzl/cli` 4.22.0
+against Bun 1.3.14, Node 22.22.0 and Deno 2.9.5, in a project whose package.json had never mentioned
+Biome: Node emitted the generator's own two-space output, and Bun emitted tab-indented Biome output,
+after downloading `@biomejs/biome` 2.5.7 and a multi-megabyte platform binary mid-generate. Running
+`drzl generate --check` under Node against the Bun-generated tree then reported every file out of
+date, which is a CI failure produced entirely by the choice of runtime.
+
+**The mechanism is that resolving a package is not the same question as having it installed, on one
+runtime.** `formatCode`'s `auto` engine tries prettier, then Biome. The Biome branch locates the
+binary with `createRequire(...).resolve('@biomejs/biome/package.json')`, because the package declares
+only `bin` and cannot be imported. Node and Deno answer a missing package with MODULE_NOT_FOUND,
+which `formatCode` catches, leaving the code unformatted. Bun answers it by auto-installing from npm
+and resolving into its own global cache:
+
+```
+node -> MODULE_NOT_FOUND
+deno -> MODULE_NOT_FOUND
+bun  -> ~/.bun/install/cache/@biomejs/biome@2.5.7@@@1/package.json
+```
+
+It was not even stable within Bun. Whether the auto-install fired depended on the state of that
+cache, so the same command on the same tree emitted different bytes at different times: with the
+cache cold it installed and formatted, with the package present it formatted, and with the package
+deleted but the manifest cache warm it did not.
+
+**A second, independent Bun difference sat behind it.** Resolution was one `createRequire` with
+`resolve(spec, { paths: [outputDir, process.cwd()] })`. Node honours that list; Bun does not. With
+Biome genuinely installed and an absolute `outDir` pointing outside the project, which is the exact
+case `paths` was added for, Node fell back to the working directory and found the real install while
+Bun never tried the second entry and auto-installed instead. Fixing only the first half would have
+left a Bun user who really had installed Biome with no formatting at all.
+
+**What changes.** `isProjectInstallPath` is exported and gates the resolution: a manifest reached
+through a `node_modules` path segment is a project install, and anything else is refused. That
+discriminator is exact rather than a heuristic, since npm, pnpm's `.pnpm` store and Yarn PnP's zip
+and unplugged paths all reach a package through one, and Bun's auto-install cache is the only shape
+that does not. Resolution now anchors a separate `createRequire` at each candidate directory in turn,
+output directory first and working directory second, preserving the order of the `paths` array it
+replaces. Under Node and Deno the guard can never fire, because their resolvers have no other kind of
+path to return, so neither runtime changes at all.
+
+**Measured after the fix**, on packed tarballs installed with npm, with an absolute `outDir` outside
+the project: with no Biome installed, Node and Bun emit byte-identical unformatted output and Bun no
+longer spawns anything; with Biome installed, Node and Bun emit byte-identical Biome-formatted
+output. With the output directory inside the project, Node, Bun and Deno agree byte for byte in both
+cases. Red-first: the guard's spec fails against the previous code, and the working-directory
+fallback has a must-fire test that fails when that anchor is removed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,35 @@ jobs:
       - run: pnpm -C packages/analyzer fuzz:gate
       - run: pnpm lint
 
+  # Bun and Deno, against the packed tarballs. Everything else in CI runs only on Node, so nothing
+  # else would notice a generator whose output depends on which runtime ran it. One did: Bun's
+  # resolver auto-installs a missing package from npm, so @biomejs/biome was fetched mid-generate
+  # and reformatted the output on a project that never depended on it, which then made
+  # `generate --check` fail back on Node.
+  #
+  # Versions are pinned to the ones docs/guide/runtimes.md names, so the page and the gate cannot
+  # drift apart. That deliberately trades early warning of an upstream regression for a claim that
+  # is exactly true; a scheduled job on the latest of each is the shape to add if the trade stops
+  # being worth it, and it belongs with plan item 99's nightly rather than here.
+  runtime-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.9.5
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build:packages
+      - run: bash scripts/runtime-compat.sh
+
   # Everything above imports from source. This job is the only one that exercises what a
   # consumer actually gets: the packed tarballs, installed with npm into a tree that shares
   # nothing with this workspace, driven through `drzl generate`, with the emitted output

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -36,6 +36,7 @@ export default {
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Configuration', link: '/guide/configuration' },
+          { text: 'Bun and Deno', link: '/guide/runtimes' },
           { text: 'Benchmarks', link: '/guide/benchmarks' },
         ],
       },

--- a/docs/guide/runtimes.md
+++ b/docs/guide/runtimes.md
@@ -1,0 +1,153 @@
+# Bun and Deno
+
+DRZL is two surfaces, and they fail independently: the code the generators emit, which runs inside
+your application, and the `drzl` CLI itself, which runs at build time. This page reports what each
+one does under Bun and under Deno, measured rather than assumed.
+
+Measured 2026-08-09 against **Node 22.22.0**, **Bun 1.3.14** and **Deno 2.9.5** (V8 15.0.245.2,
+TypeScript 6.0.3), on Linux x64. Bun reports `process.versions.node` as 24.3.0 and Deno as 26.3.0;
+neither is Node, and both are listed here because the emitted code and the CLI read that field
+through their dependencies.
+
+Everything below ran against the **packed tarballs**, not this repository: all 19 publishable
+packages at `@drzl/cli` 4.22.0 were built with `pnpm pack` and installed with `npm` into an empty
+project that has none of this repo's `node_modules`. That is the artifact a reader installs, and it
+is the only thing worth making a claim about.
+
+Supporting libraries, all at the versions a fresh `npm install` served on the day: `drizzle-orm`
+0.45.2, `zod` 4.4.3, `valibot` 1.4.2, `arktype` 2.2.3, `@sinclair/typebox` 0.34.52, `effect` 3.22.1,
+`ajv` 8.20.0, `hono` 4.13.1, `@hono/standard-validator` 0.4.0, `@orpc/server` 1.15.0, `@trpc/server`
+11.18.0, `express` 5.2.1, `fastify` 5.11.3, `graphql` 17.0.2, `@nestjs/common` 11.1.28.
+
+## The emitted output
+
+Every generator was run over one Postgres schema carrying a serial key, a uuid, a `varchar(20)` with
+two CHECK constraints, an integer with a `>= 18` CHECK, a nullable `real`, a boolean with a default,
+a `pgEnum`, a `jsonb` and a `timestamp`, plus a second table with a foreign key. The emitted modules
+were then **imported and executed**, not merely imported: an import-only check passes against a
+module whose runtime behaviour is broken.
+
+Each validator generator was given three values. A valid row must be accepted. A row with a missing
+required field and a wrong type must be rejected. A row that is well typed but violates the CHECK
+constraint (`age: 5`) must also be rejected, which is what separates "the module loaded" from "the
+schema still validates".
+
+| Generator | Bun 1.3.14 | Deno 2.9.5 | What was executed |
+| --- | --- | --- | --- |
+| `zod` | pass | pass | `safeParse` on all three values |
+| `valibot` | pass | pass | `v.safeParse` on all three values |
+| `arktype` | pass | pass | the type called directly, `ArkErrors` on failure |
+| `typebox` | pass | pass | `Value.Check` on all three values |
+| `effect` | pass | pass | the emitted Standard Schema `validate` |
+| `json-schema` | pass | pass | compiled and run through `ajv` 8.20.0 |
+| `hono` | pass | pass | real requests through `app.request`: list 200, invalid body 400, valid body reaching the handler, bad path param 400 |
+| `orpc` | pass | pass | `call()` on `list` and `delete`, and a rejected bad input |
+| `trpc` | pass | pass | a server-side caller on `list`, and a rejected bad input |
+| `express` | pass | pass | a real listening socket: list 200, invalid body 400 |
+| `fastify` | pass | pass | `app.inject`: list 200, invalid body 400 |
+| `nestjs` | pass | pass | the emitted `SchemaValidationPipe`, accepting a valid body and answering an invalid one with 400 |
+| `graphql` | pass | pass | the emitted SDL compiled by `buildSchema`, including the enum the `pgEnum` produced |
+| `service` | pass | pass | the emitted static methods called |
+
+There is one thing you have to configure for Deno, and it is the next section.
+
+## Deno needs an import specifier it accepts
+
+DRZL emits `./authors.zod.js` by default. That spelling is deliberate: it is the only form that
+resolves under every `moduleResolution` TypeScript offers, which is why it is the default. Deno does
+not accept it, and does not accept the extensionless form either. Measured, with no flags:
+
+```
+importExtension: 'js'   (default)  ->  error: Module not found ".../index.js"
+importExtension: 'none'            ->  error: Module not found ".../index"
+importExtension: 'ts'              ->  runs, 6/6 validator generators pass
+```
+
+So pick one of two options, both measured to work:
+
+**Set the extension Deno wants.** As a config excerpt, alongside your existing `generators` list:
+
+```ts
+  // resolves natively under Deno, with no flags
+  importExtension: 'ts',
+```
+
+**Or keep the default and tell Deno to be lenient.** The default `js` output runs unchanged under
+`deno run --unstable-sloppy-imports`, which was measured at 6/6 on the same suite.
+
+The tradeoff is real and worth stating, because it is a tradeoff and not a recommendation.
+`importExtension: 'ts'` emits `./authors.zod.ts`, and `tsc` rejects a `.ts` import specifier with
+`TS5097` unless `allowImportingTsExtensions` is enabled, which itself requires `noEmit` or
+`emitDeclarationOnly`. If Deno is the only thing that compiles these files, take `ts`. If the same
+files are also built by `tsc` for a Node target, keep the default and pass the Deno flag instead.
+
+Bun resolves all three forms with no configuration.
+
+## The CLI
+
+Nine commands were run under each runtime, against a real Drizzle schema, from the packed install.
+All exited 0 everywhere.
+
+| Command | Node 22.22.0 | Bun 1.3.14 | Deno 2.9.5 |
+| --- | --- | --- | --- |
+| `drzl --version` | pass | pass | pass |
+| `drzl --help` | pass | pass | pass |
+| `drzl analyze <schema> --json` | pass | pass | pass |
+| `drzl doctor` | pass | pass | pass |
+| `drzl generate` | pass | pass | pass |
+| `drzl generate --check` | pass | pass | pass |
+| `drzl generate:orpc <schema>` | pass | pass | pass |
+| `drzl generate:trpc <schema>` | pass | pass | pass |
+| `drzl init` | pass | pass | pass |
+
+The analyzer loads your `drzl.config.ts` and your schema modules through jiti, with
+`tryNative: false` so the TypeScript is transformed by jiti rather than by whatever the host runtime
+would do with it. That is what makes the three runtimes agree: config loading does not go through
+Bun's or Deno's own TypeScript handling. `node:` prefixed imports and `fs.globSync`, a Node 22
+built-in the drizzle-kit interop uses to expand `schema` globs, were each checked directly and are
+present and working on all three.
+
+## The output is byte-for-byte identical
+
+This is the claim worth making, and it is the one that keeps CI honest: a developer who generates
+under Bun and a CI job that checks under Node must not disagree.
+
+Over a config running all 14 generators, the emitted tree is **47 files, identical SHA-256 on all
+three runtimes**. `drzl analyze --json`, `drzl doctor`, `--help`, `--version`, the `init` config and
+the `generate:orpc` and `generate:trpc` trees are byte-identical too. The only differences anywhere
+in the captured output are an elapsed-milliseconds line and absolute paths, neither of which is
+written to a file.
+
+Everything in this section is re-measured by `scripts/runtime-compat.sh`, which packs the tarballs,
+installs them with npm into an empty project, generates under all three runtimes, compares the bytes
+and then executes the emitted schemas under Bun and Deno. Run it against a built tree with
+`pnpm build:packages && bash scripts/runtime-compat.sh`.
+
+That property was not free. It cost a defect found while writing this page: under Bun,
+`require.resolve` answers a missing package by silently installing it from npm, so a project that
+had never depended on Biome would still have its generated files reformatted by it, differently from
+Node, from a package downloaded mid-generate. `@drzl/validation-core` now refuses a formatter that
+resolves outside the project's own `node_modules`, and resolves each candidate directory
+independently because Bun ignores the `paths` list Node honours. A Biome you really did install is
+still used, on every runtime.
+
+## Running the CLI without Node installed
+
+`node_modules/.bin/drzl` is an npm bin shim with a `#!/usr/bin/env node` shebang, so on a machine
+with no Node on `PATH` it exits 127 before DRZL is reached. That is true of every npm-published CLI
+and is not specific to DRZL, but it is worth knowing if your image ships only Bun or only Deno.
+Both runtimes can execute the CLI themselves, measured on a `PATH` containing no `node` at all:
+
+```bash
+bun x drzl generate
+bun node_modules/@drzl/cli/dist/cli.js generate
+deno run -A node_modules/@drzl/cli/dist/cli.js generate
+```
+
+## What is not claimed
+
+Only the versions named at the top of this page were measured, on Linux x64. Nothing here was run on
+Windows or macOS, on Bun or Deno canary, or against Deno Deploy, Cloudflare Workers or any other
+hosted runtime; a worker runtime is a different environment from the Deno CLI and this page does not
+speak for it. `drzl watch`, which is long-lived and filesystem-event driven, was not exercised under
+Bun or Deno.

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -602,6 +602,78 @@ function nearestExistingDir(from: string): string {
 }
 
 /**
+ * Whether a resolved manifest path belongs to a project's installed dependencies.
+ *
+ * Resolving a package is normally the same question as having it installed, and on Node and Deno
+ * it is: their resolvers walk `node_modules` and answer a missing package with MODULE_NOT_FOUND.
+ * Bun's does not. When nothing is found it auto-installs the package from npm and resolves into
+ * its own global cache, so `require.resolve('@biomejs/biome/package.json')` succeeds under Bun
+ * against a project whose package.json has never mentioned Biome. Measured under Bun 1.3.14:
+ *
+ *   node   -> MODULE_NOT_FOUND
+ *   deno   -> MODULE_NOT_FOUND
+ *   bun    -> /home/<user>/.bun/install/cache/@biomejs/biome@2.5.7@@@1/package.json
+ *
+ * That made `drzl generate` emit Biome-formatted files under Bun and unformatted files under Node
+ * from the same schema and the same config, so `generate --check` under Node called every file
+ * out of date; and it fetched a package, plus a multi-megabyte native binary, from the network in
+ * the middle of codegen. It was not stable within Bun either, since whether the auto-install fired
+ * depended on the state of a cache outside the project.
+ *
+ * A `node_modules` path segment is the discriminator, and it is exact rather than a heuristic:
+ * npm, pnpm's `.pnpm` store and Yarn PnP's zip and unplugged paths all reach a package through
+ * one, and Bun's auto-install cache is the one shape that does not, because it is not a project
+ * install. Under Node and Deno this can never fire, since their resolvers have no other kind of
+ * path to return, so it costs those runtimes nothing. A Bun project that really does install
+ * Biome resolves through its `node_modules` like everyone else and still formats.
+ */
+export function isProjectInstallPath(manifestPath: string): boolean {
+  return manifestPath.split(path.sep).includes('node_modules');
+}
+
+/**
+ * Find `@biomejs/biome`'s manifest, anchoring each candidate directory in its own `createRequire`.
+ *
+ * The obvious spelling is one `createRequire` and `resolve(spec, { paths: [startDir, cwd] })`,
+ * which is what this was. Node honours that list; Bun does not. Measured under Bun 1.3.14 with
+ * Biome genuinely installed in the project and the output directory outside it (an absolute
+ * `outDir`), which is the exact case `paths` was added for:
+ *
+ *   node -> /app/node_modules/@biomejs/biome/package.json      (fell back to cwd, correct)
+ *   bun  -> ~/.bun/install/cache/@biomejs/biome@2.5.7@@@1/...  (auto-installed instead)
+ *
+ * So Bun never tried the second entry: rather than walking on to `process.cwd()`, it answered the
+ * miss from `startDir` by fetching the package from npm. Anchoring a separate `createRequire` at
+ * each candidate asks the question Bun does answer correctly, one directory at a time, and both
+ * runtimes then find the same project install. Order is preserved from the `paths` array it
+ * replaces: the directory being written into wins, and the process working directory is the
+ * fallback.
+ *
+ * A resolution that is not a project install is skipped rather than returned, so Bun's
+ * auto-install cache never wins over a real install further up. See `isProjectInstallPath`.
+ */
+function biomeManifest(startDir: string): string {
+  const anchors = [startDir, process.cwd()];
+  let lastError: unknown;
+  for (const anchor of anchors) {
+    let resolved: string;
+    try {
+      const require_ = createRequire(pathToFileURL(path.join(anchor, 'noop.js')));
+      resolved = require_.resolve('@biomejs/biome/package.json');
+    } catch (err) {
+      lastError = err;
+      continue;
+    }
+    if (isProjectInstallPath(resolved)) return resolved;
+    lastError = new Error(
+      `@biomejs/biome resolved to ${resolved}, which is not part of this project's installed ` +
+        'dependencies. Add @biomejs/biome to the project to format with it.'
+    );
+  }
+  throw lastError ?? new Error('@biomejs/biome could not be resolved');
+}
+
+/**
  * Locate the Biome executable belonging to the project being generated into.
  *
  * `@biomejs/biome` cannot be imported. Its manifest declares `bin` and carries no `main`, no
@@ -623,12 +695,7 @@ function nearestExistingDir(from: string): string {
  * are being written into.
  */
 function biomeBinary(startDir: string): string {
-  const require_ = createRequire(pathToFileURL(path.join(startDir, 'noop.js')));
-  // `paths` covers the case where the output directory sits outside the project, as it does for an
-  // absolute `outDir`; the process working directory is then the better anchor.
-  const manifestPath = require_.resolve('@biomejs/biome/package.json', {
-    paths: [startDir, process.cwd()],
-  });
+  const manifestPath = biomeManifest(startDir);
   const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
   // A string at 1.5.3 and below, an object from 1.9.4 on. Both shapes are still installable.
   const relative = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.biome;

--- a/packages/validation-core/test/format-biome-not-project-install.spec.ts
+++ b/packages/validation-core/test/format-biome-not-project-install.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * A Biome manifest that is not part of the project's install must not be spawned.
+ *
+ * Measured under Bun 1.3.14, which is the whole reason this guard exists. `biomeBinary` locates
+ * Biome with `createRequire(...).resolve('@biomejs/biome/package.json')`. Node and Deno answer a
+ * missing package with MODULE_NOT_FOUND, `formatCode` catches it, and the generated code comes
+ * back unformatted. Bun answers it by *auto-installing the package from npm* and resolving to its
+ * global cache:
+ *
+ *   node   -> MODULE_NOT_FOUND
+ *   deno   -> MODULE_NOT_FOUND
+ *   bun    -> /home/<user>/.bun/install/cache/@biomejs/biome@2.5.7@@@1/package.json
+ *
+ * The consequences were both observed on a packed install of @drzl/cli 4.22.0 driving a real
+ * Drizzle schema, with `@biomejs/biome` in nobody's package.json:
+ *
+ *   1. `drzl generate` emitted Biome-formatted files under Bun and unformatted files under Node,
+ *      from the same config and the same schema. `drzl generate --check` under Node then reported
+ *      every file out of date, which is a CI failure produced entirely by the choice of runtime.
+ *   2. Codegen silently downloaded a package, and a multi-megabyte native binary behind it, from
+ *      the network.
+ *
+ * Worse than either, it was not even stable within Bun: whether the auto-install fired depended on
+ * the state of a cache outside the project, so the same command on the same tree emitted different
+ * bytes on different days.
+ *
+ * The discriminator is exact and is the one asserted below. Every real install of a package,
+ * npm, pnpm's `.pnpm` store and Yarn's PnP paths alike, reaches it through a `node_modules`
+ * directory. Bun's auto-install cache is the only shape that does not, because it is not a project
+ * install at all. Under Node the guard is unreachable by construction, since Node's resolver has
+ * no other kind of path to return, which is exactly why it costs nothing there.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { formatCode, isProjectInstallPath } from '../src';
+
+describe('isProjectInstallPath', () => {
+  it('refuses the path Bun auto-install really returned', () => {
+    // Copied from the run, not invented: this is what `require.resolve` handed back under Bun
+    // 1.3.14 in a directory with no node_modules anywhere above it.
+    expect(
+      isProjectInstallPath('/home/user/.bun/install/cache/@biomejs/biome@2.5.7@@@1/package.json')
+    ).toBe(false);
+  });
+
+  it('accepts an ordinary npm install', () => {
+    expect(isProjectInstallPath('/srv/app/node_modules/@biomejs/biome/package.json')).toBe(true);
+  });
+
+  it("accepts pnpm's store layout, which nests node_modules twice", () => {
+    expect(
+      isProjectInstallPath(
+        '/srv/app/node_modules/.pnpm/@biomejs+biome@2.5.7/node_modules/@biomejs/biome/package.json'
+      )
+    ).toBe(true);
+  });
+
+  it("accepts Yarn PnP's zip and unplugged paths", () => {
+    expect(
+      isProjectInstallPath(
+        '/srv/app/.yarn/cache/@biomejs-biome-npm-2.5.7-abc.zip/node_modules/@biomejs/biome/package.json'
+      )
+    ).toBe(true);
+    expect(
+      isProjectInstallPath(
+        '/srv/app/.yarn/unplugged/@biomejs-biome-npm-2.5.7-abc/node_modules/@biomejs/biome/package.json'
+      )
+    ).toBe(true);
+  });
+
+  it('refuses a directory merely named like the marker', () => {
+    // `node_modules` has to be a whole path segment. A directory called `my_node_modules`, or a
+    // package whose own name contains the word, is not an install root.
+    expect(isProjectInstallPath('/srv/my_node_modules/@biomejs/biome/package.json')).toBe(false);
+    expect(isProjectInstallPath('/srv/node_modules_old/@biomejs/biome/package.json')).toBe(false);
+  });
+
+  it('reads the separator as a path separator on this platform', () => {
+    const p = ['', 'srv', 'app', 'node_modules', '@biomejs', 'biome', 'package.json'].join(path.sep);
+    expect(isProjectInstallPath(p)).toBe(true);
+  });
+});
+
+/**
+ * The working directory is the fallback anchor, and it has to keep working.
+ *
+ * `biomeManifest` used to be one `createRequire` with `resolve(spec, { paths: [startDir, cwd] })`.
+ * It is now a loop that anchors a fresh `createRequire` at each candidate, because Bun ignores the
+ * `paths` list and auto-installs instead of walking on to the second entry. That rewrite is only
+ * safe if the fallback it replaces still resolves, so this drives the case `paths` existed for: an
+ * absolute `outDir` whose directory has no node_modules above it, with the install in the working
+ * directory instead.
+ */
+describe('the working directory as fallback anchor', () => {
+  const cwd = process.cwd();
+  afterEach(() => {
+    process.chdir(cwd);
+    vi.restoreAllMocks();
+  });
+
+  it('finds a Biome installed in the working directory when the output dir is elsewhere', async () => {
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-biome-cwd-'));
+    const pkgDir = path.join(projectDir, 'node_modules', '@biomejs', 'biome');
+    await fs.mkdir(path.join(pkgDir, 'bin'), { recursive: true });
+    await fs.writeFile(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({ name: '@biomejs/biome', version: '2.5.7', bin: { biome: 'bin/biome' } })
+    );
+    // Echoes a fixed marker so the assertion is that this binary ran, not that Biome formats.
+    await fs.writeFile(
+      path.join(pkgDir, 'bin', 'biome'),
+      [
+        '#!/usr/bin/env node',
+        'let input = "";',
+        'process.stdin.setEncoding("utf8");',
+        'process.stdin.on("data", (c) => (input += c));',
+        'process.stdin.on("end", () => { process.stdout.write("/* formatted by cwd anchor */\\n"); });',
+      ].join('\n'),
+      { mode: 0o755 }
+    );
+
+    // Somewhere with no node_modules of its own anywhere above it, which is what an absolute
+    // outDir pointing outside the project looks like.
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drzl-biome-outside-'));
+    const filePath = path.join(outsideDir, 'users.ts');
+
+    process.chdir(projectDir);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const out = await formatCode('export const a=1\n', filePath, { engine: 'biome' });
+    expect(out).toBe('/* formatted by cwd anchor */\n');
+    expect(warn.mock.calls).toEqual([]);
+  });
+});

--- a/scripts/runtime-compat.sh
+++ b/scripts/runtime-compat.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+#
+# Bun and Deno, against the artefact a consumer installs.
+#
+# Two surfaces fail independently here. The emitted schemas run inside a user's application, and a
+# Hono app on Bun or a Deno worker is exactly the audience the route generators target. The CLI runs
+# at build time, and it loads config and schema modules through jiti, calls `fs.globSync`, and
+# resolves a formatter through `createRequire`. None of that is exercised by `pnpm -r test`, which
+# imports from source and runs only on Node, nor by verify-packed.sh, which runs only on Node.
+#
+# What this gate is really for is the byte comparison. A developer who generates under Bun and a CI
+# job that checks under Node must not disagree, and they did: Bun's resolver answers a missing
+# package by installing it from npm, so `@biomejs/biome` was auto-installed mid-generate and
+# reformatted the output on a project that had never depended on it. `drzl generate --check` under
+# Node then called every file out of date. Nothing else in CI would have noticed, because nothing
+# else in CI runs anything on Bun.
+#
+# Packs what is already built rather than building it, so a local run iterates in seconds. Run
+# `pnpm build:packages` first, which is what the CI job does.
+#
+# Run locally with: bash scripts/runtime-compat.sh   (needs bun and deno on PATH)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+TARS="$WORK/tars"
+APP="$WORK/app"
+mkdir -p "$TARS" "$APP/src/db"
+
+for tool in bun deno; do
+  command -v "$tool" >/dev/null || { echo "FAIL: $tool is not on PATH." >&2; exit 1; }
+done
+echo "==> runtimes"
+echo "    node $(node --version)"
+echo "    bun  $(bun --version)"
+echo "    deno $(deno --version | head -1)"
+
+echo "==> packing publishable packages"
+for dir in "$ROOT"/packages/*/; do
+  private="$(node -e "process.stdout.write(String(!!require('$dir/package.json').private))")"
+  [ "$private" = "true" ] && continue
+  (cd "$dir" && pnpm pack --pack-destination "$TARS" >/dev/null)
+done
+echo "    packed $(ls "$TARS" | wc -l) package(s)"
+
+# npm rather than pnpm, and an empty project rather than this workspace: a consumer shares neither.
+echo "==> installing them into an empty project"
+cd "$APP"
+npm init -y >/dev/null 2>&1
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  p.type = 'module';
+  delete p.main;
+  fs.writeFileSync('package.json', JSON.stringify(p, null, 2));
+"
+npm install --no-audit --no-fund --loglevel=error --legacy-peer-deps \
+  "$TARS"/*.tgz drizzle-orm zod valibot arktype @sinclair/typebox effect ajv ajv-formats >/dev/null
+
+# A CHECK constraint and an enum, because those are what a validator can lose while still importing.
+cat > src/db/schema.ts <<'SCHEMA'
+import { sql } from 'drizzle-orm';
+import { check, integer, pgEnum, pgTable, serial, text, varchar } from 'drizzle-orm/pg-core';
+
+export const roleEnum = pgEnum('role', ['admin', 'editor', 'viewer']);
+
+export const authors = pgTable(
+  'authors',
+  {
+    id: serial('id').primaryKey(),
+    handle: varchar('handle', { length: 20 }).notNull(),
+    email: text('email').notNull(),
+    age: integer('age').notNull(),
+    role: roleEnum('role').notNull(),
+  },
+  (t) => [check('author_adult', sql`${t.age} >= 18`)]
+);
+SCHEMA
+
+# `importExtension: 'ts'` because Deno resolves neither the default `.js` specifiers nor the
+# extensionless form without `--unstable-sloppy-imports`, which is what docs/guide/runtimes.md
+# tells a Deno reader. Generating with it here is also what keeps that instruction honest.
+cat > drzl.config.ts <<'CONFIG'
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  schema: 'src/db/schema.ts',
+  outDir: 'src/generated',
+  importExtension: 'ts',
+  generators: [
+    { kind: 'zod', path: 'src/generated/zod' },
+    { kind: 'valibot', path: 'src/generated/valibot' },
+    { kind: 'arktype', path: 'src/generated/arktype' },
+    { kind: 'typebox', path: 'src/generated/typebox' },
+    { kind: 'effect', path: 'src/generated/effect' },
+    { kind: 'json-schema', path: 'src/generated/json-schema' },
+  ],
+});
+CONFIG
+
+CLI=node_modules/@drzl/cli/dist/cli.js
+
+echo "==> drzl generate under node, bun and deno"
+for runtime in node bun deno; do
+  rm -rf src/generated
+  case "$runtime" in
+    node) node "$CLI" generate >/dev/null ;;
+    bun) bun "$CLI" generate >/dev/null ;;
+    deno) deno run -A "$CLI" generate >/dev/null ;;
+  esac
+  cp -r src/generated "$WORK/out-$runtime"
+  echo "    $runtime generated $(find "$WORK/out-$runtime" -type f | wc -l) file(s)"
+done
+
+for runtime in bun deno; do
+  if ! diff -r "$WORK/out-node" "$WORK/out-$runtime" > "$WORK/diff-$runtime.txt" 2>&1; then
+    echo "FAIL: $runtime emitted different bytes from node." >&2
+    echo "      Generated output must not depend on which runtime ran the generator." >&2
+    head -40 "$WORK/diff-$runtime.txt" >&2
+    exit 1
+  fi
+  echo "    $runtime output is byte-identical to node"
+done
+
+# Importing proves nothing about behaviour, so each generator gets a value it must accept and two it
+# must reject. `badRange` is well typed and violates the CHECK constraint, which is what separates
+# "the module loaded" from "the schema still validates".
+cat > exec-emitted.ts <<'HARNESS'
+import * as zodMod from './src/generated/zod/index.ts';
+import * as valibotMod from './src/generated/valibot/index.ts';
+import * as arktypeMod from './src/generated/arktype/index.ts';
+import * as typeboxMod from './src/generated/typebox/index.ts';
+import * as effectMod from './src/generated/effect/index.ts';
+import * as jsonSchemaMod from './src/generated/json-schema/index.ts';
+import * as v from 'valibot';
+import { ArkErrors } from 'arktype';
+import { Value } from '@sinclair/typebox/value';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const good = { handle: 'alice', email: 'alice@example.com', age: 30, role: 'admin' };
+const badType = { handle: 'ab', email: 'x', age: 'not-a-number', role: 'nope' };
+const badRange = { ...good, age: 5 };
+
+const runtime = typeof (globalThis as any).Bun !== 'undefined' ? 'bun' : 'deno';
+
+const checks: Record<string, (val: unknown) => boolean> = {
+  zod: (val) => (zodMod as any).InsertauthorsSchema.safeParse(val).success,
+  valibot: (val) => v.safeParse((valibotMod as any).InsertauthorsSchema, val).success,
+  // A failed arktype call returns an ArkErrors instance; a success returns the parsed object.
+  arktype: (val) => !((arktypeMod as any).InsertauthorsSchema(val) instanceof ArkErrors),
+  typebox: (val) => Value.Check((typeboxMod as any).InsertauthorsSchema, val),
+  effect: (val) =>
+    ((effectMod as any).StandardInsertauthorsSchema['~standard'].validate(val) as any).issues ===
+    undefined,
+  'json-schema': (val) => {
+    const ajv = new (Ajv2020 as any)({ strict: false });
+    (addFormats as any)(ajv);
+    return ajv.validate((jsonSchemaMod as any).InsertauthorsSchema, val) === true;
+  },
+};
+
+let failures = 0;
+for (const [name, check] of Object.entries(checks)) {
+  for (const [label, val, want] of [
+    ['good', good, true],
+    ['badType', badType, false],
+    ['badRange', badRange, false],
+  ] as const) {
+    let got: unknown;
+    try {
+      got = check(val);
+    } catch (e) {
+      got = 'threw: ' + String((e as any)?.message ?? e);
+    }
+    if (got !== want) {
+      failures++;
+      console.error(`FAIL ${runtime} ${name} ${label}: wanted ${want}, got ${got}`);
+    }
+  }
+}
+console.log(`    ${runtime}: ${Object.keys(checks).length - failures} generator(s) validating`);
+if (failures > 0) process.exit(1);
+HARNESS
+
+echo "==> the emitted schemas validate under bun and deno"
+bun exec-emitted.ts
+deno run -A exec-emitted.ts
+
+# The CLI's own commands, on a runtime that is not Node. `analyze --json` is compared byte for byte
+# because it is the analyzer's whole output and the thing every generator is built on.
+echo "==> CLI commands under bun and deno"
+for runtime in node bun deno; do
+  case "$runtime" in
+    node) node "$CLI" analyze src/db/schema.ts --json > "$WORK/analyze-$runtime.json" ;;
+    bun) bun "$CLI" analyze src/db/schema.ts --json > "$WORK/analyze-$runtime.json" ;;
+    deno) deno run -A "$CLI" analyze src/db/schema.ts --json > "$WORK/analyze-$runtime.json" ;;
+  esac
+done
+for runtime in bun deno; do
+  if ! cmp -s "$WORK/analyze-node.json" "$WORK/analyze-$runtime.json"; then
+    echo "FAIL: drzl analyze --json differs between node and $runtime." >&2
+    exit 1
+  fi
+  echo "    $runtime analyze --json is byte-identical to node"
+done
+for runtime in bun deno; do
+  case "$runtime" in
+    bun) bun "$CLI" doctor >/dev/null && bun "$CLI" generate --check >/dev/null ;;
+    deno) deno run -A "$CLI" doctor >/dev/null && deno run -A "$CLI" generate --check >/dev/null ;;
+  esac
+  echo "    $runtime ran doctor and generate --check"
+done
+
+echo "==> runtime compatibility holds"


### PR DESCRIPTION
Plan item 63: a measured compatibility answer for **Bun 1.3.14** and **Deno 2.9.5** beside Node 22.22.0, across both surfaces the item names, plus the defect the measurement uncovered and a CI job so the claim keeps being true.

## What was measured

Against the **packed tarballs** installed with npm into empty projects, never the workspace. All 14 generators execute under both runtimes: validators were given a valid value, a mistyped one, and a CHECK-violating one (so a loaded module cannot be mistaken for a working schema), and the route generators were driven through their real servers (Hono `app.request`, express over a socket, fastify `inject`, oRPC `call()`, a tRPC caller, NestJS through the emitted pipe, GraphQL through `buildSchema`). All 9 CLI commands exit 0 on all three runtimes, including on a PATH with no node at all. A 47-file emitted tree hashes identically across the three, as do `analyze --json`, `doctor`, `init`'s config and the orpc/trpc trees; the only differences anywhere are an elapsed-ms line and absolute paths, neither written to a file.

Deno needs `importExtension: 'ts'` (measured: the default `'js'` and `'none'` both fail with `Module not found`; the default also works under `--unstable-sloppy-imports`), and the page states the tradeoff, since `.ts` specifiers make `tsc` fail TS5097 without `allowImportingTsExtensions`. Bun resolves all three forms.

## The defect, and why the obvious half-fix was wrong

Under Bun, `require.resolve` answers a **missing** package by installing it from npm. So `@biomejs/biome` was downloaded mid-`generate` and reformatted output on a project that never depended on it: Node emitted 2-space, Bun emitted tab-indented Biome, and `generate --check` back on Node then reported every file out of date. A CI failure caused purely by which runtime ran the generator, and unstable within Bun too depending on global cache state.

Behind it sat a second, independent difference: **Bun ignores the `paths` list Node honours**, so with Biome genuinely installed and an absolute `outDir`, Node fell back to cwd and found the real install while Bun auto-installed instead. Fixing only the first half left legitimate Bun users with no formatting at all, a regression the agent hit and caught mid-fix.

Fix, red-first: formatter resolution gates on a `node_modules` path segment (exact, not heuristic: npm, pnpm's `.pnpm`, Yarn PnP zips and unplugged packages all have one, and Bun's cache is the only shape without) and anchors a separate `createRequire` per candidate. Unreachable on Node and Deno by construction. Verified in both directions: with no formatter installed, Node and Bun emit identical bytes and spawn nothing; with one installed, both emit identical Biome-formatted bytes. The cwd-fallback test carries a must-fire check.

## The CI job (controller-applied here)

`runtime-compat` runs `scripts/runtime-compat.sh` against the packed tarballs on both runtimes. Versions are **pinned to the ones the docs page names**, so the page and the gate cannot drift; that deliberately trades early warning of an upstream regression for a claim that is exactly true, and the scheduled-latest alternative is recorded in the job's comment as belonging with plan item 99's nightly rather than here.

## Filed, not guessed

**BW (Tier B)**: `json-schema` and `nestjs` mark nullable no-default columns **required** on insert while the other eight generators make them optional. Runtime-independent, reproduces on Node, and the same question the fastify and nestjs work touched from the other side ("null is not absence"), so it is a semantic decision to make once in the analyzer and have every generator read, not a per-generator patch. Either resolution moves one side of an eight-to-two split and may move the parity ledger with it.

## Gates

Full suite green including `pnpm verify:packed` (still 32 documented configs; the new page contributes 0 runnable configs, verified directly against the extractor, so no controller change was needed there). Changeset: patch for validation-core.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
