### PR TITLE
feat: a JSON Schema for drzl.config, generated and fuzzed (item 64)

### DIFF
--- a/.changeset/config-json-schema.md
+++ b/.changeset/config-json-schema.md
@@ -1,0 +1,47 @@
+---
+'@drzl/cli': minor
+'@drzl/validation-core': minor
+---
+
+A JSON Schema for `drzl.config.json`, and a config scaffold that completes
+
+`drzl.config.json` has been a supported config form since the loader was written, and it was the
+one form with no completion of any kind: a `.ts` config gets the shape from `defineConfig`, a JSON
+config got nothing. `@drzl/cli` now ships `dist/drzl.config.schema.json`, generated at build time
+from the same zod schema that validates the config, so the two cannot describe different things.
+Point at it with a `$schema` key (`./node_modules/@drzl/cli/dist/drzl.config.schema.json`), or map
+`drzl.config.json` to it in VS Code's `json.schemas`. The same file is published at
+`https://use-drzl.github.io/drzl/drzl.config.schema.json`. `$schema` is stripped by the loader, so
+the key is safe to leave in the file.
+
+Two properties of `z.toJSONSchema` decide whether a generated schema is worth shipping, and both
+are now measured rather than assumed. Its `io` option defaults to `'output'`, which marks every key
+carrying a `.default()` as `required`: `outDir`, `importExtension`, `analyzer` and `generators` are
+all defaulted, so that schema rejects all 34 configs in the documentation and every minimal config
+a reader writes. The generator passes `io: 'input'`, which rejects none of them. Refinements are
+also dropped silently, and `ConfigSchema`'s single `.superRefine` is the affix rule, so the
+generated schema would have accepted `affix: { schema: { suffix: 'my-schema' } }` and the CLI would
+then have refused to generate from it. The character half of that rule is re-encoded as a JSON
+Schema `pattern`, built from the same string `validateAffix` compiles its regex from, and a test
+fuzzes the two against each other over every printable ASCII codepoint in three positions. The
+collision half, two modes resolving to the same identifier, is a comparison between sibling values
+that JSON Schema cannot express; it stays a CLI-only error and is documented as one. Every other
+verdict matches the CLI, including unknown keys: permissive where `ConfigSchema` strips them,
+`additionalProperties: false` where the zod object is `.strict()`.
+
+`drzl watch` never reloaded a JSON config. `computeWatchTargets` carried its own copy of the config
+filenames and the copy was missing `drzl.config.json`, so the file loaded on the initial build and
+no later edit to it ever fired an event. Its test spelled the same four names a third time and
+agreed with the bug. The loader, the watcher and the test now read one exported
+`CONFIG_FILE_NAMES`.
+
+`drzl init` scaffolded a bare `export default { ... } as const`, so the first config a new user
+sees was the one with no type attached and no completion. It now emits
+`import type { DrzlConfigInput } from '@drzl/cli/config'` and `satisfies DrzlConfigInput`. The
+import is type-only on purpose: `drzl init` also runs under `npx` in a project with no local
+`@drzl/cli` to resolve, and a type-only import is erased before the config executes, where the
+`defineConfig` value import the docs use would have made the first `generate` fail on a missing
+module.
+
+`@drzl/validation-core` exports `AFFIX_PREFIX_PATTERN` and `AFFIX_SUFFIX_PATTERN`, the affix
+character rule in JSON Schema `pattern` form, beside the regexes that enforce it.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -552,13 +552,93 @@ generator's `validation.importPath` has to name the barrel file rather than its 
 
 ## Config File Formats
 
-DRZL accepts multiple config formats:
+DRZL looks for these filenames, in this order, and loads the first one that exists:
 
 - TypeScript: `drzl.config.ts`
 - ES Module: `drzl.config.mjs`
-- CommonJS: `drzl.config.js`
+- CommonJS: `drzl.config.js` and `drzl.config.cjs`
 - JSON: `drzl.config.json`
 
-When using JSON, ensure it’s strict JSON (no comments/trailing commas). TS/JS configs can export either a default object or use `defineConfig(...)`.
+`-c/--config` names a file directly and skips the search.
+
+Every form is parsed by the same schema and produces the same errors. When using JSON, ensure
+it's strict JSON (no comments/trailing commas).
+
+## Editor completion
+
+### TypeScript configs
+
+Wrap the object in `defineConfig` and your editor completes every key, every enum value and every
+generator option:
+
+```ts
+import { defineConfig } from '@drzl/cli/config';
+
+export default defineConfig({
+  schema: 'src/db/schema.ts',
+  generators: [{ kind: 'orpc' }],
+});
+```
+
+`defineConfig` is the identity function: it returns what you pass it and exists only to attach the
+type. If you would rather not import a value, the annotation alone does the same job, which is
+what `drzl init` scaffolds:
+
+```ts
+import type { DrzlConfigInput } from '@drzl/cli/config';
+
+export default {
+  schema: 'src/db/schema.ts',
+  generators: [{ kind: 'orpc' }],
+} satisfies DrzlConfigInput;
+```
+
+A type-only import is erased before the config runs, so this form also works when DRZL is not a
+local dependency, such as under `npx`.
+
+### JSON configs
+
+`drzl.config.json` gets the same completion from a JSON Schema, generated from the same zod schema
+the CLI validates with and shipped inside the package. Point at it with a `$schema` key:
+
+```json
+{
+  "$schema": "./node_modules/@drzl/cli/dist/drzl.config.schema.json",
+  "schema": "src/db/schema.ts",
+  "generators": [{ "kind": "orpc" }]
+}
+```
+
+DRZL ignores `$schema`, so the key is safe to leave in. The relative path resolves offline and
+always matches the version you installed. The same schema is published at
+`https://use-drzl.github.io/drzl/drzl.config.schema.json` if you would rather point at a URL.
+
+To avoid touching the config file, map it in VS Code's `.vscode/settings.json` instead:
+
+```json
+{
+  "json.schemas": [
+    {
+      "fileMatch": ["drzl.config.json"],
+      "url": "./node_modules/@drzl/cli/dist/drzl.config.schema.json"
+    }
+  ]
+}
+```
+
+### What the JSON Schema does not catch
+
+The schema is generated from the zod schema, and `z.toJSONSchema` drops refinements without
+reporting them. DRZL's one refinement holds the affix rules, so:
+
+- **Illegal affix characters are caught.** The rule is re-encoded as a `pattern`, and a test fuzzes
+  it against the CLI's own check over every printable ASCII position to keep the two identical.
+- **Affix collisions are not caught.** Two modes whose prefix and suffix resolve to the same
+  identifier is a comparison between sibling values, which JSON Schema cannot express. `drzl
+  generate` still refuses, naming the two modes and the identifier they collide on.
+
+Unknown top-level keys are accepted by the schema because the CLI accepts them too: it ignores
+what it does not recognise rather than failing. Keys inside `columns` and `affix` are strict in
+both.
 
 See package READMEs for generator‑specific options.

--- a/docs/public/drzl.config.schema.json
+++ b/docs/public/drzl.config.schema.json
@@ -1,0 +1,717 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://use-drzl.github.io/drzl/drzl.config.schema.json",
+  "title": "DRZL configuration",
+  "description": "Configuration for the drzl CLI. Also describes drzl.config.ts, which gets the same shape from the defineConfig export of @drzl/cli/config.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Path or URL of this schema, for editor completion. Ignored by drzl."
+    },
+    "schema": {
+      "type": "string"
+    },
+    "drizzleKit": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "outDir": {
+      "default": "src/api",
+      "type": "string"
+    },
+    "include": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "exclude": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "columns": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "omit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pick": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "importExtension": {
+      "default": "js",
+      "type": "string",
+      "enum": [
+        "js",
+        "none",
+        "ts"
+      ]
+    },
+    "analyzer": {
+      "default": {
+        "includeRelations": true,
+        "validateConstraints": true,
+        "includeHeuristicRelations": false
+      },
+      "type": "object",
+      "properties": {
+        "includeRelations": {
+          "default": true,
+          "type": "boolean"
+        },
+        "validateConstraints": {
+          "default": true,
+          "type": "boolean"
+        },
+        "includeHeuristicRelations": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "generators": {
+      "default": [
+        {
+          "kind": "orpc"
+        }
+      ],
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "orpc",
+              "trpc",
+              "hono",
+              "express",
+              "fastify",
+              "nestjs",
+              "graphql",
+              "service",
+              "zod",
+              "valibot",
+              "arktype",
+              "typebox",
+              "effect",
+              "json-schema"
+            ]
+          },
+          "validator": {
+            "type": "string",
+            "enum": [
+              "standard",
+              "zod"
+            ]
+          },
+          "importExtension": {
+            "type": "string",
+            "enum": [
+              "js",
+              "none",
+              "ts"
+            ]
+          },
+          "template": {
+            "type": "string"
+          },
+          "includeRelations": {
+            "type": "boolean"
+          },
+          "sharedEnums": {
+            "type": "boolean"
+          },
+          "coerceDates": {
+            "type": "string",
+            "enum": [
+              "input",
+              "all",
+              "none"
+            ]
+          },
+          "typedJson": {
+            "type": "boolean"
+          },
+          "typedColumns": {
+            "type": "boolean"
+          },
+          "applyDefaults": {
+            "type": "boolean"
+          },
+          "duplicateFinder": {
+            "type": "boolean"
+          },
+          "constraints": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "errorMap": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "standardSchema": {
+            "type": "boolean"
+          },
+          "nestedSchemas": {
+            "type": "boolean"
+          },
+          "nestedDepth": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "branded": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "foreignKeys": {
+                    "type": "boolean"
+                  },
+                  "aliases": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "naming": {
+            "type": "object",
+            "properties": {
+              "routerSuffix": {
+                "default": "Router",
+                "type": "string"
+              },
+              "procedureCase": {
+                "default": "camel",
+                "type": "string",
+                "enum": [
+                  "camel",
+                  "kebab",
+                  "snake"
+                ]
+              }
+            }
+          },
+          "outputHeader": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "default": true,
+                "type": "boolean"
+              },
+              "text": {
+                "type": "string"
+              }
+            }
+          },
+          "format": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "default": true,
+                "type": "boolean"
+              },
+              "engine": {
+                "default": "auto",
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "prettier",
+                  "biome"
+                ]
+              },
+              "configPath": {
+                "type": "string"
+              }
+            }
+          },
+          "target": {
+            "type": "string",
+            "enum": [
+              "draft-2020-12",
+              "openapi-3.1",
+              "openapi-3.0"
+            ]
+          },
+          "components": {
+            "type": "boolean"
+          },
+          "document": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "format": {
+                    "type": "string",
+                    "enum": [
+                      "ts",
+                      "json",
+                      "both"
+                    ]
+                  },
+                  "info": {
+                    "type": "object",
+                    "properties": {
+                      "title": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "servers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "url"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "validationStatus": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "const": 400
+                      },
+                      {
+                        "type": "number",
+                        "const": 422
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "path": {
+            "type": "string"
+          },
+          "dataAccess": {
+            "default": "stub",
+            "type": "string",
+            "enum": [
+              "stub",
+              "drizzle"
+            ]
+          },
+          "dbImportPath": {
+            "type": "string"
+          },
+          "schemaImportPath": {
+            "type": "string"
+          },
+          "schemaSuffix": {
+            "type": "string"
+          },
+          "fileSuffix": {
+            "type": "string"
+          },
+          "affix": {
+            "type": "object",
+            "properties": {
+              "tableCase": {
+                "type": "string",
+                "enum": [
+                  "preserve",
+                  "pascal"
+                ]
+              },
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prefix": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "insert": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                          },
+                          "update": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                          },
+                          "select": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "suffix": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "insert": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                          },
+                          "update": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                          },
+                          "select": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "type": {
+                "type": "object",
+                "properties": {
+                  "prefix": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "insert": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                          },
+                          "update": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                          },
+                          "select": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "suffix": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "insert": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                          },
+                          "update": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                          },
+                          "select": {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "databaseInjection": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "databaseType": {
+                "type": "string"
+              },
+              "databaseTypeImport": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "from": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "from"
+                ]
+              }
+            }
+          },
+          "validation": {
+            "type": "object",
+            "properties": {
+              "useShared": {
+                "default": false,
+                "type": "boolean"
+              },
+              "library": {
+                "default": "zod",
+                "type": "string",
+                "enum": [
+                  "zod",
+                  "valibot",
+                  "arktype"
+                ]
+              },
+              "importPath": {
+                "type": "string"
+              },
+              "schemaSuffix": {
+                "type": "string"
+              },
+              "affix": {
+                "type": "object",
+                "properties": {
+                  "tableCase": {
+                    "type": "string",
+                    "enum": [
+                      "preserve",
+                      "pascal"
+                    ]
+                  },
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "prefix": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "insert": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                              },
+                              "update": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                              },
+                              "select": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      "suffix": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "insert": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                              },
+                              "update": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                              },
+                              "select": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "type": "object",
+                    "properties": {
+                      "prefix": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "insert": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                              },
+                              "update": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                              },
+                              "select": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z_$][A-Za-z0-9_$]*)?$"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      "suffix": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "insert": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                              },
+                              "update": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                              },
+                              "select": {
+                                "type": "string",
+                                "pattern": "^(?:[A-Za-z0-9_$]+)?$"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "templateOptions": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      }
+    }
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/cli.ts src/config.ts --format esm,cjs --sourcemap --dts --clean",
+    "build": "tsup src/cli.ts src/config.ts --format esm,cjs --sourcemap --dts --clean && node scripts/gen-config-schema.mjs",
     "dev": "node --loader ts-node/esm src/cli.ts --help",
     "lint": "eslint . --ext .ts",
     "test": "vitest run --testTimeout=20000"
@@ -45,6 +45,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "ajv": "^8.17.1",
     "drizzle-orm": "^0.45.2",
     "ts-node": "^10.9.2",
     "tsup": "^8.5.1",

--- a/packages/cli/scripts/gen-config-schema.mjs
+++ b/packages/cli/scripts/gen-config-schema.mjs
@@ -1,0 +1,40 @@
+/**
+ * Write `drzl.config.schema.json` from the zod schema that actually validates the config.
+ *
+ * Runs as the tail of this package's build, from `dist/config.js` rather than from `src`, so the
+ * schema describes the same code the tarball ships. Two copies, written by one run so they cannot
+ * disagree:
+ *
+ *   - `dist/`, which `files: ["dist"]` publishes. A consumer points `$schema` at
+ *     `./node_modules/@drzl/cli/dist/drzl.config.schema.json` and gets the schema for the version
+ *     they installed, offline.
+ *   - `docs/public/`, which VitePress serves at the `$id` URL. That copy is committed, and
+ *     packages/cli/test/config-json-schema.spec.ts fails if it drifts from this generator.
+ *
+ * Writing into docs/ from a package build is deliberate: the alternative was a second entry point
+ * and a second invocation that could be forgotten independently.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, '..');
+const repoRoot = path.resolve(pkgRoot, '../..');
+
+const { buildConfigJsonSchema } = await import(
+  path.join(pkgRoot, 'dist', 'config.js')
+);
+
+const json = `${JSON.stringify(buildConfigJsonSchema(), null, 2)}\n`;
+
+const targets = [
+  path.join(pkgRoot, 'dist', 'drzl.config.schema.json'),
+  path.join(repoRoot, 'docs', 'public', 'drzl.config.schema.json'),
+];
+
+for (const target of targets) {
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, json);
+  console.log(`  config schema -> ${path.relative(repoRoot, target)}`);
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1319,7 +1319,13 @@ program
     // `index.ts` there, so a scaffold naming both would emit a config whose second generator
     // silently overwrote the first. Swapping the kind is a one-word edit; running both needs a
     // `path` on one of them, which is what the comment says.
-    const template = `export default {
+    // `import type`, not the `defineConfig` value import the docs use, because `drzl init` also
+    // runs under `npx` in a project that has no local `@drzl/cli` to resolve. A type-only import
+    // is erased before the config is ever executed, so the scaffold still runs there; a value
+    // import would have made the very first generate fail on a module that is not installed.
+    const template = `import type { DrzlConfigInput } from '@drzl/cli/config';
+
+export default {
   schema: 'src/db/schema.ts',
   outDir: 'src/api',
   analyzer: { includeRelations: true, validateConstraints: true },
@@ -1328,7 +1334,7 @@ program
     // To run both, give one of them its own \`path\`; they share \`outDir\` otherwise.
     { kind: 'orpc', template: 'standard', includeRelations: true }
   ]
-} as const\n`;
+} satisfies DrzlConfigInput\n`;
     try {
       await fs.writeFile(target, template, { flag: 'wx' });
       console.log(chalk.green(`Created ${target}`));

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,6 +1,8 @@
 import type { AffixOptions } from '@drzl/validation-core';
 import {
+  AFFIX_PREFIX_PATTERN,
   AFFIX_PROBE_TABLE,
+  AFFIX_SUFFIX_PATTERN,
   DEFAULT_IMPORT_EXTENSION,
   IMPORT_EXTENSIONS,
   NAME_MODES,
@@ -21,30 +23,38 @@ export const NamingSchema = z
   })
   .partial();
 
-/** One affix for every mode, or a per-mode map. Keys match drzl's internal mode names. */
-const AffixValueSchema = z.union(
-  [
-    z.string(),
-    z
-      .object({
-        insert: z.string().optional(),
-        update: z.string().optional(),
-        select: z.string().optional(),
-      })
-      .strict(),
-  ],
-  {
-    error:
-      'Expected a string to use for every mode, or an object with any of the keys "insert", ' +
-      '"update" and "select". Those keys are lowercase, matching the mode names drzl uses ' +
-      'everywhere else.',
-  }
-);
+/**
+ * One affix for every mode, or a per-mode map. Keys match drzl's internal mode names.
+ *
+ * `pattern` is annotation only: it changes nothing about how this parses, and exists so the
+ * generated `drzl.config.schema.json` carries the character half of the affix rule that
+ * `z.toJSONSchema` drops along with the `.superRefine` that states it. `validateAffix` remains
+ * the enforcing copy, and its message is the one a user sees.
+ */
+const affixValueSchema = (pattern: string) =>
+  z.union(
+    [
+      z.string().meta({ pattern }),
+      z
+        .object({
+          insert: z.string().meta({ pattern }).optional(),
+          update: z.string().meta({ pattern }).optional(),
+          select: z.string().meta({ pattern }).optional(),
+        })
+        .strict(),
+    ],
+    {
+      error:
+        'Expected a string to use for every mode, or an object with any of the keys "insert", ' +
+        '"update" and "select". Those keys are lowercase, matching the mode names drzl uses ' +
+        'everywhere else.',
+    }
+  );
 
 const AffixPartSchema = z
   .object({
-    prefix: AffixValueSchema.optional(),
-    suffix: AffixValueSchema.optional(),
+    prefix: affixValueSchema(AFFIX_PREFIX_PATTERN).optional(),
+    suffix: affixValueSchema(AFFIX_SUFFIX_PATTERN).optional(),
   })
   .strict();
 
@@ -501,6 +511,72 @@ export function defineConfig<T extends DrzlConfigInput>(cfg: T): T {
   return cfg;
 }
 
+/**
+ * Every filename `drzl` will load a config from, in the order it tries them.
+ *
+ * One list because there were two. `computeWatchTargets` carried its own copy of four of these
+ * names, and the copy was missing `drzl.config.json`: a JSON config loaded fine, and then
+ * `drzl watch` never noticed an edit to it, because nothing was watching the file. The watcher's
+ * test spelled the same four names a third time, so it agreed with the bug.
+ */
+export const CONFIG_FILE_NAMES = [
+  'drzl.config.ts',
+  'drzl.config.mjs',
+  'drzl.config.js',
+  'drzl.config.cjs',
+  'drzl.config.json',
+] as const;
+
+/** Where the published schema answers from, and what `$schema` in a config should point at. */
+export const CONFIG_SCHEMA_ID = 'https://use-drzl.github.io/drzl/drzl.config.schema.json';
+
+/**
+ * `ConfigSchema` as a JSON Schema, for editors pointed at a `drzl.config.json`.
+ *
+ * Two things about `z.toJSONSchema` decide the arguments here, both measured rather than assumed:
+ *
+ *  - `io` defaults to `'output'`, which marks every key carrying a `.default()` as `required`.
+ *    That is four of the nine top-level keys, so the default would produce a schema that flags
+ *    all 32 configs in the docs and every minimal config a reader writes. `'input'` describes
+ *    what a user writes, which is what a config file is.
+ *  - refinements are dropped silently. The only one here is the affix `.superRefine`; its
+ *    character half is carried by the `pattern` annotations on `affixValueSchema`, and its
+ *    collision half cannot be stated in JSON Schema at all and stays a CLI-only error.
+ *
+ * draft-07 rather than 2020-12 because that is the dialect every editor implements fully, and
+ * this schema uses nothing newer.
+ */
+export function buildConfigJsonSchema(): Record<string, unknown> {
+  const generated = z.toJSONSchema(ConfigSchema, {
+    io: 'input',
+    target: 'draft-7',
+  }) as Record<string, unknown>;
+
+  const properties = {
+    // Declared so an editor suggests it and does not report the pointer a reader was told to
+    // add as an unknown key. `ConfigSchema` is not strict, so the CLI strips it and never sees it.
+    $schema: {
+      type: 'string',
+      description: 'Path or URL of this schema, for editor completion. Ignored by drzl.',
+    },
+    ...(generated.properties as Record<string, unknown>),
+  };
+
+  // Rebuilt rather than mutated so the key order of the written file is deliberate and stable:
+  // a diff of this artefact should show what changed in the config, not a reshuffle.
+  const { $schema, properties: _dropped, ...rest } = generated;
+  return {
+    $schema,
+    $id: CONFIG_SCHEMA_ID,
+    title: 'DRZL configuration',
+    description:
+      'Configuration for the drzl CLI. Also describes drzl.config.ts, which gets the same ' +
+      'shape from the defineConfig export of @drzl/cli/config.',
+    ...rest,
+    properties,
+  };
+}
+
 type GeneratorConfig = DrzlConfig['generators'][number];
 
 /** The generators that emit an RPC router, and so share `outDir` and `validation`. */
@@ -910,15 +986,7 @@ export async function importFreshConfigModule(p: string): Promise<unknown> {
 export async function loadConfig(customPath?: string): Promise<DrzlConfig | null> {
   const fsp = await import('node:fs/promises');
 
-  const candidates = customPath
-    ? [customPath]
-    : [
-        'drzl.config.ts',
-        'drzl.config.mjs',
-        'drzl.config.js',
-        'drzl.config.cjs',
-        'drzl.config.json',
-      ];
+  const candidates = customPath ? [customPath] : [...CONFIG_FILE_NAMES];
 
   for (const c of candidates) {
     const p = path.resolve(process.cwd(), c);
@@ -1040,12 +1108,7 @@ export function computeWatchTargets(
   // not exist: no event ever fired and `drzl watch` did its initial build and then sat inert.
   // A directory is watched recursively by chokidar itself, and the extension filtering that the
   // glob was doing now happens on the event instead.
-  const targets = new Set<string>([
-    abs('drzl.config.ts'),
-    abs('drzl.config.js'),
-    abs('drzl.config.mjs'),
-    abs('drzl.config.cjs'),
-  ]);
+  const targets = new Set<string>(CONFIG_FILE_NAMES.map(abs));
   if (source) {
     // The resolved source's directories cover both shapes: the drzl `schema` file's directory,
     // or every directory the drizzle-kit config's entries live in (glob bases included, so a

--- a/packages/cli/test/commands.e2e.spec.ts
+++ b/packages/cli/test/commands.e2e.spec.ts
@@ -54,6 +54,13 @@ describe('drzl init', () => {
     expect(config).toContain('schema:');
     expect(config).toContain('generators:');
 
+    // The scaffold is the first config most users see, and it had no type annotation at all, so
+    // it got no completion in an editor. The annotation has to stay type-only: this fixture has
+    // no `@drzl/cli` to resolve, exactly like a project that ran the CLI through `npx`, and the
+    // `generate` below is what proves the import is erased rather than resolved.
+    expect(config).toContain("import type { DrzlConfigInput } from '@drzl/cli/config'");
+    expect(config).toContain('satisfies DrzlConfigInput');
+
     // The config `init` writes has to be one `generate` accepts. Scaffolding something that
     // then fails is worse than scaffolding nothing.
     await run(process.execPath, [CLI, 'generate'], { cwd: dir, maxBuffer: 20 * 1024 * 1024 });

--- a/packages/cli/test/config-json-schema.spec.ts
+++ b/packages/cli/test/config-json-schema.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * The JSON Schema shipped for `drzl.config.json`.
+ *
+ * `drzl.config.json` has always been a supported config form (`loadConfig`'s candidate list), and
+ * a JSON file gets none of the completion a `.ts` config gets from `defineConfig`. The schema is
+ * how an editor learns the shape.
+ *
+ * A generated schema is only worth shipping if its verdicts match the CLI's, so the divergences
+ * are asserted here rather than assumed:
+ *
+ *  - `z.toJSONSchema` defaults to `io: 'output'`, which marks every key carrying a `.default()`
+ *    as `required`. That schema rejects almost every real config, including all 32 in the docs.
+ *    The builder passes `io: 'input'`; `rejects nothing the CLI accepts` below is the guard.
+ *  - `z.toJSONSchema` silently drops refinements. `ConfigSchema`'s one `.superRefine` carries the
+ *    affix rules, so the character half is re-encoded as a `pattern` and proven equivalent to
+ *    `validateAffix` by differential fuzz; the collision half cannot be expressed in JSON Schema
+ *    and is asserted here as a known, documented gap rather than left to be discovered.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createJiti } from 'jiti';
+import { validateAffix, AFFIX_PREFIX_PATTERN, AFFIX_SUFFIX_PATTERN } from '@drzl/validation-core';
+import { buildConfigJsonSchema, ConfigSchema, CONFIG_FILE_NAMES } from '../src/config';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../..');
+const docsDir = path.join(repoRoot, 'docs');
+const publishedCopy = path.join(docsDir, 'public', 'drzl.config.schema.json');
+
+const schema = buildConfigJsonSchema();
+const ajv = new Ajv({ strict: false, allErrors: true });
+const validate = ajv.compile(schema);
+
+/** Every config the docs tell a reader to copy, as a plain object. */
+async function docCorpus(): Promise<{ where: string; config: Record<string, unknown> }[]> {
+  const extract = path.join(repoRoot, 'scripts', 'extract-doc-configs.mjs');
+  // The same extractor the packed gate uses, so the corpus cannot drift from the one CI runs.
+  const raw = execFileSync(process.execPath, [extract, docsDir], { encoding: 'utf8' });
+  const blocks: { file: string; line: number; config: string }[] = JSON.parse(raw);
+
+  // The OS temp dir, not a directory inside the package. These blocks have their imports stripped
+  // so they resolve nothing and do not need to sit beside node_modules, and a tree of generated
+  // `.ts` files left inside the package is picked up by eslint and by anything else that walks it.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'drzl-doc-configs-'));
+  const jiti = createJiti(path.join(tmp, 'x.ts'), { interopDefault: true, tryNative: false });
+
+  const out: { where: string; config: Record<string, unknown> }[] = [];
+  for (const [i, b] of blocks.entries()) {
+    // `defineConfig` is the identity function this package exports; declaring it locally keeps
+    // the block otherwise byte-identical to what a reader copies out of the docs.
+    const body = b.config
+      .split('\n')
+      .filter((l) => !l.trimStart().startsWith('import '))
+      .join('\n');
+    const file = path.join(tmp, `block-${i}.ts`);
+    fs.writeFileSync(file, `const defineConfig = (c: any) => c;\n${body}`);
+    const mod = (await jiti.import(file)) as { default?: unknown };
+    out.push({
+      where: `${b.file}:${b.line}`,
+      config: (mod.default ?? mod) as Record<string, unknown>,
+    });
+  }
+  return out;
+}
+
+describe('drzl.config.schema.json', () => {
+  it('is a draft-07 schema with a stable $id and a documented $schema key', () => {
+    expect(schema.$schema).toBe('http://json-schema.org/draft-07/schema#');
+    expect(schema.$id).toBe('https://use-drzl.github.io/drzl/drzl.config.schema.json');
+    // Without this a reader who adds the `$schema` key the docs tell them to add sees their own
+    // pointer flagged as an unknown property by editors that report them.
+    expect((schema.properties as Record<string, unknown>).$schema).toBeDefined();
+  });
+
+  it('accepts a $schema key, exactly as the CLI does', () => {
+    const cfg = {
+      $schema: './node_modules/@drzl/cli/dist/drzl.config.schema.json',
+      schema: 'src/db/schema.ts',
+      generators: [{ kind: 'orpc' }],
+    };
+    expect(validate(cfg), JSON.stringify(validate.errors)).toBe(true);
+    expect(() => ConfigSchema.parse(cfg)).not.toThrow();
+  });
+
+  it('rejects nothing the CLI accepts: every config in the docs validates', async () => {
+    const corpus = await docCorpus();
+    expect(corpus.length).toBeGreaterThanOrEqual(30);
+    const failures: string[] = [];
+    for (const { where, config } of corpus) {
+      // The CLI's own verdict first, so a docs config that is simply wrong is not blamed on the
+      // schema.
+      ConfigSchema.parse(config);
+      if (!validate(config)) {
+        failures.push(`${where}: ${ajv.errorsText(validate.errors, { separator: '; ' })}`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it('rejects a config the CLI rejects', () => {
+    const broken = {
+      schema: 'src/db/schema.ts',
+      outDir: 42, // outDir is a string
+      generators: [{ kind: 'not-a-real-generator' }],
+    };
+    expect(validate(broken)).toBe(false);
+    expect(() => ConfigSchema.parse(broken)).toThrow();
+  });
+
+  it('requires none of the keys that carry a default, which io:output would have', () => {
+    // The whole failure mode of a generated schema: `outDir`, `importExtension`, `analyzer` and
+    // `generators` all have `.default()`, so `io: 'output'` marks them required and every config
+    // omitting them lights up red in the editor while working perfectly.
+    expect(schema.required ?? []).toEqual([]);
+    const minimal = { schema: 'src/db/schema.ts' };
+    expect(validate(minimal), JSON.stringify(validate.errors)).toBe(true);
+    expect(() => ConfigSchema.parse(minimal)).not.toThrow();
+  });
+
+  it('mirrors the CLI on unknown keys: strict objects reject, the rest ignore', () => {
+    // `ConfigSchema` is not strict, so the CLI strips an unknown top-level key silently. The
+    // schema says the same thing rather than flagging a config that works.
+    const unknownTop = { schema: 's.ts', notAnOption: true, generators: [{ kind: 'orpc' }] };
+    expect(validate(unknownTop)).toBe(true);
+    expect(() => ConfigSchema.parse(unknownTop)).not.toThrow();
+
+    // `ColumnRulesSchema` is `.strict()`, so both reject.
+    const unknownNested = { schema: 's.ts', columns: { users: { omitt: ['x'] } } };
+    expect(validate(unknownNested)).toBe(false);
+    expect(() => ConfigSchema.parse(unknownNested)).toThrow();
+  });
+
+  it('carries the affix character rule that the dropped superRefine would have enforced', () => {
+    const bad = {
+      schema: 's.ts',
+      generators: [{ kind: 'zod', affix: { schema: { suffix: 'my-schema' } } }],
+    };
+    // A hyphen cannot appear in a TypeScript identifier. Before the pattern was re-encoded the
+    // JSON Schema said this was fine and the CLI then refused to generate.
+    expect(validate(bad)).toBe(false);
+    expect(() => ConfigSchema.parse(bad)).toThrow();
+  });
+
+  it('encodes a pattern equivalent to validateAffix, over every printable ASCII position', () => {
+    const CHAR_RULE = 'cannot appear in a TypeScript identifier';
+    const pre = new RegExp(AFFIX_PREFIX_PATTERN);
+    const suf = new RegExp(AFFIX_SUFFIX_PATTERN);
+
+    const corpus: string[] = ['', 'Insert', '_x', '$x', '9X', 'a-b', 'a b', 'a.b', 'é', '你好', '😀'];
+    for (let c = 32; c < 127; c++) {
+      const ch = String.fromCharCode(c);
+      corpus.push(ch, `a${ch}`, `${ch}a`);
+    }
+
+    const mismatches: string[] = [];
+    for (const v of corpus) {
+      // One mode only, so the collision rule cannot fire on a character-legal value and be
+      // mistaken for a character verdict.
+      const charOnly = (issues: { message: string }[]) =>
+        issues.filter((i) => i.message.includes(CHAR_RULE)).length === 0;
+      const zodPrefix = charOnly(validateAffix({ schema: { prefix: { insert: v } } }));
+      if (zodPrefix !== pre.test(v)) mismatches.push(`prefix ${JSON.stringify(v)}`);
+      const zodSuffix = charOnly(validateAffix({ schema: { suffix: { insert: v } } }));
+      if (zodSuffix !== suf.test(v)) mismatches.push(`suffix ${JSON.stringify(v)}`);
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it('cannot express the affix collision rule, which stays a CLI-only error', () => {
+    // Documented gap. Two modes resolving to the same identifier is a comparison between sibling
+    // values, which JSON Schema has no way to state. The CLI still catches it; the editor does
+    // not, and docs/guide/configuration.md says so.
+    const colliding = {
+      schema: 's.ts',
+      generators: [
+        { kind: 'zod', affix: { schema: { prefix: { insert: 'A', update: 'A', select: 'B' } } } },
+      ],
+    };
+    expect(validate(colliding)).toBe(true);
+    expect(() => ConfigSchema.parse(colliding)).toThrow(/collide/);
+  });
+
+  it('ships at the path the docs tell people to point $schema at', () => {
+    // Deliberately not an `exports` entry: `$schema` and VS Code's `json.schemas` take a
+    // filesystem path, which does not consult `exports`, and a JSON file in that map breaks
+    // every-entry-loads.spec.ts, whose premise is that every entry is a loadable module. So the
+    // contract between the docs and the build is asserted here instead of by the manifest.
+    const docPath = './node_modules/@drzl/cli/dist/drzl.config.schema.json';
+    const built = path.join(here, '..', 'dist', 'drzl.config.schema.json');
+    expect(docPath.endsWith(`/@drzl/cli/${path.relative(path.join(here, '..'), built)}`)).toBe(true);
+    expect(fs.existsSync(built), `${built} is missing; run pnpm --filter @drzl/cli build`).toBe(
+      true
+    );
+    expect(JSON.parse(fs.readFileSync(built, 'utf8'))).toEqual(schema);
+
+    // `files` has to carry it, or none of the above reaches a consumer.
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(here, '..', 'package.json'), 'utf8')
+    ) as { files: string[] };
+    expect(manifest.files).toContain('dist');
+
+    const guide = fs.readFileSync(path.join(docsDir, 'guide', 'configuration.md'), 'utf8');
+    expect(guide).toContain(docPath);
+  });
+
+  it('matches the copy published on the docs site', () => {
+    // The docs copy is what `$schema` points at over the network and what a SchemaStore entry
+    // would fetch. Regenerate with `pnpm --filter @drzl/cli build`.
+    expect(fs.existsSync(publishedCopy), `${publishedCopy} is missing`).toBe(true);
+    const onDisk = fs.readFileSync(publishedCopy, 'utf8');
+    expect(onDisk).toBe(`${JSON.stringify(schema, null, 2)}\n`);
+  });
+});
+
+describe('config file names', () => {
+  it('are one list, so the loader and the watcher cannot disagree', () => {
+    expect([...CONFIG_FILE_NAMES]).toEqual([
+      'drzl.config.ts',
+      'drzl.config.mjs',
+      'drzl.config.js',
+      'drzl.config.cjs',
+      'drzl.config.json',
+    ]);
+  });
+});

--- a/packages/cli/test/watch-targets.spec.ts
+++ b/packages/cli/test/watch-targets.spec.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import path from 'node:path';
-import { computeWatchTargets } from '../src/config';
+import { computeWatchTargets, CONFIG_FILE_NAMES } from '../src/config';
 
 const cwd = path.resolve('/project');
 const cfg = (over: Record<string, unknown> = {}) =>
@@ -37,9 +37,14 @@ describe('watch targets', () => {
   });
 
   it('still watches every config filename', () => {
+    // Iterated from the loader's own list rather than spelled out again. The list here was a
+    // second copy of the four names in `computeWatchTargets`, and both copies were missing
+    // `drzl.config.json`: a JSON config loads fine and then `drzl watch` never reloads it,
+    // because nothing was watching the file. Two enumerations agreeing with each other is not
+    // the same as either agreeing with the loader.
     const targets = computeWatchTargets(cfg(), cwd);
-    for (const name of ['drzl.config.ts', 'drzl.config.js', 'drzl.config.mjs', 'drzl.config.cjs']) {
-      expect(targets).toContain(path.resolve(cwd, name));
+    for (const name of CONFIG_FILE_NAMES) {
+      expect(targets, `not watching ${name}`).toContain(path.resolve(cwd, name));
     }
   });
 

--- a/packages/validation-core/src/naming.ts
+++ b/packages/validation-core/src/naming.ts
@@ -138,8 +138,29 @@ export function typeName(mode: NameMode, tsName: string, affix: ResolvedAffix): 
 }
 
 // A prefix opens the identifier, so it may not start with a digit. A suffix never does.
-const PREFIX_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
-const SUFFIX_RE = /^[A-Za-z0-9_$]+$/;
+const ID_START = 'A-Za-z_$';
+const ID_PART = 'A-Za-z0-9_$';
+const PREFIX_BODY = `[${ID_START}][${ID_PART}]*`;
+const SUFFIX_BODY = `[${ID_PART}]+`;
+const PREFIX_RE = new RegExp(`^${PREFIX_BODY}$`);
+const SUFFIX_RE = new RegExp(`^${SUFFIX_BODY}$`);
+
+/**
+ * The same two rules, as JSON Schema `pattern` strings, for `drzl.config.schema.json`.
+ *
+ * `z.toJSONSchema` drops refinements without saying so, and the affix rules live in
+ * `ConfigSchema`'s only `.superRefine`. A generated schema would therefore have told an editor
+ * that `suffix: 'my-schema'` was fine, and the CLI would then have refused to generate from it.
+ * Re-encoding the character half here keeps one definition of the rule rather than a regex in
+ * this file and a hand-copied pattern in the schema builder.
+ *
+ * The body is optional because `checkOne` returns early for the empty string: an empty affix
+ * means "none" and is always legal. Equivalence with `validateAffix` is not argued from that
+ * sentence, it is fuzzed over every printable ASCII position in
+ * packages/cli/test/config-json-schema.spec.ts.
+ */
+export const AFFIX_PREFIX_PATTERN = `^(?:${PREFIX_BODY})?$`;
+export const AFFIX_SUFFIX_PATTERN = `^(?:${SUFFIX_BODY})?$`;
 
 /**
  * Reject affixes that cannot produce a compilable file, before anything is written:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(mysql2@3.23.2(@types/node@26.1.2))


### PR DESCRIPTION
Plan item 64, taken at its stated minimum done properly: a JSON Schema for `drzl.config`, generated from the zod schema that already validates every config form, plus the typed-scaffold and watch fixes the work exposed. The VS Code extension half is **rejected with reasons**: a separate marketplace product with its own release channel and publishing identity, delivering nothing the schema and the existing types do not.

## Established before designing

- **`drzl.config.json` was always accepted**: `loadConfig` tries `.ts`, `.mjs`, `.js`, `.cjs`, `.json`, and the JSON branch feeds the same `ConfigSchema.parse` and `resolveConfig` as every other form. So the schema is directly useful and no new config form was needed; the drizzle-kit interop path is untouched.
- **`defineConfig` already existed** and 24 of the 32 documented configs use it, but `drzl init` scaffolded a bare object with no import, so the first config a user ever sees had no type attached.

## The two divergences, measured

1. **`io` defaults to `'output'`, which is catastrophic for a config schema**: it marks every `.default()` key as required. Compiled with ajv against the documented corpus, that variant **rejects 34 of 34 real configs**; `io: 'input'` rejects none. Shipping the default would have red-lined every config in the docs.
2. **The affix `.superRefine` is dropped silently**, as the known zod hazard predicts. Split by reading the validator: the **character** half is expressible and is now encoded as a JSON Schema `pattern` built from the same string the CLI compiles its regex from, then **fuzzed against the CLI over 334 values in three positions with zero mismatches**; the **collision** half compares sibling values, cannot be expressed, and is documented as a CLI-only error. Proof the drop was real rather than theoretical: with the pattern stripped, the schema accepts an affix the CLI rejects. The first fuzz run was wrong and the agent caught it, since a shared prefix collides across modes, so 17 reported "mismatches" were collision verdicts rather than character ones.

A tree walk found exactly one unrepresentable check in the whole config schema (that root `custom`), and unknown-key behavior matches the CLI in both directions.

## Two adjacent defects fixed

- **`drzl watch` never reloaded a JSON config**: `computeWatchTargets` carried its own copy of the config filenames without `drzl.config.json`, and its test spelled the same four names a third time, so the test agreed with the bug. Loader, watcher and test now share one exported list.
- **`drzl init` now scaffolds a typed config** (`import type` plus `satisfies`), deliberately type-only: verified empirically that jiti erases a type-only import of a package that is not installed, so `npx drzl init` still runs where a `defineConfig` value import would hard-fail.

## Proof the completion story is real

A real project with `"$schema": "./node_modules/@drzl/cli/dist/drzl.config.schema.json"`, the file resolving at exactly that path, and the CLI generating from it; 13 enum nodes across 119 declared properties, which is where the practical completion value lives; the VS Code `json.schemas` mapping and the published URL documented. **34 of 34** documented configs validate, a deliberately broken one fails both the schema and the CLI, and all 34 also generate and typecheck inside `verify:packed`, which is what proves the new `satisfies` scaffold runs in a real installed project.

Two existing package constraints were worked with rather than around: the metadata spec restricts `files` to `dist|README|LICENSE|CHANGELOG` (so no top-level `schema/` dir), and the entry-loading spec treats every `exports` entry as a loadable module (so the JSON file has no `exports` entry, which is correct anyway since a `$schema` path never consults `exports`), with a direct path-contract test asserting the docs string, the built file and `files` all agree.

Gates green: 612 CLI tests across 35 files, zero failures repo-wide, typecheck, lint, docs, and `verify:packed` with the CLI tarball manifest stage clean. Changeset: minor for `@drzl/cli`.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
