### PR TITLE
feat: drzl init asks, detects and scaffolds a validator (items 65-67)

### DIFF
--- a/.changeset/init-rework.md
+++ b/.changeset/init-rework.md
@@ -1,0 +1,50 @@
+---
+'@drzl/cli': minor
+---
+
+`drzl init` finds your schema, asks what to generate, and defaults to a validator
+
+`init` wrote `schema: 'src/db/schema.ts'` whether or not that file existed. That is not an inert
+mistake, and the measurement is the argument: in an empty directory, `drzl init` exits 0, and the
+`drzl generate` that follows it analyzes nothing, writes `src/api/placeholder.orpc.ts` reading "No
+tables detected in analysis", and also exits 0. The first two commands a new user runs both
+reported success having read no schema at all.
+
+`init` now detects the schema, drizzle-kit first. If `drizzle.config.ts` is there, DRZL reads its
+`schema` entry through the same resolver `generate` uses, expanding globs and directories exactly
+as drizzle-kit does, and the scaffolded config then states no `schema` of its own: the path stays
+written in one place and DRZL reads it from drizzle-kit at generate time. Otherwise it walks
+conventional locations, `src/db/schema.ts` first, then the same shape under `src/lib/db`, `app/db`,
+`lib/db`, `db`, `drizzle` and the project root, as a file or an `index.ts` inside a `schema/` or
+`schemas/` directory.
+
+A candidate is validated by **importing it and counting Drizzle tables**, never by `existsSync`. A
+file that imports cleanly and declares no tables is skipped and the walk continues, because a
+`schema.ts` exporting a connection string is worse than no detection: it produces exactly the
+silent placeholder run above. A file that cannot be imported at all, which is usually "install has
+not been run yet", is used with a warning instead of being skipped. When nothing is found, the
+config is still written, with `schema` left out and commented; `init` will not name a file that is
+not on disk.
+
+The default generator is now `zod` rather than `orpc`, and the rule behind it is narrower than
+taste: `init` offers only generators `@drzl/cli` depends on outright, so every kind it can
+scaffold is installed by definition beside the CLI that scaffolded it. Eight generators are
+`optionalDependencies` instead, including every route generator except oRPC, and an installer skips
+an optional dependency that is not on the registry, so scaffolding one would produce a config whose
+first `drzl generate` fails on a module that was never installed. A test asserts the offered list against `package.json` so that
+cannot drift. The choices are `zod`, `valibot`, `arktype`, `typebox` and `orpc`.
+
+`-y, --yes` was declared and then ignored: `init` and `init --yes` were byte-identical, so the
+flag advertised an interactive command that did not exist. The prompts are now real, and the flag
+keeps the meaning it always advertised. Non-interactive stays the first-class path: questions are
+asked only when stdin **and** stdout are both terminals and `CI` is unset, no readline interface is
+constructed otherwise, and closing stdin or pressing `Ctrl+D` at a prompt takes the defaults and
+stops rather than waiting. Two new flags, `--schema <path>` and `--generators <list>`, answer the
+two questions from a script, so nothing `init` asks can only be answered by a human.
+
+An existing config is still never overwritten, and now it is not shadowed either. `init` checked
+only `drzl.config.ts`, so running it beside a `drzl.config.json` wrote the scaffold, exited 0, and
+left the user's config in place but dead: the loader tries the five config names with `.ts` first,
+so the next `drzl generate` ran the scaffold instead of it. All five names are checked now. The
+message is also no longer the raw `EEXIST: file already exists, open ...` errno string, which
+named no command and suggested nothing.

--- a/2026-08-03-top-100.md
+++ b/2026-08-03-top-100.md
@@ -1,0 +1,15 @@
+
+## Item 64 verdict: shipped (PR #189)
+
+JSON Schema generated at build time from the config's own zod schema into the CLI dist and
+docs/public (so the published file cannot drift from the code), draft-07. drzl.config.json was
+already accepted through the same zod path, so no new config form was needed. Two divergences
+measured, not trusted: zod's toJSONSchema io defaults to 'output', which marks every defaulted key
+required and REJECTS 34 of 34 documented configs (io: 'input' rejects none), and the affix
+superRefine is dropped silently, its character half now encoded as a pattern fuzzed against the
+CLI over 334 values with zero mismatches while the collision half is documented CLI-only. Fixed
+two adjacent defects: drzl watch never reloaded a JSON config (computeWatchTargets kept its own
+filename list and its test spelled the names a third time, so the test agreed with the bug), and
+drzl init scaffolded an untyped bare object (now type-only import + satisfies, verified to survive
+jiti erasure so npx still works). VS Code extension half rejected with reasons. Completion story
+proven in a real project. Shipped through ship.sh: PR #189, CI 8/8, master 062f305.

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -1,6 +1,7 @@
 # Init
 
-Scaffold a minimal `drzl.config.ts` in the current directory.
+Scaffold a `drzl.config.ts` in the current directory. `init` finds your schema, asks what you want
+generated, and writes a config that runs.
 
 Usage:
 
@@ -24,13 +25,108 @@ bunx @drzl/cli init
 
 :::
 
-Output example:
+## Options
+
+| Flag                  | What it does                                                     |
+| --------------------- | ---------------------------------------------------------------- |
+| `-y, --yes`           | Ask nothing. Take the detected schema and the default generator. |
+| `--schema <path>`     | Write this path into the config, skipping detection.             |
+| `--generators <list>` | Comma-separated: `zod`, `valibot`, `arktype`, `typebox`, `orpc`. |
+
+Every prompt has a flag, and every flag skips its prompt. Nothing `init` asks can only be answered
+by a human, which is what keeps it usable from a script.
+
+## It only asks when someone is there to answer
+
+Prompts appear when **stdin and stdout are both terminals** and `CI` is unset. Otherwise `init`
+writes the config straight out, with the same result `--yes` gives. That covers `npx` one-liners,
+CI jobs, agents, and any invocation whose output is being piped somewhere.
+
+Pressing `Ctrl+D` at a prompt, or closing stdin, stops the questions and takes the defaults for
+whatever is left. `init` never waits for input it cannot get.
+
+## Finding the schema
+
+`init` does not guess a path and hope. It looks in two places, in order, and **validates a
+candidate by importing it and counting Drizzle tables** rather than by checking that a file exists.
+
+1. **Your drizzle-kit config.** If `drizzle.config.ts` (or `.js`, or `.json`) is there, DRZL reads
+   its `schema` entry, expanding globs and directories the way drizzle-kit does. When that resolves
+   to files with tables in them, the scaffolded config states **no** `schema` at all: DRZL reads it
+   from drizzle-kit at generate time, so the path stays written in exactly one place. See
+   [reading the schema path from drizzle-kit](/guide/configuration#reading-the-schema-path-from-drizzle-kit).
+2. **Conventional locations**, `src/db/schema.ts` first, then the same shape under `src/lib/db`,
+   `app/db`, `lib/db`, `db`, `drizzle` and the project root, each as a file or an `index.ts` inside
+   a `schema/` or `schemas/` directory.
+
+A candidate that imports cleanly and declares no tables is **skipped**, and the walk continues. A
+`schema.ts` that exports a connection string is worse than no detection: the config it produces
+analyzes nothing, and `drzl generate` then reports success over an empty schema. A candidate that
+cannot be imported at all, usually because dependencies are not installed yet, is used with a
+warning rather than skipped.
+
+If nothing is found, `init` still writes the config, with `schema` left out and commented:
 
 ```ts
+export default {
+  // Set this to your Drizzle schema file, for example 'src/db/schema.ts'. DRZL
+  // found no drizzle-kit config and no schema declaring tables in the usual
+  // locations, and will not name a file that is not there.
+  // schema: 'src/db/schema.ts',
+  ...
+}
+```
+
+It will not write a `schema` naming a file that is not on disk.
+
+## What it scaffolds
+
+The default is **Zod validators**, and the rule behind the choice is that `init` only offers
+generators `@drzl/cli` depends on outright. The five in the list are installed by definition
+alongside the CLI that scaffolded the config. The route generators other than oRPC are optional
+dependencies, so a config naming one may fail its first `drzl generate` on a package that was never
+installed; add them yourself once you have installed them.
+
+```ts
+import type { DrzlConfigInput } from '@drzl/cli/config';
+
+export default {
+  schema: 'src/db/schema.ts',
+  analyzer: { includeRelations: true, validateConstraints: true },
+  generators: [
+    // Other kinds this CLI already has installed: 'valibot', 'arktype', 'typebox', 'orpc'.
+    { kind: 'zod', path: 'src/validators/zod' },
+  ],
+} satisfies DrzlConfigInput;
+```
+
+Choosing `orpc` adds an `outDir` and scaffolds the router instead:
+
+```ts
+import type { DrzlConfigInput } from '@drzl/cli/config';
+
 export default {
   schema: 'src/db/schema.ts',
   outDir: 'src/api',
   analyzer: { includeRelations: true, validateConstraints: true },
-  generators: [{ kind: 'orpc', template: 'standard', includeRelations: true }],
-} as const;
+  generators: [
+    // A second router generator needs its own "path"; they share "outDir".
+    { kind: 'orpc', template: 'standard', includeRelations: true },
+  ],
+} satisfies DrzlConfigInput;
 ```
+
+The annotation is a **type-only import plus `satisfies`**, never `defineConfig`. A type import is
+erased before the config is ever executed, so the scaffold still runs under `npx` in a project with
+no local `@drzl/cli` to resolve, while an editor still gets full completion. See
+[TypeScript configs](/guide/configuration#typescript-configs).
+
+## An existing config is never overwritten
+
+If a config is already there, `init` writes nothing, names the file, and exits 1. Delete it or edit
+it by hand.
+
+All five config names are checked, not just `drzl.config.ts`. DRZL loads them in a fixed order with
+`.ts` first, so writing a `.ts` scaffold beside a `drzl.config.json` would leave that file
+untouched and still replace it in practice: the next `drzl generate` would run the scaffold. `init`
+refuses rather than shadowing.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -582,14 +582,14 @@ export default defineConfig({
 
 `defineConfig` is the identity function: it returns what you pass it and exists only to attach the
 type. If you would rather not import a value, the annotation alone does the same job, which is
-what `drzl init` scaffolds:
+what [`drzl init`](/cli/init) scaffolds:
 
 ```ts
 import type { DrzlConfigInput } from '@drzl/cli/config';
 
 export default {
   schema: 'src/db/schema.ts',
-  generators: [{ kind: 'orpc' }],
+  generators: [{ kind: 'zod', path: 'src/validators/zod' }],
 } satisfies DrzlConfigInput;
 ```
 
@@ -634,8 +634,8 @@ reporting them. DRZL's one refinement holds the affix rules, so:
 - **Illegal affix characters are caught.** The rule is re-encoded as a `pattern`, and a test fuzzes
   it against the CLI's own check over every printable ASCII position to keep the two identical.
 - **Affix collisions are not caught.** Two modes whose prefix and suffix resolve to the same
-  identifier is a comparison between sibling values, which JSON Schema cannot express. `drzl
-  generate` still refuses, naming the two modes and the identifier they collide on.
+  identifier is a comparison between sibling values, which JSON Schema cannot express.
+  `drzl generate` still refuses, naming the two modes and the identifier they collide on.
 
 Unknown top-level keys are accepted by the schema because the CLI accepts them too: it ignores
 what it does not recognise rather than failing. Keys inside `columns` and `affix` are strict in

--- a/docs/guide/runtimes.md
+++ b/docs/guide/runtimes.md
@@ -100,6 +100,12 @@ All exited 0 everywhere.
 | `drzl generate:trpc <schema>` | pass | pass | pass |
 | `drzl init` | pass | pass | pass |
 
+`drzl init` was measured before it gained schema detection and prompts. The work it does now on
+these three runtimes is a subset of what `drzl generate` above already does: it imports schema
+modules through the same analyzer. The prompts are the only new machinery, they are reached only
+when stdin and stdout are both terminals, and the `node:readline/promises` they need is imported
+inside that branch and falls back to the non-interactive defaults if a runtime cannot provide it.
+
 The analyzer loads your `drzl.config.ts` and your schema modules through jiti, with
 `tryNative: false` so the TypeScript is transformed by jiti rather than by whatever the host runtime
 would do with it. That is what makes the three runtimes agree: config loading does not go through

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -32,6 +32,7 @@ import {
 import { buildDoctorReport, renderDoctorReport } from './doctor.js';
 import { diffSnapshots, restoreSnapshot, snapshotAll } from './drift.js';
 import { GeneratorNotInstalledError, loadGenerator } from './generator-loader.js';
+import { INIT_GENERATOR_CHOICES, runInit } from './init.js';
 import { maybeShowSponsorMessage } from './sponsor.js';
 import { CLI_VERSION } from './version.js';
 
@@ -1309,39 +1310,28 @@ program
 
 program
   .command('init')
-  .description('Scaffold a drzl.config.ts')
-  .option('-y, --yes', 'accept defaults')
-  .action(async (_opts: any) => {
-    const fs = await import('node:fs/promises');
-    const path = await import('node:path');
-    const target = path.resolve(process.cwd(), 'drzl.config.ts');
-    // One router generator, not both: they default to the same `outDir` and would each write an
-    // `index.ts` there, so a scaffold naming both would emit a config whose second generator
-    // silently overwrote the first. Swapping the kind is a one-word edit; running both needs a
-    // `path` on one of them, which is what the comment says.
-    // `import type`, not the `defineConfig` value import the docs use, because `drzl init` also
-    // runs under `npx` in a project that has no local `@drzl/cli` to resolve. A type-only import
-    // is erased before the config is ever executed, so the scaffold still runs there; a value
-    // import would have made the very first generate fail on a module that is not installed.
-    const template = `import type { DrzlConfigInput } from '@drzl/cli/config';
-
-export default {
-  schema: 'src/db/schema.ts',
-  outDir: 'src/api',
-  analyzer: { includeRelations: true, validateConstraints: true },
-  generators: [
-    // For tRPC instead: { kind: 'trpc', template: 'standard', includeRelations: true }
-    // To run both, give one of them its own \`path\`; they share \`outDir\` otherwise.
-    { kind: 'orpc', template: 'standard', includeRelations: true }
-  ]
-} satisfies DrzlConfigInput\n`;
-    try {
-      await fs.writeFile(target, template, { flag: 'wx' });
-      console.log(chalk.green(`Created ${target}`));
-    } catch (e: any) {
-      console.error(chalk.red('Init failed:'), e?.message ?? e);
-      process.exit(1);
-    }
+  .description('Scaffold a drzl.config.ts, finding your schema and asking what to generate')
+  .option('-y, --yes', 'take the defaults and ask nothing')
+  .option('--schema <path>', 'the schema file to write into the config, skipping detection')
+  .option(
+    '--generators <list>',
+    `comma-separated: ${INIT_GENERATOR_CHOICES.map((c) => c.kind).join(', ')}`
+  )
+  .action(async (opts: any) => {
+    // Every prompt has a flag, and every flag skips its prompt. That equivalence is what keeps
+    // the interactive command usable from CI: nothing can only be answered by a human.
+    const outcome = await runInit({
+      cwd: process.cwd(),
+      yes: !!opts.yes,
+      schemaFlag: opts.schema,
+      generatorsFlag: opts.generators,
+      stdin: process.stdin,
+      stdout: process.stdout,
+      env: process.env,
+      log: (s) => console.log(s.startsWith('Created ') ? chalk.green(s) : chalk.gray(s)),
+      error: (s) => console.error(chalk.red(s)),
+    });
+    if (outcome.code !== 0) process.exit(outcome.code);
   });
 
 /**

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -1,0 +1,636 @@
+/**
+ * `drzl init`: find the schema, ask what to generate, write a config that runs.
+ *
+ * Three defects were fixed here at once, and they are one command's worth of work because each
+ * one is the reason the next is hard to see (plan items 65, 66, 67).
+ *
+ * **The schema path was invented (67).** `init` wrote `schema: 'src/db/schema.ts'` whether or
+ * not that file existed. Measured on the shipped 4.22.0 CLI, in an empty directory: `init`
+ * exits 0, and the `drzl generate` that follows it analyzes nothing, writes
+ * `src/api/placeholder.orpc.ts` reading "No tables detected in analysis", and also exits 0. The
+ * first two commands a new user runs therefore both report success having read no schema at
+ * all. So detection is not a convenience here; it is what stops the product from lying on its
+ * first run.
+ *
+ * Detection validates a candidate by loading it and counting Drizzle tables, never by
+ * `existsSync`. The analyzer separates the three answers cleanly, which is what makes the rule
+ * possible (measured against `@drzl/analyzer` 1.20.1):
+ *
+ *   - a real schema           -> `tables.length > 0`, no issues
+ *   - a file that is not one  -> `tables.length === 0`, no issues, dialect 'unknown'
+ *   - a file it could not run -> `tables.length === 0` plus a `DRZL_ANL_IMPORT` error issue
+ *
+ * The middle case is rejected and the walk continues, because a `schema.ts` that exports a
+ * connection string is worse than no detection: it produces exactly the silent placeholder run
+ * above. The last case is adopted with a warning rather than rejected, because "DRZL could not
+ * import it" is usually "you have not run install yet", and the file is still obviously the
+ * schema the user meant.
+ *
+ * **The default generator was a router (66).** Decided from what is installed rather than from
+ * taste: `@drzl/generator-zod` is a hard dependency of `@drzl/cli`, so it is on disk beside the
+ * CLI that scaffolds this config, while six of the seven route generators are
+ * `optionalDependencies` and may not be installed at all. `INIT_GENERATOR_CHOICES` therefore
+ * offers only kinds `@drzl/cli` depends on outright, and a test asserts that against
+ * `package.json` so nothing unpublishable can be added to the list.
+ *
+ * **`--yes` did nothing (65).** The flag was declared and the action ignored its options object,
+ * so `init` and `init --yes` were byte-identical. The flag is kept and given the meaning it
+ * always advertised, because the non-interactive path is the important one: `init` runs under
+ * `npx`, in CI and under agents far more often than it runs under a human. Prompts are the
+ * addition, and they are guarded so that they can never be the reason a pipeline stops:
+ * `isInteractive` requires stdin AND stdout to be TTYs and `CI` to be unset, and no readline
+ * interface is constructed otherwise.
+ */
+import { SchemaAnalyzer } from '@drzl/analyzer';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type * as readline from 'node:readline/promises';
+import { CONFIG_FILE_NAMES } from './config.js';
+import { resolveSchemaSource } from './drizzle-kit.js';
+
+/** A generator `init` is willing to scaffold. */
+export interface InitGeneratorChoice {
+  kind: string;
+  /** The npm package the kind loads, which must be a hard dependency of `@drzl/cli`. */
+  packageName: string;
+  label: string;
+}
+
+/**
+ * What `init` offers, in the order the prompt lists it. The first entry is the default.
+ *
+ * Every kind here is a `dependencies` entry of `@drzl/cli`, never an `optionalDependencies`
+ * one. That is the whole rule, and `init.spec.ts` enforces it against `package.json`: an
+ * optional generator is skipped by the installer when it does not exist on the registry, so
+ * scaffolding one produces a config whose first `drzl generate` fails on a missing module. The
+ * six route generators that are not oRPC are exactly that case, and so are `effect` and
+ * `json-schema`.
+ */
+export const INIT_GENERATOR_CHOICES: readonly InitGeneratorChoice[] = [
+  { kind: 'zod', packageName: '@drzl/generator-zod', label: 'Zod validators' },
+  { kind: 'valibot', packageName: '@drzl/generator-valibot', label: 'Valibot validators' },
+  { kind: 'arktype', packageName: '@drzl/generator-arktype', label: 'ArkType validators' },
+  { kind: 'typebox', packageName: '@drzl/generator-typebox', label: 'TypeBox validators' },
+  { kind: 'orpc', packageName: '@drzl/generator-orpc', label: 'oRPC router' },
+];
+
+/** The kind chosen when nothing says otherwise: `--yes`, a non-TTY, or an empty prompt answer. */
+export const DEFAULT_GENERATOR_KIND = INIT_GENERATOR_CHOICES[0].kind;
+
+/** The kinds that write routers, and so need an `outDir` in the scaffold. */
+const ROUTER_KINDS = new Set(['orpc']);
+
+/**
+ * Where a Drizzle schema conventionally lives, most specific first, as stems without an
+ * extension.
+ *
+ * Not invented. `src/db/schema.ts` and `src/db/schemas/index.ts` are the two paths this
+ * repository's own docs use (34 and 8 occurrences across `docs/`, the READMEs and `examples/`),
+ * and the rest are the same two shapes under the other roots frameworks put source in, plus
+ * `drizzle/`, which is where a kit `out` directory conventionally sits. Being wrong about any
+ * one of them costs nothing: an entry that does not exist is never opened, and an entry that
+ * exists still has to declare tables before it is used.
+ *
+ * Every stem ends in `schema` or `schemas`, and that is a rule rather than a coincidence: a
+ * candidate is validated by importing it, and importing `src/db/index.ts` on the guess that it
+ * might re-export tables would just as often open a database connection. A module named for the
+ * schema is one that declares rather than connects.
+ */
+export const SCHEMA_CANDIDATE_STEMS: readonly string[] = [
+  'src/db/schema',
+  'src/db/schema/index',
+  'src/db/schemas/index',
+  'src/lib/db/schema',
+  'src/lib/db/schema/index',
+  'src/schema',
+  'src/schema/index',
+  'src/schemas/index',
+  'app/db/schema',
+  'lib/db/schema',
+  'db/schema',
+  'db/schema/index',
+  'drizzle/schema',
+  'schema',
+];
+
+/** Extensions tried for each stem, in order. */
+const CANDIDATE_EXTENSIONS = ['.ts', '.js'] as const;
+
+/** Every conventional candidate path, in the order they are tried. */
+export function schemaCandidates(): string[] {
+  const out: string[] = [];
+  for (const stem of SCHEMA_CANDIDATE_STEMS) {
+    for (const ext of CANDIDATE_EXTENSIONS) out.push(`${stem}${ext}`);
+  }
+  return out;
+}
+
+export type CandidateVerdict =
+  /** Imported, and Drizzle tables came back. */
+  | 'confirmed'
+  /** Present, but could not be imported at all, so it is neither proved nor disproved. */
+  | 'unverified'
+  /** Imported cleanly and declares no tables, so it is not a schema. */
+  | 'rejected';
+
+export interface CandidateReport {
+  verdict: CandidateVerdict;
+  tables: number;
+  /** The import failure, when there was one. */
+  reason?: string;
+}
+
+/**
+ * Load a candidate and decide what it is. Never throws: an analyzer that blows up on a file is
+ * itself an answer, and the caller has more candidates to try.
+ */
+export async function classifySchemaCandidate(target: string | string[]): Promise<CandidateReport> {
+  let analysis: Awaited<ReturnType<SchemaAnalyzer['analyze']>>;
+  try {
+    // Relations and constraint validation are both off. Neither changes whether a table exists,
+    // and both cost time on a file that is about to be thrown away.
+    analysis = await new SchemaAnalyzer(target).analyze({
+      includeRelations: false,
+      validateConstraints: false,
+    });
+  } catch (e: any) {
+    return { verdict: 'unverified', tables: 0, reason: firstLine(String(e?.message ?? e)) };
+  }
+  if (analysis.tables.length > 0) {
+    return { verdict: 'confirmed', tables: analysis.tables.length };
+  }
+  const importError = analysis.issues.find(
+    (i) => i.level === 'error' && i.code === 'DRZL_ANL_IMPORT'
+  );
+  if (importError)
+    return { verdict: 'unverified', tables: 0, reason: firstLine(importError.message) };
+  return { verdict: 'rejected', tables: 0 };
+}
+
+/**
+ * The first line of a message, for a reason printed inline. A module resolution failure carries
+ * its whole "Require stack" behind the first newline, and pasting that into the middle of a
+ * sentence buries the sentence.
+ */
+function firstLine(message: string): string {
+  return String(message).split('\n')[0].trim();
+}
+
+export interface SchemaDetection {
+  source: 'drizzle-kit' | 'convention' | 'none';
+  /**
+   * The relative path to write as `schema`, or undefined when the config should state none: a
+   * drizzle-kit project states it once in its own config, and a project with no schema at all
+   * must not be handed a path that is not there.
+   */
+  schema?: string;
+  /** The drizzle-kit config consulted, when one answered. */
+  drizzleKitConfig?: string;
+  verdict?: CandidateVerdict;
+  tables: number;
+  /** Lines worth printing: what was found, or what was looked for and rejected. */
+  notes: string[];
+}
+
+/**
+ * Decide where the schema is, drizzle-kit first.
+ *
+ * The kit config is asked first because it is the only source that is a statement of fact
+ * rather than a guess: the user wrote the path there themselves. `resolveSchemaSource` is the
+ * whole of item 59's walk (candidate order, jiti load, glob expansion, kit's own one-level
+ * directory expansion), so `init` and `generate` can never disagree about what that config
+ * says.
+ */
+export async function detectSchema(cwd: string): Promise<SchemaDetection> {
+  const notes: string[] = [];
+
+  let kitFiles: string[] | null = null;
+  let kitPath: string | undefined;
+  try {
+    // No `schema` and no `drizzleKit` key: exactly the shape that makes `resolveSchemaSource`
+    // walk drizzle-kit's own default candidates. It throws when there is no kit config, which
+    // is the common case and not an error here.
+    const source = await resolveSchemaSource({}, cwd);
+    if (source.source === 'drizzle-kit') {
+      kitFiles = source.schema as string[];
+      kitPath = source.drizzleKitConfigPath;
+    }
+  } catch {
+    kitFiles = null;
+  }
+
+  if (kitFiles && kitPath) {
+    const rel = path.relative(cwd, kitPath) || path.basename(kitPath);
+    const report = await classifySchemaCandidate(kitFiles);
+    if (report.verdict === 'confirmed' || report.verdict === 'unverified') {
+      notes.push(
+        report.verdict === 'confirmed'
+          ? `Schema from ${rel} (${kitFiles.length} file${kitFiles.length === 1 ? '' : 's'}, ` +
+              `${report.tables} table${report.tables === 1 ? '' : 's'})`
+          : `Schema from ${rel}, which DRZL could not import yet: ${report.reason}`
+      );
+      return {
+        source: 'drizzle-kit',
+        drizzleKitConfig: rel,
+        verdict: report.verdict,
+        tables: report.tables,
+        notes,
+      };
+    }
+    notes.push(`${rel} names schema files that declare no Drizzle tables; looking elsewhere.`);
+  }
+
+  // Confirmed wins outright: the walk returns on the first confirmed candidate and only
+  // collects the unverified ones, so a real schema further down the list beats a file near the
+  // top that DRZL could not import. Within one verdict the convention order decides.
+  const present = schemaCandidates().filter((c) => fs.existsSync(path.resolve(cwd, c)));
+  const unverified: Array<{ file: string; report: CandidateReport }> = [];
+  for (const file of present) {
+    const report = await classifySchemaCandidate(path.resolve(cwd, file));
+    if (report.verdict === 'confirmed') {
+      notes.push(
+        `Schema found at ${file} (${report.tables} table${report.tables === 1 ? '' : 's'})`
+      );
+      return {
+        source: 'convention',
+        schema: file,
+        verdict: 'confirmed',
+        tables: report.tables,
+        notes,
+      };
+    }
+    if (report.verdict === 'unverified') unverified.push({ file, report });
+    else notes.push(`${file} exists but declares no Drizzle tables; not using it.`);
+  }
+  if (unverified.length) {
+    const { file, report } = unverified[0];
+    notes.push(`Schema assumed to be ${file}; DRZL could not import it: ${report.reason}`);
+    return { source: 'convention', schema: file, verdict: 'unverified', tables: 0, notes };
+  }
+
+  notes.push(
+    present.length
+      ? 'No file DRZL looked at declares any Drizzle tables.'
+      : 'No drizzle-kit config and no schema in the usual locations.'
+  );
+  return { source: 'none', tables: 0, notes };
+}
+
+export interface InitPlan {
+  /** What to write as `schema`, or undefined to write none. */
+  schema?: string;
+  schemaSource: SchemaDetection['source'];
+  /** Deduplicated, in `INIT_GENERATOR_CHOICES` order. */
+  generators: string[];
+}
+
+/** The `generators` entry each kind scaffolds as. */
+function generatorLine(kind: string): string {
+  if (kind === 'orpc') return `{ kind: 'orpc', template: 'standard', includeRelations: true }`;
+  return `{ kind: '${kind}', path: 'src/validators/${kind}' }`;
+}
+
+/**
+ * The config file text.
+ *
+ * `import type` plus `satisfies`, never `defineConfig`. The scaffold has to keep working under
+ * `npx @drzl/cli init` in a project with no local `@drzl/cli` to resolve, and a type-only import
+ * is erased before jiti ever executes the module. A value import would make the very first
+ * `drzl generate` fail on a module that is not installed, and the annotation is what gives the
+ * first config anyone sees editor completion.
+ */
+export function renderInitConfig(plan: InitPlan): string {
+  const lines: string[] = [];
+  lines.push(`import type { DrzlConfigInput } from '@drzl/cli/config';`);
+  lines.push('');
+  lines.push('export default {');
+
+  if (plan.schema) {
+    lines.push(`  schema: '${plan.schema}',`);
+  } else if (plan.schemaSource === 'drizzle-kit') {
+    lines.push(`  // No "schema" here on purpose: DRZL reads it from your drizzle-kit config, so`);
+    lines.push(
+      `  // the path is written once. Set "schema" to override it, or "drizzleKit": false`
+    );
+    lines.push(`  // to refuse the fallback.`);
+  } else {
+    lines.push(`  // Set this to your Drizzle schema file, for example 'src/db/schema.ts'. DRZL`);
+    lines.push(`  // found no drizzle-kit config and no schema declaring tables in the usual`);
+    lines.push(`  // locations, and will not name a file that is not there.`);
+    lines.push(`  // schema: 'src/db/schema.ts',`);
+  }
+
+  const hasRouter = plan.generators.some((k) => ROUTER_KINDS.has(k));
+  if (hasRouter) lines.push(`  outDir: 'src/api',`);
+  lines.push(`  analyzer: { includeRelations: true, validateConstraints: true },`);
+  lines.push('  generators: [');
+  const others = INIT_GENERATOR_CHOICES.filter((c) => !plan.generators.includes(c.kind))
+    .map((c) => `'${c.kind}'`)
+    .join(', ');
+  if (others) lines.push(`    // Other kinds this CLI already has installed: ${others}.`);
+  // Only where it can bite. Two router generators default to the same `outDir` and would each
+  // write an `index.ts` into it, so the second silently overwrites the first; a config with no
+  // router in it cannot reach that, and the line is noise there.
+  if (hasRouter) {
+    lines.push('    // A second router generator needs its own "path"; they share "outDir".');
+  }
+  // Trailing commas and a closing semicolon. Without them Prettier rewrites the scaffold the
+  // first time a project formats anything, putting a diff on a file nobody edited. Measured:
+  // `prettier --single-quote --check` on the emitted config passes, and the only thing Prettier
+  // still changes under its own defaults is the quote style, which no scaffold can satisfy both
+  // ways at once.
+  for (const kind of plan.generators) lines.push(`    ${generatorLine(kind)},`);
+  lines.push('  ],');
+  lines.push('} satisfies DrzlConfigInput;');
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Whether to ask anything at all.
+ *
+ * Both streams, not just stdin. A question printed down a redirected stdout is invisible, so
+ * waiting for its answer is a hang from the only point of view that matters. `CI` is checked
+ * too because some runners do allocate a pty, and a hung `init` in a pipeline is a worse defect
+ * than the one prompts were added to fix.
+ */
+export function isInteractive(ctx: {
+  stdin: { isTTY?: boolean };
+  stdout: { isTTY?: boolean };
+  env: Record<string, string | undefined>;
+}): boolean {
+  if (ctx.env.CI) return false;
+  return Boolean(ctx.stdin.isTTY) && Boolean(ctx.stdout.isTTY);
+}
+
+/**
+ * One question. `null` means there are no more answers coming, from any cause: the stream
+ * closed, or the user pressed Ctrl+D, which readline in TTY mode reports by rejecting with an
+ * AbortError rather than by closing. Callers take their default and stop asking.
+ */
+async function ask(rl: readline.Interface, question: string): Promise<string | null> {
+  const closed = new Promise<null>((resolve) => rl.once('close', () => resolve(null)));
+  try {
+    return await Promise.race([rl.question(question), closed]);
+  } catch {
+    return null;
+  }
+}
+
+export interface PromptResult extends InitPlan {
+  /** True when input ran out and the remaining questions took their defaults. */
+  endedEarly: boolean;
+}
+
+/**
+ * Ask what the flags did not already answer.
+ *
+ * The streams are parameters rather than `process.stdin`/`process.stdout` so the prompt logic is
+ * driven by a test on ordinary pipes. Deciding *whether* to call this is `isInteractive`'s job,
+ * and it is the only thing that reads `isTTY`.
+ */
+export async function promptForPlan(args: {
+  input: NodeJS.ReadableStream;
+  output: NodeJS.WritableStream;
+  detection: SchemaDetection;
+  cwd: string;
+  schemaFromFlag?: string;
+  generatorsFromFlag?: string[];
+}): Promise<PromptResult> {
+  const { input, output, detection, cwd } = args;
+  const write = (s: string) => output.write(s + '\n');
+
+  let schema = args.schemaFromFlag ?? detection.schema;
+  let schemaSource: SchemaDetection['source'] = args.schemaFromFlag
+    ? 'convention'
+    : detection.source;
+  let generators = args.generatorsFromFlag;
+  let endedEarly = false;
+
+  // Loaded here rather than at the top of the module, so a runtime whose `node:readline/promises`
+  // is missing or partial cannot break the non-interactive path, which is the one that runs under
+  // `npx`, in CI and under Bun and Deno. If it cannot be loaded at all, the defaults are taken
+  // and nothing is asked: a command that degrades to `--yes` is a nuisance, and one that throws
+  // where it used to write a config is a regression.
+  let readlineModule: typeof readline;
+  try {
+    readlineModule = await import('node:readline/promises');
+  } catch {
+    return {
+      schema,
+      schemaSource,
+      generators: normalizeGenerators(generators) ?? [DEFAULT_GENERATOR_KIND],
+      endedEarly: true,
+    };
+  }
+  const rl = readlineModule.createInterface({ input, output });
+  try {
+    if (args.schemaFromFlag === undefined) {
+      for (const note of detection.notes) write(note);
+      const prompt =
+        detection.source === 'drizzle-kit'
+          ? 'Schema file, or Enter to keep reading it from your drizzle-kit config: '
+          : detection.schema
+            ? `Schema file [${detection.schema}]: `
+            : 'Schema file (Enter to leave it unset): ';
+      const answer = await ask(rl, prompt);
+      if (answer === null) endedEarly = true;
+      else if (answer.trim()) {
+        const typed = answer.trim();
+        const report = await classifySchemaCandidate(path.resolve(cwd, typed));
+        if (report.verdict === 'confirmed') {
+          write(`  ${typed}: ${report.tables} table${report.tables === 1 ? '' : 's'}`);
+        } else if (report.verdict === 'unverified') {
+          write(`  ${typed}: DRZL could not import it (${report.reason}). Using it anyway.`);
+        } else {
+          write(`  ${typed}: no Drizzle tables found in it. Using it anyway.`);
+        }
+        schema = typed;
+        schemaSource = 'convention';
+      }
+    }
+
+    if (generators === undefined && !endedEarly) {
+      write('What should DRZL generate?');
+      INIT_GENERATOR_CHOICES.forEach((c, i) => write(`  ${i + 1}) ${c.label}`));
+      // Bounded, so a stream of nonsense cannot keep this open. Every exit from the loop either
+      // has an answer or falls through to the default.
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const answer = await ask(rl, `Choice [1, ${INIT_GENERATOR_CHOICES[0].label}]: `);
+        if (answer === null) {
+          endedEarly = true;
+          break;
+        }
+        const raw = answer.trim().toLowerCase();
+        if (!raw) break;
+        const byIndex = Number(raw);
+        const picked =
+          Number.isInteger(byIndex) && byIndex >= 1 && byIndex <= INIT_GENERATOR_CHOICES.length
+            ? INIT_GENERATOR_CHOICES[byIndex - 1]
+            : INIT_GENERATOR_CHOICES.find((c) => c.kind === raw);
+        if (picked) {
+          generators = [picked.kind];
+          break;
+        }
+        write(`  "${answer.trim()}" is not one of the choices.`);
+      }
+    }
+  } finally {
+    rl.close();
+  }
+
+  return {
+    schema,
+    schemaSource,
+    generators: normalizeGenerators(generators) ?? [DEFAULT_GENERATOR_KIND],
+    endedEarly,
+  };
+}
+
+/**
+ * Deduplicate and order a kind list, or throw naming the offender. Returns undefined for
+ * undefined so a missing flag stays a question rather than becoming an empty answer.
+ */
+export function normalizeGenerators(kinds: string[] | undefined): string[] | undefined {
+  if (kinds === undefined) return undefined;
+  const known = new Set(INIT_GENERATOR_CHOICES.map((c) => c.kind));
+  for (const k of kinds) {
+    if (!known.has(k)) {
+      throw new Error(
+        `drzl init: "${k}" is not a generator init can scaffold. Choose from ` +
+          `${[...known].join(', ')}. Every other kind is documented in drzl.config; the route ` +
+          `generators are optional dependencies and may not be installed.`
+      );
+    }
+  }
+  const picked = INIT_GENERATOR_CHOICES.filter((c) => kinds.includes(c.kind)).map((c) => c.kind);
+  return picked.length ? picked : undefined;
+}
+
+/** Split a `--generators zod,orpc` value. */
+export function parseGeneratorsFlag(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  const parts = value
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  if (!parts.length) throw new Error('drzl init: --generators was given no kinds.');
+  return parts;
+}
+
+export interface InitOutcome {
+  code: number;
+  /** Absolute path written, when one was. */
+  written?: string;
+  plan?: InitPlan;
+}
+
+/**
+ * The whole command. Returns an exit code rather than calling `process.exit`, so a test can run
+ * it in-process and so the caller owns the one exit in the CLI.
+ */
+export async function runInit(args: {
+  cwd: string;
+  yes?: boolean;
+  schemaFlag?: string;
+  generatorsFlag?: string;
+  stdin: NodeJS.ReadableStream & { isTTY?: boolean };
+  stdout: NodeJS.WritableStream & { isTTY?: boolean };
+  env: Record<string, string | undefined>;
+  log: (s: string) => void;
+  error: (s: string) => void;
+}): Promise<InitOutcome> {
+  const target = path.resolve(args.cwd, 'drzl.config.ts');
+
+  // Before any detection, and before any question. Everything that follows costs a jiti import
+  // of the user's schema, and none of it is worth doing for a config that will not be written.
+  //
+  // Every config name, not just `drzl.config.ts`. `loadConfig` tries the five names in a fixed
+  // order with `.ts` first, so writing a `.ts` scaffold beside an existing `drzl.config.json`
+  // does not overwrite that file and does something worse: it shadows it, and the next
+  // `drzl generate` silently runs the scaffold instead of the config the user wrote. Measured on
+  // 4.22.0, which checked only the one name.
+  const existing = CONFIG_FILE_NAMES.find((name) => fs.existsSync(path.resolve(args.cwd, name)));
+  if (existing) {
+    args.error(
+      `drzl init: ${existing} already exists, so nothing was written. Delete it, or edit it by ` +
+        `hand; init never overwrites a config, and will not write one that shadows it either.`
+    );
+    return { code: 1 };
+  }
+
+  let fromFlag: string[] | undefined;
+  try {
+    fromFlag = normalizeGenerators(parseGeneratorsFlag(args.generatorsFlag));
+  } catch (e: any) {
+    args.error(String(e?.message ?? e));
+    return { code: 1 };
+  }
+
+  const detection = await detectSchema(args.cwd);
+
+  let plan: InitPlan;
+  const interactive =
+    !args.yes && isInteractive({ stdin: args.stdin, stdout: args.stdout, env: args.env });
+
+  if (interactive) {
+    const result = await promptForPlan({
+      input: args.stdin,
+      output: args.stdout,
+      detection,
+      cwd: args.cwd,
+      schemaFromFlag: args.schemaFlag,
+      generatorsFromFlag: fromFlag,
+    });
+    plan = {
+      schema: result.schema,
+      schemaSource: result.schemaSource,
+      generators: result.generators,
+    };
+  } else {
+    for (const note of detection.notes) args.log(note);
+    plan = {
+      schema: args.schemaFlag ?? detection.schema,
+      schemaSource: args.schemaFlag ? 'convention' : detection.source,
+      generators: fromFlag ?? [DEFAULT_GENERATOR_KIND],
+    };
+    // An explicit flag is always obeyed, because a user may be scaffolding before writing the
+    // schema, but it is never obeyed silently: this is the one path that can put a path DRZL
+    // could not confirm into the config, and detection's whole point is that such a config runs
+    // and reports success having read nothing.
+    if (args.schemaFlag) {
+      const full = path.resolve(args.cwd, args.schemaFlag);
+      if (!fs.existsSync(full)) {
+        args.log(`--schema ${args.schemaFlag} is not there yet. Writing it anyway.`);
+      } else if ((await classifySchemaCandidate(full)).verdict === 'rejected') {
+        args.log(`--schema ${args.schemaFlag} declares no Drizzle tables. Writing it anyway.`);
+      }
+    }
+  }
+
+  // `wx`, so two `init` runs racing each other cannot both believe they created the file. The
+  // existsSync above is the message; this is the guarantee.
+  try {
+    fs.writeFileSync(target, renderInitConfig(plan), { flag: 'wx' });
+  } catch (e: any) {
+    if (e?.code === 'EEXIST') {
+      args.error(
+        `drzl init: drzl.config.ts already exists, so nothing was written. init never ` +
+          `overwrites a config.`
+      );
+      return { code: 1 };
+    }
+    args.error(`drzl init: could not write ${target}: ${e?.message ?? e}`);
+    return { code: 1 };
+  }
+
+  args.log(`Created ${target}`);
+  args.log(`  generators: ${plan.generators.join(', ')}`);
+  if (plan.schema) args.log(`  schema: ${plan.schema}`);
+  else if (plan.schemaSource === 'drizzle-kit') args.log('  schema: from your drizzle-kit config');
+  else
+    args.log(
+      '  schema: not set. Fill in "schema" before running `drzl generate`, or add a ' +
+        'drizzle-kit config.'
+    );
+  return { code: 0, written: target, plan };
+}

--- a/packages/cli/test/commands.e2e.spec.ts
+++ b/packages/cli/test/commands.e2e.spec.ts
@@ -1,9 +1,9 @@
 /**
- * End-to-end coverage for `init`, `generate:orpc` and `watch`, spawned as real processes.
+ * End-to-end coverage for `generate:orpc` and `watch`, spawned as real processes.
  *
- * All three shipped with no automated test of any kind. `init` in particular is the first
- * command a new user runs, and nothing checked that the config it writes can actually be run,
- * let alone that its output compiles.
+ * Both shipped with no automated test of any kind. `init` was covered here too until it grew
+ * prompts and schema detection; it now has `init.e2e.spec.ts` to itself, with its own temp root,
+ * so the two files cannot race each other's fixtures.
  *
  * Requires a build. CI builds before testing; locally, run `pnpm build` first.
  */
@@ -43,39 +43,6 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await fs.rm(ROOT, { recursive: true, force: true });
-});
-
-describe('drzl init', () => {
-  it('writes a config, and that config actually runs', async () => {
-    const dir = await project('init');
-    await run(process.execPath, [CLI, 'init'], { cwd: dir });
-
-    const config = await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8');
-    expect(config).toContain('schema:');
-    expect(config).toContain('generators:');
-
-    // The scaffold is the first config most users see, and it had no type annotation at all, so
-    // it got no completion in an editor. The annotation has to stay type-only: this fixture has
-    // no `@drzl/cli` to resolve, exactly like a project that ran the CLI through `npx`, and the
-    // `generate` below is what proves the import is erased rather than resolved.
-    expect(config).toContain("import type { DrzlConfigInput } from '@drzl/cli/config'");
-    expect(config).toContain('satisfies DrzlConfigInput');
-
-    // The config `init` writes has to be one `generate` accepts. Scaffolding something that
-    // then fails is worse than scaffolding nothing.
-    await run(process.execPath, [CLI, 'generate'], { cwd: dir, maxBuffer: 20 * 1024 * 1024 });
-    expect(existsSync(path.join(dir, 'src', 'api', 'users.ts'))).toBe(true);
-  }, 120_000);
-
-  it('points at the schema path it scaffolds for, not an invented one', async () => {
-    const dir = await project('init-path');
-    await run(process.execPath, [CLI, 'init'], { cwd: dir });
-    const schemaPath = (await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8')).match(
-      /schema:\s*['"]([^'"]+)['"]/
-    )?.[1];
-    expect(schemaPath).toBeTruthy();
-    expect(existsSync(path.join(dir, schemaPath!)), `config names ${schemaPath}`).toBe(true);
-  }, 60_000);
 });
 
 describe('drzl generate:orpc', () => {

--- a/packages/cli/test/init.e2e.spec.ts
+++ b/packages/cli/test/init.e2e.spec.ts
@@ -1,0 +1,301 @@
+/**
+ * End-to-end coverage for `drzl init`, spawned as a real process (items 65, 66, 67).
+ *
+ * `init` is the first command a new user runs, and three things about it were wrong at once:
+ *
+ *   - it advertised `-y, --yes` and then ignored the flag entirely, so the promise of an
+ *     interactive command was made in `--help` and never kept (65);
+ *   - it scaffolded a single `orpc` generator, which is not what the packages, the READMEs, the
+ *     quickstarts or the one example app steer anyone toward (66);
+ *   - it hardcoded `schema: 'src/db/schema.ts'` whether or not that file existed. A config
+ *     naming a file that is not there is not an inert mistake: `drzl generate` analyzed nothing,
+ *     wrote `placeholder.orpc.ts` and exited 0, so the first run of the product reported success
+ *     having read no schema at all (67).
+ *
+ * Requires a build. CI builds before testing; locally, run `pnpm build` first.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { promises as fs, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const run = promisify(execFile);
+const CLI = path.resolve(__dirname, '..', 'dist', 'cli.js');
+const ROOT = path.join(__dirname, '.tmp-init-e2e');
+
+const SCHEMA = `
+import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+`;
+
+/** A project directory with nothing in it. Lives under this package so drizzle-orm resolves. */
+async function bare(name: string) {
+  const dir = path.join(ROOT, name);
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+/** A project with a schema at a given path, relative to its root. */
+async function project(name: string, schemaAt = 'src/db/schema.ts', body = SCHEMA) {
+  const dir = await bare(name);
+  const full = path.join(dir, schemaAt);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, body, 'utf8');
+  return dir;
+}
+
+/** The `schema` value the scaffolded config states, or undefined when it states none. */
+function scaffoldedSchema(config: string): string | undefined {
+  // Anchored at the start of a line so a commented-out `// schema:` example is not read as one.
+  return config.match(/^\s{2}schema:\s*['"]([^'"]+)['"]/m)?.[1];
+}
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.mkdir(ROOT, { recursive: true });
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe('drzl init: the config it writes', () => {
+  it('writes a config, and that config actually runs', async () => {
+    const dir = await project('runs');
+    await run(process.execPath, [CLI, 'init'], { cwd: dir });
+
+    const config = await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8');
+    expect(config).toContain('schema:');
+    expect(config).toContain('generators:');
+
+    // The scaffold is the first config most users see, and it had no type annotation at all, so
+    // it got no completion in an editor. The annotation has to stay type-only: this fixture has
+    // no `@drzl/cli` to resolve, exactly like a project that ran the CLI through `npx`, and the
+    // `generate` below is what proves the import is erased rather than resolved.
+    expect(config).toContain("import type { DrzlConfigInput } from '@drzl/cli/config'");
+    expect(config).toContain('satisfies DrzlConfigInput');
+
+    // The config `init` writes has to be one `generate` accepts, and it has to reach the tables.
+    // Scaffolding something that then fails is worse than scaffolding nothing, and scaffolding
+    // something that succeeds over an empty analysis is worse than either.
+    await run(process.execPath, [CLI, 'generate'], { cwd: dir, maxBuffer: 20 * 1024 * 1024 });
+    expect(existsSync(path.join(dir, 'src', 'validators', 'zod', 'users.zod.ts'))).toBe(true);
+    expect(existsSync(path.join(dir, 'src', 'validators', 'zod', 'index.ts'))).toBe(true);
+  }, 120_000);
+
+  it('defaults to a validator generator, not a router (66)', async () => {
+    const dir = await project('default-generator');
+    await run(process.execPath, [CLI, 'init'], { cwd: dir });
+    const config = await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8');
+
+    // Not a style preference. `@drzl/generator-zod` is a hard dependency of `@drzl/cli`, so it
+    // is installed by definition next to the CLI that scaffolded this; six of the seven route
+    // generators are `optionalDependencies`, and five of those are still at 0.1.0. Both READMEs
+    // lead their minimal config with zod, all three quickstarts put a validator first, and the
+    // only example app in the repository configures zod and nothing else.
+    expect(config).toContain("kind: 'zod'");
+  }, 60_000);
+
+  it('generates real output from the default scaffold, not a no-tables placeholder', async () => {
+    const dir = await project('real-output');
+    await run(process.execPath, [CLI, 'init'], { cwd: dir });
+    await run(process.execPath, [CLI, 'generate'], { cwd: dir, maxBuffer: 20 * 1024 * 1024 });
+
+    // The whole point of 67. A config pointing at a file that is not there analyzed zero tables
+    // and every generator emitted its "no tables detected" placeholder, which `generate` then
+    // reported as success.
+    const written: string[] = [];
+    async function walk(d: string) {
+      for (const e of await fs.readdir(d, { withFileTypes: true })) {
+        if (e.name === 'node_modules') continue;
+        const full = path.join(d, e.name);
+        if (e.isDirectory()) await walk(full);
+        else written.push(path.relative(dir, full));
+      }
+    }
+    await walk(dir);
+    expect(written.some((f) => f.includes('placeholder'))).toBe(false);
+    expect(written.some((f) => f.includes('users'))).toBe(true);
+  }, 120_000);
+});
+
+describe('drzl init: finding the schema (67)', () => {
+  it('finds a conventional schema path and names it', async () => {
+    const dir = await project('conventional');
+    await run(process.execPath, [CLI, 'init'], { cwd: dir });
+    const config = await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8');
+    const schema = scaffoldedSchema(config);
+    expect(schema).toBe('src/db/schema.ts');
+    expect(existsSync(path.join(dir, schema!))).toBe(true);
+  }, 60_000);
+
+  it('finds a conventional schema that is not the hardcoded one', async () => {
+    const dir = await project('conventional-alt', 'src/lib/db/schema.ts');
+    await run(process.execPath, [CLI, 'init'], { cwd: dir });
+    const config = await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8');
+    const schema = scaffoldedSchema(config);
+    expect(schema).toBe('src/lib/db/schema.ts');
+    expect(existsSync(path.join(dir, schema!))).toBe(true);
+  }, 60_000);
+
+  it('reads the schema from a drizzle-kit config, wherever that puts it', async () => {
+    // Deliberately a path no convention would guess, so only reading `drizzle.config.ts` can
+    // find it. This is the reuse item 59 built and item 67 asks for.
+    const dir = await project('kit', 'db/tables/all.ts');
+    await fs.writeFile(
+      path.join(dir, 'drizzle.config.ts'),
+      `export default { dialect: 'postgresql', schema: './db/tables/*.ts', out: './drizzle' };\n`,
+      'utf8'
+    );
+    await run(process.execPath, [CLI, 'init'], { cwd: dir });
+
+    // Whatever it writes, `generate` has to reach the tables. That is the only claim that
+    // matters, and it fails outright on a config naming a file that is not there.
+    const { stdout } = await run(process.execPath, [CLI, 'generate'], {
+      cwd: dir,
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    expect(stdout).not.toContain('placeholder');
+    const config = await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8');
+    const schema = scaffoldedSchema(config);
+    // Either it states a path that exists, or it states none and lets the drizzle-kit fallback
+    // answer. What it must not do is state one that is not there.
+    if (schema) expect(existsSync(path.join(dir, schema))).toBe(true);
+  }, 120_000);
+
+  it('never writes a config naming a schema file that does not exist', async () => {
+    const dir = await bare('no-schema');
+    await run(process.execPath, [CLI, 'init'], { cwd: dir });
+    const config = await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8');
+    const schema = scaffoldedSchema(config);
+    if (schema !== undefined) {
+      expect(existsSync(path.join(dir, schema)), `config names ${schema}, which is not there`).toBe(
+        true
+      );
+    }
+  }, 60_000);
+
+  it('does not adopt a schema file that exports no drizzle tables', async () => {
+    // Existence is not the test. A `src/db/schema.ts` that exports a connection string, or that
+    // a user created empty five minutes ago, produces a config that analyzes nothing and a
+    // `generate` that reports success over an empty analysis.
+    const dir = await project('empty-schema', 'src/db/schema.ts', 'export const DATABASE = 1;\n');
+    await run(process.execPath, [CLI, 'init'], { cwd: dir });
+    const config = await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8');
+    expect(scaffoldedSchema(config)).toBeUndefined();
+  }, 60_000);
+});
+
+describe('drzl init: non-interactive is first-class (65)', () => {
+  it('writes without asking anything when stdin is not a TTY', async () => {
+    const dir = await project('non-tty');
+    // execFile gives the child a pipe for stdin and closes nothing: if `init` ever waits for
+    // input here, this rejects on the vitest timeout rather than passing.
+    await run(process.execPath, [CLI, 'init'], { cwd: dir, timeout: 20_000 });
+    expect(existsSync(path.join(dir, 'drzl.config.ts'))).toBe(true);
+  }, 40_000);
+
+  it('does not hang when stdin is a pipe that stays open', async () => {
+    const dir = await project('open-pipe');
+    const child = spawn(process.execPath, [CLI, 'init'], {
+      cwd: dir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    // Nothing is ever written to the pipe and it is never ended. A prompt reading this stdin
+    // waits for ever, which is the CI hang this command must not have.
+    const code = await new Promise<number | null>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(new Error('drzl init hung on an open stdin pipe'));
+      }, 20_000);
+      child.on('exit', (c) => {
+        clearTimeout(timer);
+        resolve(c);
+      });
+    });
+    expect(code).toBe(0);
+    expect(existsSync(path.join(dir, 'drzl.config.ts'))).toBe(true);
+  }, 40_000);
+
+  it('answers both prompts from flags, and the result generates', async () => {
+    // The flags are the non-interactive half of the prompts, and they are the only way a CI job
+    // or an agent can choose anything other than the default. Both are exercised through
+    // commander here rather than through the functions the unit tests call.
+    const dir = await project('flags', 'src/database/tables.ts');
+    await run(
+      process.execPath,
+      [CLI, 'init', '--schema', 'src/database/tables.ts', '--generators', 'zod,orpc'],
+      { cwd: dir }
+    );
+    const config = await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8');
+    expect(scaffoldedSchema(config)).toBe('src/database/tables.ts');
+    expect(config).toContain("kind: 'zod'");
+    expect(config).toContain("kind: 'orpc'");
+
+    await run(process.execPath, [CLI, 'generate'], { cwd: dir, maxBuffer: 20 * 1024 * 1024 });
+    expect(existsSync(path.join(dir, 'src', 'validators', 'zod', 'users.zod.ts'))).toBe(true);
+    expect(existsSync(path.join(dir, 'src', 'api', 'users.ts'))).toBe(true);
+  }, 120_000);
+
+  it('refuses a generator it cannot scaffold, and writes nothing', async () => {
+    const dir = await project('flags-bad');
+    const failed = await run(process.execPath, [CLI, 'init', '--generators', 'hono'], {
+      cwd: dir,
+    }).catch((e) => e);
+    expect(failed.code).toBe(1);
+    expect(existsSync(path.join(dir, 'drzl.config.ts'))).toBe(false);
+    expect(`${failed.stdout ?? ''}${failed.stderr ?? ''}`).toContain('hono');
+  }, 60_000);
+
+  it('accepts --yes and writes the same config the bare command does', async () => {
+    const plain = await project('yes-plain');
+    const flagged = await project('yes-flagged');
+    await run(process.execPath, [CLI, 'init'], { cwd: plain });
+    await run(process.execPath, [CLI, 'init', '--yes'], { cwd: flagged });
+    const a = await fs.readFile(path.join(plain, 'drzl.config.ts'), 'utf8');
+    const b = await fs.readFile(path.join(flagged, 'drzl.config.ts'), 'utf8');
+    expect(b).toBe(a);
+  }, 60_000);
+});
+
+describe('drzl init: an existing config', () => {
+  it('refuses to overwrite one, and says so in words', async () => {
+    const dir = await project('existing');
+    const target = path.join(dir, 'drzl.config.ts');
+    await fs.writeFile(target, '// mine\n', 'utf8');
+
+    const failed = await run(process.execPath, [CLI, 'init'], { cwd: dir }).catch((e) => e);
+    expect(failed.code).toBe(1);
+    // The file is untouched. That part has always held; the message was a raw Node errno string
+    // ("EEXIST: file already exists, open ..."), which names no command and suggests nothing.
+    expect(await fs.readFile(target, 'utf8')).toBe('// mine\n');
+    const said = `${failed.stdout ?? ''}${failed.stderr ?? ''}`;
+    expect(said).toContain('drzl.config.ts');
+    expect(said).not.toContain('EEXIST');
+  }, 60_000);
+
+  it('will not write a .ts scaffold that shadows a config in another format', async () => {
+    // Not overwriting is only half of "never clobber". `loadConfig` tries the five config names
+    // in a fixed order with `.ts` first, so a `drzl.config.ts` written beside a
+    // `drzl.config.json` leaves that file byte-identical and makes the next `drzl generate` run
+    // the scaffold instead of it. Measured on 4.22.0: `init` wrote the file and exited 0.
+    const dir = await project('shadowing');
+    await fs.writeFile(
+      path.join(dir, 'drzl.config.json'),
+      `{ "schema": "src/db/schema.ts", "generators": [{ "kind": "valibot" }] }\n`,
+      'utf8'
+    );
+
+    const failed = await run(process.execPath, [CLI, 'init'], { cwd: dir }).catch((e) => e);
+    expect(failed.code).toBe(1);
+    expect(existsSync(path.join(dir, 'drzl.config.ts'))).toBe(false);
+    expect(`${failed.stdout ?? ''}${failed.stderr ?? ''}`).toContain('drzl.config.json');
+  }, 60_000);
+});

--- a/packages/cli/test/init.spec.ts
+++ b/packages/cli/test/init.spec.ts
@@ -1,0 +1,475 @@
+/**
+ * `drzl init`, unit level: the detection rule, the generator list, the rendered config, and the
+ * prompt loop driven over ordinary pipes (items 65, 66, 67).
+ *
+ * The prompt functions take their streams as parameters precisely so this file can drive them.
+ * A pseudo-terminal is the one thing a portable test cannot conjure, so the split is deliberate:
+ * `isInteractive` is the only code that reads `isTTY`, and it is tested here against fake
+ * descriptors, while `promptForPlan` is tested over real streams and never learns whether they
+ * are terminals. Between the two there is nothing left for a pty to prove.
+ */
+import { PassThrough } from 'node:stream';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  classifySchemaCandidate,
+  DEFAULT_GENERATOR_KIND,
+  detectSchema,
+  INIT_GENERATOR_CHOICES,
+  isInteractive,
+  normalizeGenerators,
+  parseGeneratorsFlag,
+  promptForPlan,
+  renderInitConfig,
+  runInit,
+  schemaCandidates,
+} from '../src/init';
+
+const ROOT = path.join(__dirname, '.tmp-init-unit');
+
+const SCHEMA = `
+import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+`;
+
+async function make(name: string, files: Record<string, string> = {}) {
+  const dir = path.join(ROOT, name);
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(dir, { recursive: true });
+  for (const [rel, body] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, body, 'utf8');
+  }
+  return dir;
+}
+
+/** Collects what a command printed, so an assertion can be made about it. */
+function recorder() {
+  const lines: string[] = [];
+  return { lines, sink: (s: string) => lines.push(s), text: () => lines.join('\n') };
+}
+
+beforeAll(async () => {
+  await fs.mkdir(ROOT, { recursive: true });
+});
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe('the generators init offers (66)', () => {
+  it('offers only kinds @drzl/cli depends on outright', async () => {
+    // The rule that keeps an unpublishable generator out of the scaffold. `optionalDependencies`
+    // are skipped by the installer when they are not on the registry, which is the state eight
+    // of the generators are in, including every route generator except oRPC; a config naming one
+    // would fail its first `generate` on a module that was never installed. Asserted against
+    // package.json rather than restated, so moving a generator between the two lists moves this
+    // test with it.
+    const pkg = JSON.parse(
+      await fs.readFile(path.join(__dirname, '..', 'package.json'), 'utf8')
+    ) as {
+      dependencies: Record<string, string>;
+      optionalDependencies: Record<string, string>;
+    };
+    for (const choice of INIT_GENERATOR_CHOICES) {
+      expect(pkg.dependencies, `${choice.kind} must be a hard dependency`).toHaveProperty(
+        choice.packageName
+      );
+      expect(pkg.optionalDependencies ?? {}).not.toHaveProperty(choice.packageName);
+    }
+  });
+
+  it('defaults to a validator, not a router', () => {
+    expect(DEFAULT_GENERATOR_KIND).toBe('zod');
+    expect(INIT_GENERATOR_CHOICES[0].kind).toBe('zod');
+  });
+
+  it('refuses a kind it cannot scaffold, naming the ones it can', () => {
+    expect(() => normalizeGenerators(['trpc'])).toThrow(/not a generator init can scaffold/);
+    // The message has to carry the alternatives, or the error is a dead end.
+    expect(() => normalizeGenerators(['trpc'])).toThrow(/zod/);
+  });
+
+  it('deduplicates and orders what it is given', () => {
+    expect(normalizeGenerators(['orpc', 'zod', 'orpc'])).toEqual(['zod', 'orpc']);
+    expect(normalizeGenerators(undefined)).toBeUndefined();
+    expect(parseGeneratorsFlag('zod, orpc')).toEqual(['zod', 'orpc']);
+    expect(parseGeneratorsFlag(undefined)).toBeUndefined();
+    expect(() => parseGeneratorsFlag(' , ')).toThrow(/no kinds/);
+  });
+});
+
+describe('classifying a candidate by loading it (67)', () => {
+  it('confirms a file that declares drizzle tables', async () => {
+    const dir = await make('classify-good', { 'src/db/schema.ts': SCHEMA });
+    const report = await classifySchemaCandidate(path.join(dir, 'src/db/schema.ts'));
+    expect(report.verdict).toBe('confirmed');
+    expect(report.tables).toBe(1);
+  }, 30_000);
+
+  it('rejects a file that imports cleanly and declares none', async () => {
+    // The case that makes existence useless as a test. This file is named `schema.ts`, sits at
+    // the most conventional path there is, and is not a schema.
+    const dir = await make('classify-empty', {
+      'src/db/schema.ts': 'export const DB_URL = "x";\n',
+    });
+    const report = await classifySchemaCandidate(path.join(dir, 'src/db/schema.ts'));
+    expect(report.verdict).toBe('rejected');
+  }, 30_000);
+
+  it('leaves a file it could not import unverified rather than rejected', async () => {
+    // Almost always "install has not been run yet". Rejecting it would send a user with a
+    // perfectly good schema down the no-schema path, so it is adopted with a warning instead.
+    const dir = await make('classify-broken', {
+      'src/db/schema.ts': `import { x } from 'no-such-package-anywhere';\nexport const t = x;\n`,
+    });
+    const report = await classifySchemaCandidate(path.join(dir, 'src/db/schema.ts'));
+    expect(report.verdict).toBe('unverified');
+    expect(report.reason).toBeTruthy();
+  }, 30_000);
+
+  it('treats a missing file as rejected, not as a crash', async () => {
+    const dir = await make('classify-missing');
+    const report = await classifySchemaCandidate(path.join(dir, 'nope.ts'));
+    expect(report.verdict).toBe('rejected');
+  }, 30_000);
+});
+
+describe('detection order (67)', () => {
+  it('prefers the drizzle-kit config over a conventional path', async () => {
+    // Both are present and they disagree. The kit config is a statement the user wrote; the
+    // conventional path is a guess, so the statement wins.
+    const dir = await make('detect-kit-wins', {
+      'src/db/schema.ts': SCHEMA,
+      'db/tables/all.ts': SCHEMA,
+      'drizzle.config.ts': `export default { dialect: 'postgresql', schema: './db/tables/*.ts' };\n`,
+    });
+    const detection = await detectSchema(dir);
+    expect(detection.source).toBe('drizzle-kit');
+    // Nothing is written into `schema`: the kit config is read at generate time, so the path
+    // stays stated exactly once.
+    expect(detection.schema).toBeUndefined();
+    expect(detection.tables).toBe(1);
+  }, 30_000);
+
+  it('falls back to the conventional walk when the kit config names no tables', async () => {
+    const dir = await make('detect-kit-empty', {
+      'src/db/schema.ts': SCHEMA,
+      'db/tables/all.ts': 'export const nothing = 1;\n',
+      'drizzle.config.ts': `export default { dialect: 'postgresql', schema: './db/tables/*.ts' };\n`,
+    });
+    const detection = await detectSchema(dir);
+    expect(detection.source).toBe('convention');
+    expect(detection.schema).toBe('src/db/schema.ts');
+  }, 30_000);
+
+  it('walks past a conventional path that declares no tables to one that does', async () => {
+    // `src/db/schema.ts` comes first in the candidate order and is not a schema; the one further
+    // down is. Existence-based detection stops at the first and produces a config that analyzes
+    // nothing.
+    const dir = await make('detect-walk-past', {
+      'src/db/schema.ts': 'export const notASchema = true;\n',
+      'src/lib/db/schema.ts': SCHEMA,
+    });
+    const detection = await detectSchema(dir);
+    expect(detection.schema).toBe('src/lib/db/schema.ts');
+    expect(detection.verdict).toBe('confirmed');
+  }, 60_000);
+
+  it('prefers a confirmed candidate over an unverified one earlier in the order', async () => {
+    const dir = await make('detect-confirmed-wins', {
+      'src/db/schema.ts': `import { x } from 'no-such-package-anywhere';\nexport const t = x;\n`,
+      'src/schema.ts': SCHEMA,
+    });
+    const detection = await detectSchema(dir);
+    expect(detection.schema).toBe('src/schema.ts');
+    expect(detection.verdict).toBe('confirmed');
+  }, 60_000);
+
+  it('reports none when there is nothing, rather than inventing a path', async () => {
+    const dir = await make('detect-none');
+    const detection = await detectSchema(dir);
+    expect(detection.source).toBe('none');
+    expect(detection.schema).toBeUndefined();
+  }, 30_000);
+
+  it('lists every candidate as a real relative path with a schema-shaped name', () => {
+    const candidates = schemaCandidates();
+    expect(candidates[0]).toBe('src/db/schema.ts');
+    expect(new Set(candidates).size).toBe(candidates.length);
+    for (const c of candidates) {
+      expect(path.isAbsolute(c)).toBe(false);
+      // Importing a candidate is how it is validated, so the list must not contain a module that
+      // might open a connection rather than declare tables.
+      expect(c.replace(/\.(ts|js)$/, '').replace(/\/index$/, '')).toMatch(/(schema|schemas)$/);
+    }
+  });
+});
+
+describe('the config it renders', () => {
+  it('keeps the type-only import and the satisfies (item 64)', () => {
+    const out = renderInitConfig({
+      schema: 'a.ts',
+      schemaSource: 'convention',
+      generators: ['zod'],
+    });
+    expect(out).toContain("import type { DrzlConfigInput } from '@drzl/cli/config'");
+    expect(out).toContain('satisfies DrzlConfigInput');
+    // A value import would be executed by jiti and would fail under `npx` in a project with no
+    // local @drzl/cli. `import type` is erased first, which is the only reason the scaffold runs
+    // there at all.
+    expect(out).not.toContain('import { defineConfig }');
+  });
+
+  it('states no schema key when there is no schema to name', () => {
+    const none = renderInitConfig({ schemaSource: 'none', generators: ['zod'] });
+    expect(none).not.toMatch(/^ {2}schema:/m);
+    expect(none).toContain("// schema: 'src/db/schema.ts'");
+    const kit = renderInitConfig({ schemaSource: 'drizzle-kit', generators: ['zod'] });
+    expect(kit).not.toMatch(/^ {2}schema:/m);
+    expect(kit).toContain('drizzle-kit config');
+  });
+
+  it('only carries outDir when something writes routers into it', () => {
+    const validators = renderInitConfig({ schemaSource: 'none', generators: ['zod'] });
+    expect(validators).not.toContain('outDir');
+    const router = renderInitConfig({ schemaSource: 'none', generators: ['orpc'] });
+    expect(router).toContain(`outDir: 'src/api'`);
+  });
+});
+
+describe('deciding whether to ask (65)', () => {
+  const env = {} as Record<string, string | undefined>;
+
+  it('asks only when both streams are terminals', () => {
+    expect(isInteractive({ stdin: { isTTY: true }, stdout: { isTTY: true }, env })).toBe(true);
+    expect(isInteractive({ stdin: { isTTY: false }, stdout: { isTTY: true }, env })).toBe(false);
+    // A question printed down a redirected stdout is invisible, so waiting for its answer is a
+    // hang from the point of view of whoever is looking at the terminal.
+    expect(isInteractive({ stdin: { isTTY: true }, stdout: { isTTY: false }, env })).toBe(false);
+    expect(isInteractive({ stdin: {}, stdout: {}, env })).toBe(false);
+  });
+
+  it('never asks under CI, even on a pty', () => {
+    // Some runners do allocate one. A hung `init` in a pipeline is worse than the defect that
+    // prompts were added to fix.
+    expect(
+      isInteractive({ stdin: { isTTY: true }, stdout: { isTTY: true }, env: { CI: 'true' } })
+    ).toBe(false);
+  });
+});
+
+describe('the prompt loop, over ordinary pipes (65)', () => {
+  /** Drive `promptForPlan` with scripted answers, one per question asked. */
+  async function drive(
+    args: Omit<Parameters<typeof promptForPlan>[0], 'input' | 'output'>,
+    answers: string[]
+  ) {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    let printed = '';
+    output.on('data', (d) => {
+      printed += d.toString();
+    });
+    const done = promptForPlan({ ...args, input, output });
+    for (const a of answers) {
+      await new Promise((r) => setTimeout(r, 25));
+      input.write(a + '\n');
+    }
+    const result = await done;
+    return { result, printed };
+  }
+
+  const detected = {
+    source: 'convention' as const,
+    schema: 'src/db/schema.ts',
+    verdict: 'confirmed' as const,
+    tables: 2,
+    notes: ['Schema found at src/db/schema.ts (2 tables)'],
+  };
+
+  it('takes the detected schema and zod when both answers are empty', async () => {
+    const { result, printed } = await drive({ detection: detected, cwd: ROOT }, ['', '']);
+    expect(result.schema).toBe('src/db/schema.ts');
+    expect(result.generators).toEqual(['zod']);
+    expect(printed).toContain('Schema file [src/db/schema.ts]');
+    expect(printed).toContain('1) Zod validators');
+  }, 30_000);
+
+  it('takes a typed schema path and a numbered generator', async () => {
+    const dir = await make('prompt-typed', { 'src/database/tables.ts': SCHEMA });
+    const { result } = await drive({ detection: detected, cwd: dir }, [
+      'src/database/tables.ts',
+      '5',
+    ]);
+    expect(result.schema).toBe('src/database/tables.ts');
+    expect(result.generators).toEqual(['orpc']);
+  }, 30_000);
+
+  it('accepts a generator by name as well as by number', async () => {
+    const { result } = await drive({ detection: detected, cwd: ROOT }, ['', 'valibot']);
+    expect(result.generators).toEqual(['valibot']);
+  }, 30_000);
+
+  it('re-asks a choice that is not on the list, then falls back rather than looping', async () => {
+    const { result, printed } = await drive({ detection: detected, cwd: ROOT }, [
+      '',
+      'prisma',
+      'nonsense',
+      'still-no',
+    ]);
+    expect(printed).toContain('"prisma" is not one of the choices.');
+    expect(result.generators).toEqual(['zod']);
+  }, 30_000);
+
+  it('skips the question a flag already answered', async () => {
+    // Only one answer is scripted, and it is consumed by the generator question, which proves
+    // the schema question was never asked.
+    const { result, printed } = await drive(
+      { detection: detected, cwd: ROOT, schemaFromFlag: 'given/by/flag.ts' },
+      ['3']
+    );
+    expect(printed).not.toContain('Schema file');
+    expect(result.schema).toBe('given/by/flag.ts');
+    expect(result.generators).toEqual(['arktype']);
+  }, 30_000);
+
+  it('asks nothing at all when both flags are given', async () => {
+    const { result, printed } = await drive(
+      {
+        detection: detected,
+        cwd: ROOT,
+        schemaFromFlag: 'given/by/flag.ts',
+        generatorsFromFlag: ['zod', 'orpc'],
+      },
+      []
+    );
+    expect(printed).toBe('');
+    expect(result.generators).toEqual(['zod', 'orpc']);
+  }, 30_000);
+
+  it('takes the defaults and stops when the input ends mid-question', async () => {
+    // The Ctrl+D case, and the only thing standing between a prompt and an unkillable CI job.
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const done = promptForPlan({ input, output, detection: detected, cwd: ROOT });
+    setTimeout(() => input.end(), 30);
+    const result = await done;
+    expect(result.endedEarly).toBe(true);
+    expect(result.schema).toBe('src/db/schema.ts');
+    expect(result.generators).toEqual(['zod']);
+  }, 30_000);
+});
+
+describe('runInit as a whole', () => {
+  it('writes nothing and reports the file when a config is already there', async () => {
+    const dir = await make('run-existing', { 'drzl.config.ts': '// mine\n' });
+    const log = recorder();
+    const err = recorder();
+    const outcome = await runInit({
+      cwd: dir,
+      yes: true,
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      env: {},
+      log: log.sink,
+      error: err.sink,
+    });
+    expect(outcome.code).toBe(1);
+    expect(outcome.written).toBeUndefined();
+    expect(await fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8')).toBe('// mine\n');
+    expect(err.text()).toContain('drzl.config.ts');
+    expect(err.text()).toContain('never overwrites');
+    // The old message was the raw errno string, which named no command and suggested nothing.
+    expect(err.text()).not.toContain('EEXIST');
+  }, 30_000);
+
+  it('asks nothing under --yes even when both streams are terminals', async () => {
+    const dir = await make('run-yes-on-tty', { 'src/db/schema.ts': SCHEMA });
+    const stdin = Object.assign(new PassThrough(), { isTTY: true });
+    const stdout = Object.assign(new PassThrough(), { isTTY: true });
+    let printed = '';
+    stdout.on('data', (d) => {
+      printed += d.toString();
+    });
+    const log = recorder();
+    const outcome = await runInit({
+      cwd: dir,
+      yes: true,
+      stdin,
+      stdout,
+      env: {},
+      log: log.sink,
+      error: log.sink,
+    });
+    expect(outcome.code).toBe(0);
+    // Nothing was written to the terminal stream: every line went to `log`, and no question was
+    // asked. If `--yes` ever stopped short-circuiting, this test would time out instead.
+    expect(printed).toBe('');
+    expect(outcome.plan?.generators).toEqual(['zod']);
+    expect(outcome.plan?.schema).toBe('src/db/schema.ts');
+  }, 30_000);
+
+  it('rejects an unknown --generators kind before touching the disk', async () => {
+    const dir = await make('run-bad-generators', { 'src/db/schema.ts': SCHEMA });
+    const err = recorder();
+    const outcome = await runInit({
+      cwd: dir,
+      yes: true,
+      generatorsFlag: 'zod,hono',
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      env: {},
+      log: () => {},
+      error: err.sink,
+    });
+    expect(outcome.code).toBe(1);
+    await expect(fs.readFile(path.join(dir, 'drzl.config.ts'), 'utf8')).rejects.toThrow();
+    expect(err.text()).toContain('hono');
+  }, 30_000);
+
+  it('uses --schema verbatim and says so when it declares no tables', async () => {
+    const dir = await make('run-schema-flag', { 'weird/place.ts': 'export const x = 1;\n' });
+    const log = recorder();
+    const outcome = await runInit({
+      cwd: dir,
+      yes: true,
+      schemaFlag: 'weird/place.ts',
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      env: {},
+      log: log.sink,
+      error: log.sink,
+    });
+    expect(outcome.code).toBe(0);
+    expect(outcome.plan?.schema).toBe('weird/place.ts');
+    // An explicit flag is obeyed, because the user may be scaffolding before writing the schema.
+    // Silence would be the defect; the line is what stops it being silent.
+    expect(log.text()).toContain('declares no Drizzle tables');
+  }, 30_000);
+
+  it('says so when --schema names a file that is not there', async () => {
+    const dir = await make('run-schema-flag-missing');
+    const log = recorder();
+    const outcome = await runInit({
+      cwd: dir,
+      yes: true,
+      schemaFlag: 'src/db/not-written-yet.ts',
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      env: {},
+      log: log.sink,
+      error: log.sink,
+    });
+    expect(outcome.code).toBe(0);
+    expect(outcome.plan?.schema).toBe('src/db/not-written-yet.ts');
+    // "declares no Drizzle tables" would be the wrong sentence about a file that does not exist,
+    // and it is the one the analyzer's verdict alone would produce.
+    expect(log.text()).toContain('is not there yet');
+  }, 30_000);
+});


### PR DESCRIPTION
Plan items 65, 66 and 67 as one coherent change to `drzl init`.

## The measured starting point, worse than the plan recorded

Run against the shipped 4.22.0 binary, not the source: in an empty directory `init` exits 0 writing `schema: 'src/db/schema.ts'` for a file that is not there, and the `drzl generate` that follows **also exits 0**, analyzes nothing, and writes a placeholder reading "No tables detected in analysis". The first two commands a new user runs both report success having read no schema at all. `--yes` was never read (the action signature was `async (_opts: any)`), so `init` and `init --yes` were byte-identical, proven under a real pty as well. And `init` beside an existing `drzl.config.json` wrote `drzl.config.ts` and exited 0: nothing was clobbered, but the loader tries `.ts` first, so the user's config was **shadowed** and the next `generate` ran the scaffold instead.

## The three decisions, each argued from measurement

- **65, build the prompts.** The flag's promise is exactly the CI-safe path that must exist anyway, so dropping it would remove the name for the behavior everything depends on. Interactive requires **stdin and stdout** to be TTYs with `CI` unset, because a question printed down a redirected stdout is invisible and waiting for its answer is a hang. No prompt library was added (none is a dependency anywhere); `node:readline/promises` is imported inside the interactive branch and wrapped, so a runtime that cannot provide it degrades to defaults rather than throwing. `--schema` and `--generators` make every question answerable from a script.
- **66, default to zod, enforced structurally.** `init` offers only kinds the CLI lists in `dependencies`, never `optionalDependencies`, so every scaffoldable kind is installed beside the CLI by definition and none of the seven packages awaiting a manual first publish can be offered; a unit test asserts the offered list against `package.json`. Supporting evidence for zod: both READMEs lead with it, all three quickstarts put a validator first, and the repo's only example app is zod-only.
- **67, drizzle-kit first, then convention, validated by loading.** Detection calls item 59's `resolveSchemaSource`, so `init` and `generate` cannot disagree, and a confirmed kit config makes the scaffold state **no** `schema` key at all rather than duplicating the path. Otherwise 28 conventional candidates, every stem ending in `schema`/`schemas` because candidates are imported and guessing `src/db/index.ts` would as often open a database connection. The validation rule comes from three measured analyzer outcomes: tables found confirms; a `DRZL_ANL_IMPORT` error is adopted as unverified with a printed reason (usually "install has not run yet"); a clean zero-table load is rejected and the walk continues. Nothing found writes the key commented out, and `generate` then fails loudly instead of writing a placeholder.

## Proofs

A real pty driver (answering only when a prompt appears) covers defaults, typed answers with live feedback (`src/database/tables.ts: 1 table`), and **closing stdin mid-prompt**, which exits 0 with the defaults and no stack trace. Two e2e tests cover the shapes that would hang: a piped stdin, and a pipe held open that never closes (failing explicitly if the process does not exit). `isInteractive` is unit-tested over fake descriptors including `CI` set on a pty, and the prompt loop over real `PassThrough` streams so the interactive path is exercised without a pty in CI.

Red-first: the e2e file was written against the shipped surface and run before any source change, **6 of 12 failing**, and the failures were exactly items 66 and 67 plus the raw-errno message. All 12 pass now, plus 3 added after. End to end: the default scaffold plus `drzl generate` produces a real zod tree and no placeholder.

## Gates

Full suite green including `pnpm verify:packed` unmodified. Worth recording: **the gate caught a real defect in this branch**, since its docs-probe stage compiles every documented config standalone and reported `cli/init.md:105 DOES NOT TYPECHECK` for an example using `satisfies DrzlConfigInput` without its `import type` line. Fixed and re-run green. The gate has no `init` stage of its own (every CLI invocation in it is generate/analyze/doctor), so the changed scaffold moved nothing there.

Changeset kept at **minor**: `init` refuses to run when a config exists, so it is effectively a once-per-project human command and cannot break a re-run pipeline.

## Filed, not fixed

**BX (Tier C)**: `config.ts` defaults `generators` to `[{ kind: 'orpc' }]`, so a config that omits the key entirely still scaffolds oRPC routers, which is item 66's complaint on a second surface. Unlike `init`, changing it alters behavior for configs that already exist, so it is a bump decision (drop the default and name the choices in the error, or default to zod to match `init`) rather than a fix to slip in here.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
