### PR TITLE
feat: one output layer for the CLI (items 72, 73, 74, 76, 77)

### DIFF
--- a/.changeset/cli-output-layer.md
+++ b/.changeset/cli-output-layer.md
@@ -1,0 +1,55 @@
+---
+'@drzl/cli': minor
+---
+
+One output layer for the whole CLI: streams, colour, `--json`, `--quiet` and exit codes (plan
+items 72, 73, 74, 76, 77).
+
+**`NO_COLOR` is honoured.** It was not, at all: `chalk@6.0.0` vendors a `supports-color` that
+contains the string `NO_COLOR` zero times, so `drzl doctor` emitted the same 32 escape sequences
+with the variable set as without it. Colour is now decided in one place from `NO_COLOR`,
+`FORCE_COLOR`, `TERM` and whether the specific stream is a terminal. `NO_COLOR` wins over
+`FORCE_COLOR`, which is not what chalk does and is deliberate: `NO_COLOR` is what a person puts in
+a shell profile, `FORCE_COLOR` is what a wrapper injects.
+
+**Colour is decided per stream.** chalk's default instance takes its level from stdout alone, so
+`drzl generate > out.txt` with a terminal still on stderr turned the warnings on that terminal
+colourless. Each stream now gets its own answer.
+
+**No escape sequence reaches a pipe.** `ora`'s success symbol came from `log-symbols`, which
+colours through `yoctocolors` and never asks whether the stream is a terminal, so on any machine
+with `TERM` set `drzl analyze 2> log` wrote `\x1b[32m✔\x1b[39m` into the file. The symbol and the
+spinner frame are rendered through the shared decision now.
+
+**stdout is the answer, stderr is the narration.** The sponsor tip was written with `console.log`,
+putting 246 bytes of advertisement into the file list a script was parsing; it is on stderr now,
+and is shown only where an aside has a reader. `init` and `watch` print nothing to stdout at all,
+because what they produce is a file on disk and a running process.
+
+**`--json` and `-q, --quiet` on every command**, not three and none. `--json` writes exactly one
+JSON document to stdout and nothing anywhere else, on success and on failure alike, so
+`drzl <cmd> --json | jq .` parses with no filtering. Every document carries `command` and
+`exitCode`; failures carry `ok`, `code` and `message`. `analyze` and `doctor` keep their published
+payloads with the envelope merged in at the top level, so existing readers of `.issues` and
+`.findings` are unaffected. `--quiet` drops narration and never drops an error or changes an exit
+code.
+
+**Three exit codes, documented in one place** (`docs/cli/output.md`): `0` did the work, `1` could
+not do the work, `2` did the work and found something. Four codes moved:
+
+- `generate` with no config was `2`, now `1`.
+- `generate --check` with drift was `1`, now `2`.
+- `watch` with no config or an unresolvable schema was `2`, now `1`.
+- `analyze` on a missing or unimportable schema was `2`, now `1`; an error-level issue in a schema
+  it did read stays `2`.
+
+And a command stopped reporting success when it had failed: `generate:orpc` and `generate:trpc`
+given a schema that does not exist exited `0` after writing a placeholder file reading "No tables
+detected in analysis". They exit `1` and write nothing.
+
+**The progress bar only appears when it can say something.** It was drawn for a single table,
+painting one frame at `0%` before being wiped. Measured: the generator loop costs about 105ms fixed
+plus 3.6ms per table and `cli-progress` redraws at 10fps, so it is now drawn only at a terminal,
+only without `--quiet` or `--json`, and only from 25 tables up, which is where the loop first
+outlasts a frame. It is also started per generator rather than once for the run, which fixes a
+config with two generators drawing nothing for the second.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -61,6 +61,7 @@ export default {
           { text: 'Generate (oRPC)', link: '/cli/generate-orpc' },
           { text: 'Generate (tRPC)', link: '/cli/generate-trpc' },
           { text: 'Watch', link: '/cli/watch' },
+          { text: 'Output & exit codes', link: '/cli/output' },
         ],
       },
       {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,9 @@ bunx @drzl/cli --help
 
 :::
 
+Every command shares the same output rules, the same `--json` contract and the same three exit
+codes: see [Output & exit codes](/cli/output).
+
 Jump to commands:
 
 - Init: set up a starter config → [/cli/init](/cli/init)
@@ -32,6 +35,17 @@ Jump to commands:
 - Generate: run configured generators → [/cli/generate](/cli/generate)
 - Generate (oRPC): quick oRPC without config → [/cli/generate-orpc](/cli/generate-orpc)
 - Watch: watch schema and regenerate → [/cli/watch](/cli/watch)
+- Output: streams, colour, `--json`, exit codes → [/cli/output](/cli/output)
+
+## Every command
+
+- `--json`: write one JSON document to stdout and nothing else
+- `-q, --quiet`: drop the progress narration on stderr; errors still print
+- stdout carries the answer, stderr carries the narration
+- colour is off on a stream that is not a terminal, and off entirely under `NO_COLOR`
+- `0` did the work, `1` could not do the work, `2` did the work and found something
+
+All four are documented in [Output & exit codes](/cli/output).
 
 ## Commands & Options
 
@@ -65,10 +79,11 @@ Options:
 
 - `--relations` (default true): include relation inference
 - `--validate` (default true): validate constraints
-- `--out <file>`: write JSON to file
-- `--json` (default false): print JSON to stdout (overrides `--out`)
+- `--out <file>`: write JSON to file, as a bare `Analysis` with no envelope
+- `--json` (default false): print one JSON document to stdout (overrides `--out`)
 
-Exits non‑zero when errors are found in `issues`.
+Exits `1` when the schema could not be read at all, and `2` when it was read and `issues` holds an
+error-level entry. See [Exit codes](/cli/output#exit-codes).
 
 ### doctor
 
@@ -102,6 +117,7 @@ Options:
 - `-c, --config <path>`: which config to read the schema path from
 - `--json`: print the report as JSON instead of prose
 - `--strict`: exit `2` when anything is reported
+- `-q, --quiet`: drop the narration on stderr; the report still prints
 
 Exits `0` by default even with findings, because a schema carrying a `customType` is normal and
 usable. Exits `1` only when the schema could not be read at all.
@@ -137,11 +153,15 @@ bunx @drzl/cli generate -c drzl.config.ts
 Options:
 
 - `-c, --config <path>`: path to config file
+- `--check`: regenerate and report drift without changing the tree
+- `--json`, `-q, --quiet`
 
 Behavior:
 
 - Analyzes your schema
-- Runs each generator in `generators[]`, printing a file summary per kind
+- Runs each generator in `generators[]`, printing a file summary per kind on stdout
+- Warnings, the spinner and the progress bar go to stderr, so `drzl generate > files.txt` holds
+  only the paths that were written
 
 ### generate:orpc
 
@@ -174,6 +194,10 @@ Options:
 - `-o, --outDir <dir>` (default `src/api`)
 - `--template <name>` (default `standard`): can be `standard` or a custom path
 - `--includeRelations`: include relation endpoints
+- `--json`, `-q, --quiet`
+
+Exits `1` when the schema is missing or cannot be imported. It used to exit `0` after writing a
+placeholder file that read "No tables detected in analysis".
 
 ### generate:trpc
 
@@ -205,6 +229,9 @@ Options:
 - `--template <name>` (default `standard`): `standard` or `service`
 - `--includeRelations`: include a lookup per single-column foreign key
 - `--servicesDir <dir>` (default `src/services`): only consulted by `--template service`
+- `--json`, `-q, --quiet`
+
+Exits `1` when the schema is missing or cannot be imported.
 
 See [Generate (tRPC)](/cli/generate-trpc).
 
@@ -239,7 +266,12 @@ Options:
 - `-c, --config <path>`
 - `--pipeline <name>`: `all | analyze | generate-orpc | generate-trpc | generate-hono | generate-express | generate-fastify | generate-nestjs | generate-graphql` (default `all`)
 - `--debounce <ms>`: debounce milliseconds (default `200`)
-- `--json`: emit structured JSON logs
+- `--json`: emit structured JSON logs on stdout, one object per line
+- `-q, --quiet`: drop the narration; errors still print
+- `--poll`: force polling, which helps on WSL, Docker and network mounts
+
+A watch has no answer to give, so everything human it prints goes to stderr. Exits `1` when there
+is no config or the schema path cannot be resolved.
 
 ### init
 
@@ -265,10 +297,17 @@ bunx @drzl/cli init
 
 :::
 
+Options:
+
+- `-y, --yes`: take the defaults and ask nothing
+- `--schema <path>`, `--generators <list>`
+- `--json` (implies `--yes`), `-q, --quiet`
+
 ---
 
 See also:
 
+- Output, `--json` and exit codes: [/cli/output](/cli/output)
 - Config reference: [/guide/configuration](/guide/configuration)
 - Generators:
   - [/generators/orpc](/generators/orpc)

--- a/docs/cli/analyze.md
+++ b/docs/cli/analyze.md
@@ -28,7 +28,38 @@ Options:
 
 - `--relations` (default true): include relation inference
 - `--validate` (default true): validate constraints
-- `--out <file>`: write JSON to file
-- `--json`: print JSON to stdout (overrides `--out`)
+- `--out <file>`: write JSON to file, as a bare `Analysis` with no envelope
+- `--json`: print one JSON document to stdout (overrides `--out`)
+- `-q, --quiet`: drop the spinner on stderr; the analysis and any error still print
 
-Exits non‑zero when `issues` include any errors.
+## Streams
+
+The analysis goes to stdout and the spinner goes to stderr, so `drzl analyze src/db/schema.ts >
+analysis.json` writes a file holding JSON and nothing else. See
+[Output & exit codes](/cli/output).
+
+## `--json`
+
+The `Analysis`, with `command` and `exitCode` merged in at the top level, so `.dialect`, `.tables`
+and `.issues` are where they have always been:
+
+```json
+{ "command": "analyze", "exitCode": 0, "dialect": "postgres", "tables": [], "issues": [] }
+```
+
+A failure is a document too, never prose on stdout:
+
+```json
+{ "ok": false, "command": "analyze", "code": "DRZL_CLI_ANALYZE", "message": "...", "exitCode": 1 }
+```
+
+## Exit codes
+
+| Code | When                                                                            |
+| ---- | ------------------------------------------------------------------------------- |
+| `0`  | The schema was analysed and nothing in `issues` is an error.                    |
+| `1`  | The schema is missing, or importing it threw. There is no analysis to print.    |
+| `2`  | The schema was analysed and `issues` holds an error-level entry.                |
+
+`1` and `2` were both `2` before. They are different events: the first means the document you
+asked for is not there, the second means it is there and something in it needs looking at.

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -147,6 +147,8 @@ npx @drzl/cli doctor src/db/schema.ts --json
 
 ```json
 {
+  "command": "doctor",
+  "exitCode": 0,
   "schema": "src/db/schema.ts",
   "dialect": "postgres",
   "ok": false,
@@ -162,6 +164,11 @@ npx @drzl/cli doctor src/db/schema.ts --json
   ]
 }
 ```
+
+`ok` here means "there is nothing to report about your schema", which it has always meant. It is
+not a statement about whether the run worked: a report full of findings is a perfectly successful
+`doctor`. The run's own answer is `exitCode`, and that is why the shared envelope defines no `ok`
+of its own. See [Output & exit codes](/cli/output#one-name-two-meanings-and-why).
 
 `kind` is a stable identifier, so a CI step can count one category without matching on prose:
 
@@ -198,4 +205,5 @@ validator check the value, which nothing can do for a `customType`, but it recov
 TypeScript type so the call site is still narrowed. See
 [Generators → Zod](/generators/zod#typedjson).
 
-See also: [Analyze](/cli/analyze) · [Generate](/cli/generate)
+See also: [Analyze](/cli/analyze) · [Generate](/cli/generate) ·
+[Output & exit codes](/cli/output)

--- a/docs/cli/generate-orpc.md
+++ b/docs/cli/generate-orpc.md
@@ -29,3 +29,24 @@ Options:
 - `-o, --outDir <dir>` (default `src/api`)
 - `--template <name>` (default `standard`): can be `standard` or a custom path
 - `--includeRelations`: include relation endpoints
+- `--json`: one JSON document on stdout
+- `-q, --quiet`: silent on success, errors still on stderr
+
+## Exit codes
+
+`0` when it generated, and `1` when the schema is missing or could not be imported. It used to exit
+`0` for a schema that was never read, having written a `placeholder.orpc.ts` whose contents read
+"No tables detected in analysis": the command reported success and a CI step guarding the generated
+tree passed. See [Output & exit codes](/cli/output#exit-codes).
+
+## `--json`
+
+```json
+{
+  "ok": true,
+  "command": "generate:orpc",
+  "exitCode": 0,
+  "generators": [{ "kind": "orpc", "files": ["/abs/path/users.ts"] }]
+}
+```
+

--- a/docs/cli/generate-trpc.md
+++ b/docs/cli/generate-trpc.md
@@ -58,3 +58,25 @@ import { appRouter } from './src/api/index.js';
 
 createHTTPServer({ router: appRouter, createContext: () => ({}) }).listen(3000);
 ```
+
+## Options, output and exit codes
+
+- `-o, --outDir <dir>` (default `src/api`)
+- `--template <name>` (default `standard`): `standard` or `service`
+- `--includeRelations`, `--servicesDir <dir>`
+- `--json`: one JSON document on stdout
+- `-q, --quiet`: silent on success, errors still on stderr
+
+`0` when it generated, and `1` when the schema is missing, could not be imported, or the generator
+is not installed. It used to exit `0` for a schema that was never read.
+
+```json
+{
+  "ok": true,
+  "command": "generate:trpc",
+  "exitCode": 0,
+  "generators": [{ "kind": "trpc", "files": ["/abs/path/users.ts"] }]
+}
+```
+
+See [Output & exit codes](/cli/output).

--- a/docs/cli/generate.md
+++ b/docs/cli/generate.md
@@ -24,10 +24,21 @@ bunx @drzl/cli generate -c drzl.config.ts
 
 :::
 
+Options:
+
+- `-c, --config <path>`: path to the config
+- `--check`: regenerate and report drift without changing the tree
+- `--json`: one JSON document on stdout, described in [Output](/cli/output#generate-json)
+- `-q, --quiet`: silent on success, errors still on stderr
+
 Behavior:
 
 - Analyzes your schema then runs each generator in `generators[]`
-- Prints a file summary per generator kind
+- Prints a file summary per generator kind on stdout
+- Puts warnings, the spinner and the progress bar on stderr, so `drzl generate > files.txt` holds
+  only the paths that were written
+- Draws a progress bar only at a terminal, and only for a schema with enough tables that it will
+  move; see [Output](/cli/output)
 
 When the config has no `schema` key, the path is read from your drizzle-kit config
 (`drizzle.config.ts`, then `.js`, then `.json`), and the run says so:
@@ -40,7 +51,7 @@ When the config has no `schema` key, the path is read from your drizzle-kit conf
 npx @drzl/cli generate --check
 ```
 
-Regenerates and compares the result against what is on disk. Exits `1` if anything differs and
+Regenerates and compares the result against what is on disk. Exits `2` if anything differs and
 `0` when everything is current, naming each file:
 
 ```
@@ -59,13 +70,24 @@ with this.
 regeneration and restored afterwards whether or not anything drifted, including deleting files
 the run created. A failed check leaves the tree exactly as it found it.
 
+`2` rather than `1`, because the check ran perfectly and is reporting what it found;
+`1` is reserved for a run that could not happen, such as a config DRZL could not read. A job that
+only tests for a non-zero exit is unaffected. See [Exit codes](/cli/output#exit-codes).
+
 In GitHub Actions:
 
 ```yaml
 - run: npx @drzl/cli generate --check
 ```
 
+Or, for a machine reading the result:
+
+```bash
+npx @drzl/cli generate --check --json | jq -r '.check.drift[] | .status + " " + .file'
+```
+
 This check is only possible because DRZL writes files. Validators that derive schemas in memory
 at import time have nothing on disk to compare, so they cannot offer it.
 
-See also: [Guide → Configuration](/guide/configuration)
+See also: [Guide → Configuration](/guide/configuration) ·
+[Output & exit codes](/cli/output)

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -130,3 +130,27 @@ All five config names are checked, not just `drzl.config.ts`. DRZL loads them in
 `.ts` first, so writing a `.ts` scaffold beside a `drzl.config.json` would leave that file
 untouched and still replace it in practice: the next `drzl generate` would run the scaffold. `init`
 refuses rather than shadowing.
+
+## Output and exit codes
+
+What `init` produces is a file on disk, so everything it prints is a report about that and goes to
+stderr. `-q, --quiet` silences it; errors still print.
+
+`--json` writes one document to stdout and implies `--yes`, since a prompt written into a document
+is a question nobody answers:
+
+```json
+{
+  "ok": true,
+  "command": "init",
+  "exitCode": 0,
+  "written": "/abs/path/drzl.config.ts",
+  "schema": "src/db/schema.ts",
+  "schemaSource": "convention",
+  "generators": ["zod"]
+}
+```
+
+`schemaSource` is `convention`, `drizzle-kit` or `none`, and `schema` is `null` when the config was
+written without one. Exits `0` when a config was written and `1` when it was not. See
+[Output & exit codes](/cli/output).

--- a/docs/cli/output.md
+++ b/docs/cli/output.md
@@ -1,0 +1,277 @@
+# Output, exit codes and `--json`
+
+Every command in the `drzl` CLI answers these questions the same way: which stream a line goes
+to, whether it carries colour, what `--quiet` and `--json` do to it, and what the exit code means.
+
+## Streams: stdout is the answer, stderr is the narration
+
+**stdout** carries what you asked for and nothing else:
+
+| Command                        | On stdout                                              |
+| ------------------------------ | ------------------------------------------------------ |
+| `analyze`                      | the analysis, as JSON                                  |
+| `doctor`                       | the report, as prose or as JSON                        |
+| `generate`                     | the list of files written, one per line                |
+| `generate:orpc`, `generate:trpc` | the list of files written                            |
+| `init`                         | nothing (what it produces is a file on disk)           |
+| `watch`                        | nothing, unless `--json`, which puts the event stream there |
+| any command with `--json`      | exactly one JSON document                              |
+
+**stderr** carries everything else: the spinner, the progress bar, warnings, the "Generated
+(zod): 3 files" summary, errors, and the sponsor tip.
+
+This is what makes redirection work:
+
+```bash
+drzl analyze src/db/schema.ts > analysis.json   # the file holds JSON and nothing else
+drzl generate --json | jq '.generators[].files' # parses with no filtering
+drzl generate > files.txt 2> build.log          # the two are separated
+```
+
+## Colour: decided once, per stream
+
+Colour is decided for each stream separately, because `drzl generate > out.txt` leaves stderr a
+terminal and stdout a file, and the right answer differs between them.
+
+In order:
+
+1. `NO_COLOR` set to anything but the empty string: **no colour**, on either stream.
+2. `TERM=dumb`: **no colour**.
+3. `FORCE_COLOR`: colour on. `0` or `false` means off; `1`, `2` and `3` name a level; `true` or an
+   empty value means on at level 1.
+4. Otherwise: colour when that stream is a terminal, at the level `COLORTERM` and `TERM` describe,
+   and no colour when it is not.
+
+`NO_COLOR` wins over `FORCE_COLOR`. That is deliberate, and it is not what chalk does. `NO_COLOR`
+is the one a person puts in their shell profile; `FORCE_COLOR` is overwhelmingly injected by a
+wrapper, and CI runners set it routinely. A wrapper's guess should not overrule a refusal.
+
+No escape sequence ever reaches a stream that is not a terminal unless `FORCE_COLOR` asked for it.
+That includes the spinner's tick, the progress bar, and the report `doctor` prints.
+
+## The progress bar
+
+`drzl generate` draws a progress bar only when all of these hold:
+
+- stderr is a terminal
+- neither `--quiet` nor `--json` was passed
+- the schema has at least 25 tables
+
+The last one is measured rather than chosen. The generator loop the bar covers costs about 105ms
+fixed plus 3.6ms per table, and the bar redraws ten times a second, so below about 25 tables it
+paints a single frame reading `0%` and is then wiped without ever advancing. A bar is only drawn
+where it will move.
+
+Below that, the run is already described by the lines around it: the analysis time, and the file
+count per generator.
+
+## `--quiet`
+
+Every command takes `-q, --quiet`. It removes the narration on stderr: the spinner, the progress
+bar, warnings, the per-generator summary and the sponsor tip.
+
+It does not remove:
+
+- **errors**, which still go to stderr, because a script that cannot tell a success from a
+  swallowed failure is worse off than one with no `--quiet` at all
+- **the exit code**, which means exactly what it means without the flag
+- **the answer** on stdout for the commands whose answer is text: `analyze` still prints the
+  analysis, `doctor` still prints the report
+
+For `generate`, `generate:orpc`, `generate:trpc` and `init`, what the command produces is files on
+disk, so all of their text is a report about the work, and `--quiet` leaves them silent on success.
+
+```bash
+drzl generate --quiet          # prints nothing, exits 0
+drzl generate --quiet          # prints the error to stderr, exits 1, when the config is missing
+```
+
+`generate --check --quiet` still names the files that drifted. That list is the finding the check
+exists to produce, and an exit code of `2` with no list is an answer nobody can act on.
+
+## `--json`
+
+Every command takes `--json`. It writes **exactly one JSON document to stdout** and nothing else,
+on success and on failure alike, so this always works:
+
+```bash
+drzl generate --json | jq .
+```
+
+Nothing goes to stderr under `--json`: the warnings that would have been printed are in the
+document instead.
+
+### The envelope
+
+Every document carries:
+
+| Key        | Meaning                                                            |
+| ---------- | ------------------------------------------------------------------ |
+| `command`  | the command that produced it, for example `generate` or `doctor`   |
+| `exitCode` | the code the process is about to return, so you read one field     |
+
+A **failure** document carries three more, and no payload. It is emitted when the command could
+not produce its payload at all:
+
+```json
+{
+  "ok": false,
+  "command": "generate",
+  "code": "DRZL_CFG_001",
+  "message": "No config found (DRZL_CFG_001). Create drzl.config.ts or pass --config.",
+  "exitCode": 1
+}
+```
+
+`code` is a stable identifier. `message` is the same sentence the human run prints.
+
+### One name, two meanings, and why
+
+`ok` is **not** part of the envelope, and that is because `doctor` published an `ok` of its own
+before this contract existed, meaning "there is nothing to report about your schema". That is a
+statement about the schema, not about the run: a report full of findings is a perfectly successful
+`doctor`. Rather than redefine a published field or carry two spellings of one word, `ok` keeps its
+meaning where it already had one, appears on failure documents where nothing can collide with it,
+and `exitCode` is the field to read for how the run went.
+
+### `analyze --json`
+
+The `Analysis`, with the envelope merged in at the top level, so `.dialect`, `.tables`, `.enums`,
+`.relations` and `.issues` are exactly where they have always been.
+
+```json
+{ "command": "analyze", "exitCode": 0, "dialect": "postgres", "tables": [], "issues": [] }
+```
+
+`--out <file>` still writes the bare `Analysis`, with no envelope: that option names a file of
+analysis, not a command result.
+
+A schema that is missing or will not import is the one failure `analyze` reports through its normal
+document rather than through a failure envelope, because it still has one to give: the analysis
+comes back empty with the reason in `issues`, which says more than a one-line message would. The
+`exitCode` is `1` either way.
+
+### `doctor --json`
+
+The `DoctorReport`, with the envelope merged in at the top level. See
+[Doctor](/cli/doctor#json) for the report's own shape.
+
+```json
+{ "command": "doctor", "exitCode": 0, "schema": "src/db/schema.ts", "ok": false, "findings": [] }
+```
+
+### `generate --json`
+
+```json
+{
+  "ok": true,
+  "command": "generate",
+  "exitCode": 0,
+  "check": null,
+  "generators": [{ "kind": "zod", "files": ["/abs/path/users.zod.ts"] }],
+  "warnings": ["1 column could not be typed: ..."]
+}
+```
+
+- `generators` is one entry per configured generator, in config order, each with the absolute
+  paths it wrote.
+- `warnings` holds every warning the human run prints to stderr, as strings.
+- `check` is `null` unless `--check` was passed, and otherwise:
+
+```json
+{
+  "check": {
+    "upToDate": false,
+    "drift": [{ "file": "src/validators/zod/users.zod.ts", "status": "changed" }]
+  }
+}
+```
+
+`status` is `added`, `removed` or `changed`. Paths are relative to the working directory.
+
+### `generate:orpc --json`, `generate:trpc --json`
+
+```json
+{
+  "ok": true,
+  "command": "generate:orpc",
+  "exitCode": 0,
+  "generators": [{ "kind": "orpc", "files": ["/abs/path/users.ts"] }]
+}
+```
+
+### `init --json`
+
+`--json` implies `--yes`: a prompt written into a document is a question nobody answers and a
+document nobody can parse.
+
+```json
+{
+  "ok": true,
+  "command": "init",
+  "exitCode": 0,
+  "written": "/abs/path/drzl.config.ts",
+  "schema": "src/db/schema.ts",
+  "schemaSource": "convention",
+  "generators": ["zod"]
+}
+```
+
+`schemaSource` is `convention`, `drizzle-kit` or `none`. `schema` is `null` when the config was
+written without one.
+
+### `watch --json`
+
+The one command whose `--json` is a stream rather than a document, because a watch never finishes.
+One JSON object per line on stdout, each with an `event` key: `watching`, `trigger`,
+`watch_config_applied`, `analyze_complete`, `generate_complete`, `diff`, `error`.
+
+## Exit codes
+
+Three codes, and only three.
+
+| Code | Meaning                                                  |
+| ---- | -------------------------------------------------------- |
+| `0`  | The command did what it was asked.                       |
+| `1`  | DRZL could not do the work.                              |
+| `2`  | DRZL did the work, and found what it was asked to find.  |
+
+The distinction between `1` and `2` is the one a pipeline acts on differently: a build stops on the
+first and shows a diff or a report on the second.
+
+| Command                          | `0`                       | `1`                                                        | `2`                             |
+| -------------------------------- | ------------------------- | ---------------------------------------------------------- | ------------------------------- |
+| `analyze`                        | analysed                  | schema missing or could not be imported                    | analysed, with error-level issues |
+| `doctor`                         | reported                  | schema missing or could not be imported                    | findings **and** `--strict`     |
+| `generate`                       | generated                 | no config, invalid config, a generator threw               | `--check` found drift           |
+| `generate:orpc`, `generate:trpc` | generated                 | schema missing, could not be imported, or a generator threw | not used                        |
+| `init`                           | config written            | a config already exists, or it could not be written        | not used                        |
+| `watch`                          | (runs until interrupted)  | no config, or the schema path could not be resolved        | not used                        |
+| any command                      |                           | an unknown flag or a missing argument                      |                                 |
+
+In CI:
+
+```yaml
+- run: npx @drzl/cli generate --check # 2 means commit the regenerated files
+- run: npx @drzl/cli doctor --strict # 2 means the schema has findings
+```
+
+### What changed
+
+Codes moved, all in the same direction: towards `1` meaning "could not run".
+
+- `generate` with no config was `2`, and is now `1`. A config that is not there is not a finding.
+- `generate --check` with drift was `1`, and is now `2`. The check ran perfectly and is reporting
+  what it found. A job that only tests for a non-zero exit is unaffected.
+- `watch` with no config, or with an unresolvable schema, was `2` and is now `1`.
+- `analyze` on a schema that is missing or will not import was `2`, and is now `1`. An error-level
+  issue in a schema it *did* read is still `2`.
+
+And two commands stopped reporting success when they had failed:
+
+- `generate:orpc <missing-schema>` and `generate:trpc <missing-schema>` exited `0`, having written
+  a placeholder file whose contents read "No tables detected in analysis". They now exit `1` and
+  write nothing.
+
+`doctor`'s codes are unchanged: `0` when it read the schema, `1` when it could not, `2` with
+`--strict` and findings.

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -35,4 +35,20 @@ Options:
 - `--pipeline <name>`: `all | analyze | generate-orpc | generate-trpc | generate-hono | generate-express | generate-fastify | generate-nestjs | generate-graphql` (default `all`)
   Anything other than `all` or `analyze` runs exactly one generator kind and skips the rest.
 - `--debounce <ms>`: debounce milliseconds (default `200`)
-- `--json`: emit structured JSON logs
+- `--json`: emit structured JSON logs on stdout, one object per line
+- `-q, --quiet`: drop the narration; errors still print
+- `--poll`: force polling, which helps on WSL, Docker and network mounts
+
+## Streams
+
+A watch never finishes, so it has no answer to give: everything human it prints goes to stderr, and
+stdout carries only the `--json` event stream. Each line is one object with an `event` key, one of
+`watching`, `trigger`, `watch_config_applied`, `analyze_complete`, `generate_complete`, `diff` or
+`error`.
+
+```bash
+drzl watch --json | jq -r 'select(.event == "generate_complete") | .kind'
+```
+
+Exits `1` when there is no config, or when the schema path cannot be resolved at startup. It was
+`2` before. See [Output & exit codes](/cli/output).

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 import { SchemaAnalyzer } from '@drzl/analyzer';
 import { ORPCGenerator } from '@drzl/generator-orpc';
-import chalk from 'chalk';
 import chokidar from 'chokidar';
-import cliProgress from 'cli-progress';
 import { Command } from 'commander';
 import * as path from 'node:path';
-import ora from 'ora';
+import {
+  EXIT_FAILED,
+  EXIT_FINDINGS,
+  EXIT_OK,
+  messageOf,
+  jsonFailure,
+  Output,
+} from './output.js';
 import { jsonSchemaOptions } from './json-schema-options.js';
 import { trpcOptions } from './trpc-options.js';
 import { honoOptions } from './hono-options.js';
@@ -48,15 +53,38 @@ import { CLI_VERSION } from './version.js';
  * `loadGenerator` marks the one case that is an install problem, so the package name comes off the
  * error rather than being repeated here beside the `import()` that already spells it.
  */
-function reportGeneratorFailure(kind: string, e: unknown): void {
+function reportGeneratorFailure(out: Output, kind: string, e: unknown): string {
   if (e instanceof GeneratorNotInstalledError) {
-    console.error(
-      chalk.red(`The ${kind} generator is not installed.`),
-      chalk.yellow(`\nInstall with: npm install ${e.specifier}`)
-    );
-    return;
+    out.error(`The ${kind} generator is not installed.`);
+    out.hint(`Install with: npm install ${e.specifier}`);
+    return `The ${kind} generator is not installed. Install with: npm install ${e.specifier}`;
   }
-  console.error(chalk.red(`The ${kind} generator failed:`), (e as any)?.message ?? e);
+  const detail = messageOf(e);
+  out.error(`The ${kind} generator failed:`, detail);
+  return `The ${kind} generator failed: ${detail}`;
+}
+
+/**
+ * The output layer for one command invocation.
+ *
+ * Built per run rather than as a module singleton, so `--quiet` and `--json` are answered once and
+ * every writer downstream shares that answer. See `output.ts` for the stream and colour rules.
+ */
+function outputFor(opts: { quiet?: boolean; json?: boolean }): Output {
+  return new Output({ quiet: !!opts.quiet, json: !!opts.json });
+}
+
+/**
+ * The two flags every command carries, declared once so none of them can be the one that forgets.
+ *
+ * Item 73 was that `--json` existed on three commands out of seven and `--quiet` on none, which
+ * makes both unusable from a script: a caller cannot write `drzl <anything> --json` and know it
+ * will work.
+ */
+function withOutputFlags(command: Command): Command {
+  return command
+    .option('--json', 'write one JSON document to stdout and nothing else', false)
+    .option('-q, --quiet', 'drop the progress narration on stderr; errors still print', false);
 }
 
 const program = new Command();
@@ -66,57 +94,74 @@ program.addHelpText(
   `\nNeed a template, adapter, or generator DRZL doesn't ship yet?\n→ DM @omardulaimidev on X: https://x.com/omardulaimidev\n`
 );
 
-program
-  .command('analyze')
-  .argument('<schema>', 'path to drizzle schema (TS)')
-  .option('--relations', 'include relations', true)
-  .option('--validate', 'validate constraints', true)
-  .option('--out <file>', 'write analysis JSON to file')
-  .option('--json', 'print JSON to stdout (overrides --out)', false)
-  .action(async (schema: string, opts: any) => {
-    try {
-      const analyzer = new SchemaAnalyzer(schema);
-      const spinner = !opts.json ? ora('Analyzing schema...').start() : null;
-      const start = Date.now();
-      const res = await analyzer.analyze({
-        includeRelations: !!opts.relations,
-        validateConstraints: !!opts.validate,
-      });
-      const ms = Date.now() - start;
-      const json = JSON.stringify(res, null, 2);
-      if (opts.json) {
-        console.log(json);
-      } else if (opts.out) {
-        const fs = await import('node:fs/promises');
-        await fs.writeFile(opts.out, json, 'utf8');
-        spinner?.succeed(chalk.green(`Analysis written to ${opts.out} in ${ms}ms`));
-      } else {
-        spinner?.succeed(chalk.green(`Analyzed in ${ms}ms`));
-        console.log(json);
-      }
-      process.exit(res.issues.some((i) => i.level === 'error') ? 2 : 0);
-    } catch (e: any) {
-      const msg = e?.message ?? String(e);
-      if (opts.json)
-        console.log(JSON.stringify({ event: 'error', code: 'DRZL_CLI_ANALYZE', message: msg }));
-      else
-        console.error(
-          chalk.red('Analyze failed (DRZL_CLI_ANALYZE):'),
-          msg,
-          '\nTip: run with --json for structured output.'
-        );
-      process.exit(1);
-    }
-  });
+withOutputFlags(
+  program
+    .command('analyze')
+    .argument('<schema>', 'path to drizzle schema (TS)')
+    .option('--relations', 'include relations', true)
+    .option('--validate', 'validate constraints', true)
+    .option('--out <file>', 'write analysis JSON to file')
+).action(async (schema: string, opts: any) => {
+  const out = outputFor(opts);
+  try {
+    const analyzer = new SchemaAnalyzer(schema);
+    const spinner = out.spinner('Analyzing schema...');
+    const start = Date.now();
+    const res = await analyzer.analyze({
+      includeRelations: !!opts.relations,
+      validateConstraints: !!opts.validate,
+    });
+    const ms = Date.now() - start;
 
-program
-  .command('doctor')
-  .description('Report what DRZL cannot type or enforce in your schema, and why')
-  .argument('[schema]', 'path to drizzle schema (TS); defaults to the schema in drzl.config')
-  .option('-c, --config <path>', 'path to drzl.config, read when no schema argument is given')
-  .option('--json', 'print the report as JSON instead of prose', false)
-  .option('--strict', 'exit 2 when anything is reported', false)
-  .action(async (schema: string | undefined, opts: any) => {
+    // A schema the analyzer could not open or could not import comes back as an error-level issue
+    // rather than as a throw, and the analysis it returns is empty. That is a run that could not
+    // happen, so it is EXIT_FAILED. Every other error-level issue describes a schema that *was*
+    // read and has something wrong in it, which is the EXIT_FINDINGS case: `analyze` printed a
+    // usable document and is telling the caller to look at it.
+    const unreadable = res.issues.some(
+      (i) => i.level === 'error' && (i.code === 'DRZL_ANL_NOFILE' || i.code === 'DRZL_ANL_IMPORT')
+    );
+    const errors = res.issues.some((i) => i.level === 'error');
+    const code = unreadable ? EXIT_FAILED : errors ? EXIT_FINDINGS : EXIT_OK;
+
+    if (opts.out && !opts.json) {
+      const fs = await import('node:fs/promises');
+      // The bare `Analysis`, because that is what the option says it writes. The envelope belongs
+      // to a command's answer on stdout, not to a file of analysis someone asked to keep.
+      await fs.writeFile(opts.out, JSON.stringify(res, null, 2), 'utf8');
+      spinner.succeed(`Analysis written to ${opts.out} in ${ms}ms`);
+    } else {
+      spinner.succeed(`Analyzed in ${ms}ms`);
+      // The analysis's own keys at the top level, so every existing reader of `.issues`, `.tables`
+      // and `.dialect` keeps working, with the envelope merged in beside them. No `ok` here, for
+      // the reason spelled out on `doctor` below: on a report command that name already belongs to
+      // a statement about the schema, and the run's answer is `exitCode`.
+      // Indented, because `verify-packed.sh` redirects this to a file and a person reads it.
+      const document = opts.json ? { command: 'analyze', exitCode: code, ...res } : res;
+      out.data(JSON.stringify(document, null, 2));
+    }
+    process.exit(code);
+  } catch (e: any) {
+    const msg = messageOf(e);
+    if (opts.json) out.jsonData(jsonFailure('analyze', 'DRZL_CLI_ANALYZE', msg));
+    else {
+      out.error('Analyze failed (DRZL_CLI_ANALYZE):', msg);
+      out.hint('Tip: run with --json for structured output.');
+    }
+    process.exit(EXIT_FAILED);
+  }
+});
+
+withOutputFlags(
+  program
+    .command('doctor')
+    .description('Report what DRZL cannot type or enforce in your schema, and why')
+    .argument('[schema]', 'path to drizzle schema (TS); defaults to the schema in drzl.config')
+    .option('-c, --config <path>', 'path to drzl.config, read when no schema argument is given')
+    .option('--strict', 'exit 2 when anything is reported', false)
+).action(async (schema: string | undefined, opts: any) => {
+  const out = outputFor(opts);
+  {
     try {
       // A schema path argument, like `analyze`, or the one already named in the config, since a
       // user who has a config should not have to retype the path they put in it. Resolution
@@ -130,10 +175,9 @@ program
       }
       if (!target) {
         const msg = 'No schema given. Pass a path, or run from a directory with a drzl.config.';
-        if (opts.json)
-          console.log(JSON.stringify({ event: 'error', code: 'DRZL_CLI_DOCTOR', message: msg }));
-        else console.error(chalk.red('Doctor failed (DRZL_CLI_DOCTOR):'), msg);
-        process.exit(1);
+        if (opts.json) out.jsonData(jsonFailure('doctor', 'DRZL_CLI_DOCTOR', msg));
+        else out.error('Doctor failed (DRZL_CLI_DOCTOR):', msg);
+        process.exit(EXIT_FAILED);
         return;
       }
 
@@ -149,57 +193,82 @@ program
         Array.isArray(target) ? target.join(', ') : target
       );
 
-      if (opts.json) console.log(JSON.stringify(report, null, 2));
-      else console.log(renderDoctorReport(report));
-
-      // An error-level issue means the schema was never read: the file is missing, or importing it
-      // threw. There is no report to act on, so this exits like `analyze`'s failure path rather
+      // An error-level finding means the schema was never read: the file is missing, or importing
+      // it threw. There is no report to act on, so that exits like `analyze`'s failure path rather
       // than pretending the empty analysis was a clean bill of health.
-      if (report.findings.some((f) => f.level === 'error')) {
-        process.exit(1);
-        return;
-      }
-      // Zero by default, and that is the whole point. A schema carrying a customType or a CHECK
+      //
+      // Zero otherwise, and that is the whole point. A schema carrying a customType or a CHECK
       // this parser will not guess at is normal and usable, and a doctor that failed every
       // pipeline reading one would be switched off within a week. `--strict` is the opt-in.
-      process.exit(opts.strict && report.findings.length ? 2 : 0);
-    } catch (e: any) {
-      const msg = e?.message ?? String(e);
-      if (opts.json)
-        console.log(JSON.stringify({ event: 'error', code: 'DRZL_CLI_DOCTOR', message: msg }));
-      else
-        console.error(
-          chalk.red('Doctor failed (DRZL_CLI_DOCTOR):'),
-          msg,
-          '\nTip: run with --json for structured output.'
-        );
-      process.exit(1);
-    }
-  });
+      const unreadable = report.findings.some((f) => f.level === 'error');
+      const code = unreadable
+        ? EXIT_FAILED
+        : opts.strict && report.findings.length
+          ? EXIT_FINDINGS
+          : EXIT_OK;
 
-program
-  .command('generate')
-  .description('Run configured generators (drzl.config.*)')
-  .option('-c, --config <path>', 'path to drzl.config')
-  .option(
-    '--check',
-    'regenerate and fail if the result differs from what is on disk, without changing it'
-  )
-  .action(async (opts: any) => {
+      // The report's own keys at the top level, so every reader of `.findings` and `.counts`
+      // keeps working, with the envelope's three keys merged in beside them. `ok` is about
+      // whether DRZL could run, not about whether the schema is clean: a report full of findings
+      // is a successful doctor run, which is why it is `!unreadable` rather than `report.ok`.
+      // `command` and `exitCode` first, the report's own keys after, and the order matters: this
+      // report has published an `ok` of its own since it shipped, and it means "nothing to report
+      // about the schema", which is not the same question as "could DRZL run". The report's
+      // meaning is the one that survives, and the run's answer is `exitCode`. That is also why the
+      // envelope defines no `ok` for the two report commands; see docs/cli/output.md.
+      if (opts.json)
+        out.data(JSON.stringify({ command: 'doctor', exitCode: code, ...report }, null, 2));
+      else out.data(renderDoctorReport(report, out.outStyle));
+
+      process.exit(code);
+    } catch (e: any) {
+      const msg = messageOf(e);
+      if (opts.json) out.jsonData(jsonFailure('doctor', 'DRZL_CLI_DOCTOR', msg));
+      else {
+        out.error('Doctor failed (DRZL_CLI_DOCTOR):', msg);
+        out.hint('Tip: run with --json for structured output.');
+      }
+      process.exit(EXIT_FAILED);
+    }
+  }
+});
+
+withOutputFlags(
+  program
+    .command('generate')
+    .description('Run configured generators (drzl.config.*)')
+    .option('-c, --config <path>', 'path to drzl.config')
+    .option(
+      '--check',
+      'regenerate and fail if the result differs from what is on disk, without changing it'
+    )
+).action(async (opts: any) => {
+  const out = outputFor(opts);
+  /** Everything the `--json` document reports, filled in as the run makes it true. */
+  const emitted: Array<{ kind: string; files: string[] }> = [];
+  const warnings: string[] = [];
+  /** A warning goes to stderr for a human and into the document for a machine, never both. */
+  const warn = (text: string) => {
+    warnings.push(text);
+    out.warn(text);
+  };
+  {
     try {
       let cfg = await loadConfig(opts.config);
       if (!cfg) {
-        console.error(
-          chalk.red('No config found (DRZL_CFG_001). Create drzl.config.ts or pass --config.')
-        );
-        process.exit(2);
+        const msg = 'No config found (DRZL_CFG_001). Create drzl.config.ts or pass --config.';
+        // Was exit 2 until now, which the scheme reserves for a run that found something. A
+        // config that is not there is a run that could not start.
+        if (opts.json) out.jsonData(jsonFailure('generate', 'DRZL_CFG_001', msg));
+        else out.error(msg);
+        process.exit(EXIT_FAILED);
         return;
       }
       // Where the schema comes from: `schema` in the drzl config, or, when that is omitted,
       // the drizzle-kit config, so a kit user never states the path twice. Resolved before the
       // spinner starts, because it throws the "neither file names a schema" error.
       const source = await resolveSchemaSource(cfg);
-      for (const w of source.warnings) console.warn(chalk.yellow(w));
+      for (const w of source.warnings) warn(w);
       // `typedJson`/`typedColumns` need one module to import tables from (`schemaPath` in
       // validation-options.ts). A drizzle-kit source resolved to exactly one file is that
       // module, so the option keeps working; several files have no single module, and the
@@ -209,15 +278,17 @@ program
       }
       if (source.source === 'drizzle-kit') {
         const n = (source.schema as string[]).length;
-        console.log(
-          chalk.gray(
+        // Narration, so stderr. It says where DRZL looked, not what it produced, and it used to
+        // sit on stdout in front of the file list anyone was parsing.
+        out.note(
+          out.errStyle.gray(
             `Schema from ${path.relative(process.cwd(), source.drizzleKitConfigPath!)} ` +
               `(${n} file${n === 1 ? '' : 's'})`
           )
         );
       }
       const analyzer = new SchemaAnalyzer(source.schema);
-      const spinner = ora('Analyzing...').start();
+      const spinner = out.spinner('Analyzing...');
       const t0 = Date.now();
       const analysis = await analyzer.analyze({
         includeRelations: cfg.analyzer.includeRelations,
@@ -237,7 +308,7 @@ program
         declared: source.drizzleKitDialect,
         analyzed: analysis.dialect,
       });
-      if (dialectWarning) console.warn(chalk.yellow(dialectWarning));
+      if (dialectWarning) warn(dialectWarning);
       // Both filters are applied before any generator sees the analysis, so every one of them
       // honours them without needing to know the options exist.
       //
@@ -249,18 +320,36 @@ program
       // reached rather than what survived it.
       const filterWarnings = tableFilterWarnings(narrowed.tables, cfg);
       analysis.tables = filterTables(narrowed.tables, cfg);
-      for (const w of [...narrowed.warnings, ...filterWarnings]) console.warn(chalk.yellow(w));
-      reportWideColumns(analysis.issues);
+      for (const w of [...narrowed.warnings, ...filterWarnings]) warn(w);
+      for (const w of wideColumnWarning(analysis.issues)) warn(w);
       // Under --check the existing output is captured before anything overwrites it, so the
       // regenerated result can be compared against it and the tree put back either way.
       const driftDirs = computeGeneratorOutputDirs(cfg);
       const driftBefore = opts.check ? await snapshotAll(driftDirs) : null;
-      const progress = new cliProgress.SingleBar(
-        { hideCursor: true },
-        cliProgress.Presets.shades_classic
-      );
       const total = analysis.tables.length || 1;
-      progress.start(total, 0);
+      // Whether this draws anything at all is `shouldShowProgress`'s decision: a terminal, no
+      // `--quiet`, no `--json`, and enough tables that the bar will move (item 72).
+      const progress = out.progress(total);
+      /** One completed generator, reported the same way whichever branch produced it. */
+      const generated = (kind: string, files: string[]) => {
+        progress.stop();
+        emitted.push({ kind, files });
+        if (opts.json) return;
+        // stdout, and deliberately: for `generate` the list of files written is the answer, and a
+        // caller without `--json` has nothing else to read. `--quiet` is what removes it.
+        if (out.quiet) return;
+        out.succeed(out.errStyle.green(`Generated (${kind}): ${files.length} files`));
+        for (const f of files) out.data('  - ' + out.outStyle.cyan(f));
+      };
+      /** One generator that threw. Reports it in whichever shape was asked for, then stops. */
+      const failGenerator = (kind: string, e: unknown): never => {
+        progress.stop();
+        // Prints for a human and returns the same sentence for the document; the writers inside
+        // it are already no-ops under `--json`, so neither shape can be the one that goes stale.
+        const message = reportGeneratorFailure(out, kind, e);
+        if (opts.json) out.jsonData(jsonFailure('generate', 'DRZL_GEN_002', message));
+        process.exit(EXIT_FAILED);
+      };
       // Where the service generator is actually writing, so a router template that imports
       // services spells a path that exists. Templates default this to 'src/services', and with
       // nothing passed that default was used no matter where the services really went, emitting
@@ -269,6 +358,10 @@ program
       const servicesDir =
         cfg.generators.find((x: { kind: string }) => x.kind === 'service')?.path ?? 'src/services';
       for (const g of cfg.generators) {
+        // Per generator rather than once outside the loop. The bar used to be started before the
+        // loop and stopped by whichever branch ran first, so in a config with two generators the
+        // second updated a bar that was already stopped and drew nothing at all.
+        progress.start();
         if (g.kind === 'orpc') {
           const gen = new ORPCGenerator(analysis);
           const { files } = await gen.generate({
@@ -287,9 +380,7 @@ program
             servicesDir,
             onProgress: ({ index }) => progress.update(index),
           });
-          progress.stop();
-          ora().succeed(chalk.green(`Generated (${g.kind}): ${files.length} files`));
-          files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+          generated(g.kind, files);
         } else if (g.kind === 'trpc') {
           try {
             // An optional dependency, like the json-schema generator and unlike oRPC. A package
@@ -307,13 +398,9 @@ program
               ...trpcOptions(g, cfg, servicesDir),
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (trpc): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('trpc', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'hono') {
           try {
@@ -330,13 +417,9 @@ program
               ...honoOptions(g, cfg),
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (hono): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('hono', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'express') {
           try {
@@ -353,13 +436,9 @@ program
               ...expressOptions(g, cfg),
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (express): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('express', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'fastify') {
           try {
@@ -376,13 +455,9 @@ program
               ...fastifyOptions(g, cfg),
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (fastify): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('fastify', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'nestjs') {
           try {
@@ -399,13 +474,9 @@ program
               ...nestjsOptions(g, cfg),
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (nestjs): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('nestjs', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'graphql') {
           try {
@@ -423,13 +494,9 @@ program
               ...graphqlOptions(g, cfg),
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (graphql): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('graphql', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'service') {
           try {
@@ -453,13 +520,9 @@ program
               // the two halves of one generated project disagreed about the signature.
               databaseInjection: g.databaseInjection,
             });
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (service): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('service', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'zod') {
           try {
@@ -478,13 +541,9 @@ program
                 constraints: true,
               }) as never
             );
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (zod): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('zod', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'valibot') {
           try {
@@ -497,13 +556,9 @@ program
             const files = await gen.generate(
               validationOptions(g, cfg, target, { schemaTypes: true, constraints: true }) as never
             );
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (valibot): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('valibot', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'arktype') {
           try {
@@ -516,13 +571,9 @@ program
             const files = await gen.generate(
               validationOptions(g, cfg, target, { schemaTypes: false }) as never
             );
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (arktype): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('arktype', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'json-schema') {
           try {
@@ -537,13 +588,9 @@ program
             const gen = new JsonSchemaGenerator(analysis);
             const target = g.path ?? 'src/validators/json-schema';
             const files = await gen.generate(jsonSchemaOptions(g, cfg, target) as never);
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (json-schema): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('json-schema', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'typebox') {
           try {
@@ -559,13 +606,9 @@ program
                 standardSchema: true,
               }) as never
             );
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (typebox): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('typebox', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         } else if (g.kind === 'effect') {
           try {
@@ -578,13 +621,9 @@ program
             const files = await gen.generate(
               validationOptions(g, cfg, target, { schemaTypes: true }) as never
             );
-            progress.stop();
-            ora().succeed(chalk.green(`Generated (effect): ${files.length} files`));
-            files.forEach((f: string) => console.log('  -', chalk.cyan(f)));
+            generated('effect', files);
           } catch (e: any) {
-            progress.stop();
-            reportGeneratorFailure(g.kind, e);
-            process.exit(1);
+            failGenerator(g.kind, e);
           }
         }
       }
@@ -594,99 +633,200 @@ program
         // Restored whether or not anything drifted, so `--check` never leaves the tree altered.
         await restoreSnapshot(driftBefore, after);
 
-        if (drift.length) {
-          console.error(chalk.red(`\nGenerated output is out of date (${drift.length} file(s)):`));
+        const upToDate = drift.length === 0;
+        // Drift is EXIT_FINDINGS, not EXIT_FAILED, and that is the whole reason the scheme has two
+        // failure codes. The check ran perfectly: it regenerated, compared, restored the tree, and
+        // is reporting what it found. A CI job that wants to show a diff acts on that differently
+        // from a config it could not read, and until now both were 1.
+        const code = upToDate ? EXIT_OK : EXIT_FINDINGS;
+
+        if (opts.json) {
+          out.jsonData({
+            ok: true,
+            command: 'generate',
+            exitCode: code,
+            check: {
+              upToDate,
+              drift: drift.map((d) => ({
+                file: path.relative(process.cwd(), d.file),
+                status: d.status,
+              })),
+            },
+            generators: emitted.map((e) => ({ kind: e.kind, files: e.files })),
+            warnings,
+          });
+          process.exit(code);
+        }
+
+        if (!upToDate) {
+          out.error(`\nGenerated output is out of date (${drift.length} file(s)):`);
           for (const d of drift) {
             const mark = d.status === 'added' ? '+' : d.status === 'removed' ? '-' : '~';
-            console.error(
-              `  ${mark} ${chalk.yellow(d.status.padEnd(8))} ${path.relative(process.cwd(), d.file)}`
+            out.error(
+              `  ${mark} ${out.errStyle.yellow(d.status.padEnd(8))} ${path.relative(process.cwd(), d.file)}`
             );
           }
-          console.error(
-            chalk.dim(
-              '\nRun `drzl generate` and commit the result. Nothing was written by this check.'
-            )
-          );
-          process.exit(1);
+          out.hint('\nRun `drzl generate` and commit the result. Nothing was written by this check.');
+          process.exit(code);
         }
-        console.log(chalk.green('Generated output is up to date.'));
+        out.succeed(out.errStyle.green('Generated output is up to date.'));
+        process.exit(code);
+      }
+
+      if (opts.json) {
+        out.jsonData({
+          ok: true,
+          command: 'generate',
+          exitCode: EXIT_OK,
+          check: null,
+          generators: emitted.map((e) => ({ kind: e.kind, files: e.files })),
+          warnings,
+        });
         return;
       }
 
       if (cfg.generators.length) {
-        maybeShowSponsorMessage({ reason: 'generate' });
+        maybeShowSponsorMessage({ reason: 'generate', out });
       }
     } catch (e: any) {
-      console.error(
-        chalk.red('Generate failed (DRZL_GEN_001):'),
-        e?.message ?? e,
-        '\nTip: check your drzl.config.ts and template path.'
-      );
-      process.exit(1);
+      const msg = messageOf(e);
+      if (opts.json) out.jsonData(jsonFailure('generate', 'DRZL_GEN_001', msg));
+      else {
+        out.error('Generate failed (DRZL_GEN_001):', msg);
+        out.hint('Tip: check your drzl.config.ts and template path.');
+      }
+      process.exit(EXIT_FAILED);
     }
-  });
+  }
+});
 
-program
-  .command('generate:orpc')
-  .argument('<schema>', 'path to drizzle schema (TS)')
-  .option('-o, --outDir <dir>', 'output directory', 'src/api')
-  .option('--template <name>', 'template name', 'standard')
-  .option('--includeRelations', 'include relation endpoints')
-  .action(async (schema: string, opts: any) => {
-    try {
-      const analyzer = new SchemaAnalyzer(schema);
-      const analysis = await analyzer.analyze({
-        includeRelations: !!opts.includeRelations,
-        validateConstraints: true,
-      });
-      const gen = new ORPCGenerator(analysis);
-      const { files } = await gen.generate({
-        outputDir: opts.outDir,
-        template: opts.template,
-        includeRelations: !!opts.includeRelations,
-      });
-      console.log(chalk.green(`Generated:`), files.map((f) => chalk.cyan(f)).join(', '));
-      maybeShowSponsorMessage({ reason: 'generate:orpc' });
-    } catch (e: any) {
-      console.error(chalk.red('Generate orpc failed:'), e?.message ?? e);
-      process.exit(1);
-    }
-  });
+/**
+ * Refuse to generate from a schema that was never read.
+ *
+ * `generate:orpc no-such-file.ts` used to exit 0, having written a `placeholder.orpc.ts` whose
+ * contents read "No tables detected in analysis". Measured on 4.22.0 and again here. That is the
+ * same defect item 67 fixed in `init`, one command along: the first thing a new user runs reports
+ * success having read nothing, and a CI step guarding the generated tree passes.
+ *
+ * `NOFILE` and `IMPORT` are the analyzer's two "there is nothing to work with" codes; anything
+ * else it says is a description of a schema it did read.
+ */
+function unreadableSchema(issues: Array<{ level?: string; code?: string; message?: string }>) {
+  return issues.find(
+    (i) => i.level === 'error' && (i.code === 'DRZL_ANL_NOFILE' || i.code === 'DRZL_ANL_IMPORT')
+  );
+}
 
-program
-  .command('generate:trpc')
-  .argument('<schema>', 'path to drizzle schema (TS)')
-  .option('-o, --outDir <dir>', 'output directory', 'src/api')
-  .option('--template <name>', 'standard | service', 'standard')
-  .option('--includeRelations', 'include relation endpoints')
-  .option('--servicesDir <dir>', 'where the service generator writes', 'src/services')
-  .action(async (schema: string, opts: any) => {
-    try {
-      const analyzer = new SchemaAnalyzer(schema);
-      const analysis = await analyzer.analyze({
-        includeRelations: !!opts.includeRelations,
-        validateConstraints: true,
-      });
-      const { TRPCGenerator } = await loadGenerator(
-        '@drzl/generator-trpc',
-        () => import('@drzl/generator-trpc')
-      );
-      const gen = new TRPCGenerator(analysis);
-      const { files } = await gen.generate({
-        outputDir: opts.outDir,
-        template: opts.template,
-        includeRelations: !!opts.includeRelations,
-        // Only consulted by `--template service`, and passed unconditionally so this command
-        // cannot become the branch that forgets it.
-        servicesDir: opts.servicesDir,
-      });
-      console.log(chalk.green(`Generated:`), files.map((f: string) => chalk.cyan(f)).join(', '));
-      maybeShowSponsorMessage({ reason: 'generate:trpc' });
-    } catch (e: any) {
-      reportGeneratorFailure('trpc', e);
-      process.exit(1);
+withOutputFlags(
+  program
+    .command('generate:orpc')
+    .argument('<schema>', 'path to drizzle schema (TS)')
+    .option('-o, --outDir <dir>', 'output directory', 'src/api')
+    .option('--template <name>', 'template name', 'standard')
+    .option('--includeRelations', 'include relation endpoints')
+).action(async (schema: string, opts: any) => {
+  const out = outputFor(opts);
+  try {
+    const analyzer = new SchemaAnalyzer(schema);
+    const analysis = await analyzer.analyze({
+      includeRelations: !!opts.includeRelations,
+      validateConstraints: true,
+    });
+    const unreadable = unreadableSchema(analysis.issues);
+    if (unreadable) {
+      const msg = unreadable.message ?? `Schema could not be read: ${schema}`;
+      if (opts.json) out.jsonData(jsonFailure('generate:orpc', 'DRZL_CLI_SCHEMA', msg));
+      else out.error('Generate orpc failed:', msg);
+      process.exit(EXIT_FAILED);
+      return;
     }
-  });
+    const gen = new ORPCGenerator(analysis);
+    const { files } = await gen.generate({
+      outputDir: opts.outDir,
+      template: opts.template,
+      includeRelations: !!opts.includeRelations,
+    });
+    if (opts.json) {
+      out.jsonData({
+        ok: true,
+        command: 'generate:orpc',
+        exitCode: EXIT_OK,
+        generators: [{ kind: 'orpc', files }],
+      });
+      return;
+    }
+    if (!out.quiet) {
+      out.data(out.outStyle.green('Generated:') + ' ' + files.map((f) => out.outStyle.cyan(f)).join(', '));
+    }
+    maybeShowSponsorMessage({ reason: 'generate:orpc', out });
+  } catch (e: any) {
+    const msg = messageOf(e);
+    if (opts.json) out.jsonData(jsonFailure('generate:orpc', 'DRZL_CLI_ORPC', msg));
+    else out.error('Generate orpc failed:', msg);
+    process.exit(EXIT_FAILED);
+  }
+});
+
+withOutputFlags(
+  program
+    .command('generate:trpc')
+    .argument('<schema>', 'path to drizzle schema (TS)')
+    .option('-o, --outDir <dir>', 'output directory', 'src/api')
+    .option('--template <name>', 'standard | service', 'standard')
+    .option('--includeRelations', 'include relation endpoints')
+    .option('--servicesDir <dir>', 'where the service generator writes', 'src/services')
+).action(async (schema: string, opts: any) => {
+  const out = outputFor(opts);
+  try {
+    const analyzer = new SchemaAnalyzer(schema);
+    const analysis = await analyzer.analyze({
+      includeRelations: !!opts.includeRelations,
+      validateConstraints: true,
+    });
+    const unreadable = unreadableSchema(analysis.issues);
+    if (unreadable) {
+      const msg = unreadable.message ?? `Schema could not be read: ${schema}`;
+      if (opts.json) out.jsonData(jsonFailure('generate:trpc', 'DRZL_CLI_SCHEMA', msg));
+      else out.error('Generate trpc failed:', msg);
+      process.exit(EXIT_FAILED);
+      return;
+    }
+    const { TRPCGenerator } = await loadGenerator(
+      '@drzl/generator-trpc',
+      () => import('@drzl/generator-trpc')
+    );
+    const gen = new TRPCGenerator(analysis);
+    const { files } = await gen.generate({
+      outputDir: opts.outDir,
+      template: opts.template,
+      includeRelations: !!opts.includeRelations,
+      // Only consulted by `--template service`, and passed unconditionally so this command
+      // cannot become the branch that forgets it.
+      servicesDir: opts.servicesDir,
+    });
+    if (opts.json) {
+      out.jsonData({
+        ok: true,
+        command: 'generate:trpc',
+        exitCode: EXIT_OK,
+        generators: [{ kind: 'trpc', files }],
+      });
+      return;
+    }
+    if (!out.quiet) {
+      out.data(
+        out.outStyle.green('Generated:') +
+          ' ' +
+          files.map((f: string) => out.outStyle.cyan(f)).join(', ')
+      );
+    }
+    maybeShowSponsorMessage({ reason: 'generate:trpc', out });
+  } catch (e: any) {
+    const message = reportGeneratorFailure(out, 'trpc', e);
+    if (opts.json) out.jsonData(jsonFailure('generate:trpc', 'DRZL_CLI_TRPC', message));
+    process.exit(EXIT_FAILED);
+  }
+});
 
 program
   .command('watch')
@@ -699,12 +839,17 @@ program
   )
   .option('--debounce <ms>', 'debounce ms', '200')
   .option('--json', 'emit JSON logs', false)
+  .option('-q, --quiet', 'drop the progress narration on stderr; errors still print', false)
   .option('--poll', 'force polling (helps WSL/Docker/remote FS)', false)
   .action(async (opts: any) => {
+    // `watch` has no answer to give: it is narration until it is stopped. So everything human it
+    // prints goes to stderr, and stdout carries only the `--json` event stream, which is the one
+    // thing here a program reads.
+    const out = outputFor(opts);
     let cfg = await loadConfig(opts.config);
     if (!cfg) {
-      console.error(chalk.red('No config found. Create drzl.config.ts or pass --config.'));
-      process.exit(2);
+      out.error('No config found (DRZL_CFG_001). Create drzl.config.ts or pass --config.');
+      process.exit(EXIT_FAILED);
       return;
     }
 
@@ -723,11 +868,11 @@ program
     try {
       source = await resolveSchemaSource(cfg);
     } catch (e: any) {
-      console.error(chalk.red(String(e?.message ?? e)));
-      process.exit(2);
+      out.error(messageOf(e));
+      process.exit(EXIT_FAILED);
       return;
     }
-    for (const w of source.warnings) console.warn(chalk.yellow(w));
+    for (const w of source.warnings) out.warn(w);
 
     const ignoredOutDirs = new Set<string>(computeGeneratorOutputDirs(cfg).map(abs));
     const currentTargets = new Set<string>(
@@ -777,7 +922,7 @@ program
     });
 
     const logTrigger = (type: 'add' | 'change' | 'unlink', file: string) => {
-      if (opts.json) console.log(JSON.stringify({ event: 'trigger', type, file }));
+      if (opts.json) out.jsonData({ event: 'trigger', type, file });
     };
 
     watcher
@@ -795,6 +940,24 @@ program
       });
 
     let lastFiles: string[] = [];
+
+    /**
+     * One generator finishing a watch rebuild, reported the same way from all thirteen branches.
+     *
+     * The event keys are the ones `--json` has always emitted, because a watch feeding a script is
+     * the only reader that shape has. The human form is narration, so it goes to stderr with
+     * everything else this command prints.
+     */
+    const watchGenerated = (kind: string, files: string[]) => {
+      if (opts.json) {
+        out.jsonData({ event: 'generate_complete', kind, files });
+        return;
+      }
+      out.succeed(
+        out.errStyle.green(`Generated (${kind}): ${files.length} files`) +
+          (files.length ? ' ' + files.map((f) => out.errStyle.cyan(f)).join(', ') : '')
+      );
+    };
 
     const run = async () => {
       try {
@@ -824,17 +987,15 @@ program
         if (!opts.json) console.clear();
 
         if (opts.json) {
-          console.log(
-            JSON.stringify({
-              event: 'watch_config_applied',
-              targets: Array.from(currentTargets),
-              ignored: Array.from(ignoredOutDirs),
-            })
-          );
+          out.jsonData({
+            event: 'watch_config_applied',
+            targets: Array.from(currentTargets),
+            ignored: Array.from(ignoredOutDirs),
+          });
         }
 
         // After the console.clear() above, or the warning would be wiped before anyone saw it.
-        if (!opts.json) for (const w of source.warnings) console.warn(chalk.yellow(w));
+        for (const w of source.warnings) out.warn(w);
 
         const analyzer = new SchemaAnalyzer(source.schema);
         const analysis = await analyzer.analyze({
@@ -849,28 +1010,25 @@ program
           declared: source.drizzleKitDialect,
           analyzed: analysis.dialect,
         });
-        if (dialectWarning && !opts.json) console.warn(chalk.yellow(dialectWarning));
+        if (dialectWarning) out.warn(dialectWarning);
         // Same order and the same reasons as `generate`. A config edited mid-watch that names a
         // column that does not exist throws here, and `run`'s own catch reports it and keeps
         // watching, so the next save can fix it.
         const narrowed = filterColumns(analysis.tables, cfg.columns);
         const filterWarnings = tableFilterWarnings(narrowed.tables, cfg);
         analysis.tables = filterTables(narrowed.tables, cfg);
-        if (!opts.json)
-          for (const w of [...narrowed.warnings, ...filterWarnings]) console.warn(chalk.yellow(w));
-        if (!opts.json) reportWideColumns(analysis.issues);
+        for (const w of [...narrowed.warnings, ...filterWarnings]) out.warn(w);
+        for (const w of wideColumnWarning(analysis.issues)) out.warn(w);
 
         if (opts.pipeline === 'analyze') {
           if (opts.json) {
-            console.log(
-              JSON.stringify({
-                event: 'analyze_complete',
-                issues: analysis.issues,
-                tables: analysis.tables.length,
-              })
-            );
+            out.jsonData({
+              event: 'analyze_complete',
+              issues: analysis.issues,
+              tables: analysis.tables.length,
+            });
           } else {
-            console.log(chalk.green('Analyze complete.'));
+            out.succeed('Analyze complete.');
           }
           return;
         }
@@ -914,12 +1072,7 @@ program
               databaseInjection: g.databaseInjection,
               servicesDir,
             });
-            opts.json
-              ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-              : console.log(
-                  chalk.green(`Generated (${g.kind}):`),
-                  files.map((f: string) => chalk.cyan(f)).join(', ')
-                );
+            watchGenerated(g.kind, files);
             newFiles.push(...files);
           } else if (g.kind === 'trpc') {
             try {
@@ -931,15 +1084,10 @@ program
               // The same builder `generate` uses, so the two dispatch loops cannot disagree
               // about what this generator is given.
               const { files } = await gen.generate(trpcOptions(g, cfg, servicesDir));
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (trpc): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'hono') {
@@ -952,15 +1100,10 @@ program
               // The same builder `generate` uses, so the two dispatch loops cannot disagree
               // about what this generator is given.
               const { files } = await gen.generate(honoOptions(g, cfg));
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (hono): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'express') {
@@ -973,15 +1116,10 @@ program
               // The same builder `generate` uses, so the two dispatch loops cannot disagree
               // about what this generator is given.
               const { files } = await gen.generate(expressOptions(g, cfg));
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (express): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'fastify') {
@@ -994,15 +1132,10 @@ program
               // The same builder `generate` uses, so the two dispatch loops cannot disagree
               // about what this generator is given.
               const { files } = await gen.generate(fastifyOptions(g, cfg));
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (fastify): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'nestjs') {
@@ -1015,15 +1148,10 @@ program
               // The same builder `generate` uses, so the two dispatch loops cannot disagree
               // about what this generator is given.
               const { files } = await gen.generate(nestjsOptions(g, cfg));
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (nestjs): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'graphql') {
@@ -1036,15 +1164,10 @@ program
               // The same builder `generate` uses, so the two dispatch loops cannot disagree
               // about what this generator is given.
               const { files } = await gen.generate(graphqlOptions(g, cfg));
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (graphql): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'service') {
@@ -1065,15 +1188,10 @@ program
                 importExtension: g.importExtension,
                 databaseInjection: g.databaseInjection,
               });
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (service): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'zod') {
@@ -1098,15 +1216,10 @@ program
                   constraints: true,
                 }) as never
               );
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (zod): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'valibot') {
@@ -1128,15 +1241,10 @@ program
                   constraints: true,
                 }) as never
               );
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (valibot): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'arktype') {
@@ -1155,15 +1263,10 @@ program
               const files = await gen.generate(
                 validationOptions(g, cfg, target, { schemaTypes: false }) as never
               );
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (arktype): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'typebox') {
@@ -1185,15 +1288,10 @@ program
                   standardSchema: true,
                 }) as never
               );
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (typebox): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'effect') {
@@ -1210,15 +1308,10 @@ program
               const files = await gen.generate(
                 validationOptions(g, cfg, target, { schemaTypes: true }) as never
               );
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (effect): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           } else if (g.kind === 'json-schema') {
@@ -1232,15 +1325,10 @@ program
               // The same builder `generate` uses, so the two dispatch loops cannot disagree about
               // what this generator is given.
               const files = await gen.generate(jsonSchemaOptions(g, cfg, target) as never);
-              opts.json
-                ? console.log(JSON.stringify({ event: 'generate_complete', kind: g.kind, files }))
-                : console.log(
-                    chalk.green(`Generated (json-schema): ${files.length} files`),
-                    files.map((f: string) => chalk.cyan(f)).join(', ')
-                  );
+              watchGenerated(g.kind, files);
               newFiles.push(...files);
             } catch (e: any) {
-              reportGeneratorFailure(g.kind, e);
+              reportGeneratorFailure(out, g.kind, e);
               return;
             }
           }
@@ -1248,22 +1336,22 @@ program
 
         const added = newFiles.filter((f) => !lastFiles.includes(f));
         const removed = lastFiles.filter((f) => !newFiles.includes(f));
-        opts.json
-          ? console.log(JSON.stringify({ event: 'diff', added, removed }))
-          : (() => {
-              if (added.length) console.log(chalk.blue(`Added: ${added.join(', ')}`));
-              if (removed.length) console.log(chalk.yellow(`Removed: ${removed.join(', ')}`));
-            })();
-        if (newFiles.length && !opts.json) {
+        if (opts.json) {
+          out.jsonData({ event: 'diff', added, removed });
+        } else {
+          if (added.length) out.note(out.errStyle.blue(`Added: ${added.join(', ')}`));
+          if (removed.length) out.warn(`Removed: ${removed.join(', ')}`);
+        }
+        if (newFiles.length) {
           const reason =
             opts.pipeline && opts.pipeline !== 'all' ? `watch:${opts.pipeline}` : 'watch';
-          maybeShowSponsorMessage({ reason });
+          maybeShowSponsorMessage({ reason, out });
         }
         lastFiles = newFiles;
       } catch (e: any) {
-        opts.json
-          ? console.log(JSON.stringify({ event: 'error', message: String(e?.message ?? e) }))
-          : console.error(chalk.red('Watch pipeline failed:'), e?.message ?? e);
+        const msg = messageOf(e);
+        if (opts.json) out.jsonData({ event: 'error', message: msg });
+        else out.error('Watch pipeline failed:', msg);
       }
     };
 
@@ -1281,16 +1369,14 @@ program
     };
 
     if (opts.json) {
-      console.log(
-        JSON.stringify({
-          event: 'watching',
-          targets: Array.from(currentTargets),
-          ignored: Array.from(ignoredOutDirs),
-        })
-      );
+      out.jsonData({
+        event: 'watching',
+        targets: Array.from(currentTargets),
+        ignored: Array.from(ignoredOutDirs),
+      });
     } else {
-      console.log(
-        chalk.gray(
+      out.note(
+        out.errStyle.gray(
           'Watching:\n  ' +
             Array.from(currentTargets)
               .map((p) => path.relative(process.cwd(), p))
@@ -1303,36 +1389,63 @@ program
       .on('add', (p) => trigger(p))
       .on('change', (p) => trigger(p))
       .on('unlink', (p) => trigger(p))
-      .on('error', (err) => console.error(chalk.red('Watcher error:'), err));
+      .on('error', (err) => out.error('Watcher error:', messageOf(err)));
 
     await run();
   });
 
-program
-  .command('init')
-  .description('Scaffold a drzl.config.ts, finding your schema and asking what to generate')
-  .option('-y, --yes', 'take the defaults and ask nothing')
-  .option('--schema <path>', 'the schema file to write into the config, skipping detection')
-  .option(
-    '--generators <list>',
-    `comma-separated: ${INIT_GENERATOR_CHOICES.map((c) => c.kind).join(', ')}`
-  )
-  .action(async (opts: any) => {
-    // Every prompt has a flag, and every flag skips its prompt. That equivalence is what keeps
-    // the interactive command usable from CI: nothing can only be answered by a human.
-    const outcome = await runInit({
-      cwd: process.cwd(),
-      yes: !!opts.yes,
-      schemaFlag: opts.schema,
-      generatorsFlag: opts.generators,
-      stdin: process.stdin,
-      stdout: process.stdout,
-      env: process.env,
-      log: (s) => console.log(s.startsWith('Created ') ? chalk.green(s) : chalk.gray(s)),
-      error: (s) => console.error(chalk.red(s)),
-    });
-    if (outcome.code !== 0) process.exit(outcome.code);
+withOutputFlags(
+  program
+    .command('init')
+    .description('Scaffold a drzl.config.ts, finding your schema and asking what to generate')
+    .option('-y, --yes', 'take the defaults and ask nothing')
+    .option('--schema <path>', 'the schema file to write into the config, skipping detection')
+    .option(
+      '--generators <list>',
+      `comma-separated: ${INIT_GENERATOR_CHOICES.map((c) => c.kind).join(', ')}`
+    )
+).action(async (opts: any) => {
+  const out = outputFor(opts);
+  const failures: string[] = [];
+  // Every prompt has a flag, and every flag skips its prompt. That equivalence is what keeps
+  // the interactive command usable from CI: nothing can only be answered by a human.
+  //
+  // `--json` forces the non-interactive path as well as the shape. A prompt written into a
+  // document is a question nobody will answer and a document nobody can parse, and `--json` is
+  // only ever passed by something that is not a person.
+  const outcome = await runInit({
+    cwd: process.cwd(),
+    yes: !!opts.yes || !!opts.json,
+    schemaFlag: opts.schema,
+    generatorsFlag: opts.generators,
+    stdin: process.stdin,
+    stdout: process.stdout,
+    env: process.env,
+    // Narration on stderr, all of it: what `init` produces is a file on disk, and the lines it
+    // prints are a report about that.
+    log: (s) => out.note(s.startsWith('Created ') ? out.errStyle.green(s) : out.errStyle.gray(s)),
+    error: (s) => {
+      failures.push(s);
+      out.error(s);
+    },
   });
+  if (opts.json) {
+    out.jsonData(
+      outcome.code === 0
+        ? {
+            ok: true,
+            command: 'init',
+            exitCode: EXIT_OK,
+            written: outcome.written,
+            schema: outcome.plan?.schema ?? null,
+            schemaSource: outcome.plan?.schemaSource ?? null,
+            generators: outcome.plan?.generators ?? [],
+          }
+        : jsonFailure('init', 'DRZL_CLI_INIT', failures.join(' ') || 'init did not write a config')
+    );
+  }
+  process.exit(outcome.code === 0 ? EXIT_OK : EXIT_FAILED);
+});
 
 /**
  * Tell the user which columns got a validator that accepts anything.
@@ -1346,21 +1459,24 @@ program
  * Printed once with a count rather than a line per column, so a schema with fifty custom types
  * stays readable.
  */
-function reportWideColumns(issues: Array<{ code?: string; message?: string; hint?: string }>) {
+function wideColumnWarning(
+  issues: Array<{ code?: string; message?: string; hint?: string }>
+): string[] {
   const wide = issues.filter((i) => i.code === 'DRZL_ANL_UNKNOWN_COLUMN');
-  if (!wide.length) return;
-  console.warn(
-    chalk.yellow(`\n${wide.length} column${wide.length === 1 ? '' : 's'} could not be typed:`)
-  );
-  for (const i of wide.slice(0, 10)) console.warn(chalk.gray(`  - ${i.message}`));
-  if (wide.length > 10) console.warn(chalk.gray(`  ... and ${wide.length - 10} more`));
+  if (!wide.length) return [];
+  // One string rather than a write per line. The caller both prints it and puts it in the
+  // `--json` document, and a warning split across six writes cannot be put in a document at all
+  // without the two shapes drifting apart.
+  const lines = [`\n${wide.length} column${wide.length === 1 ? '' : 's'} could not be typed:`];
+  for (const i of wide.slice(0, 10)) lines.push(`  - ${i.message}`);
+  if (wide.length > 10) lines.push(`  ... and ${wide.length - 10} more`);
   // One hint for the set, since they are almost always the same two.
-  const hints = [...new Set(wide.map((i) => i.hint).filter(Boolean))];
-  for (const h of hints) console.warn(chalk.gray(`  ${h}`));
+  for (const h of [...new Set(wide.map((i) => i.hint).filter(Boolean))]) lines.push(`  ${h}`);
   // Untypeable columns are the only thing this line can see. A CHECK constraint the generators
   // decline produces no output at all and so cannot be counted here without parsing every one of
   // them on the generate path, which is what `doctor` is for.
-  console.warn(chalk.gray('  Run `drzl doctor` for the full report.'));
+  lines.push('  Run `drzl doctor` for the full report.');
+  return [lines.join('\n')];
 }
 
 program.parseAsync(process.argv);

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -39,7 +39,17 @@
  */
 import type { Analysis, Column, Issue, Table } from '@drzl/analyzer';
 import { lengthMeasure, parseCheck, type LengthCheck } from '@drzl/validation-core';
-import chalk from 'chalk';
+import { Chalk, type ChalkInstance } from 'chalk';
+
+/**
+ * The styling this report uses when the caller does not say.
+ *
+ * Level 0, so a caller who forgets gets plain text rather than escape sequences in a file. This
+ * file used to import chalk's default instance, which decides colour from `process.stdout` alone
+ * and ignores `NO_COLOR` entirely, so `drzl doctor` printed the same 32 escapes with the variable
+ * set as without it. The decision belongs to `output.ts` and is passed in.
+ */
+const PLAIN: ChalkInstance = new Chalk({ level: 0 });
 
 export type DoctorFindingKind =
   /** A column whose validator will accept any value. */
@@ -472,7 +482,8 @@ function wrap(text: string, indent: string, first = indent, width = 96): string 
  * A clean schema prints what was looked at rather than nothing, because an empty page cannot be
  * told apart from a command that failed to run.
  */
-export function renderDoctorReport(report: DoctorReport): string {
+export function renderDoctorReport(report: DoctorReport, style: ChalkInstance = PLAIN): string {
+  const chalk = style;
   const out: string[] = [];
   const plural = (n: number, one: string) => `${n} ${one}${n === 1 ? '' : 's'}`;
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,0 +1,382 @@
+/**
+ * Everything the CLI writes: which stream, in what shape, and whether it carries colour.
+ *
+ * Five plan items are one layer, and this file is that layer (items 72, 73, 74, 76, 77). Before it
+ * existed, each of the seven commands answered those questions for itself by reaching for `chalk`,
+ * `ora`, `cli-progress` and `console.log` at the call site, and the answers disagreed. Four of the
+ * disagreements were measured against the built 4.22.0 CLI, each command run with stdout and stderr
+ * on separate channels so the two could be told apart:
+ *
+ * - **`NO_COLOR` did nothing at all (item 76).** `chalk@6.0.0` vendors its own `supports-color`,
+ *   and that copy contains the string `FORCE_COLOR` ten times and the string `NO_COLOR` zero
+ *   times. Measured: on a pty with `NO_COLOR=1`, `chalk.level` is still 3 and `chalk.green('x')`
+ *   still returns `[32mx[39m`. `drzl doctor` emitted the same 32 escape sequences with
+ *   the variable set as without it.
+ *
+ * - **Colour was decided from the wrong stream (items 76, 77).** chalk's default instance takes
+ *   its level from `supportsColor.stdout` alone (`const colorLevel = stdoutColor ? ... : 0`), and
+ *   the CLI writes most of its narration to stderr. So `drzl generate > out.txt` with a terminal
+ *   still on stderr turned the warnings on that terminal colourless, because a *different* stream
+ *   had been redirected. chalk exposes `supportsColor.stderr` as well; nothing used it.
+ *
+ * - **An escape leaked into piped output regardless (item 77).** Not from chalk, which does check
+ *   `isTTY`, but from `ora`'s success symbol: `log-symbols` colours it with `yoctocolors`, which
+ *   reads `TERM`, `COLORTERM`, `FORCE_COLOR` and `NO_COLOR` and never asks whether the stream is a
+ *   terminal. Measured on an ordinary developer machine where `TERM` is set: `drzl analyze 2> log`
+ *   wrote `[32m✔[39m Analyzed in 46ms` into the file. So the symbol is rendered
+ *   here now and `ora` is asked only to spin.
+ *
+ * - **Narration sat on stdout (item 73).** The sponsor tip was written with `console.log`, so
+ *   `drzl generate | ...` fed 246 bytes of advertisement into whatever was parsing the file list.
+ *   `--json` cannot be a contract while anything but the document shares that stream.
+ *
+ * The rule the rest of the CLI follows from here: **stdout carries the answer, stderr carries the
+ * narration.** Under `--json` stdout carries exactly one JSON document and nothing else, on
+ * success and on failure alike, so `drzl <cmd> --json | jq .` parses with no filtering.
+ */
+import { Chalk, type ChalkInstance } from 'chalk';
+import cliProgress from 'cli-progress';
+import ora, { type Ora } from 'ora';
+
+/** The subset of a stream this module needs, so tests can pass an ordinary object. */
+export interface OutputStream {
+  write(chunk: string): unknown;
+  isTTY?: boolean;
+  columns?: number;
+}
+
+export type Env = Record<string, string | undefined>;
+
+export type ColorLevel = 0 | 1 | 2 | 3;
+
+/**
+ * The three exit codes, and there are only three on purpose.
+ *
+ * Before this, `2` meant "the analysis found errors" from `analyze`, "findings were reported and
+ * you asked for strictness" from `doctor`, and "there is no config file" from `generate` and
+ * `watch`; `1` meant "the schema could not be read" from `doctor` but "a generator threw" from
+ * `generate`. Three commands used the same number for three unrelated events, which is the same as
+ * having no scheme.
+ *
+ * The distinction worth encoding is the one a pipeline acts on differently: work that could not be
+ * done at all, against work that was done and turned something up. A build reacts to the first by
+ * stopping, and to the second by showing a diff or a report. Everything else is prose and belongs
+ * in the message.
+ */
+export const EXIT_OK = 0;
+/** DRZL could not do the work: bad config, unreadable schema, a generator threw, a write failed. */
+export const EXIT_FAILED = 1;
+/**
+ * DRZL did the work and found what it was asked to look for: `generate --check` drift,
+ * `doctor --strict` findings, `analyze` error-level issues.
+ */
+export const EXIT_FINDINGS = 2;
+
+/**
+ * How many tables make a progress bar worth drawing.
+ *
+ * Measured rather than chosen. The generator loop the bar covers costs about 105ms fixed plus
+ * 3.6ms per table on this machine (1 table 109ms, 10 tables 181ms, 50 tables 354ms, 100 tables
+ * 561ms, 200 tables 901ms, 400 tables 1549ms), and `cli-progress` redraws at 10fps. A bar drawn
+ * over a shorter loop therefore paints one frame reading `0%` and is then wiped by `stop()`
+ * without ever advancing, which is exactly what item 72 reports: a full-width bar appearing for a
+ * single table and saying nothing.
+ *
+ * 25 tables is where the loop first outlasts a frame, so the bar is only ever drawn when it will
+ * move at least once. Below it the run is already described by the two lines around it: the
+ * analysis time, and the file count per generator.
+ */
+export const PROGRESS_MIN_TABLES = 25;
+
+/**
+ * Whether a stream should carry colour, and how much.
+ *
+ * Asked once per stream rather than once per process. That is the whole of item 77 and half of
+ * item 76: `drzl generate > file` leaves stderr a terminal and stdout a file, and the two answers
+ * differ.
+ *
+ * `NO_COLOR` beats `FORCE_COLOR`, which is the one place this departs from chalk. The reason is
+ * which of them a human sets: `NO_COLOR` goes in a shell profile and is a standing preference,
+ * while `FORCE_COLOR` is overwhelmingly injected by a wrapper (CI runners set it, and so does the
+ * shell this was developed in, which set `FORCE_COLOR=3` and made every command look like a colour
+ * leak until it was stripped). A wrapper's guess must not overrule a person's refusal. It also
+ * makes every colour rule testable through an ordinary pipe, with no pseudo-terminal, because
+ * `FORCE_COLOR=1` turns colour on where a pipe would have it off.
+ *
+ * `NO_COLOR` follows no-color.org: any value except the empty string counts as set.
+ */
+export function colorLevelFor(stream: OutputStream, env: Env): ColorLevel {
+  if (env.NO_COLOR !== undefined && env.NO_COLOR !== '') return 0;
+  if (env.TERM === 'dumb') return 0;
+
+  const forced = env.FORCE_COLOR;
+  if (forced !== undefined) {
+    if (forced === 'false' || forced === '0') return 0;
+    if (forced === '' || forced === 'true') return 1;
+    const n = Number.parseInt(forced, 10);
+    if (Number.isInteger(n)) return Math.min(Math.max(n, 0), 3) as ColorLevel;
+    return 1;
+  }
+
+  if (!stream.isTTY) return 0;
+  // A terminal that says it can do more is believed, and one that says nothing gets the sixteen
+  // colours every terminal emulator has had for thirty years.
+  if (env.COLORTERM === 'truecolor' || env.COLORTERM === '24bit') return 3;
+  if (env.TERM?.includes('256')) return 2;
+  return 1;
+}
+
+/** Whether a progress bar earns its place. Split out so the four reasons can be tested apart. */
+export function shouldShowProgress(opts: {
+  tables: number;
+  stderr: OutputStream;
+  quiet: boolean;
+  json: boolean;
+}): boolean {
+  if (opts.quiet || opts.json) return false;
+  if (!opts.stderr.isTTY) return false;
+  return opts.tables >= PROGRESS_MIN_TABLES;
+}
+
+/** What `createProgress` hands back, so the call site never touches `cli-progress` directly. */
+export interface Progress {
+  start(): void;
+  update(value: number): void;
+  stop(): void;
+}
+
+/** A progress bar, or a shaped hole where one would have been. */
+function createProgress(enabled: boolean, total: number, stream: OutputStream): Progress {
+  if (!enabled) {
+    return { start() {}, update() {}, stop() {} };
+  }
+  const bar = new cliProgress.SingleBar(
+    { hideCursor: true, stream: stream as NodeJS.WritableStream },
+    cliProgress.Presets.shades_classic
+  );
+  // `running` is what makes `start` and `stop` safe to call in any order. The dispatch loop calls
+  // `stop()` from thirteen branches and from their catch blocks, and before this the bar was
+  // started once outside the loop, so the second generator in a config updated a bar that the
+  // first had already stopped.
+  let running = false;
+  return {
+    start() {
+      if (running) return;
+      bar.start(total, 0);
+      running = true;
+    },
+    update(value: number) {
+      if (running) bar.update(value);
+    },
+    stop() {
+      if (!running) return;
+      bar.stop();
+      running = false;
+    },
+  };
+}
+
+/** A spinner, or a shaped hole. Never renders the completion symbol itself; see `Output.succeed`. */
+export interface Spinner {
+  succeed(text: string): void;
+  fail(text: string): void;
+  stop(): void;
+}
+
+export interface OutputOptions {
+  stdout?: OutputStream;
+  stderr?: OutputStream;
+  env?: Env;
+  quiet?: boolean;
+  json?: boolean;
+}
+
+/**
+ * Every write the CLI makes, with the stream and the colour already decided.
+ *
+ * `data` is the only method that reaches stdout. Everything else is narration and goes to stderr,
+ * where `--quiet` can drop it without touching either the answer or the exit code.
+ */
+export class Output {
+  readonly stdout: OutputStream;
+  readonly stderr: OutputStream;
+  readonly env: Env;
+  readonly quiet: boolean;
+  readonly json: boolean;
+  /** Chalk bound to stdout's answer. */
+  readonly outStyle: ChalkInstance;
+  /** Chalk bound to stderr's answer, which is a different question. */
+  readonly errStyle: ChalkInstance;
+
+  constructor(options: OutputOptions = {}) {
+    this.stdout = options.stdout ?? process.stdout;
+    this.stderr = options.stderr ?? process.stderr;
+    this.env = options.env ?? process.env;
+    this.quiet = options.quiet ?? false;
+    this.json = options.json ?? false;
+    this.outStyle = new Chalk({ level: colorLevelFor(this.stdout, this.env) });
+    this.errStyle = new Chalk({ level: colorLevelFor(this.stderr, this.env) });
+  }
+
+  /** The command's answer. Never suppressed by `--quiet`, because then nothing would be left. */
+  data(text: string): void {
+    this.stdout.write(text.endsWith('\n') ? text : text + '\n');
+  }
+
+  /**
+   * The one JSON document `--json` promises, and the reason nothing else may touch stdout.
+   *
+   * Stringified without indentation on purpose: this is a machine's copy, `jq` formats it for a
+   * human, and the two commands that already print an indented document (`analyze`, `doctor`) keep
+   * doing so through `data` because their shape is a published contract.
+   */
+  jsonData(payload: unknown): void {
+    this.data(JSON.stringify(payload));
+  }
+
+  /** Narration. Dropped by `--quiet` and by `--json`. */
+  note(text: string): void {
+    if (this.quiet || this.json) return;
+    this.stderr.write(text + '\n');
+  }
+
+  /** A warning: narration a user asked to be quiet still does not need. */
+  warn(text: string): void {
+    if (this.quiet || this.json) return;
+    this.stderr.write(this.errStyle.yellow(text) + '\n');
+  }
+
+  /**
+   * A failure. Never suppressed by anything, because a script that cannot tell a success from a
+   * swallowed failure is worse off than one with no `--quiet` at all.
+   *
+   * Under `--json` the machine-readable failure goes to stdout as the document, so this stays
+   * quiet there rather than printing the same fact twice in two shapes.
+   */
+  error(text: string, detail?: string): void {
+    if (this.json) return;
+    const line = this.errStyle.red(text) + (detail ? ' ' + detail : '');
+    this.stderr.write(line + '\n');
+  }
+
+  /** A hint under an error. Suppressed by `--quiet`: the error above it already said what broke. */
+  hint(text: string): void {
+    if (this.quiet || this.json) return;
+    this.stderr.write(this.errStyle.dim(text) + '\n');
+  }
+
+  /**
+   * A spinner on stderr, or nothing.
+   *
+   * `ora` is constructed only when stderr is a terminal. Given a pipe it still writes its text
+   * once as `- Analyzing...`, which is a line nobody reading a log wants, and given `NO_COLOR` it
+   * writes a coloured symbol anyway. Both are avoided by not building it.
+   */
+  spinner(text: string): Spinner {
+    const live: Ora | null =
+      !this.quiet && !this.json && this.stderr.isTTY
+        ? ora({
+            text,
+            stream: this.stderr as NodeJS.WritableStream,
+            // ora paints its own frame cyan through its own chalk, which is a second colour
+            // decision beside this one and does not read `NO_COLOR` either. Measured with the
+            // variable set: everything else on the line went plain and the spinner frame arrived
+            // as `[36m⠋[39m`. `false` is ora's documented way to turn that off.
+            color: this.errStyle.level > 0 ? 'cyan' : false,
+          }).start()
+        : null;
+    return {
+      succeed: (done: string) => {
+        live?.stop();
+        this.succeed(done);
+      },
+      fail: (done: string) => {
+        live?.stop();
+        this.error(done);
+      },
+      stop: () => live?.stop(),
+    };
+  }
+
+  /**
+   * A completed step.
+   *
+   * The tick is rendered here rather than by `ora.succeed`, which is the fix for the escape that
+   * reached piped output: `log-symbols` colours the symbol from the environment alone and never
+   * looks at the stream, so `drzl analyze 2> log` used to write `[32m✔[39m` into
+   * the file. Here the symbol goes through the same per-stream decision as everything else.
+   */
+  succeed(text: string): void {
+    if (this.quiet || this.json) return;
+    this.stderr.write(this.errStyle.green('✔') + ' ' + text + '\n');
+  }
+
+  /** A progress bar for `tables` items, or a no-op. See `shouldShowProgress` for the four gates. */
+  progress(tables: number): Progress {
+    return createProgress(
+      shouldShowProgress({
+        tables,
+        stderr: this.stderr,
+        quiet: this.quiet,
+        json: this.json,
+      }),
+      tables,
+      this.stderr
+    );
+  }
+
+  /**
+   * Whether an unrequested extra, such as the sponsor tip, should be shown at all.
+   *
+   * A terminal is the only place an aside has a reader. Piped into a file it is noise in someone's
+   * log, and under `--json` it would be noise in the middle of a document.
+   */
+  get wantsAsides(): boolean {
+    return !this.quiet && !this.json && Boolean(this.stderr.isTTY);
+  }
+}
+
+/** The failure document every command emits under `--json`, whatever went wrong. */
+export interface JsonFailure {
+  ok: false;
+  command: string;
+  code: string;
+  message: string;
+  exitCode: number;
+}
+
+/**
+ * The failure half of the `--json` contract.
+ *
+ * A `--json` run writes one document on stdout whether it worked or not, because the case people
+ * script against is the one that fails, and a command whose failure exists only as prose on stderr
+ * forces every caller to parse English.
+ *
+ * `ok: false` appears here and nowhere in the shared envelope, which is deliberate: `doctor` has
+ * published an `ok` of its own since it shipped, meaning "nothing to report about your schema",
+ * and that is a different question from whether the run worked. Redefining it would break a
+ * documented field and carrying both spellings would let them disagree, so the run's answer is
+ * `exitCode` on every document, and `ok` keeps its own meaning where it already had one. A failure
+ * document has no payload to collide with, so it says `ok: false` plainly.
+ */
+export function jsonFailure(
+  command: string,
+  code: string,
+  message: string,
+  exitCode: number = EXIT_FAILED
+): JsonFailure {
+  return { ok: false, command, code, message, exitCode };
+}
+
+/**
+ * The message off a thrown value, whatever was thrown.
+ *
+ * Whole, not the first line. The config validator throws a zod error whose message is a formatted
+ * JSON array, and the first line of that is `[`, so truncating it would turn "your config names no
+ * generators" into a bracket. The `--json` document carries the same string, where newlines cost
+ * nothing.
+ */
+export function messageOf(value: unknown): string {
+  const message = (value as { message?: string })?.message;
+  return String(message ?? value);
+}

--- a/packages/cli/src/sponsor.ts
+++ b/packages/cli/src/sponsor.ts
@@ -1,11 +1,22 @@
-import chalk from 'chalk';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { Output } from './output.js';
 
 export interface SponsorMessageOptions {
   reason?: string;
   minIntervalMs?: number;
   force?: boolean;
+  /**
+   * Where to write, and whether to write at all.
+   *
+   * This used to be `console.log`, which put an advertisement on stdout in the middle of the file
+   * list a script was parsing: 246 bytes of it, measured on 4.22.0. It is narration, so it goes to
+   * stderr, and `Output.wantsAsides` is what decides whether an unrequested aside has a reader:
+   * not under `--quiet`, not under `--json`, and not when stderr is a pipe, because a tip written
+   * into somebody's build log is only noise. The pre-existing `CI` gate below is the same idea
+   * arrived at one environment at a time.
+   */
+  out?: Output;
 }
 
 interface SponsorCachePayload {
@@ -27,18 +38,20 @@ const tips = [
   'Use output headers to track generated files and trim noisy diffs.',
 ];
 
-const green = (msg: string) => chalk.hex('#6ee7b7')(msg);
-const cyan = (msg: string) => chalk.cyan(msg);
-const gray = (msg: string) => chalk.gray(msg);
-
 export function maybeShowSponsorMessage({
   reason = 'generate',
   minIntervalMs = DEFAULT_INTERVAL_MS,
   force = false,
+  out = new Output(),
 }: SponsorMessageOptions = {}) {
+  const green = (msg: string) => out.errStyle.hex('#6ee7b7')(msg);
+  const cyan = (msg: string) => out.errStyle.cyan(msg);
+  const gray = (msg: string) => out.errStyle.gray(msg);
+
   const hideViaEnv = process.env.DRZL_HIDE_SPONSOR?.toLowerCase();
   const hideRequested = hideViaEnv === '1' || hideViaEnv === 'true';
   if (hideRequested || (process.env.CI && !force) || (shownThisProcess && !force)) return;
+  if (!out.wantsAsides && !force) return;
 
   try {
     mkdirSync(CACHE_DIR, { recursive: true });
@@ -60,11 +73,11 @@ export function maybeShowSponsorMessage({
     shownThisProcess = true;
     const tip = tips[payload.runs % tips.length];
 
-    console.log(
+    out.stderr.write(
       `\n${cyan(`🚀 DRZL finished a ${reason} run (#${payload.runs.toLocaleString()}).`)}\n\n` +
         `${green('✨ Sponsors keep DRZL shipping. Consider supporting ongoing dev:')}\n` +
         `  ${green('GitHub Sponsors')}  ${gray('→ https://github.com/sponsors/omar-dulaimi')}\n\n` +
-        `${green('Pro tip:')} ${tip}\n`
+        `${green('Pro tip:')} ${tip}\n\n`
     );
   } catch {
     // Swallow to avoid impacting generator success paths

--- a/packages/cli/test/cli-output.e2e.spec.ts
+++ b/packages/cli/test/cli-output.e2e.spec.ts
@@ -1,0 +1,490 @@
+/**
+ * What the CLI writes, to which stream, in what shape (plan items 72, 73, 74, 76, 77).
+ *
+ * Every assertion here is on bytes rather than on a screenshot of a terminal. "No colour leaked
+ * into the pipe" is `indexOf(0x1b) === -1` on the captured buffer, because a visual check of a
+ * terminal is exactly the check that cannot see an escape sequence: the terminal consumes it.
+ *
+ * The colour rules are exercised through ordinary pipes, with no pseudo-terminal, because
+ * `FORCE_COLOR=1` turns colour on where a pipe would have it off. That is what makes
+ * `NO_COLOR` testable at all: on a pipe with nothing forced there is no colour to refuse, so a
+ * green run would prove nothing. Every "no escapes" assertion is therefore paired with a run that
+ * must produce escapes, or the assertion could pass against a CLI that had stopped printing.
+ *
+ * The two assertions that genuinely need a terminal (a progress bar appears, a spinner appears)
+ * use `script(1)`, and skip themselves where it is not installed. The window size is set from
+ * inside the session on purpose: a pty opened with no size reports zero columns, and `ora` divides
+ * by the width to decide how many lines to erase, so a zero there made the CLI emit 180MB of erase
+ * sequences in 30 seconds and never finish.
+ *
+ * Requires a build. CI builds before testing; locally, run `pnpm build` first.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawn } from 'node:child_process';
+import { existsSync, promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const CLI = path.resolve(__dirname, '..', 'dist', 'cli.js');
+const ROOT = path.join(__dirname, '.tmp-output');
+
+const ESC = 0x1b;
+
+interface Run {
+  code: number;
+  out: Buffer;
+  err: Buffer;
+  outText: string;
+  errText: string;
+}
+
+/**
+ * Run the built CLI with both streams on their own pipe and keep the raw bytes.
+ *
+ * The three variables under test are removed from the inherited environment before `env` is
+ * applied, because the shell a developer runs `pnpm test` from may well export one of them. This
+ * one exports `FORCE_COLOR=3`, which turns every row of the matrix into an apparent colour leak.
+ */
+function run(args: string[], opts: { cwd: string; env?: Record<string, string> } = { cwd: ROOT }) {
+  return new Promise<Run>((resolve, reject) => {
+    const env: Record<string, string | undefined> = { ...process.env, ...(opts.env ?? {}) };
+    for (const key of ['CI', 'NO_COLOR', 'FORCE_COLOR']) {
+      if (!(key in (opts.env ?? {}))) delete env[key];
+    }
+    const child = spawn(process.execPath, [CLI, ...args], {
+      cwd: opts.cwd,
+      env: env as NodeJS.ProcessEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout.on('data', (c: Buffer) => out.push(c));
+    child.stderr.on('data', (c: Buffer) => err.push(c));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const o = Buffer.concat(out);
+      const e = Buffer.concat(err);
+      resolve({ code: code ?? -1, out: o, err: e, outText: o.toString('utf8'), errText: e.toString('utf8') });
+    });
+  });
+}
+
+/** True when `script(1)` can give a command a real terminal on both streams. */
+async function hasScript(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn('script', ['--version'], { stdio: 'ignore' });
+    child.on('error', () => resolve(false));
+    child.on('close', (code) => resolve(code === 0));
+  });
+}
+
+/** Run the CLI with stdout and stderr on one pty of a known size. Output is the merged stream. */
+function runTty(args: string[], cwd: string, extraEnv: Record<string, string> = {}) {
+  return new Promise<{ code: number; text: string }>((resolve, reject) => {
+    const env: Record<string, string | undefined> = { ...process.env, ...extraEnv };
+    for (const key of ['CI', 'NO_COLOR', 'FORCE_COLOR']) {
+      if (!(key in extraEnv)) delete env[key];
+    }
+    const inner = `stty rows 24 cols 80; ${JSON.stringify(process.execPath)} ${JSON.stringify(CLI)} ${args
+      .map((a) => JSON.stringify(a))
+      .join(' ')}`;
+    const child = spawn('script', ['-qec', inner, '/dev/null'], {
+      cwd,
+      env: env as NodeJS.ProcessEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const chunks: Buffer[] = [];
+    child.stdout.on('data', (c: Buffer) => chunks.push(c));
+    child.stderr.on('data', (c: Buffer) => chunks.push(c));
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code: code ?? -1, text: Buffer.concat(chunks).toString('utf8') }));
+  });
+}
+
+const SCHEMA_HEAD = `import { pgTable, integer, serial, text, customType, check } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+
+const money = customType<{ data: string; driverData: string }>({ dataType: () => 'numeric(12,2)' });
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+
+export const invoices = pgTable(
+  'invoices',
+  {
+    id: integer().primaryKey(),
+    reference: text().notNull(),
+    balance: money().notNull(),
+  },
+  (t) => [check('ref_or_id', sql\`\${t.reference} <> '' OR \${t.id} > 0\`)]
+);
+`;
+
+/** A project with `tables` plain tables, for the progress-bar threshold. */
+function wideSchema(tables: number): string {
+  const lines = [`import { pgTable, serial, text } from 'drizzle-orm/pg-core';`];
+  for (let i = 0; i < tables; i++) {
+    lines.push(
+      `export const t${i} = pgTable('t${i}', { id: serial('id').primaryKey(), a: text('a') });`
+    );
+  }
+  return lines.join('\n') + '\n';
+}
+
+/** A fresh project directory. Lives under this package so drizzle-orm resolves normally. */
+async function project(name: string, schema = SCHEMA_HEAD, withConfig = true) {
+  const dir = path.join(ROOT, name);
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(path.join(dir, 'src', 'db'), { recursive: true });
+  await fs.writeFile(path.join(dir, 'src', 'db', 'schema.ts'), schema, 'utf8');
+  if (withConfig) {
+    await fs.writeFile(
+      path.join(dir, 'drzl.config.ts'),
+      `export default {
+         schema: './src/db/schema.ts',
+         outDir: './out',
+         analyzer: { includeRelations: true, validateConstraints: true },
+         generators: [{ kind: 'zod', path: './zod' }],
+       };`,
+      'utf8'
+    );
+  }
+  return dir;
+}
+
+let script = false;
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.mkdir(ROOT, { recursive: true });
+  script = await hasScript();
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+/** Every command, with an invocation that reaches its real work rather than its usage text. */
+const COMMANDS: Array<{ name: string; args: string[] }> = [
+  { name: 'analyze', args: ['analyze', 'src/db/schema.ts'] },
+  { name: 'doctor', args: ['doctor', 'src/db/schema.ts'] },
+  { name: 'generate', args: ['generate'] },
+  { name: 'generate:orpc', args: ['generate:orpc', 'src/db/schema.ts', '--outDir', 'out-orpc'] },
+  { name: 'generate:trpc', args: ['generate:trpc', 'src/db/schema.ts', '--outDir', 'out-trpc'] },
+];
+
+describe('item 77: no escape sequence reaches a stream that is not a terminal', () => {
+  for (const { name, args } of COMMANDS) {
+    it(`${name} writes no escapes to either pipe`, async () => {
+      const dir = await project(`esc-${name.replace(':', '-')}`);
+      const r = await run(args, { cwd: dir });
+      expect(r.out.indexOf(ESC), `stdout of ${name}: ${JSON.stringify(r.outText.slice(0, 300))}`).toBe(-1);
+      expect(r.err.indexOf(ESC), `stderr of ${name}: ${JSON.stringify(r.errText.slice(0, 300))}`).toBe(-1);
+    }, 120_000);
+  }
+
+  it('the failure paths are colourless through a pipe too', async () => {
+    const dir = await project('esc-fail');
+    const missing = await run(['analyze', 'no-such.ts'], { cwd: dir });
+    expect(missing.out.indexOf(ESC)).toBe(-1);
+    expect(missing.err.indexOf(ESC)).toBe(-1);
+
+    const noConfig = await run(['generate', '--config', 'no-such.config.ts'], { cwd: dir });
+    expect(noConfig.out.indexOf(ESC)).toBe(-1);
+    expect(noConfig.err.indexOf(ESC)).toBe(-1);
+  }, 120_000);
+
+  // Without this the assertions above hold just as well against a CLI that prints nothing at all,
+  // and against one whose colour was removed rather than gated.
+  it('the same commands do emit colour when it is asked for, so the checks above are not vacuous', async () => {
+    const dir = await project('esc-forced');
+    const r = await run(['generate'], { cwd: dir, env: { FORCE_COLOR: '1' } });
+    expect(r.out.indexOf(ESC)).toBeGreaterThan(-1);
+    expect(r.err.indexOf(ESC)).toBeGreaterThan(-1);
+  }, 120_000);
+});
+
+describe('item 76: NO_COLOR', () => {
+  it('turns colour off on a pipe that FORCE_COLOR would have turned on', async () => {
+    const dir = await project('nc-generate');
+    const forced = await run(['generate'], { cwd: dir, env: { FORCE_COLOR: '1' } });
+    expect(forced.err.indexOf(ESC)).toBeGreaterThan(-1);
+
+    const refused = await run(['generate'], { cwd: dir, env: { FORCE_COLOR: '1', NO_COLOR: '1' } });
+    expect(refused.out.indexOf(ESC)).toBe(-1);
+    expect(refused.err.indexOf(ESC)).toBe(-1);
+  }, 120_000);
+
+  it('is honoured by every command, including the ones that only print a report', async () => {
+    const dir = await project('nc-all');
+    for (const { name, args } of COMMANDS) {
+      const r = await run(args, { cwd: dir, env: { FORCE_COLOR: '1', NO_COLOR: '1' } });
+      expect(r.out.indexOf(ESC), `stdout of ${name}`).toBe(-1);
+      expect(r.err.indexOf(ESC), `stderr of ${name}`).toBe(-1);
+    }
+  }, 240_000);
+
+  it('an empty NO_COLOR is not set, which is what no-color.org says', async () => {
+    const dir = await project('nc-empty');
+    const r = await run(['generate'], { cwd: dir, env: { FORCE_COLOR: '1', NO_COLOR: '' } });
+    expect(r.err.indexOf(ESC)).toBeGreaterThan(-1);
+  }, 120_000);
+
+  it('a terminal still gets colour when nothing refuses it', async () => {
+    if (!script) return;
+    const dir = await project('nc-tty');
+    const r = await runTty(['doctor', 'src/db/schema.ts'], dir);
+    expect(r.text).toContain('[');
+  }, 120_000);
+
+  it('and none when NO_COLOR is set, on that same terminal', async () => {
+    if (!script) return;
+    const dir = await project('nc-tty-off');
+    const loud = await runTty(['doctor', 'src/db/schema.ts'], dir);
+    expect(loud.text).toContain('[');
+    const off = await runTty(['doctor', 'src/db/schema.ts'], dir, { NO_COLOR: '1' });
+    // The report itself, with no SGR sequence anywhere in it. `script` echoes nothing of its own.
+    expect(off.text).toContain('DRZL doctor');
+    expect(off.text).not.toContain('[3');
+  }, 120_000);
+
+  // Cursor moves and line erases are not colour, and a spinner has to make them to be a spinner.
+  // So this asserts on SGR sequences alone, which is the only kind NO_COLOR speaks about. It
+  // covers the spinner frame in particular: ora paints that one through a chalk of its own, and
+  // with the variable set everything else on the line went plain while the frame still arrived as
+  // an escape-wrapped cyan glyph.
+  it('leaves cursor control alone and removes only the colour', async () => {
+    if (!script) return;
+    const dir = await project('nc-sgr', wideSchema(30));
+    const sgr = /\[[0-9;]*m/;
+    const loud = await runTty(['generate'], dir);
+    expect(loud.text).toMatch(sgr);
+    const off = await runTty(['generate'], dir, { NO_COLOR: '1' });
+    expect(off.text).toContain('Analysis complete');
+    expect(off.text).not.toMatch(sgr);
+  }, 300_000);
+});
+
+describe('item 72: the progress bar', () => {
+  const GLYPHS = /[█░]/;
+
+  it('is absent for a single table on a terminal', async () => {
+    if (!script) return;
+    const dir = await project('bar-one', wideSchema(1));
+    const r = await runTty(['generate'], dir);
+    expect(r.text).not.toMatch(GLYPHS);
+  }, 180_000);
+
+  it('appears once there are enough tables for it to move', async () => {
+    if (!script) return;
+    const dir = await project('bar-many', wideSchema(30));
+    const r = await runTty(['generate'], dir);
+    expect(r.text).toMatch(GLYPHS);
+  }, 240_000);
+
+  it('never appears when the stream is not a terminal, however many tables there are', async () => {
+    const dir = await project('bar-pipe', wideSchema(30));
+    const r = await run(['generate'], { cwd: dir });
+    expect(r.outText).not.toMatch(GLYPHS);
+    expect(r.errText).not.toMatch(GLYPHS);
+  }, 240_000);
+
+  it('is gone under --quiet on a terminal', async () => {
+    if (!script) return;
+    const dir = await project('bar-quiet', wideSchema(30));
+    const r = await runTty(['generate', '--quiet'], dir);
+    expect(r.text).not.toMatch(GLYPHS);
+  }, 240_000);
+});
+
+describe('item 73: --json is one document on stdout, for every command', () => {
+  const JSON_COMMANDS: Array<{ name: string; args: string[] }> = [
+    { name: 'analyze', args: ['analyze', 'src/db/schema.ts', '--json'] },
+    { name: 'doctor', args: ['doctor', 'src/db/schema.ts', '--json'] },
+    { name: 'generate', args: ['generate', '--json'] },
+    { name: 'generate:orpc', args: ['generate:orpc', 'src/db/schema.ts', '--outDir', 'o', '--json'] },
+    { name: 'generate:trpc', args: ['generate:trpc', 'src/db/schema.ts', '--outDir', 't', '--json'] },
+    { name: 'init', args: ['init', '--yes', '--json'] },
+  ];
+
+  for (const { name, args } of JSON_COMMANDS) {
+    it(`${name} --json parses with no filtering`, async () => {
+      const dir = await project(`json-${name.replace(':', '-')}`, SCHEMA_HEAD, name !== 'init');
+      const r = await run(args, { cwd: dir });
+      expect(r.out.indexOf(ESC)).toBe(-1);
+      expect(() => JSON.parse(r.outText)).not.toThrow();
+    }, 120_000);
+  }
+
+  it('a failure is a document too, not prose on stderr', async () => {
+    const dir = await project('json-fail');
+    const r = await run(['generate', '--config', 'no-such.config.ts', '--json'], { cwd: dir });
+    const doc = JSON.parse(r.outText);
+    expect(doc.ok).toBe(false);
+    expect(doc.command).toBe('generate');
+    expect(typeof doc.code).toBe('string');
+    expect(typeof doc.message).toBe('string');
+    expect(doc.exitCode).toBe(r.code);
+  }, 120_000);
+
+  it('every document names its command and repeats the process exit code', async () => {
+    const dir = await project('json-envelope');
+    const cases: Array<[string[], string]> = [
+      [['analyze', 'src/db/schema.ts', '--json'], 'analyze'],
+      [['doctor', 'src/db/schema.ts', '--json'], 'doctor'],
+      [['generate', '--json'], 'generate'],
+      [['generate:orpc', 'src/db/schema.ts', '--outDir', 'o', '--json'], 'generate:orpc'],
+      [['generate:trpc', 'src/db/schema.ts', '--outDir', 't', '--json'], 'generate:trpc'],
+    ];
+    for (const [args, command] of cases) {
+      const r = await run(args, { cwd: dir });
+      const doc = JSON.parse(r.outText);
+      expect(doc.command, args.join(' ')).toBe(command);
+      expect(doc.exitCode, args.join(' ')).toBe(r.code);
+    }
+  }, 300_000);
+
+  it("doctor's own `ok` still means the schema is clean, not that the run worked", async () => {
+    const dir = await project('json-doctor-ok');
+    // This schema carries an untypeable customType and a CHECK using OR, so there are findings.
+    const withFindings = JSON.parse(
+      (await run(['doctor', 'src/db/schema.ts', '--json'], { cwd: dir })).outText
+    );
+    expect(withFindings.ok).toBe(false);
+    expect(withFindings.exitCode).toBe(0);
+    expect(withFindings.findings.length).toBeGreaterThan(0);
+  }, 120_000);
+
+  it('the sponsor tip never reaches stdout, with or without --json', async () => {
+    const dir = await project('json-sponsor');
+    const plain = await run(['generate'], { cwd: dir });
+    expect(plain.outText).not.toContain('Sponsors keep DRZL shipping');
+    const asJson = await run(['generate', '--json'], { cwd: dir });
+    expect(asJson.outText).not.toContain('Sponsors keep DRZL shipping');
+  }, 120_000);
+
+  it('--json keeps stdout to the document even when there are warnings to print', async () => {
+    // This schema carries an untypeable customType, so the human run prints a warning block.
+    const dir = await project('json-warn');
+    const human = await run(['generate'], { cwd: dir });
+    expect(human.errText).toContain('could not be typed');
+    const asJson = await run(['generate', '--json'], { cwd: dir });
+    expect(asJson.errText).toBe('');
+    const doc = JSON.parse(asJson.outText);
+    expect(doc.warnings.join(' ')).toContain('could not be typed');
+  }, 120_000);
+});
+
+describe('item 73: --quiet is quiet, not silent', () => {
+  it('drops the narration and keeps the answer', async () => {
+    const dir = await project('quiet-analyze');
+    const loud = await run(['analyze', 'src/db/schema.ts'], { cwd: dir });
+    const quiet = await run(['analyze', 'src/db/schema.ts', '--quiet'], { cwd: dir });
+    expect(quiet.errText).toBe('');
+    expect(quiet.outText).toBe(loud.outText);
+    expect(quiet.code).toBe(loud.code);
+  }, 120_000);
+
+  it('still reports a failure, and still exits non-zero', async () => {
+    const dir = await project('quiet-fail');
+    const r = await run(['generate', '--config', 'no-such.config.ts', '--quiet'], { cwd: dir });
+    expect(r.code).toBe(1);
+    expect(r.errText.length).toBeGreaterThan(0);
+    expect(r.errText).toContain('DRZL_CFG_001');
+  }, 120_000);
+
+  it('is available on every command', async () => {
+    const dir = await project('quiet-all');
+    for (const { name, args } of COMMANDS) {
+      const r = await run([...args, '--quiet'], { cwd: dir });
+      expect(r.code, `${name} --quiet should not be a usage error`).not.toBe(1);
+    }
+    const init = await run(['init', '--yes', '--quiet'], {
+      cwd: await project('quiet-init', SCHEMA_HEAD, false),
+    });
+    expect(init.code).toBe(0);
+    expect(init.errText).toBe('');
+  }, 240_000);
+});
+
+describe('item 74: exit codes', () => {
+  it('0 when the command did what it was asked', async () => {
+    const dir = await project('exit-ok');
+    expect((await run(['analyze', 'src/db/schema.ts'], { cwd: dir })).code).toBe(0);
+    expect((await run(['doctor', 'src/db/schema.ts'], { cwd: dir })).code).toBe(0);
+    expect((await run(['generate'], { cwd: dir })).code).toBe(0);
+    expect((await run(['generate', '--check'], { cwd: dir })).code).toBe(0);
+  }, 240_000);
+
+  it('1 when DRZL could not run', async () => {
+    const dir = await project('exit-failed');
+    expect((await run(['generate', '--config', 'nope.config.ts'], { cwd: dir })).code).toBe(1);
+    expect((await run(['doctor', 'no-such.ts'], { cwd: dir })).code).toBe(1);
+    // A schema path that is not there is not a schema with problems: it is a run that could not
+    // happen. `generate:orpc` used to write a placeholder file and exit 0 for exactly this.
+    expect((await run(['generate:orpc', 'no-such.ts', '--outDir', 'o'], { cwd: dir })).code).toBe(1);
+    expect((await run(['generate:trpc', 'no-such.ts', '--outDir', 't'], { cwd: dir })).code).toBe(1);
+  }, 240_000);
+
+  it('2 when it ran fine and found what it was asked to look for', async () => {
+    const dir = await project('exit-findings');
+    // A customType the analyzer cannot type is a finding, and --strict is the opt-in.
+    expect((await run(['doctor', 'src/db/schema.ts', '--strict'], { cwd: dir })).code).toBe(2);
+    // Drift: generate once, edit the output, then check.
+    expect((await run(['generate'], { cwd: dir })).code).toBe(0);
+    await fs.appendFile(path.join(dir, 'zod', 'users.zod.ts'), '\n// edited by hand\n', 'utf8');
+    expect((await run(['generate', '--check'], { cwd: dir })).code).toBe(2);
+  }, 240_000);
+
+  it('a missing schema is 1 from every command that takes one', async () => {
+    const dir = await project('exit-missing');
+    for (const args of [
+      ['analyze', 'no-such.ts'],
+      ['doctor', 'no-such.ts'],
+      ['generate:orpc', 'no-such.ts', '--outDir', 'o'],
+      ['generate:trpc', 'no-such.ts', '--outDir', 't'],
+    ]) {
+      const r = await run(args, { cwd: dir });
+      expect(r.code, `${args.join(' ')}`).toBe(1);
+    }
+  }, 240_000);
+
+  it('the JSON document reports the same code the process returns', async () => {
+    const dir = await project('exit-json');
+    for (const args of [
+      ['doctor', 'src/db/schema.ts', '--strict', '--json'],
+      ['analyze', 'no-such.ts', '--json'],
+      ['generate', '--config', 'nope.config.ts', '--json'],
+    ]) {
+      const r = await run(args, { cwd: dir });
+      const doc = JSON.parse(r.outText);
+      expect(doc.exitCode, `${args.join(' ')}`).toBe(r.code);
+    }
+  }, 240_000);
+});
+
+describe('the stream rule: stdout is the answer, stderr is the narration', () => {
+  it('analyze puts the analysis on stdout and the spinner line on stderr', async () => {
+    const dir = await project('stream-analyze');
+    const r = await run(['analyze', 'src/db/schema.ts'], { cwd: dir });
+    expect(() => JSON.parse(r.outText)).not.toThrow();
+    expect(r.errText).toContain('Analyzed in');
+  }, 120_000);
+
+  it('generate keeps warnings and progress off stdout', async () => {
+    const dir = await project('stream-generate');
+    const r = await run(['generate'], { cwd: dir });
+    expect(r.outText).not.toContain('could not be typed');
+    expect(r.errText).toContain('could not be typed');
+  }, 120_000);
+
+  it('every failure message is on stderr, and stdout stays empty', async () => {
+    const dir = await project('stream-fail');
+    const r = await run(['generate', '--config', 'nope.config.ts'], { cwd: dir });
+    expect(r.outText).toBe('');
+    expect(r.errText).toContain('DRZL_CFG_001');
+  }, 120_000);
+});

--- a/packages/cli/test/drizzle-kit-interop.e2e.spec.ts
+++ b/packages/cli/test/drizzle-kit-interop.e2e.spec.ts
@@ -90,11 +90,15 @@ afterAll(async () => {
 describe('drzl generate with no schema in drzl.config', () => {
   it('reads drizzle.config.ts, expands its glob, and generates for every table', async () => {
     const dir = await project('generate');
-    const { stdout } = await run(process.execPath, [CLI, 'generate'], {
+    const { stdout, stderr } = await run(process.execPath, [CLI, 'generate'], {
       cwd: dir,
       maxBuffer: 20 * 1024 * 1024,
     });
-    expect(stdout).toContain('drizzle.config.ts');
+    // stderr, not stdout. This line says where DRZL went looking, which is narration about the
+    // run rather than a thing the run produced, and it used to sit on stdout directly in front of
+    // the file list a caller was parsing. See docs/cli/output.md for the rule.
+    expect(stderr).toContain('drizzle.config.ts');
+    expect(stdout).not.toContain('drizzle.config.ts');
     // `.zod.ts`: the zod generator's default fileSuffix.
     expect(existsSync(path.join(dir, 'out', 'zod', 'users.zod.ts'))).toBe(true);
     expect(existsSync(path.join(dir, 'out', 'zod', 'posts.zod.ts'))).toBe(true);

--- a/packages/cli/test/output.spec.ts
+++ b/packages/cli/test/output.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * The two decisions the whole output layer rests on, exercised without spawning anything.
+ *
+ * `colorLevelFor` and `shouldShowProgress` are pure so that the combinations can be enumerated
+ * here rather than sampled through a terminal. The end-to-end file next door proves the CLI
+ * actually routes through them; this proves they are right.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  colorLevelFor,
+  EXIT_FAILED,
+  EXIT_FINDINGS,
+  EXIT_OK,
+  jsonFailure,
+  messageOf,
+  Output,
+  PROGRESS_MIN_TABLES,
+  shouldShowProgress,
+} from '../src/output.js';
+
+const tty = { write: () => {}, isTTY: true };
+const pipe = { write: () => {}, isTTY: false };
+
+describe('colorLevelFor', () => {
+  it('is off on a pipe and on at a terminal', () => {
+    expect(colorLevelFor(pipe, {})).toBe(0);
+    expect(colorLevelFor(tty, {})).toBeGreaterThan(0);
+  });
+
+  it('answers per stream, so one redirected stream does not decide for the other', () => {
+    // `drzl generate > out.txt` from a terminal. The old behaviour took stdout's answer for both.
+    const env = { TERM: 'xterm-256color' };
+    expect(colorLevelFor(pipe, env)).toBe(0);
+    expect(colorLevelFor(tty, env)).toBeGreaterThan(0);
+  });
+
+  it('reads the terminal it was given rather than guessing a level', () => {
+    expect(colorLevelFor(tty, { COLORTERM: 'truecolor' })).toBe(3);
+    expect(colorLevelFor(tty, { TERM: 'xterm-256color' })).toBe(2);
+    expect(colorLevelFor(tty, { TERM: 'xterm' })).toBe(1);
+  });
+
+  it('honours NO_COLOR, which chalk 6 does not', () => {
+    expect(colorLevelFor(tty, { NO_COLOR: '1', COLORTERM: 'truecolor' })).toBe(0);
+    expect(colorLevelFor(tty, { NO_COLOR: 'anything' })).toBe(0);
+  });
+
+  it('treats an empty NO_COLOR as unset, per no-color.org', () => {
+    expect(colorLevelFor(tty, { NO_COLOR: '' })).toBeGreaterThan(0);
+  });
+
+  it('lets NO_COLOR win over FORCE_COLOR', () => {
+    // The precedence chalk does not use, and the reason is in the module comment: FORCE_COLOR is
+    // usually a wrapper's doing and NO_COLOR is usually a person's.
+    expect(colorLevelFor(pipe, { FORCE_COLOR: '3', NO_COLOR: '1' })).toBe(0);
+    expect(colorLevelFor(tty, { FORCE_COLOR: '3', NO_COLOR: '1' })).toBe(0);
+  });
+
+  it('reads FORCE_COLOR the way every other tool does', () => {
+    expect(colorLevelFor(pipe, { FORCE_COLOR: '1' })).toBe(1);
+    expect(colorLevelFor(pipe, { FORCE_COLOR: '2' })).toBe(2);
+    expect(colorLevelFor(pipe, { FORCE_COLOR: '3' })).toBe(3);
+    expect(colorLevelFor(pipe, { FORCE_COLOR: '' })).toBe(1);
+    expect(colorLevelFor(pipe, { FORCE_COLOR: 'true' })).toBe(1);
+    expect(colorLevelFor(pipe, { FORCE_COLOR: '0' })).toBe(0);
+    expect(colorLevelFor(pipe, { FORCE_COLOR: 'false' })).toBe(0);
+    expect(colorLevelFor(tty, { FORCE_COLOR: '9', COLORTERM: 'truecolor' })).toBe(3);
+  });
+
+  it('refuses a terminal that says it cannot do colour', () => {
+    expect(colorLevelFor(tty, { TERM: 'dumb' })).toBe(0);
+  });
+});
+
+describe('shouldShowProgress', () => {
+  const base = { stderr: tty, quiet: false, json: false };
+
+  it('is off below the measured threshold and on at it', () => {
+    expect(shouldShowProgress({ ...base, tables: 1 })).toBe(false);
+    expect(shouldShowProgress({ ...base, tables: PROGRESS_MIN_TABLES - 1 })).toBe(false);
+    expect(shouldShowProgress({ ...base, tables: PROGRESS_MIN_TABLES })).toBe(true);
+  });
+
+  it('is off whenever nobody is watching the stream', () => {
+    expect(shouldShowProgress({ ...base, stderr: pipe, tables: 500 })).toBe(false);
+  });
+
+  it('is off under --quiet and under --json', () => {
+    expect(shouldShowProgress({ ...base, tables: 500, quiet: true })).toBe(false);
+    expect(shouldShowProgress({ ...base, tables: 500, json: true })).toBe(false);
+  });
+});
+
+/** A stream that keeps what was written to it, so a write can be asserted byte for byte. */
+function sink(isTTY: boolean) {
+  const chunks: string[] = [];
+  return {
+    isTTY,
+    write: (s: string) => {
+      chunks.push(s);
+      return true;
+    },
+    get text() {
+      return chunks.join('');
+    },
+  };
+}
+
+describe('Output', () => {
+  it('puts data on stdout and narration on stderr', () => {
+    const stdout = sink(false);
+    const stderr = sink(false);
+    const out = new Output({ stdout, stderr, env: {} });
+    out.data('answer');
+    out.note('narration');
+    out.warn('careful');
+    out.error('broke');
+    expect(stdout.text).toBe('answer\n');
+    expect(stderr.text).toBe('narration\ncareful\nbroke\n');
+  });
+
+  it('drops narration under --quiet and keeps the answer and the error', () => {
+    const stdout = sink(false);
+    const stderr = sink(false);
+    const out = new Output({ stdout, stderr, env: {}, quiet: true });
+    out.data('answer');
+    out.note('narration');
+    out.warn('careful');
+    out.succeed('done');
+    out.error('broke');
+    expect(stdout.text).toBe('answer\n');
+    expect(stderr.text).toBe('broke\n');
+  });
+
+  it('writes nothing but the document to stdout under --json, and nothing at all to stderr', () => {
+    const stdout = sink(false);
+    const stderr = sink(false);
+    const out = new Output({ stdout, stderr, env: {}, json: true });
+    out.note('narration');
+    out.warn('careful');
+    out.error('broke');
+    out.succeed('done');
+    out.jsonData({ ok: true });
+    expect(stdout.text).toBe('{"ok":true}\n');
+    expect(stderr.text).toBe('');
+  });
+
+  it('colours each stream from its own answer', () => {
+    const stdout = sink(false);
+    const stderr = sink(true);
+    const out = new Output({ stdout, stderr, env: { TERM: 'xterm' } });
+    expect(out.outStyle.level).toBe(0);
+    expect(out.errStyle.level).toBe(1);
+    // The tick is rendered here rather than by ora, which is what stops the symbol carrying a
+    // colour decision of its own; see the module comment on `succeed`.
+    out.succeed('done');
+    expect(stderr.text).toContain('[32m');
+    out.data(out.outStyle.cyan('plain'));
+    expect(stdout.text).toBe('plain\n');
+  });
+
+  it('shows an aside only where one has a reader', () => {
+    const env = {};
+    expect(new Output({ stderr: sink(true), env }).wantsAsides).toBe(true);
+    expect(new Output({ stderr: sink(false), env }).wantsAsides).toBe(false);
+    expect(new Output({ stderr: sink(true), env, quiet: true }).wantsAsides).toBe(false);
+    expect(new Output({ stderr: sink(true), env, json: true }).wantsAsides).toBe(false);
+  });
+});
+
+describe('the exit codes', () => {
+  it('are three, and distinct', () => {
+    expect(new Set([EXIT_OK, EXIT_FAILED, EXIT_FINDINGS]).size).toBe(3);
+    expect(EXIT_OK).toBe(0);
+    expect(EXIT_FAILED).toBe(1);
+    expect(EXIT_FINDINGS).toBe(2);
+  });
+
+  it('are repeated in the failure document, so a caller reads one field', () => {
+    expect(jsonFailure('generate', 'DRZL_CFG_001', 'no config')).toEqual({
+      ok: false,
+      command: 'generate',
+      code: 'DRZL_CFG_001',
+      message: 'no config',
+      exitCode: EXIT_FAILED,
+    });
+  });
+});
+
+describe('messageOf', () => {
+  it('keeps the whole message, because a config error is a formatted block', () => {
+    const zodish = new Error('[\n  {\n    "path": ["generators"],\n    "message": "too small"\n  }\n]');
+    expect(messageOf(zodish)).toContain('generators');
+    expect(messageOf(zodish).split('\n').length).toBeGreaterThan(1);
+  });
+
+  it('survives a thrown non-error', () => {
+    expect(messageOf('plain string')).toBe('plain string');
+    expect(messageOf(undefined)).toBe('undefined');
+  });
+});


### PR DESCRIPTION
Plan items 72, 73, 74, 76 and 77 as one change, because they are all the same layer: what the CLI writes, to which stream, in what shape.

## Measured before designing

A probe giving **stdout and stderr separate channels** (each its own pty or pipe), because a single `script(1)` pty cannot express "stdout redirected, stderr still a terminal", which is exactly the case both defect items are about. Six conditions, 18 invocations each, before and after.

Two measurement artifacts worth recording: a pty opened with no window size reports **0 columns**, and ora divides by the width to decide how many lines to erase, which produced **180 MB of erase sequences in 30 seconds** before `TIOCSWINSZ` was set; and the agent's own shell exports `FORCE_COLOR=3`, which made every row look like a colour leak until stripped (the test harness now strips all three variables for the same reason).

## What the five items turned out to be

- **76 was worse than filed**: `NO_COLOR` did nothing at all. `chalk@6.0.0` vendors a `supports-color` containing the string `NO_COLOR` **zero** times and `FORCE_COLOR` ten; with the variable set on a pty, `chalk.level` was still 3 and `doctor` emitted the same 32 escapes.
- **77 was real but not where filed**: chalk does check `isTTY`, so no chalk escape reached a pipe. The leak was **ora's success symbol**, coloured by `log-symbols` through `yoctocolors`, which reads `TERM`/`COLORTERM` and never asks whether the stream is a terminal. The same measurement found the **mirror defect**: chalk's default instance takes its level from `supportsColor.stdout` alone, so `drzl generate > out.txt` turned the stderr narration colourless on a terminal that was still there.
- **72 confirmed and quantified**: for one table the bar painted a single frame reading `0% | 0/1` and was wiped without advancing. The loop costs ~105 ms fixed plus 3.6 ms per table against a 10 fps redraw, so below ~25 tables it cannot move. Threshold set at 25 plus terminal-only. The measurement also exposed an unreported bug: the bar was started once outside the loop and `stop()`ed by whichever generator finished first, so **a second generator updated a dead bar**.
- **73**: `--json` existed on 3 of 7 commands and `--quiet` on none; both now on every command through one helper.
- **74**: `2` meant three unrelated things and `1` meant two. New scheme: `0` did the work, `1` could not do the work, `2` did the work and found something, which is the only distinction a pipeline acts on differently. `generate:orpc`/`generate:trpc` on a missing schema **exited 0** after writing a placeholder reading "No tables detected in analysis", the same defect item 67 fixed in `init`; they now exit 1 and write nothing.

## Rules now enforced

stdout carries the answer and stderr the narration; `--json` puts exactly one document on stdout and writes nothing to stderr; `--quiet` drops narration but never an error, an exit code, or the answer (`generate --check --quiet` still names drifted files, since that list *is* the finding). Colour precedence is `NO_COLOR` > `TERM=dumb` > `FORCE_COLOR` > per-stream `isTTY`, with `NO_COLOR` beating `FORCE_COLOR` deliberately (a profile setting should beat a wrapper's injection) and with the payoff that every colour rule becomes testable through an ordinary pipe.

One collision is documented rather than papered over: `doctor` has a published `ok` meaning "nothing to report about your schema", which is not "did the run work", so the envelope deliberately carries `exitCode` rather than adding a second `ok`.

## Verification

Red-first: both test files written before touching `cli.ts`, **21 of 36 failing** against the unchanged CLI with every item represented; 59 green after, CLI package at 715 tests. Every no-escapes claim is `buffer.indexOf(0x1b) === -1` on the raw bytes, each **paired with a must-fire `FORCE_COLOR=1` run** so it cannot pass against a CLI that merely stopped printing. Residual escapes under `NO_COLOR` are cursor control only (`?25l`, `1G`, `0K`), classified sequence by sequence; zero SGR remain, and piped and `CI=1` rows carry zero escapes on either stream for every command.

Gates green including `pnpm verify:packed` unmodified, all 29 stages, nothing moved (its only two stdout-reading invocations are `analyze --json` and `doctor --json`, and the envelope merge is additive).

## Changeset level

Kept at **minor**. Exit codes were never documented (item 74 exists because they were undocumented and inconsistent), and every move preserves "non-zero means a problem", so `set -e`, `||` and `if ! cmd` patterns are unaffected; only a script asserting an exact code would notice, and there was no published contract to assert against.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
