### PR TITLE
feat: say what went wrong instead of a green tick (items 70, 71, 78, 79)

### DIFF
--- a/.changeset/cli-error-reporting.md
+++ b/.changeset/cli-error-reporting.md
@@ -1,0 +1,86 @@
+---
+'@drzl/cli': minor
+---
+
+Fail loudly when there is nothing to generate, and name the key when a config is wrong (plan items
+70, 71, 78, 79)
+
+**A run that produces nothing is now a failure.** Seven inputs were measured on the built 4.22.0
+CLI, and every one of them printed a green tick, exited `0`, and wrote a single `index.ts`
+containing three comment lines and no exports: a schema module that throws on import, one importing
+a package that is not installed, one with a syntax error, a `schema:` naming a file that does not
+exist, a module exporting no tables, a module exporting only helpers, and a config whose
+`include`/`exclude` removed every table. That barrel is how the `.array()` typing bug hid: the run
+that should have reported it reported success.
+
+All seven exit `1` and write no files. The three causes are three messages, because the fixes have
+nothing in common:
+
+```
+Could not load the schema module src/db/schema.ts (DRZL_SCHEMA_001): Error: Cannot find module 'postgres'
+No Drizzle tables found in src/db/schema.ts (DRZL_SCHEMA_002).
+Every table was removed by this config's filters (DRZL_SCHEMA_003). src/db/schema.ts declares 3 tables: users, posts, comments.
+```
+
+The distinction is the analyzer's own, not a guess from an empty table list: `DRZL_ANL_IMPORT` and
+`DRZL_ANL_NOFILE` mean the module never ran, and anything else it says describes a module that did.
+That is the same rule `drzl init` was built on. The failing module's file name is in the message,
+which the analyzer's own wording does not carry, because a project with four schema modules and one
+bad import needs to be told which one.
+
+This covers `--check` as well, where it matters most: a check on a schema that would not load used
+to compare an empty tree with itself and report it up to date, so a CI job guarding the generated
+output passed on a schema nobody could read. `generate:orpc` and `generate:trpc` stop writing
+`placeholder.orpc.ts`, whose contents read "No tables detected in analysis", on a schema that
+imports cleanly and declares nothing.
+
+**`drzl watch` reports all three and keeps watching.** The one place they are not fatal, and
+deliberately: a watcher exists to be running while the schema is being edited, and a file saved
+mid-expression, a file being written from scratch and a filter being adjusted are all ordinary
+intermediate states. Exiting would mean restarting the watcher to recover from a typo.
+`--pipeline analyze` still completes on a schema with no tables, matching `drzl analyze`, which
+exits `0` on one because that is a true answer to the question it was asked.
+
+**A config that does not validate names the offending key.** `ConfigSchema.parse` throws a
+`ZodError` whose message is a formatted JSON array of issue objects, and that array was printed
+verbatim: eleven lines in which `outDir` appeared once, inside a `path` array, three levels down.
+Now:
+
+```
+drzl.config.ts is not valid (DRZL_CFG_002). 3 problems:
+  - outDir: expected string, received number (found 123)
+  - generators[0].nestedDepth: expected number, received string (found "deep")
+  - columns.users: unrecognized key "ommit". Did you mean "omit"?
+```
+
+Array entries are indexed and a key that is not an identifier is quoted, so
+`generators[1].validation.library` and `columns["app_*"].omit` can be pasted back into the file.
+Every problem is listed rather than the first, capped at eight. The value found there is shown
+when it fits, through `String` rather than `JSON.stringify`, so a `NaN` is reported as `NaN` and
+not as the four characters `null`.
+
+**An unknown config key warns instead of vanishing.** The root object and `GeneratorSchema` are
+both permissive, so zod dropped an unrecognised key in silence: `outDirr` at the root, `typedJsn`
+in a generator entry and `validation: { librari: 'zod' }` in a nested object all generated normally
+and exited `0`. Each is now named, with a suggestion when it is a typo of a real key rather than a
+different word:
+
+```
+drzl config: unknown key "typedJsn" in generators[0]; it is ignored. Did you mean "typedJson"?
+```
+
+A warning rather than an error, because the run really did honour the rest of the config. Nothing
+is warned about where the key is legitimately the user's own: `columns` is keyed by table pattern,
+`templateOptions` by whatever a template reads, and `$schema` is declared for editors. Where the
+config is strict, an unknown key stays the validation error it already was and gets the key path
+and the suggestion above.
+
+The known keys at every level are read from the JSON Schema generated from the zod config schema,
+rather than from a list maintained beside it, so `additionalProperties: false` is what tells the
+strict levels from the permissive ones and neither can drift as the config grows.
+
+**Config warnings go through the output layer.** They were written with `console.warn` from inside
+`loadConfig`, which no flag could see: `drzl generate --json` printed them beside the document that
+is supposed to be the only thing on that channel, and `--quiet` could not remove them. They are
+warnings like any other now, so `--quiet` drops them and `--json` puts them in the document's
+`warnings` array.

--- a/docs/cli/generate.md
+++ b/docs/cli/generate.md
@@ -45,6 +45,49 @@ When the config has no `schema` key, the path is read from your drizzle-kit conf
 `Schema from drizzle.config.ts (3 files)`. See
 [Reading the schema path from drizzle-kit](/guide/configuration#reading-the-schema-path-from-drizzle-kit).
 
+## When there is nothing to generate from
+
+A run that would write nothing but an empty barrel exits `1` and writes no files at all. There are
+three ways to get there and they have three different fixes, so they are three different messages.
+
+**The schema module would not load** (`DRZL_SCHEMA_001`). The file is not there, or importing it
+threw: a syntax error, a missing package, a module that runs code at import time and fails.
+
+```
+Could not load the schema module src/db/schema.ts (DRZL_SCHEMA_001): Error: Cannot find module 'postgres'
+Fix that error and run again. `drzl analyze src/db/schema.ts` prints it in full. Nothing was generated.
+```
+
+```
+Schema file not found (DRZL_SCHEMA_001): src/db/schema.ts
+Check the "schema" path in your drzl config, or point --config at another one. Nothing was generated.
+```
+
+**The module loaded and declares no tables** (`DRZL_SCHEMA_002`). Nothing is wrong with your
+imports; the module exports no `pgTable`, `mysqlTable` or `sqliteTable`.
+
+```
+No Drizzle tables found in src/db/schema.ts (DRZL_SCHEMA_002).
+That module imported cleanly and exported no tables, so every generator would write an empty
+barrel. Export them from it, for example: export const users = pgTable(...). Nothing was generated.
+```
+
+**The config's filters removed every table** (`DRZL_SCHEMA_003`). The schema is fine and
+`include`/`exclude` left nothing, so the message names the tables that were really there:
+
+```
+Every table was removed by this config's filters (DRZL_SCHEMA_003). src/db/schema.ts declares 3 tables: users, posts, comments.
+Check "include" and "exclude" in your drzl config. A pattern is matched against the whole database
+table name, with * as the only metacharacter. Nothing was generated.
+```
+
+All three exit `1` under `--check` too: a check needs something to compare, and reporting an empty
+tree as up to date is how a broken schema passes CI. `generate:orpc` and `generate:trpc` report the
+same three and, unlike before, write no placeholder file.
+
+`drzl watch` reports all three and keeps watching rather than exiting, because a file saved
+mid-edit is expected to be in one of these states for a moment. See [Watch](/cli/watch).
+
 ## `--check`: fail CI when generated output is stale
 
 ```bash

--- a/docs/cli/output.md
+++ b/docs/cli/output.md
@@ -125,6 +125,16 @@ not produce its payload at all:
 
 `code` is a stable identifier. `message` is the same sentence the human run prints.
 
+| Code              | Meaning                                                                |
+| ----------------- | ---------------------------------------------------------------------- |
+| `DRZL_CFG_001`    | There is no `drzl.config`                                              |
+| `DRZL_CFG_002`    | The config does not validate; the message names each key                |
+| `DRZL_SCHEMA_001` | The schema file is missing, or the module would not import             |
+| `DRZL_SCHEMA_002` | The schema imported cleanly and declares no Drizzle tables             |
+| `DRZL_SCHEMA_003` | The config's `include`/`exclude` filters removed every table           |
+| `DRZL_GEN_001`    | `generate` failed for any other reason                                 |
+| `DRZL_GEN_002`    | A generator threw, or is not installed                                 |
+
 ### One name, two meanings, and why
 
 `ok` is **not** part of the envelope, and that is because `doctor` published an `ok` of its own
@@ -243,11 +253,16 @@ first and shows a diff or a report on the second.
 | -------------------------------- | ------------------------- | ---------------------------------------------------------- | ------------------------------- |
 | `analyze`                        | analysed                  | schema missing or could not be imported                    | analysed, with error-level issues |
 | `doctor`                         | reported                  | schema missing or could not be imported                    | findings **and** `--strict`     |
-| `generate`                       | generated                 | no config, invalid config, a generator threw               | `--check` found drift           |
-| `generate:orpc`, `generate:trpc` | generated                 | schema missing, could not be imported, or a generator threw | not used                        |
+| `generate`                       | generated                 | no config, invalid config, nothing to generate from, a generator threw | `--check` found drift |
+| `generate:orpc`, `generate:trpc` | generated                 | nothing to generate from, or a generator threw             | not used                        |
 | `init`                           | config written            | a config already exists, or it could not be written        | not used                        |
 | `watch`                          | (runs until interrupted)  | no config, or the schema path could not be resolved        | not used                        |
 | any command                      |                           | an unknown flag or a missing argument                      |                                 |
+
+"Nothing to generate from" is a schema that would not load, a schema declaring no tables, or a
+config whose filters removed all of them. See
+[Generate](/cli/generate#when-there-is-nothing-to-generate-from). `watch` reports all three and
+keeps running rather than exiting.
 
 In CI:
 

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -52,3 +52,31 @@ drzl watch --json | jq -r 'select(.event == "generate_complete") | .kind'
 
 Exits `1` when there is no config, or when the schema path cannot be resolved at startup. It was
 `2` before. See [Output & exit codes](/cli/output).
+
+## A broken schema does not stop the watcher
+
+The three states that make `drzl generate` exit `1` are reported here and then waited out: a schema
+module that will not load (`DRZL_SCHEMA_001`), one that declares no tables (`DRZL_SCHEMA_002`), and
+a config whose filters remove all of them (`DRZL_SCHEMA_003`). See
+[Generate](/cli/generate#when-there-is-nothing-to-generate-from) for what each one says.
+
+This is deliberate, and it is the one place those three are not fatal. A watcher exists to be
+running while the schema is being edited, and all three are ordinary intermediate states: a file
+saved mid-expression does not parse, a file being written from scratch declares no tables yet, and
+a table filter is usually adjusted with the watcher up. Exiting would mean restarting the watcher
+to recover from a typo. So the run says what is wrong, writes nothing, and rebuilds on the next
+save, exactly as it already did for a generator that threw.
+
+Under `--json` each one is an `error` event carrying the code:
+
+```json
+{
+  "event": "error",
+  "code": "DRZL_SCHEMA_002",
+  "message": "No Drizzle tables found in src/db/schema.ts (DRZL_SCHEMA_002)."
+}
+```
+
+`--pipeline analyze` is the exception to the second one: it reports an analysis rather than
+generating, and an analysis of a schema with no tables is a true answer, so it completes normally
+just as `drzl analyze` does.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -637,8 +637,52 @@ reporting them. DRZL's one refinement holds the affix rules, so:
   identifier is a comparison between sibling values, which JSON Schema cannot express.
   `drzl generate` still refuses, naming the two modes and the identifier they collide on.
 
-Unknown top-level keys are accepted by the schema because the CLI accepts them too: it ignores
-what it does not recognise rather than failing. Keys inside `columns` and `affix` are strict in
-both.
+Unknown top-level keys are accepted by the schema because the CLI accepts them too: it ignores what
+it does not recognise rather than failing, though it now says so first. Keys inside `columns` and
+`affix` are strict in both.
+
+## When the config does not load
+
+### A validation error names the key
+
+A config that does not parse is reported one problem per line, each naming the key it is about the
+way you would write it in the file:
+
+```
+drzl.config.ts is not valid (DRZL_CFG_002). 3 problems:
+  - outDir: expected string, received number (found 123)
+  - generators[0].nestedDepth: expected number, received string (found "deep")
+  - columns.users: unrecognized key "ommit". Did you mean "omit"?
+```
+
+Array entries are indexed, so `generators[1].validation.library` says which generator, and a key
+that is not an identifier is quoted, so a table pattern reads as `columns["app_*"].omit`. The
+value that was found is shown when it fits on the line. Eight problems are listed and the rest are
+counted.
+
+The exit code is `1` and nothing is written. Under `--json` the same sentence is the `message` of
+the [failure document](/cli/output#the-envelope), with `"code": "DRZL_CFG_002"`.
+
+### An unknown key is a warning
+
+Most of the config is permissive: an unrecognised key is dropped rather than refused, so a config
+carrying one still runs. Each one is now named on stderr before the run continues:
+
+```
+drzl config: unknown key "outDirr" at the top level; it is ignored. Did you mean "outDir"?
+drzl config: unknown key "typedJsn" in generators[0]; it is ignored. Did you mean "typedJson"?
+drzl config: unknown key "librari" in generators[0].validation; it is ignored. Did you mean "library"?
+```
+
+A suggestion appears when the key is a typo of a real one rather than a different word. The run
+still exits `0`, because the setting was dropped and the rest of the config was honoured, which is
+what happened before this warning existed as well. `--quiet` drops the warnings; `--json` puts them
+in the document's `warnings` array.
+
+Nothing is warned about where a key is legitimately your own: the keys of `columns` are table
+patterns, the keys of `templateOptions` belong to whichever template reads them, and `$schema` is
+declared for editors. Where the config is strict instead, `columns`, `affix`, and the object forms
+of `meta`, `constraints`, `branded` and `document`, an unknown key is a validation error rather
+than a warning, and gets the key path and the suggestion above.
 
 See package READMEs for generator‑specific options.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,12 @@ export default [
       '**/.tmp-e2e/**',
       '**/.e2e-tmp/**',
       '**/.cmd-tmp/**',
+      // One pattern rather than a name per spec, for the reason `.gitignore` carries the same
+      // rule: the enumerated list works until a new spec picks a directory nobody added to it.
+      // `cli-errors.e2e.spec.ts` writes a schema that deliberately does not parse, so a run
+      // interrupted before its cleanup leaves a file that fails lint outright rather than
+      // warning, and the failure is in a fixture nobody is looking at.
+      '**/.tmp-*/**',
       '**/*.mjs',
       '**/.wrangler/**',
     ],

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,6 +28,12 @@ import {
   loadConfig,
   tableFilterWarnings,
 } from './config.js';
+import { ConfigValidationError } from './config-errors.js';
+import {
+  nothingToGenerate,
+  schemaLoadFailure,
+  type SchemaProblem,
+} from './schema-outcome.js';
 import { filterColumns } from './column-filter.js';
 import {
   dialectMismatchWarning,
@@ -72,6 +78,33 @@ function reportGeneratorFailure(out: Output, kind: string, e: unknown): string {
  */
 function outputFor(opts: { quiet?: boolean; json?: boolean }): Output {
   return new Output({ quiet: !!opts.quiet, json: !!opts.json });
+}
+
+/**
+ * The code a thrown value reports, when it is one of ours.
+ *
+ * `instanceof`, rather than reading `e.code`, because that property is Node's own convention:
+ * `ENOENT` off a failed `readFile` would otherwise be published in the `--json` document as
+ * though it were a DRZL identifier.
+ */
+function drzlErrorCode(error: unknown, fallback: string): string {
+  return error instanceof ConfigValidationError ? error.code : fallback;
+}
+
+/**
+ * A run that has nothing to generate from, reported and stopped (items 70 and 71).
+ *
+ * `EXIT_FAILED`, not `EXIT_FINDINGS`: an empty schema is not something the command was asked to
+ * look for, it is the command being unable to do the work. The hint is a hint, so `--quiet` drops
+ * it and the failure itself survives, which is the rule every other error here follows.
+ */
+function reportSchemaProblem(out: Output, command: string, problem: SchemaProblem): never {
+  if (out.json) out.jsonData(jsonFailure(command, problem.code, problem.message));
+  else {
+    out.error(problem.message);
+    out.hint(problem.hint);
+  }
+  process.exit(EXIT_FAILED);
 }
 
 /**
@@ -170,7 +203,7 @@ withOutputFlags(
       // both files, which is strictly more useful than the generic line below.
       let target: string | string[] | undefined = schema;
       if (!target) {
-        const cfg = await loadConfig(opts.config);
+        const cfg = await loadConfig(opts.config, (w) => out.warn(w));
         if (cfg) target = (await resolveSchemaSource(cfg)).schema;
       }
       if (!target) {
@@ -223,8 +256,13 @@ withOutputFlags(
       process.exit(code);
     } catch (e: any) {
       const msg = messageOf(e);
-      if (opts.json) out.jsonData(jsonFailure('doctor', 'DRZL_CLI_DOCTOR', msg));
-      else {
+      const code = drzlErrorCode(e, 'DRZL_CLI_DOCTOR');
+      if (opts.json) out.jsonData(jsonFailure('doctor', code, msg));
+      else if (e instanceof ConfigValidationError) {
+        // Already a report naming each key, so it prints as it is. See the same branch in
+        // `generate` for why a second header over it would say less.
+        out.error(msg);
+      } else {
         out.error('Doctor failed (DRZL_CLI_DOCTOR):', msg);
         out.hint('Tip: run with --json for structured output.');
       }
@@ -254,7 +292,10 @@ withOutputFlags(
   };
   {
     try {
-      let cfg = await loadConfig(opts.config);
+      // The config's own warnings go through `warn`, so they reach the `--json` document and
+      // `--quiet` removes them, exactly like every other warning this command produces. They used
+      // to be written with `console.warn` from inside `loadConfig`, which neither flag could see.
+      let cfg = await loadConfig(opts.config, warn);
       if (!cfg) {
         const msg = 'No config found (DRZL_CFG_001). Create drzl.config.ts or pass --config.';
         // Was exit 2 until now, which the scheme reserves for a run that found something. A
@@ -295,6 +336,15 @@ withOutputFlags(
         validateConstraints: cfg.analyzer.validateConstraints,
         includeHeuristicRelations: cfg.analyzer.includeHeuristicRelations,
       });
+      // Item 70, and before the tick rather than after it: a module that never loaded has not
+      // been analysed, and "Analysis complete" over the top of it is the green tick this item was
+      // filed about. Everything below reads `analysis.tables`, which is empty here for a reason
+      // that has nothing to do with the schema's contents.
+      const loadFailure = schemaLoadFailure(analysis.issues, source.schema);
+      if (loadFailure) {
+        spinner.stop();
+        reportSchemaProblem(out, 'generate', loadFailure);
+      }
       // After the spinner rather than before it, because `filterColumns` throws on a config it
       // cannot honour and a thrown error under a live ora spinner prints into a line the spinner
       // then overwrites.
@@ -322,6 +372,15 @@ withOutputFlags(
       analysis.tables = filterTables(narrowed.tables, cfg);
       for (const w of [...narrowed.warnings, ...filterWarnings]) warn(w);
       for (const w of wideColumnWarning(analysis.issues)) warn(w);
+      // Item 71, after the filters so it can tell the two empty states apart, and before
+      // `--check` snapshots anything so a check on a schema that produces nothing fails rather
+      // than comparing an empty tree with itself and reporting it up to date.
+      const empty = nothingToGenerate({
+        schema: source.schema,
+        analyzed: narrowed.tables,
+        remaining: analysis.tables,
+      });
+      if (empty) reportSchemaProblem(out, 'generate', empty);
       // Under --check the existing output is captured before anything overwrites it, so the
       // regenerated result can be compared against it and the tree put back either way.
       const driftDirs = computeGeneratorOutputDirs(cfg);
@@ -690,8 +749,14 @@ withOutputFlags(
       }
     } catch (e: any) {
       const msg = messageOf(e);
-      if (opts.json) out.jsonData(jsonFailure('generate', 'DRZL_GEN_001', msg));
-      else {
+      const code = drzlErrorCode(e, 'DRZL_GEN_001');
+      if (opts.json) out.jsonData(jsonFailure('generate', code, msg));
+      else if (e instanceof ConfigValidationError) {
+        // Already a report about named keys, so it prints as it is: prefixing it with "Generate
+        // failed" would put a second header over a message that has one, and the generic tip
+        // below tells a reader to check the file the message is already about.
+        out.error(msg);
+      } else {
         out.error('Generate failed (DRZL_GEN_001):', msg);
         out.hint('Tip: check your drzl.config.ts and template path.');
       }
@@ -701,19 +766,27 @@ withOutputFlags(
 });
 
 /**
- * Refuse to generate from a schema that was never read.
+ * Refuse to generate from a schema that was never read, or that declares nothing.
  *
  * `generate:orpc no-such-file.ts` used to exit 0, having written a `placeholder.orpc.ts` whose
- * contents read "No tables detected in analysis". Measured on 4.22.0 and again here. That is the
- * same defect item 67 fixed in `init`, one command along: the first thing a new user runs reports
- * success having read nothing, and a CI step guarding the generated tree passes.
+ * contents read "No tables detected in analysis". Item 67 stopped the first half of that; the
+ * second half survived it, because a schema that imports cleanly and exports nothing produces the
+ * identical placeholder and the identical exit 0, measured again here. Both are `EXIT_FAILED`
+ * now, and neither writes a file.
  *
- * `NOFILE` and `IMPORT` are the analyzer's two "there is nothing to work with" codes; anything
- * else it says is a description of a schema it did read.
+ * The two are told apart by `schema-outcome.ts`, which reads the analyzer's own verdict rather
+ * than guessing from an empty table list.
  */
-function unreadableSchema(issues: Array<{ level?: string; code?: string; message?: string }>) {
-  return issues.find(
-    (i) => i.level === 'error' && (i.code === 'DRZL_ANL_NOFILE' || i.code === 'DRZL_ANL_IMPORT')
+function schemaProblemFor(
+  analysis: {
+    issues: Array<{ level?: string; code?: string; message?: string }>;
+    tables: Array<{ name: string }>;
+  },
+  schema: string
+): SchemaProblem | undefined {
+  return (
+    schemaLoadFailure(analysis.issues, schema) ??
+    nothingToGenerate({ schema, analyzed: analysis.tables, remaining: analysis.tables })
   );
 }
 
@@ -732,14 +805,8 @@ withOutputFlags(
       includeRelations: !!opts.includeRelations,
       validateConstraints: true,
     });
-    const unreadable = unreadableSchema(analysis.issues);
-    if (unreadable) {
-      const msg = unreadable.message ?? `Schema could not be read: ${schema}`;
-      if (opts.json) out.jsonData(jsonFailure('generate:orpc', 'DRZL_CLI_SCHEMA', msg));
-      else out.error('Generate orpc failed:', msg);
-      process.exit(EXIT_FAILED);
-      return;
-    }
+    const problem = schemaProblemFor(analysis, schema);
+    if (problem) reportSchemaProblem(out, 'generate:orpc', problem);
     const gen = new ORPCGenerator(analysis);
     const { files } = await gen.generate({
       outputDir: opts.outDir,
@@ -783,14 +850,8 @@ withOutputFlags(
       includeRelations: !!opts.includeRelations,
       validateConstraints: true,
     });
-    const unreadable = unreadableSchema(analysis.issues);
-    if (unreadable) {
-      const msg = unreadable.message ?? `Schema could not be read: ${schema}`;
-      if (opts.json) out.jsonData(jsonFailure('generate:trpc', 'DRZL_CLI_SCHEMA', msg));
-      else out.error('Generate trpc failed:', msg);
-      process.exit(EXIT_FAILED);
-      return;
-    }
+    const problem = schemaProblemFor(analysis, schema);
+    if (problem) reportSchemaProblem(out, 'generate:trpc', problem);
     const { TRPCGenerator } = await loadGenerator(
       '@drzl/generator-trpc',
       () => import('@drzl/generator-trpc')
@@ -846,12 +907,48 @@ program
     // prints goes to stderr, and stdout carries only the `--json` event stream, which is the one
     // thing here a program reads.
     const out = outputFor(opts);
-    let cfg = await loadConfig(opts.config);
-    if (!cfg) {
+
+    /**
+     * A schema `watch` has nothing to generate from, reported without stopping (items 70, 71).
+     *
+     * The one place in this change where the failure is not an exit code, and deliberately. A
+     * watcher exists to be running while the schema is being edited, and the states this reports
+     * are all ordinary intermediate ones: a file saved mid-expression does not parse, a file
+     * being written from scratch declares no tables yet, and a table filter is usually adjusted
+     * with the watcher up. Exiting on any of them would mean the user has to restart the watcher
+     * to recover from a typo, which is the opposite of what the command is for. So it says what is
+     * wrong, writes nothing, and waits for the next save, exactly as `run`'s own catch already
+     * does for a generator that throws.
+     */
+    const reportWatchProblem = (problem: SchemaProblem) => {
+      if (opts.json) {
+        out.jsonData({ event: 'error', code: problem.code, message: problem.message });
+        return;
+      }
+      out.error(problem.message);
+      out.hint(problem.hint);
+    };
+
+    // Wrapped, unlike the reload inside `run`, which has its own catch. A config that does not
+    // validate throws out of here, and with nothing around it the rejection escapes the action
+    // and Node prints a stack trace over the report that names each offending key.
+    let loaded: DrzlConfig | null;
+    try {
+      loaded = await loadConfig(opts.config, (w) => out.warn(w));
+    } catch (e: any) {
+      out.error(messageOf(e));
+      process.exit(EXIT_FAILED);
+      return;
+    }
+    if (!loaded) {
       out.error('No config found (DRZL_CFG_001). Create drzl.config.ts or pass --config.');
       process.exit(EXIT_FAILED);
       return;
     }
+    // Through a second binding rather than narrowing the first, so `cfg` stays non-nullable for
+    // the closures below: `run` and the watcher callbacks capture it, and a `let` a closure reads
+    // does not keep the narrowing a guard in this scope gave it.
+    let cfg: DrzlConfig = loaded;
 
     const abs = (p: string) => path.resolve(process.cwd(), p);
     const isInside = (child: string, parent: string) => {
@@ -961,7 +1058,7 @@ program
 
     const run = async () => {
       try {
-        const reloaded = await loadConfig(opts.config);
+        const reloaded = await loadConfig(opts.config, (w) => out.warn(w));
         if (!reloaded) throw new Error('Config disappeared during watch.');
         cfg = reloaded;
 
@@ -1011,6 +1108,11 @@ program
           analyzed: analysis.dialect,
         });
         if (dialectWarning) out.warn(dialectWarning);
+        const loadFailure = schemaLoadFailure(analysis.issues, source.schema);
+        if (loadFailure) {
+          reportWatchProblem(loadFailure);
+          return;
+        }
         // Same order and the same reasons as `generate`. A config edited mid-watch that names a
         // column that does not exist throws here, and `run`'s own catch reports it and keeps
         // watching, so the next save can fix it.
@@ -1030,6 +1132,21 @@ program
           } else {
             out.succeed('Analyze complete.');
           }
+          return;
+        }
+
+        // Item 71, and after the analyze pipeline rather than before it, so the two commands that
+        // report an analysis agree: `drzl analyze` on a schema with no tables exits 0 and prints
+        // an analysis with none, because that is a true answer to the question it was asked.
+        // Generating from it is a different question, and the answer to that one is that there is
+        // nothing to write.
+        const empty = nothingToGenerate({
+          schema: source.schema,
+          analyzed: narrowed.tables,
+          remaining: analysis.tables,
+        });
+        if (empty) {
+          reportWatchProblem(empty);
           return;
         }
 

--- a/packages/cli/src/config-errors.ts
+++ b/packages/cli/src/config-errors.ts
@@ -1,0 +1,385 @@
+/**
+ * What a bad `drzl.config` says, and what a silently-dropped key says instead of nothing.
+ *
+ * Two plan items, one file, because they are the same question asked at two levels of the config
+ * schema. Both were measured on the built 4.22.0 CLI before anything here existed.
+ *
+ * **A validation failure printed the zod dump (item 78).** `ConfigSchema.parse` throws a
+ * `ZodError` whose `.message` is a formatted JSON array of issue objects, and the CLI printed it
+ * verbatim. A config that set `outDir: 123` produced eleven lines of JSON in which the word
+ * `outDir` appeared once, inside a `path` array, three levels down. zod already knows which key
+ * it was talking about; it was thrown away at the point of printing.
+ *
+ * **An unknown key produced no output at all (item 79).** `ConfigSchema` and `GeneratorSchema`
+ * are both permissive, so zod strips a key it does not recognise and says nothing. Measured:
+ * `outDirr: 'src/api'` at the root, `typedJsn: true` in a generator entry and
+ * `validation: { librari: 'zod' }` in a nested object all generated normally and exited 0. This
+ * repository has already shipped that failure twice from the other direction, as a documented
+ * option the config schema did not declare (`databaseInjection`, `coerceDates`), and the user
+ * side of it is identical: a setting that is written down, has no effect, and is never mentioned.
+ *
+ * The known keys at every level come from the JSON Schema `buildConfigJsonSchema()` derives from
+ * `ConfigSchema` (item 64), rather than from a list maintained here. That matters for more than
+ * duplication: `additionalProperties: false` appears in it exactly where the zod object is
+ * `.strict()`, so the same walk distinguishes the levels zod refuses a key at from the levels it
+ * drops one at, and neither can drift from the schema as the config grows.
+ */
+
+/** A JSON Schema node, read rather than validated against, so nothing here needs a resolver. */
+type SchemaNode = Record<string, unknown>;
+
+/**
+ * An own property, without `Object.hasOwn`, which needs the ES2022 lib this repository does not
+ * target, and without a bare `in`, which walks the prototype chain and would answer yes to
+ * `constructor` and `toString` on every object walked here.
+ */
+function hasOwn(object: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+/** The code a config that does not parse reports, on stderr and in the `--json` document. */
+export const CONFIG_INVALID_CODE = 'DRZL_CFG_002';
+
+/**
+ * A config that could not be parsed, carrying the code the failure document needs.
+ *
+ * A class rather than a `code` property on a plain `Error`, because the `generate` catch has to
+ * tell this apart from every other throw, and `e.code` is a convention Node already uses:
+ * `ENOENT` from a filesystem call would otherwise land in the `--json` document as though it
+ * were one of ours.
+ */
+export class ConfigValidationError extends Error {
+  readonly code = CONFIG_INVALID_CODE;
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConfigValidationError';
+  }
+}
+
+/** The subset of a zod issue this file reads. Structural, so it is not tied to a zod version. */
+export interface ConfigIssue {
+  code?: string;
+  path?: readonly PropertyKey[];
+  message?: string;
+  /** Present on `unrecognized_keys`, which is what a `.strict()` object produces. */
+  keys?: readonly string[];
+}
+
+/** How many problems are listed before the rest are counted instead. */
+const MAX_LISTED_PROBLEMS = 8;
+
+/** How long a value may be before showing it costs more than it explains. */
+const MAX_VALUE_CHARS = 60;
+
+/**
+ * A key path as a reader would write it: `generators[1].validation.library`.
+ *
+ * Not `generators.1.validation.library` and not the flattened blob zod prints. A path a user can
+ * paste back into their own config file is the whole of item 78; anything else makes them count
+ * array entries by hand.
+ *
+ * A key that is not an identifier is bracketed and quoted, because `columns` is keyed by table
+ * pattern and `columns.app_*` reads as though `*` were part of the path language.
+ */
+export function renderConfigPath(segments: readonly PropertyKey[]): string {
+  if (!segments.length) return '(root)';
+  let out = '';
+  for (const segment of segments) {
+    if (typeof segment === 'number') {
+      out += `[${segment}]`;
+      continue;
+    }
+    const key = String(segment);
+    if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)) out += out ? `.${key}` : key;
+    else out += `[${JSON.stringify(key)}]`;
+  }
+  return out;
+}
+
+/**
+ * What the config actually said at that key, short enough to sit on the line.
+ *
+ * Numbers go through `String`, never `JSON.stringify`. `JSON.stringify(NaN)` is the four
+ * characters `null`, and so is `JSON.stringify(Infinity)`, so a config written `nestedDepth: NaN`
+ * would be reported as having said `null`: a different mistake, with a different fix, stated with
+ * total confidence. That exact substitution has already turned one real defect in this repository
+ * into a reasoned-through false conclusion.
+ *
+ * Returns `null` when there is nothing worth showing, which is what keeps a whole generator entry
+ * out of a message about one of its keys.
+ */
+export function describeValue(value: unknown): string | null {
+  if (value === undefined) return 'undefined';
+  if (value === null) return 'null';
+  switch (typeof value) {
+    case 'boolean':
+      return String(value);
+    case 'number':
+      return String(value);
+    case 'bigint':
+      return `${value}n`;
+    case 'function':
+      return '[function]';
+    case 'symbol':
+      return String(value);
+    case 'string':
+      return value.length <= MAX_VALUE_CHARS
+        ? JSON.stringify(value)
+        : `${JSON.stringify(value.slice(0, MAX_VALUE_CHARS))} ... (${value.length} characters)`;
+  }
+  let json: string;
+  try {
+    json = JSON.stringify(value) as string;
+  } catch {
+    return null;
+  }
+  if (typeof json !== 'string') return null;
+  return json.length <= MAX_VALUE_CHARS ? json : null;
+}
+
+/** The value the config really holds at a path, and whether the path leads anywhere at all. */
+function valueAt(
+  raw: unknown,
+  segments: readonly PropertyKey[]
+): { found: boolean; value: unknown } {
+  let current: unknown = raw;
+  for (const segment of segments) {
+    if (current === null || typeof current !== 'object') return { found: false, value: undefined };
+    // `hasOwn` rather than `in`, which walks the prototype chain: a path segment of `constructor`
+    // or `toString` would otherwise be reported as a value the config states.
+    if (!hasOwn(current, String(segment))) return { found: false, value: undefined };
+    current = (current as Record<PropertyKey, unknown>)[segment as never];
+  }
+  return { found: true, value: current };
+}
+
+/**
+ * Levenshtein distance, iteratively over two rows.
+ *
+ * Written here rather than installed. Config keys are a handful of characters and there are under
+ * forty of them, so this costs nothing worth measuring, and a dependency added to suggest a
+ * spelling is a dependency on every install of the CLI for ever.
+ */
+export function editDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (!a.length) return b.length;
+  if (!b.length) return a.length;
+  let previous = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const current = new Array<number>(b.length + 1);
+    current[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const substitution = previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1);
+      current[j] = Math.min(current[j - 1] + 1, previous[j] + 1, substitution);
+    }
+    previous = current;
+  }
+  return previous[b.length];
+}
+
+/**
+ * The key the writer probably meant, or nothing.
+ *
+ * A typo, not a different word. One edit for a short key and two for anything from five
+ * characters up: `librari` to `library` is one, `typedJsn` to `typedJson` is one, `outDirr` to
+ * `outDir` is one, and `abc` to `kind` is three, which is somebody meaning something else. A
+ * wrong suggestion is worse than none, because it sends a reader to change a line that was right.
+ *
+ * Ties go to the earliest known key, which is schema declaration order, so the suggestion for a
+ * given typo is the same on every run.
+ */
+export function nearestKey(key: string, known: readonly string[]): string | undefined {
+  const budget = key.length >= 5 ? 2 : 1;
+  let best: string | undefined;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const candidate of known) {
+    if (candidate === key) return undefined;
+    const distance = editDistance(key, candidate);
+    if (distance <= budget && distance < bestDistance) {
+      best = candidate;
+      bestDistance = distance;
+    }
+  }
+  return best;
+}
+
+/**
+ * The object description at a node, seeing through a `anyOf`.
+ *
+ * A union is only followed when exactly one of its branches describes an object. Two would mean
+ * guessing which one the value was written against, and a wrong guess reports keys that are
+ * perfectly valid, which is the one outcome item 79 must not produce.
+ */
+function objectNodeFor(node: unknown): SchemaNode | undefined {
+  if (!node || typeof node !== 'object') return undefined;
+  const record = node as SchemaNode;
+  const anyOf = record.anyOf;
+  if (Array.isArray(anyOf)) {
+    const branches = anyOf.filter(
+      (branch) =>
+        branch &&
+        typeof branch === 'object' &&
+        ((branch as SchemaNode).properties !== undefined ||
+          typeof (branch as SchemaNode).additionalProperties === 'object')
+    ) as SchemaNode[];
+    return branches.length === 1 ? branches[0] : undefined;
+  }
+  if (record.properties !== undefined || record.additionalProperties !== undefined) return record;
+  return undefined;
+}
+
+/** One key the config states and the schema does not declare. */
+export interface UnknownConfigKey {
+  /** Where the object holding it lives, as instance-path segments. */
+  path: readonly PropertyKey[];
+  key: string;
+  suggestion?: string;
+}
+
+/**
+ * Every key a permissive level of the config schema would drop in silence.
+ *
+ * Strict levels are skipped deliberately: zod refuses those outright, so nothing reaches this
+ * walk with one set, and `formatConfigProblems` gives that refusal the same key path and the same
+ * suggestion this produces. Record levels are skipped too, and for the opposite reason: the keys
+ * of `columns` are table patterns and the keys of `templateOptions` are a template's own options,
+ * so there is no such thing as an unknown one there.
+ */
+export function unknownConfigKeys(raw: unknown, schema: SchemaNode): UnknownConfigKey[] {
+  const found: UnknownConfigKey[] = [];
+  walkForUnknownKeys(raw, schema, [], found);
+  return found;
+}
+
+function walkForUnknownKeys(
+  value: unknown,
+  node: unknown,
+  segments: PropertyKey[],
+  found: UnknownConfigKey[]
+): void {
+  if (value === null || typeof value !== 'object') return;
+
+  if (Array.isArray(value)) {
+    const items = (node as SchemaNode | undefined)?.items;
+    if (!items) return;
+    value.forEach((entry, index) => walkForUnknownKeys(entry, items, [...segments, index], found));
+    return;
+  }
+
+  const object = objectNodeFor(node);
+  if (!object) return;
+
+  const properties = object.properties as Record<string, unknown> | undefined;
+  const additional = object.additionalProperties;
+
+  if (!properties) {
+    // A record. Only the values are described by the schema, so the keys are the user's data and
+    // every one of them is legitimate.
+    if (additional && typeof additional === 'object') {
+      for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+        walkForUnknownKeys(entry, additional, [...segments, key], found);
+      }
+    }
+    return;
+  }
+
+  const known = Object.keys(properties);
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (hasOwn(properties, key)) {
+      walkForUnknownKeys(entry, properties[key], [...segments, key], found);
+      continue;
+    }
+    if (additional === false) continue;
+    found.push({ path: [...segments], key, suggestion: nearestKey(key, known) });
+  }
+}
+
+/** The warning lines for every key the config states and the schema drops. */
+export function unknownKeyWarnings(raw: unknown, schema: SchemaNode): string[] {
+  return unknownConfigKeys(raw, schema).map((unknown) => {
+    const where = unknown.path.length ? `in ${renderConfigPath(unknown.path)}` : 'at the top level';
+    const suggestion = unknown.suggestion ? ` Did you mean "${unknown.suggestion}"?` : '';
+    return `drzl config: unknown key "${unknown.key}" ${where}; it is ignored.${suggestion}`;
+  });
+}
+
+/** The schema node an instance path leads to, for reading the known keys off a strict object. */
+function nodeAt(schema: SchemaNode, segments: readonly PropertyKey[]): SchemaNode | undefined {
+  let node: unknown = schema;
+  for (const segment of segments) {
+    if (typeof segment === 'number') {
+      node = (node as SchemaNode | undefined)?.items;
+      continue;
+    }
+    const object = objectNodeFor(node);
+    if (!object) return undefined;
+    const properties = object.properties as Record<string, unknown> | undefined;
+    if (properties && hasOwn(properties, String(segment))) {
+      node = properties[String(segment)];
+      continue;
+    }
+    const additional = object.additionalProperties;
+    if (additional && typeof additional === 'object') {
+      node = additional;
+      continue;
+    }
+    return undefined;
+  }
+  return objectNodeFor(node);
+}
+
+/** The keys declared at a path, so a strict object's refusal can carry a suggestion too. */
+function knownKeysAt(schema: SchemaNode, segments: readonly PropertyKey[]): string[] {
+  const node = nodeAt(schema, segments);
+  const properties = node?.properties as Record<string, unknown> | undefined;
+  return properties ? Object.keys(properties) : [];
+}
+
+/** One issue, as one line: where it is, what is wrong, and what the file actually says. */
+function renderIssue(issue: ConfigIssue, raw: unknown, schema: SchemaNode): string[] {
+  const segments = issue.path ?? [];
+  const where = renderConfigPath(segments);
+
+  if (issue.code === 'unrecognized_keys' && issue.keys?.length) {
+    const known = knownKeysAt(schema, segments);
+    return issue.keys.map((key) => {
+      const suggestion = nearestKey(key, known);
+      return `${where}: unrecognized key "${key}".${suggestion ? ` Did you mean "${suggestion}"?` : ''}`;
+    });
+  }
+
+  // zod prefixes every type failure with "Invalid input: ", which restates the header this line
+  // already sits under.
+  const what = String(issue.message ?? 'is not valid').replace(/^Invalid input:\s*/, '');
+  const { found, value } = valueAt(raw, segments);
+  const shown = found ? describeValue(value) : null;
+  return [`${where}: ${what}${shown === null ? '' : ` (found ${shown})`}`];
+}
+
+/**
+ * Every problem in a config that would not parse, one per line, each naming its key.
+ *
+ * All of them rather than the first, because a config written from an old example usually has
+ * three or four problems of the same kind, and reporting one per run makes the user run the CLI
+ * once per typo. Capped, because a config whose top-level shape is wrong can produce an issue per
+ * key and a screen of them says less than eight and a count.
+ *
+ * The order is zod's, which is declaration order of the schema rather than of the file, and it is
+ * stable across runs.
+ */
+export function formatConfigProblems(
+  file: string,
+  issues: readonly ConfigIssue[],
+  raw: unknown,
+  schema: SchemaNode
+): string {
+  const lines = issues.flatMap((issue) => renderIssue(issue, raw, schema));
+  const shown = lines.slice(0, MAX_LISTED_PROBLEMS);
+  const rest = lines.length - shown.length;
+  const header = `${file} is not valid (${CONFIG_INVALID_CODE}). ${lines.length} problem${
+    lines.length === 1 ? '' : 's'
+  }:`;
+  const body = shown.map((line) => `  - ${line}`);
+  if (rest > 0) body.push(`  ... and ${rest} more`);
+  return [header, ...body].join('\n');
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -14,6 +14,11 @@ import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { z } from 'zod';
+import {
+  ConfigValidationError,
+  formatConfigProblems,
+  unknownKeyWarnings,
+} from './config-errors.js';
 import { ambiguousPatternWarnings, matchesTable } from './patterns.js';
 
 export const NamingSchema = z
@@ -935,13 +940,55 @@ export function resolveConfig(cfg: DrzlConfig): { config: DrzlConfig; warnings: 
 }
 
 /**
- * Parse, then resolve cross-generator defaults. Both `generate` and `watch` go through
+ * `ConfigSchema` as a JSON Schema, once, for the two things that read it back.
+ *
+ * Rebuilt on every call it would cost about 0.7ms, which is nothing for `generate` and is paid on
+ * every rebuild of a `watch` that may run for a day. Held apart from `buildConfigJsonSchema`
+ * itself so the exported function keeps handing every caller a fresh object it may write to; this
+ * one is only ever read.
+ */
+let configShape: Record<string, unknown> | null = null;
+function configShapeForReading(): Record<string, unknown> {
+  return (configShape ??= buildConfigJsonSchema());
+}
+
+/**
+ * How the config file is named in a message: relative to where the command was run, unless that
+ * would be a walk back up out of it, which says less than the path itself.
+ */
+function displayConfigPath(file: string, cwd = process.cwd()): string {
+  const relative = path.relative(cwd, file);
+  return relative && !relative.startsWith('..') ? relative : file;
+}
+
+/**
+ * Parse, report, then resolve cross-generator defaults. Both `generate` and `watch` go through
  * loadConfig, so putting the resolution here is what keeps the two duplicated generator
  * dispatch blocks in cli.ts from needing the logic twice.
+ *
+ * `safeParse` rather than `parse`, because the thrown `ZodError`'s message is a formatted JSON
+ * array of issue objects and that array is what the CLI used to print (item 78). The issues
+ * themselves carry the key path; only the rendering was missing.
+ *
+ * Unknown keys are reported after the parse succeeds and not before (item 79). A config that does
+ * not parse has a failure to fix first, and listing the keys that would have been dropped from a
+ * config nobody can load yet is noise under an error.
  */
-function finalize(raw: unknown): DrzlConfig {
-  const { config, warnings } = resolveConfig(ConfigSchema.parse(raw));
-  for (const w of warnings) console.warn(w);
+function finalize(raw: unknown, file: string, onWarn: (warning: string) => void): DrzlConfig {
+  const parsed = ConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new ConfigValidationError(
+      formatConfigProblems(
+        displayConfigPath(file),
+        parsed.error.issues,
+        raw,
+        configShapeForReading()
+      )
+    );
+  }
+  for (const w of unknownKeyWarnings(raw, configShapeForReading())) onWarn(w);
+  const { config, warnings } = resolveConfig(parsed.data);
+  for (const w of warnings) onWarn(w);
   return config;
 }
 
@@ -983,7 +1030,21 @@ export async function importFreshConfigModule(p: string): Promise<unknown> {
   return mod?.default ?? mod;
 }
 
-export async function loadConfig(customPath?: string): Promise<DrzlConfig | null> {
+/**
+ * The config, or `null` when there is none.
+ *
+ * `onWarn` exists so the config's warnings reach the output layer rather than the process. They
+ * went to `console.warn` until now, which is stderr with no route through `--quiet` or `--json`:
+ * `drzl generate --json` printed them beside the document it promises is the only thing on
+ * stdout's channel, and `--quiet` could not remove them. Item 79 adds a warning to exactly this
+ * path, so the path is fixed here rather than gaining a second writer that bypasses `Output`.
+ *
+ * The default keeps the old behaviour for any caller that has no output layer to hand.
+ */
+export async function loadConfig(
+  customPath?: string,
+  onWarn: (warning: string) => void = (warning) => console.warn(warning)
+): Promise<DrzlConfig | null> {
   const fsp = await import('node:fs/promises');
 
   const candidates = customPath ? [customPath] : [...CONFIG_FILE_NAMES];
@@ -995,7 +1056,7 @@ export async function loadConfig(customPath?: string): Promise<DrzlConfig | null
     } catch {
       continue;
     }
-    return finalize(await importFreshConfigModule(p));
+    return finalize(await importFreshConfigModule(p), p, onWarn);
   }
 
   return null;

--- a/packages/cli/src/schema-outcome.ts
+++ b/packages/cli/src/schema-outcome.ts
@@ -1,0 +1,163 @@
+/**
+ * Whether a run has anything to generate from, and which of the three reasons it has not.
+ *
+ * Items 70 and 71 are one moment for the user ("I ran generate and got nothing useful") and three
+ * different causes, and the fixes have nothing in common: fix your import, export your tables,
+ * loosen your filter. Measured on the built 4.22.0 CLI, every one of them printed a green tick and
+ * exited 0, having written a barrel with no exports in it:
+ *
+ * | input                                            | exit | wrote          |
+ * | ------------------------------------------------ | ---- | -------------- |
+ * | a schema module that throws on import            | 0    | `out/index.ts` |
+ * | a schema importing a package that is not there   | 0    | `out/index.ts` |
+ * | a schema with a syntax error                     | 0    | `out/index.ts` |
+ * | `schema:` naming a file that does not exist      | 0    | `out/index.ts` |
+ * | a module that exports no tables                  | 0    | `out/index.ts` |
+ * | a module that exports things that are not tables | 0    | `out/index.ts` |
+ * | every table removed by `include`/`exclude`       | 0    | `out/index.ts` |
+ *
+ * The distinction is not guessed at here. The analyzer already separates the three answers, which
+ * is what `init` was built on in item 67 and what this reuses:
+ *
+ *   - a module it could not run  -> `DRZL_ANL_NOFILE` or `DRZL_ANL_IMPORT`, an error-level issue
+ *   - a module that is not one   -> no issues, and `tables` empty
+ *   - a real schema              -> `tables` non-empty
+ *
+ * Surfacing that rather than re-deriving it is what keeps the two messages honest: the first says
+ * DRZL never read your file and repeats the reason, the second says DRZL read it and it declares
+ * nothing.
+ */
+
+/** DRZL could not read the schema at all: the file is missing, or importing it threw. */
+export const SCHEMA_UNREADABLE_CODE = 'DRZL_SCHEMA_001';
+/** DRZL read the schema, and it declares no Drizzle tables. */
+export const SCHEMA_EMPTY_CODE = 'DRZL_SCHEMA_002';
+/** The schema declares tables and the config's own filters removed all of them. */
+export const SCHEMA_FILTERED_CODE = 'DRZL_SCHEMA_003';
+
+export interface SchemaProblem {
+  /** The stable identifier, which is also what the `--json` failure document carries. */
+  code: string;
+  /** The failure itself. Printed in red, never suppressed, and named in the document. */
+  message: string;
+  /** How to fix it. Printed dim under the message, and dropped by `--quiet` like every hint. */
+  hint: string;
+}
+
+/** The least this file needs to know about an analyzer issue. */
+export interface AnalyzerIssue {
+  code?: string;
+  level?: string;
+  message?: string;
+}
+
+/** The two analyzer codes that mean "there is nothing to work with", as opposed to a description. */
+const UNREADABLE_CODES = new Set(['DRZL_ANL_NOFILE', 'DRZL_ANL_IMPORT']);
+
+/** The first line of a message. A module resolution failure carries its whole require stack. */
+function firstLine(message: string): string {
+  return String(message).split('\n')[0].trim();
+}
+
+/** What to call the schema in a sentence: the path as the config spells it, or the file count. */
+export function describeSchemaTarget(schema: string | readonly string[]): string {
+  if (typeof schema === 'string') return schema;
+  if (schema.length === 1) return schema[0];
+  return `${schema.length} schema files`;
+}
+
+/**
+ * Item 70: the module never loaded, so nothing downstream means anything.
+ *
+ * The single-path message is built here rather than taken from the analyzer, because the
+ * analyzer's is `Failed to import schema: <error>` and deliberately keeps those historical bytes,
+ * which do not name the file. Naming the file is the point of the item: a user with four schema
+ * modules and one bad import needs to be told which one, and the message that stops saying so is
+ * the regression worth a test.
+ */
+export function schemaLoadFailure(
+  issues: readonly AnalyzerIssue[],
+  schema: string | readonly string[]
+): SchemaProblem | undefined {
+  const blocking = issues.filter(
+    (issue) => issue.level === 'error' && issue.code && UNREADABLE_CODES.has(issue.code)
+  );
+  if (!blocking.length) return undefined;
+
+  const first = blocking[0];
+  const more = blocking.length > 1 ? ` (and ${blocking.length - 1} more)` : '';
+  const single = typeof schema === 'string' ? schema : schema.length === 1 ? schema[0] : undefined;
+
+  if (first.code === 'DRZL_ANL_NOFILE') {
+    const named = single ?? afterPrefix(first.message, 'Schema file not found:');
+    return {
+      code: SCHEMA_UNREADABLE_CODE,
+      message: `Schema file not found (${SCHEMA_UNREADABLE_CODE}): ${named}${more}`,
+      hint: 'Check the "schema" path in your drzl config, or point --config at another one. Nothing was generated.',
+    };
+  }
+
+  const reason = single
+    ? firstLine(afterPrefix(first.message, 'Failed to import schema:'))
+    : firstLine(String(first.message ?? ''));
+  const message = single
+    ? `Could not load the schema module ${single} (${SCHEMA_UNREADABLE_CODE}): ${reason}${more}`
+    : `Could not load a schema module (${SCHEMA_UNREADABLE_CODE}): ${reason}${more}`;
+
+  return {
+    code: SCHEMA_UNREADABLE_CODE,
+    message,
+    hint: single
+      ? `Fix that error and run again. \`drzl analyze ${single}\` prints it in full. Nothing was generated.`
+      : 'Fix that error and run again. Nothing was generated.',
+  };
+}
+
+/** A message with a known prefix taken off, or the message unchanged when it has none. */
+function afterPrefix(message: string | undefined, prefix: string): string {
+  const text = String(message ?? '');
+  return text.startsWith(prefix) ? text.slice(prefix.length).trim() : text;
+}
+
+/**
+ * Item 71: the module loaded and the run would emit nothing but a barrel.
+ *
+ * Two codes rather than one, because the schema declaring nothing and the config's filter removing
+ * everything are different mistakes in different files. The filtered case names the tables that
+ * were really there, which is the fact that turns "why is my output empty" into "my pattern is
+ * wrong", and it is the only place the CLI can say it: the filter has already run by then.
+ */
+export function nothingToGenerate(opts: {
+  schema: string | readonly string[];
+  /** The tables the analyzer found, before `include`, `exclude` and `columns` were applied. */
+  analyzed: readonly { name: string }[];
+  /** The tables left for the generators. */
+  remaining: readonly { name: string }[];
+}): SchemaProblem | undefined {
+  if (opts.remaining.length > 0) return undefined;
+  const target = describeSchemaTarget(opts.schema);
+
+  if (!opts.analyzed.length) {
+    return {
+      code: SCHEMA_EMPTY_CODE,
+      message: `No Drizzle tables found in ${target} (${SCHEMA_EMPTY_CODE}).`,
+      hint:
+        'That module imported cleanly and exported no tables, so every generator would write an ' +
+        'empty barrel. Export them from it, for example: export const users = pgTable(...). ' +
+        'Nothing was generated.',
+    };
+  }
+
+  const names = opts.analyzed.map((table) => table.name);
+  const shown = names.slice(0, 6).join(', ');
+  const rest = names.length > 6 ? `, and ${names.length - 6} more` : '';
+  return {
+    code: SCHEMA_FILTERED_CODE,
+    message:
+      `Every table was removed by this config's filters (${SCHEMA_FILTERED_CODE}). ` +
+      `${target} declares ${names.length} table${names.length === 1 ? '' : 's'}: ${shown}${rest}.`,
+    hint:
+      'Check "include" and "exclude" in your drzl config. A pattern is matched against the whole ' +
+      'database table name, with * as the only metacharacter. Nothing was generated.',
+  };
+}

--- a/packages/cli/test/cli-errors.e2e.spec.ts
+++ b/packages/cli/test/cli-errors.e2e.spec.ts
@@ -1,0 +1,554 @@
+/**
+ * What the CLI says when the input is broken (plan items 70, 71, 78, 79).
+ *
+ * All four are defects, and all four were measured on the built CLI before a line was changed:
+ *
+ * | input                                   | exit | stdout                  | stderr        |
+ * | --------------------------------------- | ---- | ----------------------- | ------------- |
+ * | schema module throws on import          | 0    | the barrel path         | green tick    |
+ * | schema imports a package not installed  | 0    | the barrel path         | green tick    |
+ * | schema has a syntax error               | 0    | the barrel path         | green tick    |
+ * | `schema` names a file that is not there | 0    | the barrel path         | green tick    |
+ * | schema exports no tables                | 0    | the barrel path         | green tick    |
+ * | config key of the wrong type            | 1    | (empty)                 | a JSON array  |
+ * | misspelled key at the root              | 0    | generated               | (silence)     |
+ * | misspelled key in a generator entry     | 0    | generated               | (silence)     |
+ * | misspelled key in a nested object       | 0    | generated               | (silence)     |
+ *
+ * The barrel in every row above is an `index.ts` holding three comment lines and no exports,
+ * which is the file item 70 was filed about.
+ *
+ * Every assertion here is on the exact stream and the exact exit code, per `docs/cli/output.md`,
+ * and on the sentences themselves. Pinning the sentence is the point: a message that stops naming
+ * the schema file, or stops naming the offending config key, is the regression that matters, and
+ * an assertion on the exit code alone would not see it.
+ *
+ * Requires a build. CI builds before testing; locally, run `pnpm build` first.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn } from 'node:child_process';
+import { promises as fs, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const CLI = path.resolve(__dirname, '..', 'dist', 'cli.js');
+const ROOT = path.join(__dirname, '.tmp-errors');
+
+interface Run {
+  code: number;
+  out: string;
+  err: string;
+}
+
+/**
+ * Run the built CLI with the two streams on separate pipes.
+ *
+ * `FORCE_COLOR` and `NO_COLOR` are stripped from the inherited environment rather than trusted:
+ * the shell this was developed in exports `FORCE_COLOR=3`, which puts escape sequences around
+ * every message here and makes a `toContain` on a plain sentence fail for a reason that has
+ * nothing to do with the sentence.
+ */
+function run(args: string[], cwd: string): Promise<Run> {
+  return new Promise((resolve, reject) => {
+    const env: Record<string, string | undefined> = { ...process.env };
+    for (const key of ['CI', 'NO_COLOR', 'FORCE_COLOR']) delete env[key];
+    const child = spawn(process.execPath, [CLI, ...args], {
+      cwd,
+      env: env as NodeJS.ProcessEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    let err = '';
+    child.stdout.on('data', (c) => (out += String(c)));
+    child.stderr.on('data', (c) => (err += String(c)));
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code: code ?? -1, out, err }));
+  });
+}
+
+const GOOD_SCHEMA = `
+import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+`;
+
+/**
+ * A project directory holding one schema and one config.
+ *
+ * Under this package, so the schema's `drizzle-orm` import resolves by the ordinary node_modules
+ * walk. A directory in the system temp resolves nothing.
+ */
+async function project(name: string, schema: string, config: string) {
+  const dir = path.join(ROOT, name);
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'schema.ts'), schema, 'utf8');
+  await fs.writeFile(path.join(dir, 'drzl.config.ts'), config, 'utf8');
+  return dir;
+}
+
+const ZOD_CONFIG = `export default {
+  schema: './schema.ts',
+  generators: [{ kind: 'zod', path: './out' }],
+};`;
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.mkdir(ROOT, { recursive: true });
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+// -------------------------------------------------------------------------------------------
+// Item 70: the schema module failed to load
+// -------------------------------------------------------------------------------------------
+
+describe('generate: the schema module fails to load (item 70)', () => {
+  it('refuses a module that throws on import, names it, and writes nothing', async () => {
+    const dir = await project(
+      'throws',
+      `throw new Error('boom from schema module');\nexport const x = 1;\n`,
+      ZOD_CONFIG
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    // The whole of item 70: this run used to write `out/index.ts`, a barrel with no exports,
+    // and exit 0.
+    expect(existsSync(path.join(dir, 'out'))).toBe(false);
+    expect(r.out).toBe('');
+    expect(r.err).toContain('Could not load the schema module ./schema.ts (DRZL_SCHEMA_001):');
+    expect(r.err).toContain('boom from schema module');
+    // Not the "loaded fine and had nothing in it" sentence. The two causes have different fixes.
+    expect(r.err).not.toContain('DRZL_SCHEMA_002');
+  }, 120_000);
+
+  it('names the module a schema could not import', async () => {
+    const dir = await project(
+      'missing-package',
+      `import { thing } from 'no-such-package-xyz';\nexport const x = thing;\n`,
+      ZOD_CONFIG
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('Could not load the schema module ./schema.ts (DRZL_SCHEMA_001):');
+    expect(r.err).toContain('no-such-package-xyz');
+    expect(existsSync(path.join(dir, 'out'))).toBe(false);
+  }, 120_000);
+
+  it('refuses a schema that does not parse', async () => {
+    const dir = await project(
+      'syntax',
+      `import { pgTable, text } from 'drizzle-orm/pg-core';\nexport const users = pgTable('users', { id: text('id') \n`,
+      ZOD_CONFIG
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('Could not load the schema module ./schema.ts (DRZL_SCHEMA_001):');
+    expect(existsSync(path.join(dir, 'out'))).toBe(false);
+  }, 120_000);
+
+  it('refuses a config whose schema path does not exist', async () => {
+    const dir = await project(
+      'no-file',
+      GOOD_SCHEMA,
+      ZOD_CONFIG.replace('./schema.ts', './nope.ts')
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('./nope.ts');
+    expect(r.err).toContain('DRZL_SCHEMA_001');
+    expect(existsSync(path.join(dir, 'out'))).toBe(false);
+  }, 120_000);
+
+  it('reports the failure as the one JSON document under --json', async () => {
+    const dir = await project(
+      'throws-json',
+      `throw new Error('boom from schema module');\nexport const x = 1;\n`,
+      ZOD_CONFIG
+    );
+    const r = await run(['generate', '--json'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toBe('');
+    const doc = JSON.parse(r.out);
+    expect(doc).toMatchObject({
+      ok: false,
+      command: 'generate',
+      code: 'DRZL_SCHEMA_001',
+      exitCode: 1,
+    });
+    expect(doc.message).toContain('./schema.ts');
+  }, 120_000);
+
+  it('still prints the failure under --quiet', async () => {
+    const dir = await project(
+      'throws-quiet',
+      `throw new Error('boom from schema module');\nexport const x = 1;\n`,
+      ZOD_CONFIG
+    );
+    const r = await run(['generate', '--quiet'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('DRZL_SCHEMA_001');
+    expect(r.err).toContain('./schema.ts');
+  }, 120_000);
+});
+
+// -------------------------------------------------------------------------------------------
+// Item 71: the module loaded and had nothing in it
+// -------------------------------------------------------------------------------------------
+
+describe('generate: zero tables (item 71)', () => {
+  it('refuses a schema that exports no tables, with its own sentence', async () => {
+    const dir = await project('empty', `export {};\n`, ZOD_CONFIG);
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.out).toBe('');
+    // This exact run printed a green tick and exited 0, having written only `index.ts`.
+    expect(existsSync(path.join(dir, 'out', 'index.ts'))).toBe(false);
+    expect(r.err).toContain('No Drizzle tables found in ./schema.ts (DRZL_SCHEMA_002).');
+    // Distinguished from item 70: this module loaded perfectly well.
+    expect(r.err).not.toContain('DRZL_SCHEMA_001');
+    expect(r.err).not.toContain('Could not load');
+  }, 120_000);
+
+  it('refuses a module that exports things that are not tables', async () => {
+    const dir = await project(
+      'not-tables',
+      `export const helper = (a: number) => a + 1;\nexport const NAMES = ['a'];\n`,
+      ZOD_CONFIG
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('DRZL_SCHEMA_002');
+    expect(existsSync(path.join(dir, 'out'))).toBe(false);
+  }, 120_000);
+
+  it('says so when the table filter, not the schema, is what emptied the run', async () => {
+    const dir = await project(
+      'filtered-empty',
+      GOOD_SCHEMA,
+      `export default {
+         schema: './schema.ts',
+         include: ['nosuchtable'],
+         generators: [{ kind: 'zod', path: './out' }],
+       };`
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('DRZL_SCHEMA_003');
+    // Names the filter as the cause and the tables that were there, since the schema is fine.
+    expect(r.err).toContain('users');
+    expect(existsSync(path.join(dir, 'out'))).toBe(false);
+  }, 120_000);
+
+  it('fails `--check` rather than reporting an up-to-date tree', async () => {
+    const dir = await project('empty-check', `export {};\n`, ZOD_CONFIG);
+    const r = await run(['generate', '--check'], dir);
+
+    // 1, not 0 and not 2. Nothing was checked, because nothing could be generated.
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('DRZL_SCHEMA_002');
+  }, 120_000);
+
+  it('refuses to write a placeholder from generate:orpc', async () => {
+    const dir = await project('orpc-empty', `export {};\n`, ZOD_CONFIG);
+    const r = await run(['generate:orpc', './schema.ts', '--outDir', './out'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('DRZL_SCHEMA_002');
+    // `placeholder.orpc.ts`, reading "No tables detected in analysis", is what used to be written
+    // here with an exit code of 0.
+    expect(existsSync(path.join(dir, 'out'))).toBe(false);
+  }, 120_000);
+
+  it('reports zero tables as the JSON failure document', async () => {
+    const dir = await project('empty-json', `export {};\n`, ZOD_CONFIG);
+    const r = await run(['generate', '--json'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toBe('');
+    expect(JSON.parse(r.out)).toMatchObject({
+      ok: false,
+      command: 'generate',
+      code: 'DRZL_SCHEMA_002',
+      exitCode: 1,
+    });
+  }, 120_000);
+});
+
+describe('watch: an empty schema does not kill the watcher (item 71)', () => {
+  it('reports the empty schema, keeps watching, and generates once a table appears', async () => {
+    const dir = await project('watch-empty', `export {};\n`, ZOD_CONFIG);
+    const env: Record<string, string | undefined> = { ...process.env };
+    for (const key of ['CI', 'NO_COLOR', 'FORCE_COLOR']) delete env[key];
+    // `--poll` for the reason `commands.e2e.spec.ts` records: filesystem events do not reach
+    // chokidar reliably on WSL, Docker or a network mount, and a test that depends on inotify
+    // reports the environment rather than the product.
+    const child = spawn(process.execPath, [CLI, 'watch', '--debounce', '50', '--poll'], {
+      cwd: dir,
+      env: env as NodeJS.ProcessEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let err = '';
+    child.stderr.on('data', (c) => (err += String(c)));
+
+    try {
+      await waitFor(() => err.includes('DRZL_SCHEMA_002'), 30_000, 'the empty-schema report');
+      // The watcher is still alive: the process has not exited, and the next save fixes it.
+      expect(child.exitCode).toBe(null);
+
+      await new Promise((r) => setTimeout(r, 1000));
+      await fs.writeFile(path.join(dir, 'schema.ts'), GOOD_SCHEMA, 'utf8');
+
+      await waitFor(
+        () => existsSync(path.join(dir, 'out', 'users.zod.ts')),
+        60_000,
+        'regeneration after a table was added'
+      );
+    } finally {
+      child.kill('SIGTERM');
+    }
+  }, 180_000);
+});
+
+// -------------------------------------------------------------------------------------------
+// Item 78: a config error names the key
+// -------------------------------------------------------------------------------------------
+
+describe('config validation names the key path (item 78)', () => {
+  it('names a wrong-typed top-level key and shows what it found', async () => {
+    const dir = await project(
+      'cfg-type',
+      GOOD_SCHEMA,
+      `export default {
+         schema: './schema.ts',
+         outDir: 123,
+         generators: [{ kind: 'zod', path: './out' }],
+       };`
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('drzl.config.ts is not valid (DRZL_CFG_002)');
+    expect(r.err).toContain('outDir: expected string, received number (found 123)');
+    // The raw zod dump is what this replaces: a formatted JSON array of issue objects.
+    expect(r.err).not.toContain('"code": "invalid_type"');
+  }, 120_000);
+
+  it('renders a nested path as a reader would write it', async () => {
+    const dir = await project(
+      'cfg-nested-path',
+      GOOD_SCHEMA,
+      `export default {
+         schema: './schema.ts',
+         generators: [
+           { kind: 'zod', path: './out' },
+           { kind: 'orpc', validation: { library: 'nope' } },
+         ],
+       };`
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('generators[1].validation.library:');
+  }, 120_000);
+
+  it('names every problem, not just the first', async () => {
+    const dir = await project(
+      'cfg-many',
+      GOOD_SCHEMA,
+      `export default {
+         schema: 42,
+         outDir: 123,
+         generators: [{ kind: 'zod', path: 7, nestedDepth: 'deep' }],
+       };`
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('4 problems');
+    expect(r.err).toContain('schema:');
+    expect(r.err).toContain('outDir:');
+    expect(r.err).toContain('generators[0].path:');
+    expect(r.err).toContain('generators[0].nestedDepth:');
+  }, 120_000);
+
+  it('gives a key path and a suggestion to a strict object zod already rejects', async () => {
+    const dir = await project(
+      'cfg-strict',
+      GOOD_SCHEMA,
+      `export default {
+         schema: './schema.ts',
+         columns: { users: { ommit: ['email'] } },
+         generators: [{ kind: 'zod', path: './out' }],
+       };`
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toContain('columns.users: unrecognized key "ommit"');
+    expect(r.err).toContain('Did you mean "omit"?');
+  }, 120_000);
+
+  it('carries the same sentence into the JSON failure document', async () => {
+    const dir = await project(
+      'cfg-type-json',
+      GOOD_SCHEMA,
+      `export default {
+         schema: './schema.ts',
+         outDir: 123,
+         generators: [{ kind: 'zod', path: './out' }],
+       };`
+    );
+    const r = await run(['generate', '--json'], dir);
+
+    expect(r.code).toBe(1);
+    expect(r.err).toBe('');
+    const doc = JSON.parse(r.out);
+    expect(doc).toMatchObject({
+      ok: false,
+      command: 'generate',
+      code: 'DRZL_CFG_002',
+      exitCode: 1,
+    });
+    expect(doc.message).toContain('outDir: expected string, received number (found 123)');
+  }, 120_000);
+});
+
+// -------------------------------------------------------------------------------------------
+// Item 79: an unknown key is a warning, not silence
+// -------------------------------------------------------------------------------------------
+
+describe('an unknown config key warns (item 79)', () => {
+  it('warns about a misspelled key at the root and still generates', async () => {
+    const dir = await project(
+      'unknown-root',
+      GOOD_SCHEMA,
+      `export default {
+         schema: './schema.ts',
+         outDirr: 'src/api',
+         generators: [{ kind: 'zod', path: './out' }],
+       };`
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(0);
+    expect(r.err).toContain('drzl config: unknown key "outDirr" at the top level; it is ignored.');
+    expect(r.err).toContain('Did you mean "outDir"?');
+    expect(existsSync(path.join(dir, 'out', 'users.zod.ts'))).toBe(true);
+  }, 120_000);
+
+  it('warns about a misspelled key inside a generator entry', async () => {
+    const dir = await project(
+      'unknown-generator',
+      GOOD_SCHEMA,
+      `export default {
+         schema: './schema.ts',
+         generators: [{ kind: 'zod', path: './out', typedJsn: true }],
+       };`
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(0);
+    expect(r.err).toContain('drzl config: unknown key "typedJsn" in generators[0]; it is ignored.');
+    expect(r.err).toContain('Did you mean "typedJson"?');
+  }, 120_000);
+
+  it('warns about a misspelled key inside a nested object', async () => {
+    const dir = await project(
+      'unknown-nested',
+      GOOD_SCHEMA,
+      `export default {
+         schema: './schema.ts',
+         generators: [{ kind: 'orpc', validation: { useShared: true, librari: 'zod' } }],
+       };`
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(0);
+    expect(r.err).toContain(
+      'drzl config: unknown key "librari" in generators[0].validation; it is ignored.'
+    );
+    expect(r.err).toContain('Did you mean "library"?');
+  }, 120_000);
+
+  it('says nothing about keys the schema deliberately accepts', async () => {
+    const dir = await project(
+      'unknown-none',
+      GOOD_SCHEMA,
+      // Three keys nothing may warn about: `$schema`, which an editor needs and the config schema
+      // declares for that reason; a `columns` key, which is a table pattern rather than a name the
+      // schema knows; and `templateOptions`, whose keys belong to whichever template reads them.
+      `export default {
+         $schema: './drzl.config.schema.json',
+         schema: './schema.ts',
+         columns: { 'us*': { omit: ['email'] } },
+         generators: [
+           { kind: 'zod', path: './out' },
+           { kind: 'orpc', templateOptions: { whateverKey: 1, another: 'x' } },
+         ],
+       };`
+    );
+    const r = await run(['generate'], dir);
+
+    expect(r.code).toBe(0);
+    expect(r.err).not.toContain('unknown key');
+  }, 120_000);
+
+  it('puts the warning in the document under --json and nothing on stderr', async () => {
+    const dir = await project(
+      'unknown-json',
+      GOOD_SCHEMA,
+      `export default {
+         schema: './schema.ts',
+         outDirr: 'src/api',
+         generators: [{ kind: 'zod', path: './out' }],
+       };`
+    );
+    const r = await run(['generate', '--json'], dir);
+
+    expect(r.code).toBe(0);
+    expect(r.err).toBe('');
+    const doc = JSON.parse(r.out);
+    expect(doc.warnings.join('\n')).toContain('unknown key "outDirr"');
+  }, 120_000);
+
+  it('drops the warning under --quiet, and still exits 0', async () => {
+    const dir = await project(
+      'unknown-quiet',
+      GOOD_SCHEMA,
+      `export default {
+         schema: './schema.ts',
+         outDirr: 'src/api',
+         generators: [{ kind: 'zod', path: './out' }],
+       };`
+    );
+    const r = await run(['generate', '--quiet'], dir);
+
+    expect(r.code).toBe(0);
+    expect(r.err).toBe('');
+  }, 120_000);
+});
+
+/** Poll until `check` holds, or fail naming what was being waited for. */
+async function waitFor(check: () => boolean, timeoutMs: number, what: string) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${what}`);
+}

--- a/packages/cli/test/config-errors.spec.ts
+++ b/packages/cli/test/config-errors.spec.ts
@@ -1,0 +1,262 @@
+/**
+ * The pure halves of items 78 and 79: how a key path is written, what is shown of the value that
+ * was found there, and which levels of the config schema an unknown key is dropped at.
+ *
+ * These are here rather than in the end-to-end spec because each of them has a case that costs a
+ * whole spawned process to reach through a config file and is one line to state directly: a
+ * non-finite number, a 400-character string, a union with two object branches. The end-to-end
+ * spec pins the sentences a user reads; this one pins the rules that build them.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildConfigJsonSchema } from '../src/config';
+import {
+  CONFIG_INVALID_CODE,
+  describeValue,
+  editDistance,
+  formatConfigProblems,
+  nearestKey,
+  renderConfigPath,
+  unknownConfigKeys,
+  unknownKeyWarnings,
+} from '../src/config-errors';
+
+const SHAPE = buildConfigJsonSchema();
+
+describe('renderConfigPath', () => {
+  it('writes an array entry the way a config file spells it', () => {
+    expect(renderConfigPath(['generators', 1, 'validation', 'library'])).toBe(
+      'generators[1].validation.library'
+    );
+  });
+
+  it('brackets a key that is not an identifier', () => {
+    // `columns` is keyed by table pattern, and `columns.app_*` reads as though `*` were part of
+    // the path language rather than part of the key.
+    expect(renderConfigPath(['columns', 'app_*', 'omit'])).toBe('columns["app_*"].omit');
+  });
+
+  it('names the root when there is no path at all', () => {
+    expect(renderConfigPath([])).toBe('(root)');
+  });
+});
+
+describe('describeValue', () => {
+  it('states a non-finite number as itself', () => {
+    // `JSON.stringify(NaN)` is the four characters `null`, and so is `JSON.stringify(Infinity)`.
+    // Reporting `nestedDepth: NaN` as `null` would name a different mistake with a different fix.
+    expect(describeValue(NaN)).toBe('NaN');
+    expect(describeValue(Infinity)).toBe('Infinity');
+    expect(describeValue(-Infinity)).toBe('-Infinity');
+    expect(describeValue(0)).toBe('0');
+  });
+
+  it('quotes a string and truncates a long one', () => {
+    expect(describeValue('zod')).toBe('"zod"');
+    const long = 'x'.repeat(400);
+    const shown = describeValue(long);
+    expect(shown).toContain('(400 characters)');
+    expect(shown!.length).toBeLessThan(120);
+  });
+
+  it('shows a small object and declines a large one', () => {
+    expect(describeValue({ enabled: true })).toBe('{"enabled":true}');
+    expect(
+      describeValue({ kind: 'zod', path: 'src/validators/zod', typedJson: true, meta: true })
+    ).toBe(null);
+  });
+
+  it('distinguishes the three empty things', () => {
+    expect(describeValue(undefined)).toBe('undefined');
+    expect(describeValue(null)).toBe('null');
+    expect(describeValue('')).toBe('""');
+  });
+});
+
+describe('nearestKey', () => {
+  const known = ['outDir', 'include', 'exclude', 'columns', 'generators', 'schema'];
+
+  it('suggests a one-edit typo', () => {
+    expect(nearestKey('outDirr', known)).toBe('outDir');
+    expect(nearestKey('column', known)).toBe('columns');
+  });
+
+  it('says nothing about a word that is not a typo of any of them', () => {
+    expect(nearestKey('database', known)).toBeUndefined();
+    expect(nearestKey('abc', ['kind', 'path'])).toBeUndefined();
+  });
+
+  it('holds a short key to one edit and a longer one to two', () => {
+    // `pat` to `path` is one edit and suggested; `pa` to `path` is two, which on a two-character
+    // key is a different word entirely.
+    expect(nearestKey('pat', ['path'])).toBe('path');
+    expect(nearestKey('pa', ['path'])).toBeUndefined();
+    expect(nearestKey('typedJsn', ['typedJson', 'typedColumns'])).toBe('typedJson');
+  });
+
+  it('suggests nothing for a key that is already known', () => {
+    expect(nearestKey('outDir', known)).toBeUndefined();
+  });
+
+  it('breaks a tie towards the earlier key, so a run is repeatable', () => {
+    expect(nearestKey('pick', ['pica', 'pico'])).toBe('pica');
+  });
+
+  it('measures the distance it claims to', () => {
+    expect(editDistance('library', 'librari')).toBe(1);
+    expect(editDistance('', 'abc')).toBe(3);
+    expect(editDistance('abc', 'abc')).toBe(0);
+    expect(editDistance('kitten', 'sitting')).toBe(3);
+  });
+});
+
+describe('unknownConfigKeys', () => {
+  it('finds a key at the root, in a generator entry and in a nested object at once', () => {
+    const found = unknownConfigKeys(
+      {
+        outDirr: 'x',
+        generators: [{ kind: 'zod', typedJsn: true, validation: { librari: 'zod' } }],
+      },
+      SHAPE
+    );
+    expect(found.map((f) => `${renderConfigPath(f.path)}:${f.key}`)).toEqual([
+      '(root):outDirr',
+      'generators[0]:typedJsn',
+      'generators[0].validation:librari',
+    ]);
+  });
+
+  it("says nothing about a record key, because those are the user's own names", () => {
+    // `columns` is keyed by table pattern and `templateOptions` by whatever the template reads.
+    expect(
+      unknownConfigKeys(
+        {
+          columns: { 'app_*': { omit: ['deleted_at'] } },
+          generators: [{ kind: 'orpc', templateOptions: { anything: 1 } }],
+        },
+        SHAPE
+      )
+    ).toEqual([]);
+  });
+
+  it('says nothing about a strict object, which zod refuses before this runs', () => {
+    // `ColumnRulesSchema` is `.strict()`, so `ommit` never reaches a successful parse. Reporting
+    // it here as well would print the same mistake twice in two different shapes.
+    expect(unknownConfigKeys({ columns: { users: { ommit: ['a'] } } }, SHAPE)).toEqual([]);
+  });
+
+  it('says nothing about $schema, which an editor needs and the schema declares', () => {
+    expect(unknownConfigKeys({ $schema: './drzl.config.schema.json' }, SHAPE)).toEqual([]);
+  });
+
+  it('declines a union whose branches cannot be told apart', () => {
+    // Two object branches means guessing which one the value was written against, and a wrong
+    // guess reports keys that are perfectly valid.
+    const ambiguous = {
+      type: 'object',
+      properties: {
+        thing: {
+          anyOf: [
+            { type: 'object', properties: { a: {} } },
+            { type: 'object', properties: { b: {} } },
+          ],
+        },
+      },
+    };
+    expect(unknownConfigKeys({ thing: { zzz: 1 } }, ambiguous)).toEqual([]);
+  });
+
+  it('follows a union with exactly one object branch', () => {
+    // `meta`, `constraints`, `branded` and `document` all take this shape: a boolean shorthand
+    // beside an object. The object branch is the only one a key can live in.
+    const found = unknownConfigKeys(
+      { generators: [{ kind: 'zod', outputHeader: { enabled: true, txt: 'x' } }] },
+      SHAPE
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].key).toBe('txt');
+    expect(found[0].suggestion).toBe('text');
+  });
+
+  it('phrases the warning so the key and the place are both in it', () => {
+    expect(unknownKeyWarnings({ outDirr: 'x' }, SHAPE)).toEqual([
+      'drzl config: unknown key "outDirr" at the top level; it is ignored. Did you mean "outDir"?',
+    ]);
+    expect(unknownKeyWarnings({ nonsenseKeyName: 1 }, SHAPE)).toEqual([
+      'drzl config: unknown key "nonsenseKeyName" at the top level; it is ignored.',
+    ]);
+  });
+});
+
+describe('formatConfigProblems', () => {
+  it('counts the problems and names every key', () => {
+    const text = formatConfigProblems(
+      'drzl.config.ts',
+      [
+        {
+          code: 'invalid_type',
+          path: ['outDir'],
+          message: 'Invalid input: expected string, received number',
+        },
+        {
+          code: 'invalid_type',
+          path: ['generators', 0, 'nestedDepth'],
+          message: 'Invalid input: expected number, received string',
+        },
+      ],
+      { outDir: 123, generators: [{ nestedDepth: 'deep' }] },
+      SHAPE
+    );
+    expect(text).toBe(
+      [
+        `drzl.config.ts is not valid (${CONFIG_INVALID_CODE}). 2 problems:`,
+        '  - outDir: expected string, received number (found 123)',
+        '  - generators[0].nestedDepth: expected number, received string (found "deep")',
+      ].join('\n')
+    );
+  });
+
+  it("gives a strict object's refusal the same key path and a suggestion", () => {
+    const text = formatConfigProblems(
+      'drzl.config.ts',
+      [{ code: 'unrecognized_keys', path: ['columns', 'users'], keys: ['ommit'], message: 'x' }],
+      { columns: { users: { ommit: [] } } },
+      SHAPE
+    );
+    expect(text).toContain('columns.users: unrecognized key "ommit". Did you mean "omit"?');
+  });
+
+  it('says "1 problem" rather than "1 problems"', () => {
+    const text = formatConfigProblems(
+      'drzl.config.ts',
+      [{ code: 'invalid_type', path: ['outDir'], message: 'Invalid input: expected string' }],
+      { outDir: 1 },
+      SHAPE
+    );
+    expect(text).toContain('. 1 problem:');
+  });
+
+  it('caps a long list and counts the rest', () => {
+    const issues = Array.from({ length: 12 }, (_, i) => ({
+      code: 'invalid_type',
+      path: ['generators', i, 'path'],
+      message: 'Invalid input: expected string, received number',
+    }));
+    const text = formatConfigProblems('drzl.config.ts', issues, {}, SHAPE);
+    expect(text).toContain('. 12 problems:');
+    expect(text).toContain('  ... and 4 more');
+    expect(text.split('\n')).toHaveLength(10);
+  });
+
+  it('omits the value when the config does not hold one at that path', () => {
+    // A `required` issue points at a key that is not there, and "(found undefined)" restates the
+    // message it would be appended to.
+    const text = formatConfigProblems(
+      'drzl.config.ts',
+      [{ code: 'invalid_type', path: ['generators'], message: 'Invalid input: expected array' }],
+      {},
+      SHAPE
+    );
+    expect(text).toContain('  - generators: expected array');
+    expect(text).not.toContain('found');
+  });
+});


### PR DESCRIPTION
Plan items 70, 71, 78 and 79 as one change. Built on the three PRs that just landed rather than around them: every message goes through PR #191's output layer and picks one of its three exit codes, the "read the analyzer's verdict" rule comes from PR #190, and item 79 decides per level by reading the JSON Schema PR #189 generates.

## The measured starting point

Seven distinct broken inputs all exited **0** with the same two green ticks and wrote a barrel with no exports: a module that throws on import, one importing a package that is not installed, one with a syntax error, **a schema path that does not exist** (not on the plan's list; PR #190 fixed "no schema configured", which is a different thing), a module exporting no tables, one exporting only helpers, and a filter that removed every table. Config errors printed a formatted array of raw zod issue objects, and unknown keys were silently dropped at every permissive level.

## Three causes, three codes, three sentences

Read from the analyzer's own verdict rather than guessed from an empty table list: `DRZL_SCHEMA_001` the module never ran, `DRZL_SCHEMA_002` it ran and declares nothing, `DRZL_SCHEMA_003` the filters removed what it found (and that one names the tables it found). Each names the file. Two placement details matter: the 001 check runs **before** the spinner succeeds, so a green tick can no longer appear over a module that never loaded, and the 002/003 check runs **before `--check` snapshots anything**, so a check against an unreadable schema now fails instead of comparing an empty tree with itself and reporting it up to date.

The filename in the message is supplied by the CLI, not the analyzer, whose own `Failed to import schema:` bytes are deliberately preserved.

## The empty-state decision

Three candidates were examined and only one survived. **Watch** is a legitimate empty state (a file saved mid-expression does not parse, a file being written from scratch has no tables yet, and filters get edited with the watcher up), so it reports all three conditions and returns without exiting, tested by asserting the child process is still alive and then generating once a table is added. **`--check` on an empty tree is deliberately not exempt**, since that is the CI case that most needs to fail. A fresh project mid-setup is not one either, because `init` already refuses a candidate that declares no tables. `--pipeline analyze` is exempt from 002, matching `drzl analyze`, which correctly exits 0 on a zero-table schema because that is a true answer.

## Config errors and unknown keys

Item 78 lists **every** problem with a rendered key path (`generators[0].nestedDepth`, `columns["app_*"].omit` bracketed because that level is keyed by table pattern, `(root)` for the empty path), capped at 8 with a count, showing the received value when it fits in 60 characters and rendering it with `String` rather than `JSON.stringify`, so `NaN` reads `NaN` instead of the four characters `null`. That substitution is the one that previously turned a real defect in this project into a confidently reasoned false waiver, so it is unit-tested here.

Item 79 decides **per level by reading the generated JSON Schema**, not a hand-kept list: permissive levels warn (with a Levenshtein suggestion written in place, no dependency), `additionalProperties: false` levels defer to 78's rendering since zod already errors, record-keyed levels never warn because those keys are the user's own, and a union is only followed when exactly one branch is an object, since two would mean guessing.

**One interaction fixed because item 79 sits on it**: config warnings were `console.warn` from inside `loadConfig`, invisible to every flag, so `--json` printed them beside the document that is supposed to be alone on that channel and `--quiet` could not remove them. They now flow through the same warning path that feeds the JSON `warnings` array.

## Verification

Red-first: the e2e file was written first and run against the unmodified build, **23 of 24 failing**. The one that passed was "drops the warning under `--quiet`", vacuous because no warning existed at all, and is meaningful now. 24/24 after, plus 25 unit tests for the rules the e2e cannot reach cheaply. CLI package at 764 tests.

Gates green including `pnpm verify:packed` unmodified, all 29 stages, nothing moved. The stage most at risk drives every documented config through `generate`; it still reports all 35 generating and typechecking, and running those 35 with stderr captured produced **zero unknown-key warnings**, so no documented config tells a reader to write a key that does nothing.

Two incidental fixes: `Object.hasOwn` needs the ES2022 lib against this repo's ES2021 target, replaced with a local helper that also closes a latent prototype-chain bug (`'constructor' in obj` is true); and eslint's ignore list enumerated three temp roots by name rather than matching the shape, so an interrupted test run could fail `pnpm lint` outright on a fixture that deliberately does not parse.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
