### PR TITLE
feat: one write plan behind dry-run, change reports and check diffs (items 68, 75, 80, 81, 82)

### DIFF
--- a/.changeset/generate-plan-and-watch.md
+++ b/.changeset/generate-plan-and-watch.md
@@ -1,0 +1,112 @@
+---
+'@drzl/cli': minor
+'@drzl/validation-core': minor
+'@drzl/generator-orpc': minor
+'@drzl/generator-trpc': minor
+'@drzl/generator-hono': minor
+'@drzl/generator-express': minor
+'@drzl/generator-fastify': minor
+'@drzl/generator-nestjs': minor
+'@drzl/generator-graphql': minor
+'@drzl/generator-service': minor
+'@drzl/generator-zod': minor
+'@drzl/generator-valibot': minor
+'@drzl/generator-arktype': minor
+'@drzl/generator-typebox': minor
+'@drzl/generator-effect': minor
+'@drzl/generator-json-schema': minor
+---
+
+`generate` knows what it is about to write before it writes it (plan items 68, 80, 81, 75, 82)
+
+**One mechanism, three features.** `--dry-run`, "say what changed rather than how many files", and
+"a `--check` failure should show a diff" are the same question asked once per file: what content is
+about to land here, and what is here now. So generators now hand their writes to a `fileSink`
+instead of calling `node:fs/promises` themselves, and `generate` decides whether that sink writes.
+Fourteen generator packages changed by exactly one line each, because the sink is shaped like the
+`fs` namespace they already used, plus one option on their public type.
+
+The tempting alternative was to leave the generators alone and patch `node:fs/promises` for the
+duration of a run, and it was measured and rejected. Patching the CommonJS exports object is
+visible through a later dynamic import, but a module namespace that already exists is a snapshot
+and never changes: with `const ns = await import('node:fs/promises')` evaluated first,
+`require('node:fs/promises').writeFile = spy` leaves `ns.writeFile` untouched, on Node 22.22. The
+CLI links `chokidar`, which imports `node:fs/promises` at module scope, so a dry run built on that
+would write real files whenever an unrelated dependency happened to import first.
+
+**`drzl generate --dry-run` writes nothing at all** (item 68). Not "writes and puts it back":
+no file, no directory, no formatter output. A dry run in a project that has never been generated
+into leaves the directory byte-for-byte as it found it, asserted per entry and per byte rather than
+by looking for generated files. It exits `0` whether or not anything would change, because a dry
+run that computed its answer did what it was asked, and `2` is for a run that found what it was told
+to look for; `--check` is the flag whose question is "is anything stale". stdout still carries one
+absolute path per line, so `drzl generate --dry-run > files.txt` gives the list that _would_ be
+written in the same shape as the list that was.
+
+Because generators are separate packages that a user can install at a different version from the
+CLI, the claim is also checked at runtime rather than only in a test. A run that promised to write
+nothing and wrote something restores the tree, exits `1` with the new `DRZL_GEN_003`, and names the
+generator to update.
+
+**Every run says what it did to each file** (item 80): created, changed or unchanged, with the
+counts and the names of the ones that are not the same as before.
+
+```
+✔ Generated (zod): 3 files (1 created, 1 changed, 1 unchanged)
+  + zod/posts.zod.ts
+  ~ zod/index.ts
+```
+
+A run that rewrote twelve identical files and one real change used to say `13 files`. Unchanged
+files are counted rather than listed: the list is what changed. That report is narration, so it is
+on stderr, `--quiet` drops it, and **stdout is unchanged**, still one absolute path per line.
+`--json` gains a `changes` array per generator beside the existing `files`, and a `dryRun` flag.
+
+**`--check` prints a unified diff under each drifted file** (item 81), `a/` being what is on disk
+and `b/` what the schema produces, so it reads like `git diff` and applies like a patch. "Changed"
+alone cannot tell a regenerated header from somebody's hand-edit to a generated file, and those two
+want opposite responses. Diffs are capped at the first 20 files, at 4000 lines and at 1500 line
+edits, and every cap states itself in the output; every drifted file is still named in the list
+above the diffs, so what is capped is the explanation and never the finding. `--quiet` keeps the
+list and drops the diffs. The diff is written here rather than installed: `diff` (jsdiff) is only
+resolvable in this workspace as a transitive dependency of a devDependency, and adding it as a real
+one costs a package on every install of the CLI in exchange for about a hundred lines of a
+published algorithm. It is checked by applying its own output: every case in its suite requires the
+emitted patch, replayed against the "before" text, to reproduce the "after" text exactly.
+
+**`--check` also stopped writing.** It used to snapshot the output directories, let the generators
+overwrite them for real, compare, and restore the snapshot, so the one command documented as never
+touching your tree was the command that rewrote every generated file on every CI run, with a window
+in which a killed process left the tree modified. It now compares in memory. One consequence: a file
+in an output directory that the run no longer produces is not reported, and the `removed` drift
+status is no longer produced. Reporting every unrecognised file in an output directory would mean a
+config whose `outDir` is `src` failed CI over every hand-written module in the project.
+
+**`drzl watch` runs one rebuild at a time** (item 75). The debounce that was there covered the wait
+and not the work: it collapsed changes arriving close together and then started a rebuild that took
+as long as it took, and every change arriving during _that_ started another one on top of it,
+writing the same output directory. Measured on a 600-table schema where one rebuild takes about
+1.4s, six saves 700ms apart produced six rebuilds with four running at once. A save that arrives
+during a rebuild is now remembered rather than started, and produces exactly one more rebuild when
+the current one finishes, however many arrive; the same measurement now shows at most one in
+flight. No save is dropped, because refusing one loses an edit, which is worse than the overlap.
+
+`--debounce` keeps its 200ms default, now measured rather than inherited: with the write-settling
+this watcher asks chokidar for, one editor save arrives as a single event and the widest gap inside
+one burst was 9ms; without it, a chunked write spread to 62ms, an atomic save to 101ms and
+format-on-save to 121ms. `--debounce 0` now works, having previously been read as absent by
+`Number(x) || 200` and silently replaced, and a value that is not a number is refused with a warning
+instead of quietly becoming 200.
+
+**Clearing the screen is opt-in** (item 75). `drzl watch` cleared the terminal on every rebuild with
+no way to stop it, throwing away the previous rebuild's errors and the banner naming the watched
+directories. It is now `--clear`, off by default, and it writes to the stream the output is actually
+on: the old `console.clear()` decided from stdout while every human-readable line goes to stderr, so
+`drzl watch > events.json` at a terminal cleared nothing and aimed the escape at the stream carrying
+the JSON.
+
+**The analysis was already shared between generators** (item 82), and there is now a test that says
+so. Measured on a 200-table schema: one, two, three and five generators each report exactly one
+analysis step, at a constant 37ms, and the four extra generators cost 2468ms of generator work
+where four extra analyses would have added about 148ms. `watch` re-analyses per rebuild, which is
+what keeps a cached analysis from going stale when the schema changes.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -153,13 +153,16 @@ bunx @drzl/cli generate -c drzl.config.ts
 Options:
 
 - `-c, --config <path>`: path to config file
-- `--check`: regenerate and report drift without changing the tree
+- `--check`: regenerate and report drift, with a diff, without writing anything
+- `--dry-run`: report what would be written, and write nothing
 - `--json`, `-q, --quiet`
 
 Behavior:
 
 - Analyzes your schema
 - Runs each generator in `generators[]`, printing a file summary per kind on stdout
+- Says how many files it created, changed and left alone, and names the ones that are not the same
+  as before
 - Warnings, the spinner and the progress bar go to stderr, so `drzl generate > files.txt` holds
   only the paths that were written
 
@@ -265,7 +268,8 @@ Options:
 
 - `-c, --config <path>`
 - `--pipeline <name>`: `all | analyze | generate-orpc | generate-trpc | generate-hono | generate-express | generate-fastify | generate-nestjs | generate-graphql` (default `all`)
-- `--debounce <ms>`: debounce milliseconds (default `200`)
+- `--debounce <ms>`: wait this long after the last change before rebuilding (default `200`)
+- `--clear`: clear the terminal before each rebuild, off by default
 - `--json`: emit structured JSON logs on stdout, one object per line
 - `-q, --quiet`: drop the narration; errors still print
 - `--poll`: force polling, which helps on WSL, Docker and network mounts

--- a/docs/cli/generate.md
+++ b/docs/cli/generate.md
@@ -27,7 +27,8 @@ bunx @drzl/cli generate -c drzl.config.ts
 Options:
 
 - `-c, --config <path>`: path to the config
-- `--check`: regenerate and report drift without changing the tree
+- `--check`: regenerate and report drift, with a diff, without writing anything
+- `--dry-run`: report what would be written, and write nothing
 - `--json`: one JSON document on stdout, described in [Output](/cli/output#generate-json)
 - `-q, --quiet`: silent on success, errors still on stderr
 
@@ -35,6 +36,7 @@ Behavior:
 
 - Analyzes your schema then runs each generator in `generators[]`
 - Prints a file summary per generator kind on stdout
+- Says what changed, not only how many files it wrote
 - Puts warnings, the spinner and the progress bar on stderr, so `drzl generate > files.txt` holds
   only the paths that were written
 - Draws a progress bar only at a terminal, and only for a schema with enough tables that it will
@@ -44,6 +46,56 @@ When the config has no `schema` key, the path is read from your drizzle-kit conf
 (`drizzle.config.ts`, then `.js`, then `.json`), and the run says so:
 `Schema from drizzle.config.ts (3 files)`. See
 [Reading the schema path from drizzle-kit](/guide/configuration#reading-the-schema-path-from-drizzle-kit).
+
+## What changed, not how many files
+
+Every run reports each file as **created**, **changed** or **unchanged**, and names the ones that
+are not the same as they were:
+
+```
+✔ Analysis complete in 41ms
+✔ Generated (zod): 3 files (1 created, 1 changed, 1 unchanged)
+  + zod/posts.zod.ts
+  ~ zod/index.ts
+```
+
+A run that rewrote twelve identical files and one real change used to say `13 files`, which is true
+and is not the sentence anyone was looking for. Unchanged files are counted rather than listed: the
+list is what changed.
+
+That report is narration, so it is on stderr and `--quiet` drops it. **stdout is unchanged**: still
+one absolute path per line, so anything parsing `drzl generate > files.txt` is unaffected.
+
+## `--dry-run`: what would happen
+
+```bash
+npx @drzl/cli generate --dry-run
+```
+
+Runs every generator, computes every file, and writes none of them. stdout still lists the paths,
+because "what would you write" and "what did you write" are the same answer to the same question, so
+`drzl generate --dry-run > files.txt` works. stderr says what each file would be:
+
+```
+✔ Would write (zod): 3 files (1 created, 1 changed, 1 unchanged)
+  + zod/posts.zod.ts
+  ~ zod/index.ts
+✔ Dry run: 3 file(s) would be written (1 created, 1 changed, 1 unchanged). Nothing was written.
+```
+
+**Nothing at all is written**, and that includes directories: a dry run in a project that has never
+been generated into leaves the directory byte-for-byte as it found it, with no `mkdir`, no output
+and no formatter cache. That is asserted by test rather than claimed, and checked at runtime as
+well, because generators are separate packages: a run that promised to write nothing and then wrote
+something puts the tree back and exits `1` with `DRZL_GEN_003`, telling you to update your
+`@drzl/generator-*` packages.
+
+It exits `0` whether or not anything would change. A dry run that computed its answer did what it
+was asked, and `2` is reserved for a run that found what it was told to look for. `--check` is the
+flag whose question is "is anything stale", and it still answers `2`.
+
+Passing both is not an error. `--check` already writes nothing, so `--dry-run` adds nothing to it,
+and `--check` decides the exit code.
 
 ## When there is nothing to generate from
 
@@ -95,23 +147,53 @@ npx @drzl/cli generate --check
 ```
 
 Regenerates and compares the result against what is on disk. Exits `2` if anything differs and
-`0` when everything is current, naming each file:
+`0` when everything is current, naming each file and then showing what is different about it:
 
 ```
 Generated output is out of date (2 file(s)):
   ~ changed  src/validators/zod/people.zod.ts
   + added    src/validators/zod/extra.zod.ts
 
+--- a/src/validators/zod/people.zod.ts
++++ b/src/validators/zod/people.zod.ts
+@@ -6,7 +6,7 @@
+
+ export const InsertpeopleSchema = z.object({
+   id: z.number().int().optional(),
+-  email: z.string().email(),
++  email: z.string(),
+ });
+
 Run `drzl generate` and commit the result. Nothing was written by this check.
 ```
+
+The diff is a standard unified diff, so it greps, it reads the way `git diff` reads, and it applies:
+`a/` is what is on disk and `b/` is what this schema produces. That distinction is the point.
+"Changed" alone cannot tell a regenerated header from a hand-edit somebody made to a generated file,
+and those two want opposite responses.
+
+Diffs are capped at the first **20** files, and a file longer than 4000 lines, or one that differs
+by more than 1500 line edits, prints a one-line summary instead of hunks. Every cap says so in the
+output, and every drifted file is still named in the list above the diffs: what is capped is the
+explanation, never the finding.
+
+`--quiet` keeps the list and drops the diffs. The list is the finding, which a `2` with nothing to
+read makes unusable; the diff is the explanation.
 
 It catches the two things that actually happen: someone edits a generated file by hand, and
 someone changes the schema without regenerating. Both are review problems today and CI problems
 with this.
 
-**It never modifies your working tree.** The output directories are snapshotted before
-regeneration and restored afterwards whether or not anything drifted, including deleting files
-the run created. A failed check leaves the tree exactly as it found it.
+**It never writes anything.** Not "writes and puts it back": the files are produced in memory and
+compared there, so there is no window in which your tree is in an intermediate state and nothing to
+restore if the process is killed. Before 4.23 this snapshotted the output directories, let the
+generators overwrite them for real, compared, and restored the snapshot.
+
+One consequence worth stating: a file in an output directory that the run no longer produces is not
+reported. `--check` compares the files this schema generates against what is on disk under those
+names, and a `removed` status is no longer possible. Reporting every unrecognised file in an output
+directory would mean a config whose `outDir` is `src` failed CI over every hand-written module in
+the project.
 
 `2` rather than `1`, because the check ran perfectly and is reporting what it found;
 `1` is reserved for a run that could not happen, such as a config DRZL could not read. A job that

--- a/docs/cli/output.md
+++ b/docs/cli/output.md
@@ -87,7 +87,8 @@ drzl generate --quiet          # prints the error to stderr, exits 1, when the c
 ```
 
 `generate --check --quiet` still names the files that drifted. That list is the finding the check
-exists to produce, and an exit code of `2` with no list is an answer nobody can act on.
+exists to produce, and an exit code of `2` with no list is an answer nobody can act on. It does drop
+the diff under each one, which is the explanation rather than the finding.
 
 ## `--json`
 
@@ -134,6 +135,11 @@ not produce its payload at all:
 | `DRZL_SCHEMA_003` | The config's `include`/`exclude` filters removed every table           |
 | `DRZL_GEN_001`    | `generate` failed for any other reason                                 |
 | `DRZL_GEN_002`    | A generator threw, or is not installed                                 |
+| `DRZL_GEN_003`    | A generator wrote to disk during `--dry-run` or `--check`; see below   |
+
+`DRZL_GEN_003` means an installed `@drzl/generator-*` package is older than the CLI and does not
+know how to report a file instead of writing it. Anything it wrote has been put back, and the fix
+is to update the generator packages.
 
 ### One name, two meanings, and why
 
@@ -178,26 +184,53 @@ The `DoctorReport`, with the envelope merged in at the top level. See
   "command": "generate",
   "exitCode": 0,
   "check": null,
-  "generators": [{ "kind": "zod", "files": ["/abs/path/users.zod.ts"] }],
+  "dryRun": false,
+  "generators": [
+    {
+      "kind": "zod",
+      "files": ["/abs/path/users.zod.ts"],
+      "changes": [{ "file": "src/validators/zod/users.zod.ts", "status": "unchanged" }]
+    }
+  ],
   "warnings": ["1 column could not be typed: ..."]
 }
 ```
 
 - `generators` is one entry per configured generator, in config order, each with the absolute
   paths it wrote.
+- `changes` is the same set of files with a verdict each: `created`, `changed` or `unchanged`.
+  Paths are relative to the working directory, so a document is readable and comparable across
+  machines. `files` keeps its absolute paths, unchanged.
 - `warnings` holds every warning the human run prints to stderr, as strings.
+- `dryRun` is `true` when `--dry-run` was passed. The document is otherwise identical, because a
+  dry run answers the same question; nothing was written.
 - `check` is `null` unless `--check` was passed, and otherwise:
 
 ```json
 {
   "check": {
     "upToDate": false,
-    "drift": [{ "file": "src/validators/zod/users.zod.ts", "status": "changed" }]
+    "diffFileCap": 20,
+    "drift": [
+      {
+        "file": "src/validators/zod/users.zod.ts",
+        "status": "changed",
+        "diff": "--- a/src/validators/zod/users.zod.ts\n+++ b/...\n@@ -6,7 +6,7 @@\n..."
+      }
+    ]
   }
 }
 ```
 
-`status` is `added`, `removed` or `changed`. Paths are relative to the working directory.
+`status` is `added` or `changed`. Paths are relative to the working directory.
+
+`diff` is a unified diff of the file on disk (`a/`) against what the schema produces (`b/`), or
+`null` for the entries past `diffFileCap`. Those entries are still listed with their status: the cap
+limits the explanation, never the finding. A file too long or too different to diff carries a
+one-line summary saying which cap it hit rather than an empty string.
+
+`removed` was a possible `status` before 4.23 and is not produced any more. See
+[Generate](/cli/generate#check-fail-ci-when-generated-output-is-stale) for why.
 
 ### `generate:orpc --json`, `generate:trpc --json`
 
@@ -254,6 +287,7 @@ first and shows a diff or a report on the second.
 | `analyze`                        | analysed                  | schema missing or could not be imported                    | analysed, with error-level issues |
 | `doctor`                         | reported                  | schema missing or could not be imported                    | findings **and** `--strict`     |
 | `generate`                       | generated                 | no config, invalid config, nothing to generate from, a generator threw | `--check` found drift |
+| `generate --dry-run`             | reported what it would write | as `generate`                                           | not used                        |
 | `generate:orpc`, `generate:trpc` | generated                 | nothing to generate from, or a generator threw             | not used                        |
 | `init`                           | config written            | a config already exists, or it could not be written        | not used                        |
 | `watch`                          | (runs until interrupted)  | no config, or the schema path could not be resolved        | not used                        |

--- a/docs/cli/watch.md
+++ b/docs/cli/watch.md
@@ -12,19 +12,19 @@ Usage:
 ::: code-group
 
 ```bash [pnpm]
-pnpm dlx @drzl/cli watch -c drzl.config.ts --pipeline all --debounce 200 [--json]
+pnpm dlx @drzl/cli watch -c drzl.config.ts --pipeline all --debounce 200 [--clear] [--json]
 ```
 
 ```bash [npm]
-npx @drzl/cli watch -c drzl.config.ts --pipeline all --debounce 200 [--json]
+npx @drzl/cli watch -c drzl.config.ts --pipeline all --debounce 200 [--clear] [--json]
 ```
 
 ```bash [yarn]
-yarn dlx @drzl/cli watch -c drzl.config.ts --pipeline all --debounce 200 [--json]
+yarn dlx @drzl/cli watch -c drzl.config.ts --pipeline all --debounce 200 [--clear] [--json]
 ```
 
 ```bash [bun]
-bunx @drzl/cli watch -c drzl.config.ts --pipeline all --debounce 200 [--json]
+bunx @drzl/cli watch -c drzl.config.ts --pipeline all --debounce 200 [--clear] [--json]
 ```
 
 :::
@@ -34,10 +34,43 @@ Options:
 - `-c, --config <path>`
 - `--pipeline <name>`: `all | analyze | generate-orpc | generate-trpc | generate-hono | generate-express | generate-fastify | generate-nestjs | generate-graphql` (default `all`)
   Anything other than `all` or `analyze` runs exactly one generator kind and skips the rest.
-- `--debounce <ms>`: debounce milliseconds (default `200`)
+- `--debounce <ms>`: wait this long after the last change before rebuilding (default `200`)
+- `--clear`: clear the terminal before each rebuild, off by default
 - `--json`: emit structured JSON logs on stdout, one object per line
 - `-q, --quiet`: drop the narration; errors still print
 - `--poll`: force polling, which helps on WSL, Docker and network mounts
+
+## One rebuild at a time
+
+A save that lands while a rebuild is running does not start a second one. It is remembered, and one
+more rebuild follows when the current one finishes, however many saves arrived meanwhile.
+
+This is what the debounce alone could not do. `--debounce` collapses changes arriving close
+together and then starts a rebuild that takes as long as it takes; every change arriving during
+_that_ used to start another one on top of it, writing the same output directory. Measured on a
+600-table schema where one rebuild takes about 1.4s, six saves 700ms apart produced six rebuilds
+with four running at once. Now the same burst produces at most one rebuild in flight, and no save
+is dropped.
+
+`--debounce` itself stays at 200ms, which is measured rather than chosen. With the write-settling
+this watcher asks chokidar for, one editor save reaches it as a single event, and the widest gap
+inside one burst was 9ms, from a tool rewriting two files back to back. Without that settling the
+same bursts spread out to at most 121ms, from format-on-save. 200ms covers the widest of them and
+is short enough that a save still feels immediate.
+
+`--debounce 0` is allowed and means "rebuild on the next tick". A value that is not a number is
+now refused with a warning instead of being silently replaced by 200.
+
+## Clearing the screen
+
+`--clear` wipes the terminal before each rebuild, so the screen holds only the current run. It is
+**off by default**, because a watcher left running all day should not throw away the previous
+rebuild's errors without being asked, and it does nothing at all when stderr is not a terminal, so
+`drzl watch 2> build.log` never puts an escape sequence in the log.
+
+Before 4.23 the screen was cleared on every rebuild with no way to stop it, and the decision was
+made from stdout rather than from the stream the output is on, so `drzl watch > events.json` at a
+terminal cleared nothing.
 
 ## Streams
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -41,7 +41,19 @@ import {
   type ResolvedSchemaSource,
 } from './drizzle-kit.js';
 import { buildDoctorReport, renderDoctorReport } from './doctor.js';
-import { diffSnapshots, restoreSnapshot, snapshotAll } from './drift.js';
+import { snapshotAll } from './drift.js';
+import {
+  describeCounts,
+  displayPath,
+  driftStatusOf,
+  EmitPlan,
+  pendingChanges,
+  verifyNothingWasWritten,
+  type EmittedFile,
+  type FileVerdict,
+} from './emit-plan.js';
+import { unifiedDiff } from './unified-diff.js';
+import { createRebuildScheduler, resolveDebounce } from './watch-loop.js';
 import { GeneratorNotInstalledError, loadGenerator } from './generator-loader.js';
 import { INIT_GENERATOR_CHOICES, runInit } from './init.js';
 import { maybeShowSponsorMessage } from './sponsor.js';
@@ -105,6 +117,57 @@ function reportSchemaProblem(out: Output, command: string, problem: SchemaProble
     out.hint(problem.hint);
   }
   process.exit(EXIT_FAILED);
+}
+
+/**
+ * How many drifted files `--check` prints a diff for.
+ *
+ * A cap rather than no cap, because the case that produces the most drift is the one where a diff
+ * helps least: a bumped generator version rewrites the header of every file, and a CI log holding
+ * eight hundred near-identical hunks is a log nobody opens. Twenty is enough to read.
+ *
+ * The number of files beyond it is always stated, and every file is still named in the list above
+ * the diffs, so nothing is hidden: what is capped is the explanation, never the finding.
+ */
+const DIFF_FILE_CAP = 20;
+
+/**
+ * Show what changed in each drifted file (item 81).
+ *
+ * On stderr, with the rest of the narration, for the reason `--check`'s file list is: the diff is
+ * a report about the work rather than the work, and `drzl generate --check > out.txt` should not
+ * put a patch in the file. `--quiet` drops these and keeps the list, which is the finding.
+ */
+function printCheckDiffs(out: Output, drift: EmittedFile[]): void {
+  const shown = drift.slice(0, DIFF_FILE_CAP);
+  for (const d of shown) {
+    const label = displayPath(d.file);
+    const text = unifiedDiff(d.before ?? '', d.after, {
+      fromLabel: `a/${label}`,
+      toLabel: `b/${label}`,
+    });
+    if (!text) continue;
+    out.note('');
+    for (const line of text.split('\n')) {
+      if (!line) continue;
+      // Coloured per line rather than per hunk, so a redirected stream gets the same text with no
+      // escapes at all; `errStyle` has already answered that question for this stream.
+      if (line.startsWith('+++') || line.startsWith('---')) out.note(out.errStyle.bold(line));
+      else if (line.startsWith('@@')) out.note(out.errStyle.cyan(line));
+      else if (line.startsWith('+')) out.note(out.errStyle.green(line));
+      else if (line.startsWith('-')) out.note(out.errStyle.red(line));
+      else out.note(out.errStyle.gray(line));
+    }
+  }
+  if (drift.length > shown.length) {
+    out.note('');
+    out.note(
+      out.errStyle.gray(
+        `${drift.length - shown.length} more file(s) differ. Diffs are capped at ` +
+          `${DIFF_FILE_CAP} files; every drifted file is named in the list above.`
+      )
+    );
+  }
 }
 
 /**
@@ -280,10 +343,25 @@ withOutputFlags(
       '--check',
       'regenerate and fail if the result differs from what is on disk, without changing it'
     )
+    .option('--dry-run', 'report what would be written, and write nothing', false)
 ).action(async (opts: any) => {
   const out = outputFor(opts);
+  /**
+   * Whether this run writes anything at all.
+   *
+   * `--check` and `--dry-run` are the same run with different reports at the end: both compute
+   * every file's content, neither puts any of it on disk. `--check` then asks whether anything
+   * differs and fails if it does; `--dry-run` prints what it found and succeeds either way.
+   * Passing both is not an error, it is a `--check` that also says nothing was written, which is
+   * already what `--check` says.
+   */
+  const planning = !!opts.check || !!opts.dryRun;
   /** Everything the `--json` document reports, filled in as the run makes it true. */
-  const emitted: Array<{ kind: string; files: string[] }> = [];
+  const emitted: Array<{
+    kind: string;
+    files: string[];
+    changes: Array<{ file: string; status: FileVerdict }>;
+  }> = [];
   const warnings: string[] = [];
   /** A warning goes to stderr for a human and into the document for a machine, never both. */
   const warn = (text: string) => {
@@ -381,10 +459,23 @@ withOutputFlags(
         remaining: analysis.tables,
       });
       if (empty) reportSchemaProblem(out, 'generate', empty);
-      // Under --check the existing output is captured before anything overwrites it, so the
-      // regenerated result can be compared against it and the tree put back either way.
-      const driftDirs = computeGeneratorOutputDirs(cfg);
-      const driftBefore = opts.check ? await snapshotAll(driftDirs) : null;
+      // Where every generator writes, which is both the set `--check` and `--dry-run` have to know
+      // the current contents of, and the set they have to prove they left alone afterwards.
+      const outputDirs = computeGeneratorOutputDirs(cfg);
+      // Read once, up front, for two jobs at the same time: it is the "what is on disk now" half
+      // of every per-file verdict below, so the plan never reads a file itself, and it is the
+      // baseline `verifyNothingWasWritten` compares against at the end. Only for a run that writes
+      // nothing; an ordinary `generate` reads each file as it emits it, which costs one read per
+      // generated file rather than one per file in the output tree.
+      const existing = planning ? await snapshotAll(outputDirs) : undefined;
+      /**
+       * Every file this run produces, with the content already there beside it.
+       *
+       * Handed to each generator as `fileSink`, so the content is captured at the moment it would
+       * be written rather than inferred afterwards from what landed on disk. Items 68, 80 and 81
+       * all read this one object.
+       */
+      const plan = new EmitPlan({ write: !planning, existing });
       const total = analysis.tables.length || 1;
       // Whether this draws anything at all is `shouldShowProgress`'s decision: a terminal, no
       // `--quiet`, no `--json`, and enough tables that the bar will move (item 72).
@@ -392,12 +483,58 @@ withOutputFlags(
       /** One completed generator, reported the same way whichever branch produced it. */
       const generated = (kind: string, files: string[]) => {
         progress.stop();
-        emitted.push({ kind, files });
+        // A path the generator says it wrote that never reached the sink is a generator that
+        // ignored `fileSink`, which on a user's machine means an installed generator package older
+        // than this CLI. Under `--dry-run` or `--check` that is a run writing to a tree it promised
+        // not to touch, so it stops here rather than reporting a plan that is not what happened.
+        // `verifyNothingWasWritten` catches the same thing from the other side; this one can name
+        // the generator.
+        const missed = plan.unrecorded(files);
+        if (missed.length && planning) {
+          const message =
+            `The ${kind} generator wrote ${missed.length} file(s) directly instead of reporting ` +
+            `them, so this run could not be a preview. Update @drzl/generator-${kind} to a ` +
+            `version that supports --dry-run. First file: ${displayPath(missed[0])}`;
+          if (opts.json) out.jsonData(jsonFailure('generate', 'DRZL_GEN_003', message));
+          else out.error(message);
+          process.exit(EXIT_FAILED);
+        }
+        const verdicts = plan.verdictsFor(files).filter(Boolean) as EmittedFile[];
+        // One entry per generator *entry*, keyed by nothing: a config may list two generators of
+        // the same kind pointed at different paths, and a lookup by kind would report the first
+        // one's verdicts twice.
+        emitted.push({
+          kind,
+          files,
+          changes: verdicts.map((v) => ({ file: v.file, status: v.verdict })),
+        });
         if (opts.json) return;
-        // stdout, and deliberately: for `generate` the list of files written is the answer, and a
-        // caller without `--json` has nothing else to read. `--quiet` is what removes it.
         if (out.quiet) return;
-        out.succeed(out.errStyle.green(`Generated (${kind}): ${files.length} files`));
+        // Item 80: the count is what the run cost, the verdicts are what it did. A generator that
+        // rewrote twelve identical files and one changed one used to report "13 files", which is
+        // true and is not the sentence anyone was looking for.
+        //
+        // The verb changes with the mode, because "Generated" over a run that wrote nothing is the
+        // same class of untruth as the green tick items 70 and 71 were filed about.
+        out.succeed(
+          out.errStyle.green(
+            `${planning ? 'Would write' : 'Generated'} (${kind}): ${files.length} files`
+          ) + out.errStyle.gray(` (${describeCounts(plan.counts(files))})`)
+        );
+        // Only the files that are not the same as before, and named relative to the working
+        // directory, because this is the short list a person scans. The full absolute list is
+        // still on stdout below, unchanged, for whatever is parsing it. Skipped under `--check`,
+        // which prints the same files again below with their drift status and a diff each.
+        for (const v of verdicts) {
+          if (opts.check) break;
+          if (v.verdict === 'unchanged') continue;
+          const mark = v.verdict === 'created' ? '+' : '~';
+          out.note('  ' + out.errStyle.cyan(mark + ' ' + displayPath(v.file)));
+        }
+        // stdout, and deliberately: for `generate` the list of files written is the answer, and a
+        // caller without `--json` has nothing else to read. `--quiet` is what removes it. Under
+        // `--dry-run` it is the list that *would* be written, which is the same answer to the same
+        // question and keeps `drzl generate --dry-run > files.txt` working.
         for (const f of files) out.data('  - ' + out.outStyle.cyan(f));
       };
       /** One generator that threw. Reports it in whichever shape was asked for, then stops. */
@@ -437,6 +574,7 @@ withOutputFlags(
             // file, because the config schema had no such key and zod stripped it in silence.
             databaseInjection: g.databaseInjection,
             servicesDir,
+            fileSink: plan,
             onProgress: ({ index }) => progress.update(index),
           });
           generated(g.kind, files);
@@ -455,6 +593,7 @@ withOutputFlags(
             const gen = new TRPCGenerator(analysis);
             const { files } = await gen.generate({
               ...trpcOptions(g, cfg, servicesDir),
+              fileSink: plan,
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
             generated('trpc', files);
@@ -474,6 +613,7 @@ withOutputFlags(
             const gen = new HonoGenerator(analysis);
             const { files } = await gen.generate({
               ...honoOptions(g, cfg),
+              fileSink: plan,
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
             generated('hono', files);
@@ -493,6 +633,7 @@ withOutputFlags(
             const gen = new ExpressGenerator(analysis);
             const { files } = await gen.generate({
               ...expressOptions(g, cfg),
+              fileSink: plan,
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
             generated('express', files);
@@ -512,6 +653,7 @@ withOutputFlags(
             const gen = new FastifyGenerator(analysis);
             const { files } = await gen.generate({
               ...fastifyOptions(g, cfg),
+              fileSink: plan,
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
             generated('fastify', files);
@@ -531,6 +673,7 @@ withOutputFlags(
             const gen = new NestJSGenerator(analysis);
             const { files } = await gen.generate({
               ...nestjsOptions(g, cfg),
+              fileSink: plan,
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
             generated('nestjs', files);
@@ -551,6 +694,7 @@ withOutputFlags(
             const gen = new GraphQLGenerator(analysis);
             const { files } = await gen.generate({
               ...graphqlOptions(g, cfg),
+              fileSink: plan,
               onProgress: ({ index }: { index: number }) => progress.update(index),
             });
             generated('graphql', files);
@@ -578,6 +722,7 @@ withOutputFlags(
               // mode has a `db` parameter to receive it. This branch never passed the option, so
               // the two halves of one generated project disagreed about the signature.
               databaseInjection: g.databaseInjection,
+              fileSink: plan,
             });
             generated('service', files);
           } catch (e: any) {
@@ -593,13 +738,14 @@ withOutputFlags(
             const target = g.path ?? 'src/validators/zod';
             // `meta` is zod-only; see `GeneratorCapabilities.meta` for why it is not passed to the
             // other four rather than being passed and ignored.
-            const files = await gen.generate(
-              validationOptions(g, cfg, target, {
+            const files = await gen.generate({
+              ...validationOptions(g, cfg, target, {
                 schemaTypes: true,
                 meta: true,
                 constraints: true,
-              }) as never
-            );
+              }),
+              fileSink: plan,
+            } as never);
             generated('zod', files);
           } catch (e: any) {
             failGenerator(g.kind, e);
@@ -612,9 +758,10 @@ withOutputFlags(
             );
             const gen = new ValibotGenerator(analysis);
             const target = g.path ?? 'src/validators/valibot';
-            const files = await gen.generate(
-              validationOptions(g, cfg, target, { schemaTypes: true, constraints: true }) as never
-            );
+            const files = await gen.generate({
+              ...validationOptions(g, cfg, target, { schemaTypes: true, constraints: true }),
+              fileSink: plan,
+            } as never);
             generated('valibot', files);
           } catch (e: any) {
             failGenerator(g.kind, e);
@@ -627,9 +774,10 @@ withOutputFlags(
             );
             const gen = new ArkTypeGenerator(analysis);
             const target = g.path ?? 'src/validators/arktype';
-            const files = await gen.generate(
-              validationOptions(g, cfg, target, { schemaTypes: false }) as never
-            );
+            const files = await gen.generate({
+              ...validationOptions(g, cfg, target, { schemaTypes: false }),
+              fileSink: plan,
+            } as never);
             generated('arktype', files);
           } catch (e: any) {
             failGenerator(g.kind, e);
@@ -646,7 +794,10 @@ withOutputFlags(
             );
             const gen = new JsonSchemaGenerator(analysis);
             const target = g.path ?? 'src/validators/json-schema';
-            const files = await gen.generate(jsonSchemaOptions(g, cfg, target) as never);
+            const files = await gen.generate({
+              ...jsonSchemaOptions(g, cfg, target),
+              fileSink: plan,
+            } as never);
             generated('json-schema', files);
           } catch (e: any) {
             failGenerator(g.kind, e);
@@ -659,12 +810,13 @@ withOutputFlags(
             );
             const gen = new TypeBoxGenerator(analysis);
             const target = g.path ?? 'src/validators/typebox';
-            const files = await gen.generate(
-              validationOptions(g, cfg, target, {
+            const files = await gen.generate({
+              ...validationOptions(g, cfg, target, {
                 schemaTypes: true,
                 standardSchema: true,
-              }) as never
-            );
+              }),
+              fileSink: plan,
+            } as never);
             generated('typebox', files);
           } catch (e: any) {
             failGenerator(g.kind, e);
@@ -677,26 +829,54 @@ withOutputFlags(
             );
             const gen = new EffectGenerator(analysis);
             const target = g.path ?? 'src/validators/effect';
-            const files = await gen.generate(
-              validationOptions(g, cfg, target, { schemaTypes: true }) as never
-            );
+            const files = await gen.generate({
+              ...validationOptions(g, cfg, target, { schemaTypes: true }),
+              fileSink: plan,
+            } as never);
             generated('effect', files);
           } catch (e: any) {
             failGenerator(g.kind, e);
           }
         }
       }
-      if (driftBefore) {
-        const after = await snapshotAll(driftDirs);
-        const drift = diffSnapshots(driftBefore, after);
-        // Restored whether or not anything drifted, so `--check` never leaves the tree altered.
-        await restoreSnapshot(driftBefore, after);
+      /**
+       * The `generators` array both document shapes carry, with the verdicts merged in.
+       *
+       * `files` keeps its absolute paths, because that is what it has always published and a
+       * script resolving them is entitled to keep working. `changes` is relative, because it is
+       * new and a document naming somebody's home directory in every entry is worse to read and
+       * impossible to compare across machines.
+       */
+      const generatorsDocument = () =>
+        emitted.map((e) => ({
+          kind: e.kind,
+          files: e.files,
+          changes: e.changes.map((c) => ({ file: displayPath(c.file), status: c.status })),
+        }));
 
+      if (planning) {
+        // The claim `--dry-run` and `--check` make, checked rather than asserted. `existing` is the
+        // snapshot taken before any generator ran, so anything that differs now was written by a
+        // generator that ignored the sink, and it is put back before this reports.
+        const wrote = await verifyNothingWasWritten(outputDirs, existing!);
+        if (wrote.length) {
+          const message =
+            `${wrote.length} file(s) were written by a run that promised to write none, and have ` +
+            `been restored. This means an installed generator package is older than this CLI. ` +
+            `Update your @drzl/generator-* packages. First file: ${displayPath(wrote[0])}`;
+          if (opts.json) out.jsonData(jsonFailure('generate', 'DRZL_GEN_003', message));
+          else out.error(message);
+          process.exit(EXIT_FAILED);
+        }
+      }
+
+      if (opts.check) {
+        const drift = pendingChanges(plan);
         const upToDate = drift.length === 0;
         // Drift is EXIT_FINDINGS, not EXIT_FAILED, and that is the whole reason the scheme has two
-        // failure codes. The check ran perfectly: it regenerated, compared, restored the tree, and
-        // is reporting what it found. A CI job that wants to show a diff acts on that differently
-        // from a config it could not read, and until now both were 1.
+        // failure codes. The check ran perfectly: it regenerated in memory, compared, wrote
+        // nothing, and is reporting what it found. A CI job that wants to show a diff acts on that
+        // differently from a config it could not read, and until 4.23 both were 1.
         const code = upToDate ? EXIT_OK : EXIT_FINDINGS;
 
         if (opts.json) {
@@ -706,12 +886,22 @@ withOutputFlags(
             exitCode: code,
             check: {
               upToDate,
-              drift: drift.map((d) => ({
-                file: path.relative(process.cwd(), d.file),
-                status: d.status,
+              drift: drift.map((d, i) => ({
+                file: displayPath(d.file),
+                status: driftStatusOf(d.verdict),
+                // Item 81. Beyond the cap the entry is still here with its status, and only the
+                // diff is absent, so a machine reading this never loses a file.
+                diff:
+                  i < DIFF_FILE_CAP
+                    ? unifiedDiff(d.before ?? '', d.after, {
+                        fromLabel: `a/${displayPath(d.file)}`,
+                        toLabel: `b/${displayPath(d.file)}`,
+                      })
+                    : null,
               })),
+              diffFileCap: DIFF_FILE_CAP,
             },
-            generators: emitted.map((e) => ({ kind: e.kind, files: e.files })),
+            generators: generatorsDocument(),
             warnings,
           });
           process.exit(code);
@@ -720,11 +910,17 @@ withOutputFlags(
         if (!upToDate) {
           out.error(`\nGenerated output is out of date (${drift.length} file(s)):`);
           for (const d of drift) {
-            const mark = d.status === 'added' ? '+' : d.status === 'removed' ? '-' : '~';
+            const status = driftStatusOf(d.verdict);
+            const mark = status === 'added' ? '+' : '~';
             out.error(
-              `  ${mark} ${out.errStyle.yellow(d.status.padEnd(8))} ${path.relative(process.cwd(), d.file)}`
+              `  ${mark} ${out.errStyle.yellow(status.padEnd(8))} ${displayPath(d.file)}`
             );
           }
+          // Item 81: the list says which files, the diff says what about them. Printed after the
+          // list rather than instead of it, so a reader who only wants the names still gets them
+          // on the first few lines, and `--quiet` keeps the list and drops the diffs, since the
+          // list is the finding and the diff is the explanation.
+          printCheckDiffs(out, drift);
           out.hint('\nRun `drzl generate` and commit the result. Nothing was written by this check.');
           process.exit(code);
         }
@@ -738,10 +934,26 @@ withOutputFlags(
           command: 'generate',
           exitCode: EXIT_OK,
           check: null,
-          generators: emitted.map((e) => ({ kind: e.kind, files: e.files })),
+          dryRun: !!opts.dryRun,
+          generators: generatorsDocument(),
           warnings,
         });
         return;
+      }
+
+      if (opts.dryRun) {
+        // Item 68, and `EXIT_OK` on purpose. A dry run that computed its answer did what it was
+        // asked; `2` is for a run that found what it was told to look for, and "this file would
+        // change" is not a finding here, it is the answer. A preview of a project that has never
+        // been generated would otherwise exit non-zero for being new, and the flag people reach
+        // for before their first `generate` would look like a failure. `--check` is the flag whose
+        // question is "is anything stale", and it still answers `2`.
+        const counts = plan.counts();
+        out.succeed(
+          out.errStyle.green(`Dry run: ${counts.total} file(s) would be written`) +
+            out.errStyle.gray(` (${describeCounts(counts)}). Nothing was written.`)
+        );
+        process.exit(EXIT_OK);
       }
 
       if (cfg.generators.length) {
@@ -898,7 +1110,8 @@ program
     'all | analyze | generate-orpc | generate-trpc | generate-hono | generate-express | generate-fastify | generate-nestjs | generate-graphql',
     'all'
   )
-  .option('--debounce <ms>', 'debounce ms', '200')
+  .option('--debounce <ms>', 'wait this long after the last change before rebuilding', '200')
+  .option('--clear', 'clear the terminal before each rebuild', false)
   .option('--json', 'emit JSON logs', false)
   .option('-q, --quiet', 'drop the progress narration on stderr; errors still print', false)
   .option('--poll', 'force polling (helps WSL/Docker/remote FS)', false)
@@ -927,6 +1140,37 @@ program
       }
       out.error(problem.message);
       out.hint(problem.hint);
+    };
+
+    /**
+     * Wipe the terminal before a rebuild, if that was asked for and there is a terminal (item 75).
+     *
+     * Three things were wrong with the `console.clear()` this replaces, and only the first is the
+     * one the plan item names.
+     *
+     * It was not optional. Every rebuild wiped the screen, taking the previous rebuild's errors
+     * and the startup banner listing the watched directories with it, so the answer to "what did
+     * it say last time" was always "it is gone". A watcher a person leaves running all day is the
+     * last place to throw away scrollback without being asked.
+     *
+     * It was decided from the wrong stream. `console.clear()` writes to stdout and does nothing
+     * when stdout is not a terminal, but everything this command prints for a human is on stderr.
+     * So `drzl watch > events.json` on a terminal left the terminal uncleared, and the stream that
+     * would have been cleared was the one carrying the JSON. That is the same defect item 77 fixed
+     * for colour, arrived at from the other direction.
+     *
+     * It also wrote the escape to a stream a program may be reading. Node happens to make that
+     * harmless by checking `isTTY` first, which is why nothing leaked, but the check belonged to
+     * the stream being cleared rather than to whichever one `console` was bound to.
+     *
+     * `2J` erases the display and `3J` the scrollback, then the cursor goes home. Sent together,
+     * because erasing the display alone leaves the previous rebuild one scroll away and the point
+     * of asking for this is a screen holding only the current run.
+     */
+    const clearScreen = () => {
+      if (!opts.clear || opts.json || out.quiet) return;
+      if (!out.stderr.isTTY) return;
+      out.stderr.write('\u001b[2J\u001b[3J\u001b[H');
     };
 
     // Wrapped, unlike the reload inside `run`, which has its own catch. A config that does not
@@ -1081,7 +1325,7 @@ program
         );
         syncWatcherTargets(watcher, nextTargets);
 
-        if (!opts.json) console.clear();
+        clearScreen();
 
         if (opts.json) {
           out.jsonData({
@@ -1091,7 +1335,7 @@ program
           });
         }
 
-        // After the console.clear() above, or the warning would be wiped before anyone saw it.
+        // After the clear above, or the warning would be wiped before anyone saw it.
         for (const w of source.warnings) out.warn(w);
 
         const analyzer = new SchemaAnalyzer(source.schema);
@@ -1472,8 +1716,14 @@ program
       }
     };
 
-    const debounced = Number(opts.debounce) || 200;
-    let timer: NodeJS.Timeout | null = null;
+    // Item 75. The debounce that was here collapsed the wait and not the work, so a change
+    // arriving during a rebuild started a second one on top of it; see `watch-loop.ts` for the
+    // measurement. `run` itself is unchanged, and the scheduler decides when it happens.
+    const scheduler = createRebuildScheduler({
+      run,
+      debounceMs: resolveDebounce(opts.debounce, (w) => out.warn(w)),
+    });
+
     const trigger = (file?: string) => {
       if (file) {
         const full = abs(file);
@@ -1481,8 +1731,7 @@ program
           if (full === dir || isInside(full, dir)) return;
         }
       }
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(run, debounced);
+      scheduler.trigger();
     };
 
     if (opts.json) {
@@ -1508,7 +1757,10 @@ program
       .on('unlink', (p) => trigger(p))
       .on('error', (err) => out.error('Watcher error:', messageOf(err)));
 
-    await run();
+    // Through the same guard as every later rebuild, so a save landing during the startup build
+    // waits for it rather than racing it. The watcher is attached by now, which is exactly when
+    // that becomes possible.
+    await scheduler.runNow();
   });
 
 withOutputFlags(

--- a/packages/cli/src/emit-plan.ts
+++ b/packages/cli/src/emit-plan.ts
@@ -1,0 +1,209 @@
+/**
+ * What a generate run is about to put on disk, and how that differs from what is there (plan items
+ * 68, 80, 81).
+ *
+ * The three items read as three features and are one mechanism. `--dry-run` is "compute this and
+ * stop", `generate` reporting what changed is "compute this and write it", and `--check` is
+ * "compute this, do not write it, and show the difference". All three need exactly one fact per
+ * file: the content about to be written, beside the content already there. So that fact is
+ * produced once, here, and the three commands differ only in what they do with it.
+ *
+ * ## The plan is the sink
+ *
+ * Generators hand their writes to a `FileSink` (see `emit.ts` in `@drzl/validation-core`). This
+ * class is that sink. In `write` mode it records and then writes; in `plan` mode it records and
+ * stops. Nothing else about a run changes between the two, which is what makes a dry run an honest
+ * preview rather than a second implementation that can drift from the real one.
+ *
+ * ## Why `--check` no longer writes
+ *
+ * `--check` used to snapshot the output directories, let the generators overwrite them for real,
+ * compare, and put the snapshot back. That works and was tested, but it means the one command
+ * documented as never touching your tree is the command that rewrites every generated file on
+ * every CI run, and a process killed between the write and the restore leaves the tree modified
+ * with no record of it. On the plan it compares without writing at all, so there is no window.
+ *
+ * The snapshot is still taken, for a different job: see `verifyNothingWasWritten`.
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { FileSink } from '@drzl/validation-core';
+import { diffSnapshots, restoreSnapshot, snapshotAll } from './drift.js';
+
+/** What happened, or would happen, to one file. */
+export type FileVerdict = 'created' | 'changed' | 'unchanged';
+
+export interface EmittedFile {
+  /** Absolute path, exactly as the generator spelled it. */
+  file: string;
+  verdict: FileVerdict;
+  /** What is on disk now, or `null` when nothing is. */
+  before: string | null;
+  /** What the run produced for it. */
+  after: string;
+}
+
+export interface EmitCounts {
+  total: number;
+  created: number;
+  changed: number;
+  unchanged: number;
+}
+
+export interface EmitPlanOptions {
+  /**
+   * Whether the recorded writes also reach the filesystem.
+   *
+   * `false` is `--dry-run` and `--check`. Nothing is written and no directory is created, which is
+   * the whole claim those two flags make.
+   */
+  write: boolean;
+  /**
+   * Content already on disk, keyed by absolute path, when the caller has it.
+   *
+   * `--check` and `--dry-run` snapshot the output directories before the run anyway, so handing
+   * that map over here saves reading every file a second time. A path missing from the map is
+   * taken to be absent from disk, which is why this must only ever be a snapshot of directories
+   * that cover everything the run can write. Omitted, each file is read as it is emitted, which is
+   * what an ordinary `generate` does.
+   */
+  existing?: Map<string, string>;
+}
+
+export class EmitPlan implements FileSink {
+  readonly writes: boolean;
+  private readonly existing?: Map<string, string>;
+  private readonly byFile = new Map<string, EmittedFile>();
+  private readonly dirs = new Set<string>();
+
+  constructor(options: EmitPlanOptions) {
+    this.writes = options.write;
+    this.existing = options.existing;
+  }
+
+  async mkdir(dir: string): Promise<void> {
+    this.dirs.add(dir);
+    if (this.writes) await fs.mkdir(dir, { recursive: true });
+  }
+
+  async writeFile(file: string, contents: string): Promise<void> {
+    // The first recording of a path owns its `before`. Two generators pointed at one directory,
+    // or one generator writing a file twice, would otherwise have the second write compare itself
+    // against the first write's output and report `unchanged` for a file that really did change.
+    const prior = this.byFile.get(file);
+    const before = prior ? prior.before : await this.read(file);
+    this.byFile.set(file, {
+      file,
+      before,
+      after: contents,
+      verdict: before === null ? 'created' : before === contents ? 'unchanged' : 'changed',
+    });
+    if (this.writes) await fs.writeFile(file, contents, 'utf8');
+  }
+
+  private async read(file: string): Promise<string | null> {
+    if (this.existing) return this.existing.get(file) ?? null;
+    try {
+      return await fs.readFile(file, 'utf8');
+    } catch {
+      return null;
+    }
+  }
+
+  /** Every directory a generator asked for, whether or not it was created. */
+  get directories(): string[] {
+    return [...this.dirs];
+  }
+
+  /** Every recorded file, in the order it was first written. */
+  get files(): EmittedFile[] {
+    return [...this.byFile.values()];
+  }
+
+  /**
+   * The verdicts for a list of paths, in the order given.
+   *
+   * A path with no verdict is a path the generator reported writing without routing it through
+   * the sink, which is the one shape a version mismatch takes: a `@drzl/cli` that knows about
+   * `fileSink` beside a generator package that predates it. It is returned rather than thrown on
+   * so the caller can name the generator; see `unrecorded`.
+   */
+  verdictsFor(paths: string[]): Array<EmittedFile | undefined> {
+    return paths.map((p) => this.byFile.get(p));
+  }
+
+  /** The paths a generator claims to have written that never reached this sink. */
+  unrecorded(paths: string[]): string[] {
+    return paths.filter((p) => !this.byFile.has(p));
+  }
+
+  counts(paths?: string[]): EmitCounts {
+    const entries = paths ? (this.verdictsFor(paths).filter(Boolean) as EmittedFile[]) : this.files;
+    const counts: EmitCounts = { total: entries.length, created: 0, changed: 0, unchanged: 0 };
+    for (const e of entries) counts[e.verdict]++;
+    return counts;
+  }
+}
+
+/** `3 created, 1 changed, 8 unchanged`, with the zeroes left out. */
+export function describeCounts(counts: EmitCounts): string {
+  const parts: string[] = [];
+  if (counts.created) parts.push(`${counts.created} created`);
+  if (counts.changed) parts.push(`${counts.changed} changed`);
+  if (counts.unchanged) parts.push(`${counts.unchanged} unchanged`);
+  return parts.join(', ') || 'nothing to write';
+}
+
+/** The files a plan would not leave alone. `--check` calls this drift; a dry run calls it the news. */
+export function pendingChanges(plan: EmitPlan): EmittedFile[] {
+  return plan.files
+    .filter((f) => f.verdict !== 'unchanged')
+    .sort((a, b) => a.file.localeCompare(b.file));
+}
+
+/**
+ * The `--check` drift statuses, kept exactly as they were published.
+ *
+ * `created` is reported as `added`, because that is the word the `--json` contract, the docs and
+ * every CI job reading them have used since `--check` shipped. `removed` is still a value of the
+ * published union and is still produced by `drift.ts`; the plan cannot produce one, since a plan
+ * is a list of writes and a write never deletes. Reporting every file in an output directory that
+ * the run did not emit would produce them, and was deliberately not done: `outDir` is whatever the
+ * config says, a project that points it at `src` would have every hand-written module in the tree
+ * reported as drift, and turning that into a failing CI job is not a change anyone asked for.
+ */
+export function driftStatusOf(verdict: FileVerdict): 'added' | 'changed' {
+  return verdict === 'created' ? 'added' : 'changed';
+}
+
+/**
+ * Prove that a plan-mode run really wrote nothing, and put the tree back if it did.
+ *
+ * This is a guard against one specific failure, and it is worth its cost because that failure is
+ * silent and destructive. `fileSink` is an option, so a generator package that predates it accepts
+ * it, ignores it, and writes to disk. Inside this repository that cannot happen, since everything
+ * is built together; on a user's machine `@drzl/cli` and the generators are separate packages on
+ * separate versions, and npm is free to install a new CLI beside an old generator.
+ *
+ * The comparison is the snapshot the run already took for its `before` content, against the same
+ * directories afterwards. Anything that differs is restored, and the caller is told, because a
+ * `--dry-run` that quietly rewrote the tree is the worst outcome this feature has.
+ *
+ * Returns the paths that were written, empty when the run behaved.
+ */
+export async function verifyNothingWasWritten(
+  dirs: string[],
+  before: Map<string, string>
+): Promise<string[]> {
+  const after = await snapshotAll(dirs);
+  const drift = diffSnapshots(before, after);
+  if (!drift.length) return [];
+  await restoreSnapshot(before, after);
+  return drift.map((d) => d.file).sort();
+}
+
+/** A path as a reader of the terminal wants to see it: relative to where they ran the command. */
+export function displayPath(file: string, cwd = process.cwd()): string {
+  const rel = path.relative(cwd, file);
+  return rel && !rel.startsWith('..') ? rel : file;
+}

--- a/packages/cli/src/unified-diff.ts
+++ b/packages/cli/src/unified-diff.ts
@@ -1,0 +1,317 @@
+/**
+ * A unified diff of two texts, written here rather than installed (plan item 81).
+ *
+ * `generate --check` named the files that had drifted and stopped there, which tells a reviewer
+ * that something is stale and nothing about what. The diff is the part that turns a red CI job
+ * into a decision: a regenerated header, a column that gained a length cap, and a hand-edit
+ * somebody made to a generated file all read identically as "changed".
+ *
+ * ## Why not a dependency
+ *
+ * `diff` (jsdiff) is the obvious choice and is already resolvable in this workspace, but only as a
+ * transitive dependency of `ts-node`, which is a devDependency of the CLI package. Relying on that
+ * would be relying on a hoist. Adding it as a real dependency of `@drzl/cli` costs a package on
+ * every install of a CLI whose whole job is to write files, in exchange for about a hundred lines
+ * of a published algorithm, and this repository publishes through npm's trusted-publisher OIDC
+ * flow where every new dependency is another thing to keep resolvable. So it is here, with the
+ * property test that matters: applying the emitted diff to the "before" text has to reproduce the
+ * "after" text exactly, which is the only check that can tell a plausible-looking diff from a
+ * correct one.
+ *
+ * ## Format
+ *
+ * Unified, because it is the format `git`, `patch`, review tools and every developer already read,
+ * and because it greps: a line beginning `+` or `-` is a change, and the `@@` header names where.
+ * The alternative worth considering was a side-by-side or a word-level diff, which reads better
+ * for prose and worse for generated code, where the interesting change is usually one whole line.
+ *
+ * ## Caps
+ *
+ * Myers is O((N+M)D): fast when the two texts are close, which is the case that matters, and
+ * quadratic when they are not. Both bounds below are stated in the output when they bite, because
+ * a diff that silently stops is worse than no diff: a reviewer who cannot see the truncation reads
+ * the visible hunks as the whole story.
+ */
+
+/** The two bounds, and the context width. */
+export interface DiffLimits {
+  /** Longest file, in lines, this will diff line by line. */
+  maxLines: number;
+  /** Largest edit script, in inserted plus deleted lines, before it gives up. */
+  maxEdits: number;
+  /** Unchanged lines kept around each hunk. Three is what `diff -u` and `git` use. */
+  context: number;
+}
+
+export const DEFAULT_DIFF_LIMITS: DiffLimits = {
+  maxLines: 4000,
+  maxEdits: 1500,
+  context: 3,
+};
+
+type Op = { kind: 'equal' | 'insert' | 'delete'; a: number; b: number };
+
+/**
+ * Split into lines, keeping the fact of a trailing newline separate.
+ *
+ * `'a\nb\n'.split('\n')` is `['a', 'b', '']`, and that empty string is not a line; carrying it
+ * would put a spurious empty line at the end of every hunk that reaches the end of a file. So it
+ * is dropped and remembered, which is also what produces the `\ No newline at end of file` marker
+ * when only one side has it.
+ */
+function toLines(text: string): { lines: string[]; newlineAtEnd: boolean } {
+  if (text === '') return { lines: [], newlineAtEnd: true };
+  const newlineAtEnd = text.endsWith('\n');
+  const lines = text.split('\n');
+  if (newlineAtEnd) lines.pop();
+  return { lines, newlineAtEnd };
+}
+
+/**
+ * Myers' shortest edit script, capped.
+ *
+ * The published greedy algorithm: for each edit distance `d`, walk the diagonals reachable with
+ * `d` edits and take the furthest point on each. `trace` keeps the frontier per `d` so the path
+ * can be walked back afterwards, which is what turns "the distance is 4" into "these four lines".
+ *
+ * Returns `null` when the distance exceeds `maxEdits`, which the caller reports rather than hides.
+ */
+function shortestEdit(a: string[], b: string[], maxEdits: number): Int32Array[] | null {
+  const n = a.length;
+  const m = b.length;
+  const max = n + m;
+  const offset = max;
+  const v = new Int32Array(2 * max + 1);
+  const trace: Int32Array[] = [];
+  const limit = Math.min(max, maxEdits);
+
+  for (let d = 0; d <= limit; d++) {
+    trace.push(Int32Array.prototype.slice.call(v));
+    for (let k = -d; k <= d; k += 2) {
+      let x: number;
+      if (k === -d || (k !== d && v[k - 1 + offset] < v[k + 1 + offset])) x = v[k + 1 + offset];
+      else x = v[k - 1 + offset] + 1;
+      let y = x - k;
+      while (x < n && y < m && a[x] === b[y]) {
+        x++;
+        y++;
+      }
+      v[k + offset] = x;
+      if (x >= n && y >= m) return trace;
+    }
+  }
+  return null;
+}
+
+/** Walk the frontier back from the end, producing the operations in order. */
+function backtrack(trace: Int32Array[], a: string[], b: string[]): Op[] {
+  const max = a.length + b.length;
+  const offset = max;
+  let x = a.length;
+  let y = b.length;
+  const ops: Op[] = [];
+
+  for (let d = trace.length - 1; d >= 0; d--) {
+    const v = trace[d];
+    const k = x - y;
+    let prevK: number;
+    if (k === -d || (k !== d && v[k - 1 + offset] < v[k + 1 + offset])) prevK = k + 1;
+    else prevK = k - 1;
+    const prevX = v[prevK + offset];
+    const prevY = prevX - prevK;
+
+    while (x > prevX && y > prevY) {
+      x--;
+      y--;
+      ops.push({ kind: 'equal', a: x, b: y });
+    }
+    if (d > 0) {
+      if (x === prevX) {
+        y--;
+        ops.push({ kind: 'insert', a: x, b: y });
+      } else {
+        x--;
+        ops.push({ kind: 'delete', a: x, b: y });
+      }
+    }
+  }
+  ops.reverse();
+  return ops;
+}
+
+/**
+ * The operations turning `a` into `b`, or `null` when a cap was hit.
+ *
+ * Common leading and trailing lines are stripped before Myers runs and put back as `equal`
+ * afterwards. That is not an optimisation for its own sake: the pair this is asked about is
+ * almost always a generated file against the same file with one table changed, where the shared
+ * head and tail are the whole file bar a few lines, and stripping them takes the edit distance
+ * that Myers has to search from thousands to single figures.
+ */
+export function diffLines(a: string[], b: string[], maxEdits: number): Op[] | null {
+  let head = 0;
+  while (head < a.length && head < b.length && a[head] === b[head]) head++;
+  let tail = 0;
+  while (
+    tail < a.length - head &&
+    tail < b.length - head &&
+    a[a.length - 1 - tail] === b[b.length - 1 - tail]
+  ) {
+    tail++;
+  }
+
+  const midA = a.slice(head, a.length - tail);
+  const midB = b.slice(head, b.length - tail);
+
+  // Nothing left to compare once the shared head and tail are gone. Myers is skipped rather than
+  // handed two empty arrays, where its `v` array is a single element and every neighbour lookup
+  // reads past the end.
+  let mid: Op[] = [];
+  if (midA.length || midB.length) {
+    const trace = shortestEdit(midA, midB, maxEdits);
+    if (!trace) return null;
+    mid = backtrack(trace, midA, midB);
+  }
+
+  const ops: Op[] = [];
+  for (let i = 0; i < head; i++) ops.push({ kind: 'equal', a: i, b: i });
+  for (const op of mid) ops.push({ kind: op.kind, a: op.a + head, b: op.b + head });
+  for (let i = 0; i < tail; i++) {
+    ops.push({ kind: 'equal', a: a.length - tail + i, b: b.length - tail + i });
+  }
+  return ops;
+}
+
+export interface UnifiedDiffOptions {
+  /** What the left side is called in the `---` header. */
+  fromLabel: string;
+  /** What the right side is called in the `+++` header. */
+  toLabel: string;
+  limits?: Partial<DiffLimits>;
+}
+
+/**
+ * A unified diff, or a single line saying why there is not one.
+ *
+ * Returns the empty string when the two texts are identical, so a caller can treat "no diff" and
+ * "nothing to say" the same way.
+ */
+export function unifiedDiff(before: string, after: string, opts: UnifiedDiffOptions): string {
+  if (before === after) return '';
+  const limits: DiffLimits = { ...DEFAULT_DIFF_LIMITS, ...(opts.limits ?? {}) };
+
+  const from = toLines(before);
+  const to = toLines(after);
+  // A file that lost or gained only its final newline still differs, and every line of it still
+  // compares equal, so without this the diff would be empty for a file the check has just called
+  // out of date. Marking the last line of a side that has no trailing newline makes it a real
+  // difference to Myers, and the marker is what `diff` itself prints for the same case.
+  const beforeLines = withNoNewlineMark(from);
+  const afterLines = withNoNewlineMark(to);
+
+  if (from.lines.length > limits.maxLines || to.lines.length > limits.maxLines) {
+    return (
+      `--- ${opts.fromLabel}\n+++ ${opts.toLabel}\n` +
+      `@@ no line diff @@\n` +
+      `  ${from.lines.length} lines on disk, ${to.lines.length} lines regenerated. ` +
+      `Not diffed: the file is longer than the ${limits.maxLines}-line cap.\n`
+    );
+  }
+
+  const ops = diffLines(beforeLines, afterLines, limits.maxEdits);
+  if (!ops) {
+    return (
+      `--- ${opts.fromLabel}\n+++ ${opts.toLabel}\n` +
+      `@@ no line diff @@\n` +
+      `  ${from.lines.length} lines on disk, ${to.lines.length} lines regenerated. ` +
+      `Not diffed: the two differ by more than the ${limits.maxEdits}-edit cap, ` +
+      `so the whole file is effectively new.\n`
+    );
+  }
+
+  const hunks = buildHunks(ops, beforeLines, afterLines, limits.context);
+  if (!hunks.length) return '';
+  return `--- ${opts.fromLabel}\n+++ ${opts.toLabel}\n${hunks.join('')}`;
+}
+
+const NO_NEWLINE = '\\ No newline at end of file';
+
+/**
+ * The sentinel a line with no newline after it carries while it is being compared.
+ *
+ * Two NUL characters and a word, because it has to be something a line of generated TypeScript
+ * cannot be. It never reaches the output: `renderLine` strips it and prints the marker instead.
+ */
+const NO_NEWLINE_MARK = '\u0000\u0000drzl:no-newline';
+
+function withNoNewlineMark(side: { lines: string[]; newlineAtEnd: boolean }): string[] {
+  if (side.newlineAtEnd || !side.lines.length) return side.lines;
+  const marked = side.lines.slice();
+  marked[marked.length - 1] += NO_NEWLINE_MARK;
+  return marked;
+}
+
+/** One diff line: its prefix, its text, and the marker underneath it when it had no newline. */
+function renderLine(prefix: string, line: string, into: string[]): void {
+  if (line.endsWith(NO_NEWLINE_MARK)) {
+    into.push(prefix + line.slice(0, -NO_NEWLINE_MARK.length));
+    into.push(NO_NEWLINE);
+    return;
+  }
+  into.push(prefix + line);
+}
+
+/** Group the operations into hunks with `context` unchanged lines around each run of changes. */
+function buildHunks(
+  ops: Op[],
+  beforeLines: string[],
+  afterLines: string[],
+  context: number
+): string[] {
+  const changed: number[] = [];
+  ops.forEach((op, i) => {
+    if (op.kind !== 'equal') changed.push(i);
+  });
+  if (!changed.length) return [];
+
+  /** Ranges of operation indices to print, merged where their context windows touch. */
+  const ranges: Array<[number, number]> = [];
+  for (const i of changed) {
+    const start = Math.max(0, i - context);
+    const end = Math.min(ops.length - 1, i + context);
+    const last = ranges[ranges.length - 1];
+    if (last && start <= last[1] + 1) last[1] = Math.max(last[1], end);
+    else ranges.push([start, end]);
+  }
+
+  const hunks: string[] = [];
+  for (const [start, end] of ranges) {
+    let aStart = -1;
+    let bStart = -1;
+    let aCount = 0;
+    let bCount = 0;
+    const body: string[] = [];
+
+    for (let i = start; i <= end; i++) {
+      const op = ops[i];
+      if (op.kind === 'equal' || op.kind === 'delete') {
+        if (aStart < 0) aStart = op.a;
+        aCount++;
+      }
+      if (op.kind === 'equal' || op.kind === 'insert') {
+        if (bStart < 0) bStart = op.b;
+        bCount++;
+      }
+      if (op.kind === 'equal') renderLine(' ', beforeLines[op.a], body);
+      else if (op.kind === 'delete') renderLine('-', beforeLines[op.a], body);
+      else renderLine('+', afterLines[op.b], body);
+    }
+
+    // A hunk covering nothing on one side is numbered from 0, which is what `diff -u` emits for a
+    // pure insertion into an empty file.
+    const aFrom = aCount === 0 ? 0 : aStart + 1;
+    const bFrom = bCount === 0 ? 0 : bStart + 1;
+    hunks.push(`@@ -${aFrom},${aCount} +${bFrom},${bCount} @@\n${body.join('\n')}\n`);
+  }
+  return hunks;
+}

--- a/packages/cli/src/watch-loop.ts
+++ b/packages/cli/src/watch-loop.ts
@@ -1,0 +1,150 @@
+/**
+ * When `drzl watch` rebuilds, and how many rebuilds one burst of saves is allowed to become
+ * (plan item 75).
+ *
+ * ## What was measured
+ *
+ * The watcher already had a debounce, so the item reads as done until you watch it run. The
+ * debounce covers the *wait* and not the *work*: `setTimeout(run, 200)` collapses changes arriving
+ * within 200ms of each other and then starts a rebuild that takes as long as it takes. Every
+ * change arriving during that rebuild starts another one 200ms later, on top of the first, writing
+ * the same files.
+ *
+ * Measured against the shipped 4.22 build, with a 600-table schema where one rebuild takes about
+ * 1.4s, saving two files alternately 700ms apart:
+ *
+ *   32370ms START  in flight 1
+ *   33195ms START  in flight 2
+ *   33814ms START  in flight 3
+ *   34379ms END    in flight 2
+ *   34475ms START  in flight 3
+ *   35174ms START  in flight 4      <- four rebuilds writing one output directory
+ *
+ * Six saves, six rebuilds, four of them running at once. Each one reloads the config, re-resolves
+ * the schema, re-runs the analysis and rewrites every generated file, so the last writer wins per
+ * file with no ordering between them.
+ *
+ * Chokidar's own `awaitWriteFinish` is why this is not worse: with a 400ms stability threshold, one
+ * save of one file arrives as exactly one event, so the ordinary case never reached the overlap.
+ * The bursts that do reach it are the ones that span a rebuild, which is any refactor across a
+ * schema split into several modules.
+ *
+ * ## What this does about it
+ *
+ * One rebuild in flight at a time, and a change arriving during one is remembered rather than
+ * dropped, so it gets exactly one rebuild afterwards however many changes arrived. The alternative,
+ * refusing a change while busy, loses edits, which is worse than the overlap it fixes.
+ */
+
+/** What `--debounce` means when it is not given, or is given something that is not a number. */
+export const DEFAULT_WATCH_DEBOUNCE_MS = 200;
+
+/**
+ * How long `watch` waits after the last change before rebuilding.
+ *
+ * 200ms is kept, and it is kept because it was measured rather than because it was already there.
+ * With the `awaitWriteFinish: { stabilityThreshold: 400 }` this watcher passes chokidar, one
+ * logical save reaches the trigger as a single event in every shape tested, and the widest gap
+ * inside one burst was 9ms, from a tool rewriting two files back to back. With `awaitWriteFinish`
+ * off, which is what a future version of this file might reach for to cut the 400ms it adds to
+ * every rebuild, the same bursts spread out: a chunked write became five events with a 62ms
+ * maximum gap, an atomic save became three events spanning 101ms, and format-on-save became two
+ * events 121ms apart. 200ms covers the widest of those with headroom and is short enough that a
+ * save still feels immediate. Every one of those numbers was taken with chokidar 5 on this
+ * filesystem, under both inotify and polling.
+ *
+ * `0` is accepted and means "rebuild on the next tick", which is what the tests want and what
+ * somebody debugging the watcher wants. It was previously impossible: `Number(opts.debounce) ||
+ * 200` reads `0` as absent and silently used 200, and read `--debounce banana` as absent too. A
+ * value that cannot be honoured now says so rather than being quietly replaced.
+ */
+export function resolveDebounce(value: unknown, warn: (message: string) => void): number {
+  if (value === undefined || value === null || value === '') return DEFAULT_WATCH_DEBOUNCE_MS;
+  const ms = Number(value);
+  if (!Number.isFinite(ms) || ms < 0) {
+    warn(
+      `--debounce ${String(value)} is not a number of milliseconds. ` +
+        `Using ${DEFAULT_WATCH_DEBOUNCE_MS}ms.`
+    );
+    return DEFAULT_WATCH_DEBOUNCE_MS;
+  }
+  return ms;
+}
+
+export interface RebuildScheduler {
+  /** A file changed. Rebuild after the debounce, or after the rebuild already running. */
+  trigger(): void;
+  /** Rebuild now, skipping the debounce, still one at a time. The startup build uses this. */
+  runNow(): Promise<void>;
+  /** Drop a pending debounce. Nothing calls this in the CLI; tests and a shutdown path do. */
+  cancel(): void;
+  /** Whether a rebuild is in flight. Exposed for tests rather than for the CLI. */
+  readonly busy: boolean;
+}
+
+export interface RebuildSchedulerOptions {
+  run: () => Promise<void>;
+  debounceMs: number;
+  /**
+   * Injected so a test does not have to spend real milliseconds.
+   *
+   * Defaults to the global timers. A fake clock is the difference between a debounce test that
+   * takes 5ms and one that takes a second and is flaky on a loaded CI machine.
+   */
+  timers?: {
+    setTimeout: (fn: () => void, ms: number) => unknown;
+    clearTimeout: (handle: unknown) => void;
+  };
+}
+
+export function createRebuildScheduler(options: RebuildSchedulerOptions): RebuildScheduler {
+  const timers = options.timers ?? {
+    setTimeout: (fn: () => void, ms: number) => setTimeout(fn, ms),
+    clearTimeout: (handle: unknown) => clearTimeout(handle as NodeJS.Timeout),
+  };
+
+  let handle: unknown = null;
+  let running = false;
+  let pending = false;
+
+  const drain = async () => {
+    if (running) {
+      // Remembered, not merged: the rebuild in flight has already read the old file, so a change
+      // that arrives now needs its own pass. One pass, however many changes arrive, because they
+      // will all be on disk by the time it reads them.
+      pending = true;
+      return;
+    }
+    running = true;
+    try {
+      await options.run();
+      while (pending) {
+        pending = false;
+        await options.run();
+      }
+    } finally {
+      running = false;
+      pending = false;
+    }
+  };
+
+  return {
+    trigger() {
+      if (handle !== null) timers.clearTimeout(handle);
+      handle = timers.setTimeout(() => {
+        handle = null;
+        void drain();
+      }, options.debounceMs);
+    },
+    runNow() {
+      return drain();
+    },
+    cancel() {
+      if (handle !== null) timers.clearTimeout(handle);
+      handle = null;
+    },
+    get busy() {
+      return running;
+    },
+  };
+}

--- a/packages/cli/test/emit-plan.spec.ts
+++ b/packages/cli/test/emit-plan.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * The per-file verdict every one of items 68, 80 and 81 reads (see `emit-plan.ts`).
+ *
+ * The two properties worth pinning here are the ones a run cannot recover from if they are wrong:
+ * a plan-mode sink must not touch the filesystem at all, not even to create the directory a
+ * generator asks for, and a `before` must be the content that was on disk when the run started
+ * rather than whatever the run itself put there a moment ago.
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  describeCounts,
+  displayPath,
+  driftStatusOf,
+  EmitPlan,
+  pendingChanges,
+  verifyNothingWasWritten,
+} from '../src/emit-plan';
+
+async function tmp() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'drzl-plan-'));
+}
+
+/** Every path under `dir`, files and directories alike, so "untouched" means both. */
+async function tree(dir: string): Promise<string[]> {
+  const found: string[] = [];
+  async function walk(current: string) {
+    for (const e of await fs.readdir(current, { withFileTypes: true })) {
+      const full = path.join(current, e.name);
+      found.push(path.relative(dir, full) + (e.isDirectory() ? '/' : ''));
+      if (e.isDirectory()) await walk(full);
+    }
+  }
+  await walk(dir);
+  return found.sort();
+}
+
+describe('EmitPlan in plan mode', () => {
+  it('writes nothing and creates no directory', async () => {
+    const root = await tmp();
+    const plan = new EmitPlan({ write: false });
+
+    await plan.mkdir(path.join(root, 'out', 'nested'));
+    await plan.writeFile(path.join(root, 'out', 'nested', 'a.ts'), 'A');
+    await plan.writeFile(path.join(root, 'out', 'b.ts'), 'B');
+
+    // The assertion item 68 is really about: an empty directory stays empty, byte for byte.
+    expect(await tree(root)).toEqual([]);
+    expect(plan.files.map((f) => f.after)).toEqual(['A', 'B']);
+  });
+
+  it('still reports the directories a generator asked for', async () => {
+    const root = await tmp();
+    const plan = new EmitPlan({ write: false });
+    await plan.mkdir(path.join(root, 'zod'));
+    expect(plan.directories).toEqual([path.join(root, 'zod')]);
+  });
+
+  it('calls a file that is not there created', async () => {
+    const root = await tmp();
+    const plan = new EmitPlan({ write: false });
+    await plan.writeFile(path.join(root, 'new.ts'), 'X');
+    expect(plan.files[0].verdict).toBe('created');
+    expect(plan.files[0].before).toBeNull();
+  });
+
+  it('calls a file with different content changed, and keeps what was there', async () => {
+    const root = await tmp();
+    const file = path.join(root, 'a.ts');
+    await fs.writeFile(file, 'OLD', 'utf8');
+    const plan = new EmitPlan({ write: false });
+    await plan.writeFile(file, 'NEW');
+    expect(plan.files[0].verdict).toBe('changed');
+    expect(plan.files[0].before).toBe('OLD');
+    expect(plan.files[0].after).toBe('NEW');
+  });
+
+  it('calls a byte-identical file unchanged', async () => {
+    const root = await tmp();
+    const file = path.join(root, 'a.ts');
+    await fs.writeFile(file, 'SAME', 'utf8');
+    const plan = new EmitPlan({ write: false });
+    await plan.writeFile(file, 'SAME');
+    expect(plan.files[0].verdict).toBe('unchanged');
+  });
+
+  it('takes `before` from a snapshot when one is given, without reading the disk', async () => {
+    // The snapshot is authoritative on purpose: `--check` reads the output directories once and
+    // hands the map over, so a file the run writes twice cannot see its own first write.
+    const existing = new Map([['/abs/a.ts', 'FROM SNAPSHOT']]);
+    const plan = new EmitPlan({ write: false, existing });
+    await plan.writeFile('/abs/a.ts', 'FROM SNAPSHOT');
+    await plan.writeFile('/abs/b.ts', 'NEW');
+    expect(plan.files[0].verdict).toBe('unchanged');
+    expect(plan.files[1].verdict).toBe('created');
+  });
+});
+
+describe('EmitPlan in write mode', () => {
+  it('writes the file and creates the directory', async () => {
+    const root = await tmp();
+    const plan = new EmitPlan({ write: true });
+    await plan.mkdir(path.join(root, 'out'));
+    await plan.writeFile(path.join(root, 'out', 'a.ts'), 'A');
+    expect(await fs.readFile(path.join(root, 'out', 'a.ts'), 'utf8')).toBe('A');
+  });
+
+  it('reports the verdict against what was on disk before this run, not after its own write', async () => {
+    // A generator writing the same path twice, or two generators pointed at one directory. The
+    // second write would otherwise compare itself against the first and report `unchanged` for a
+    // file that changed.
+    const root = await tmp();
+    const file = path.join(root, 'a.ts');
+    await fs.writeFile(file, 'ORIGINAL', 'utf8');
+    const plan = new EmitPlan({ write: true });
+    await plan.writeFile(file, 'FIRST');
+    await plan.writeFile(file, 'SECOND');
+    expect(plan.files).toHaveLength(1);
+    expect(plan.files[0].before).toBe('ORIGINAL');
+    expect(plan.files[0].after).toBe('SECOND');
+    expect(plan.files[0].verdict).toBe('changed');
+    expect(await fs.readFile(file, 'utf8')).toBe('SECOND');
+  });
+});
+
+describe('counts and reporting', () => {
+  it('counts each verdict, over all files or over one generator’s', async () => {
+    const root = await tmp();
+    await fs.writeFile(path.join(root, 'same.ts'), 'S', 'utf8');
+    await fs.writeFile(path.join(root, 'diff.ts'), 'OLD', 'utf8');
+    const plan = new EmitPlan({ write: false });
+    await plan.writeFile(path.join(root, 'same.ts'), 'S');
+    await plan.writeFile(path.join(root, 'diff.ts'), 'NEW');
+    await plan.writeFile(path.join(root, 'new.ts'), 'N');
+
+    expect(plan.counts()).toEqual({ total: 3, created: 1, changed: 1, unchanged: 1 });
+    expect(plan.counts([path.join(root, 'new.ts')])).toEqual({
+      total: 1,
+      created: 1,
+      changed: 0,
+      unchanged: 0,
+    });
+  });
+
+  it('leaves the zeroes out of the sentence', () => {
+    expect(describeCounts({ total: 3, created: 3, changed: 0, unchanged: 0 })).toBe('3 created');
+    expect(describeCounts({ total: 2, created: 0, changed: 1, unchanged: 1 })).toBe(
+      '1 changed, 1 unchanged'
+    );
+    expect(describeCounts({ total: 0, created: 0, changed: 0, unchanged: 0 })).toBe(
+      'nothing to write'
+    );
+  });
+
+  it('lists only what would change, sorted, so a report reads the same every run', async () => {
+    const root = await tmp();
+    await fs.writeFile(path.join(root, 'z.ts'), 'OLD', 'utf8');
+    await fs.writeFile(path.join(root, 'keep.ts'), 'K', 'utf8');
+    const plan = new EmitPlan({ write: false });
+    await plan.writeFile(path.join(root, 'z.ts'), 'NEW');
+    await plan.writeFile(path.join(root, 'keep.ts'), 'K');
+    await plan.writeFile(path.join(root, 'a.ts'), 'A');
+    expect(pendingChanges(plan).map((f) => path.basename(f.file))).toEqual(['a.ts', 'z.ts']);
+  });
+
+  it('keeps the published drift vocabulary', () => {
+    // `added` rather than `created`, because that is the word the --json contract and the docs
+    // have used since --check shipped.
+    expect(driftStatusOf('created')).toBe('added');
+    expect(driftStatusOf('changed')).toBe('changed');
+  });
+
+  it('names a path relative to where the command was run, and leaves an outside path alone', () => {
+    expect(displayPath('/a/b/c.ts', '/a')).toBe(path.join('b', 'c.ts'));
+    expect(displayPath('/elsewhere/c.ts', '/a')).toBe('/elsewhere/c.ts');
+  });
+
+  it('reports a path the generator claims but never routed through the sink', async () => {
+    const plan = new EmitPlan({ write: false });
+    await plan.writeFile('/abs/known.ts', 'K');
+    expect(plan.unrecorded(['/abs/known.ts', '/abs/hidden.ts'])).toEqual(['/abs/hidden.ts']);
+  });
+});
+
+describe('verifyNothingWasWritten', () => {
+  it('says nothing when the tree is untouched', async () => {
+    const root = await tmp();
+    await fs.writeFile(path.join(root, 'a.ts'), 'A', 'utf8');
+    const before = new Map([[path.join(root, 'a.ts'), 'A']]);
+    expect(await verifyNothingWasWritten([root], before)).toEqual([]);
+  });
+
+  it('names what was written and puts it back', async () => {
+    // The version-skew case: a generator that predates `fileSink` accepts it, ignores it, and
+    // writes. The guard is what stops a dry run silently rewriting somebody's tree.
+    const root = await tmp();
+    const kept = path.join(root, 'a.ts');
+    await fs.writeFile(kept, 'ORIGINAL', 'utf8');
+    const before = new Map([[kept, 'ORIGINAL']]);
+
+    await fs.writeFile(kept, 'OVERWRITTEN', 'utf8');
+    const rogue = path.join(root, 'rogue.ts');
+    await fs.writeFile(rogue, 'NEW', 'utf8');
+
+    const written = await verifyNothingWasWritten([root], before);
+    expect(written).toEqual([kept, rogue].sort());
+    expect(await fs.readFile(kept, 'utf8')).toBe('ORIGINAL');
+    await expect(fs.access(rogue)).rejects.toThrow();
+  });
+});

--- a/packages/cli/test/generate-plan.e2e.spec.ts
+++ b/packages/cli/test/generate-plan.e2e.spec.ts
@@ -1,0 +1,350 @@
+/**
+ * What `drzl generate` would write, what it did write, and what differs (plan items 68, 80, 81,
+ * and the evidence for 82), spawned as real processes.
+ *
+ * All four read one mechanism, so they are tested against one fixture. The assertions that carry
+ * weight:
+ *
+ *  - **68**: a dry run in a project that has never been generated into leaves the directory
+ *    byte-for-byte what it was, directories included. Not "no generated files appeared": no
+ *    entry appeared and no existing byte changed, which is the only form of the claim that also
+ *    catches a stray `mkdir`, a lockfile or a formatter cache.
+ *  - **80**: the report distinguishes created from changed from unchanged. A run that rewrites
+ *    twelve identical files and one real change used to say "13 files".
+ *  - **81**: a failing `--check` prints a diff that names the file and shows the changed lines.
+ *  - **82**: the analysis happens once per run however many generators are configured.
+ *
+ * Requires a build. CI builds before testing; locally, run `pnpm build` first.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promises as fs, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const CLI = path.resolve(__dirname, '..', 'dist', 'cli.js');
+const ROOT = path.join(__dirname, '.tmp-generate-plan');
+
+const SCHEMA = `
+import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+`;
+
+const EXTRA_TABLE = `export const posts = pgTable('posts', { id: serial('id').primaryKey() });\n`;
+
+interface Run {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Spawn the built CLI, keeping the exit code rather than throwing on a non-zero one. */
+function run(args: string[], cwd: string): Promise<Run> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [CLI, ...args],
+      {
+        cwd,
+        maxBuffer: 40 * 1024 * 1024,
+        // `NO_COLOR` so the assertions are on words rather than on escape sequences, and
+        // `DRZL_HIDE_SPONSOR` so no run of this file writes the sponsor cache into the fixture.
+        env: { ...process.env, NO_COLOR: '1', DRZL_HIDE_SPONSOR: '1', FORCE_COLOR: '0' },
+      },
+      (error, stdout, stderr) => {
+        if (error && typeof error.code !== 'number') return reject(error);
+        resolve({ code: (error?.code as number) ?? 0, stdout, stderr });
+      }
+    );
+  });
+}
+
+/** Every entry under `dir`, with file contents, so "unchanged" means bytes and not a listing. */
+async function tree(dir: string): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  async function walk(current: string) {
+    for (const e of await fs.readdir(current, { withFileTypes: true })) {
+      const full = path.join(current, e.name);
+      const rel = path.relative(dir, full);
+      if (e.isDirectory()) {
+        out.set(rel + path.sep, '<dir>');
+        await walk(full);
+      } else {
+        out.set(rel, await fs.readFile(full, 'utf8'));
+      }
+    }
+  }
+  await walk(dir);
+  return out;
+}
+
+/**
+ * A fresh project. Lives under this package so `drizzle-orm` resolves by the normal node_modules
+ * walk, and so the project directory itself holds nothing but what this test put there.
+ */
+async function project(name: string, generators: string) {
+  const dir = path.join(ROOT, name);
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(path.join(dir, 'src', 'db'), { recursive: true });
+  await fs.writeFile(path.join(dir, 'src', 'db', 'schema.ts'), SCHEMA, 'utf8');
+  await fs.writeFile(
+    path.join(dir, 'drzl.config.ts'),
+    `export default { schema: './src/db/schema.ts', outDir: './out', generators: [${generators}] };`,
+    'utf8'
+  );
+  return dir;
+}
+
+const ZOD = `{ kind: 'zod', path: './zod' }`;
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.mkdir(ROOT, { recursive: true });
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe('generate --dry-run (item 68)', () => {
+  it('leaves an ungenerated project byte-for-byte what it was', async () => {
+    const dir = await project(
+      'dry-fresh',
+      `{ kind: 'orpc' }, ${ZOD}, { kind: 'service', path: './svc' }`
+    );
+    const before = await tree(dir);
+
+    const r = await run(['generate', '--dry-run'], dir);
+    expect(r.code).toBe(0);
+
+    const after = await tree(dir);
+    expect([...after.keys()].sort()).toEqual([...before.keys()].sort());
+    for (const [key, contents] of before) expect(after.get(key)).toBe(contents);
+  }, 180_000);
+
+  it('still says what it would have written, on stdout, one path per line', async () => {
+    const dir = await project('dry-list', ZOD);
+    const r = await run(['generate', '--dry-run'], dir);
+    const lines = r.stdout.split('\n').filter(Boolean);
+    expect(lines.every((l) => l.startsWith('  - '))).toBe(true);
+    expect(lines.some((l) => l.endsWith(path.join('zod', 'users.zod.ts')))).toBe(true);
+    expect(lines.some((l) => l.endsWith(path.join('zod', 'index.ts')))).toBe(true);
+  }, 180_000);
+
+  it('says nothing was written, and does not claim to have generated anything', async () => {
+    const dir = await project('dry-words', ZOD);
+    const r = await run(['generate', '--dry-run'], dir);
+    expect(r.stderr).toContain('Nothing was written');
+    expect(r.stderr).toContain('Would write (zod)');
+    expect(r.stderr).not.toContain('Generated (zod)');
+  }, 180_000);
+
+  it('exits 0 even when everything would change, because that is the answer and not a finding', async () => {
+    // The distinction from `--check`, which is the flag whose question is "is anything stale".
+    const dir = await project('dry-exit', ZOD);
+    const fresh = await run(['generate', '--dry-run'], dir);
+    expect(fresh.code).toBe(0);
+    await run(['generate'], dir);
+    const clean = await run(['generate', '--dry-run'], dir);
+    expect(clean.code).toBe(0);
+  }, 240_000);
+
+  it('carries the verdicts and a dryRun flag in the --json document', async () => {
+    const dir = await project('dry-json', ZOD);
+    const r = await run(['generate', '--dry-run', '--json'], dir);
+    const doc = JSON.parse(r.stdout);
+    expect(doc.dryRun).toBe(true);
+    expect(doc.exitCode).toBe(0);
+    expect(doc.check).toBeNull();
+    const zod = doc.generators.find((g: any) => g.kind === 'zod');
+    expect(zod.files.length).toBe(zod.changes.length);
+    expect(zod.changes.every((c: any) => c.status === 'created')).toBe(true);
+    // Relative, so a document is readable and comparable across machines.
+    expect(zod.changes[0].file.startsWith('/')).toBe(false);
+  }, 180_000);
+});
+
+describe('generate reports what changed (item 80)', () => {
+  it('calls a first run created and a repeat run unchanged', async () => {
+    const dir = await project('verdicts', ZOD);
+    const first = await run(['generate'], dir);
+    expect(first.stderr).toContain('2 created');
+
+    const second = await run(['generate'], dir);
+    expect(second.stderr).toContain('2 unchanged');
+    expect(second.stderr).not.toContain('created');
+  }, 240_000);
+
+  it('separates created from changed from unchanged in one run', async () => {
+    const dir = await project('verdicts-mixed', ZOD);
+    await run(['generate'], dir);
+    await fs.appendFile(path.join(dir, 'src', 'db', 'schema.ts'), EXTRA_TABLE, 'utf8');
+
+    const r = await run(['generate'], dir);
+    // A new table adds its own module, rewrites the barrel, and leaves the other module alone.
+    expect(r.stderr).toContain('1 created, 1 changed, 1 unchanged');
+    expect(r.stderr).toContain('+ ' + path.join('zod', 'posts.zod.ts'));
+    expect(r.stderr).toContain('~ ' + path.join('zod', 'index.ts'));
+    // The unchanged one is counted and not listed: the list is what changed.
+    expect(r.stderr).not.toContain('~ ' + path.join('zod', 'users.zod.ts'));
+  }, 240_000);
+
+  it('keeps the file list on stdout in the shape it has always had', async () => {
+    // The verdicts are narration on stderr. stdout stays the answer, so anything parsing
+    // `drzl generate > files.txt` is unaffected.
+    const dir = await project('verdicts-stdout', ZOD);
+    const r = await run(['generate'], dir);
+    for (const line of r.stdout.split('\n').filter(Boolean)) {
+      expect(line.startsWith('  - ')).toBe(true);
+      expect(path.isAbsolute(line.slice(4))).toBe(true);
+    }
+  }, 180_000);
+
+  it('puts a per-file status in the --json document', async () => {
+    const dir = await project('verdicts-json', ZOD);
+    await run(['generate'], dir);
+    await fs.appendFile(path.join(dir, 'src', 'db', 'schema.ts'), EXTRA_TABLE, 'utf8');
+    const r = await run(['generate', '--json'], dir);
+    const doc = JSON.parse(r.stdout);
+    const changes: Array<{ file: string; status: string }> = doc.generators[0].changes;
+    const byStatus = (s: string) => changes.filter((c) => c.status === s).map((c) => c.file);
+    expect(byStatus('created')).toEqual([path.join('zod', 'posts.zod.ts')]);
+    expect(byStatus('changed')).toEqual([path.join('zod', 'index.ts')]);
+    expect(byStatus('unchanged')).toEqual([path.join('zod', 'users.zod.ts')]);
+  }, 240_000);
+
+  it('stays silent on success under --quiet', async () => {
+    const dir = await project('verdicts-quiet', ZOD);
+    const r = await run(['generate', '--quiet'], dir);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(r.stderr).toBe('');
+  }, 180_000);
+});
+
+describe('generate --check prints a diff (item 81)', () => {
+  it('names the file and shows the changed lines when someone edited generated output', async () => {
+    const dir = await project('check-handedit', ZOD);
+    await run(['generate'], dir);
+
+    const target = path.join(dir, 'zod', 'users.zod.ts');
+    const original = await fs.readFile(target, 'utf8');
+    await fs.writeFile(target, original.replace('z.string()', 'z.string().min(1)'), 'utf8');
+
+    const r = await run(['generate', '--check'], dir);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('out of date');
+    // The file, named twice: once in the list, once in the diff header.
+    expect(r.stderr).toContain('~ changed  ' + path.join('zod', 'users.zod.ts'));
+    expect(r.stderr).toContain('--- a/' + path.join('zod', 'users.zod.ts'));
+    expect(r.stderr).toContain('+++ b/' + path.join('zod', 'users.zod.ts'));
+    // The changed lines, in both directions.
+    expect(r.stderr).toContain('-  email: z.string().min(1),');
+    expect(r.stderr).toContain('+  email: z.string(),');
+    // A hunk header, so the diff is greppable and applies.
+    expect(/@@ -\d+,\d+ \+\d+,\d+ @@/.test(r.stderr)).toBe(true);
+  }, 240_000);
+
+  it('shows a whole new file as an addition when the schema gained a table', async () => {
+    const dir = await project('check-newtable', ZOD);
+    await run(['generate'], dir);
+    await fs.appendFile(path.join(dir, 'src', 'db', 'schema.ts'), EXTRA_TABLE, 'utf8');
+
+    const r = await run(['generate', '--check'], dir);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('+ added    ' + path.join('zod', 'posts.zod.ts'));
+    expect(r.stderr).toContain('@@ -0,0 +1,');
+    expect(r.stderr).toContain('+export const InsertpostsSchema');
+  }, 240_000);
+
+  it('writes nothing at all, so the hand-edit and the stale tree both survive', async () => {
+    // Stronger than the old guarantee. `--check` used to regenerate over the tree and restore it
+    // from a snapshot, so the window between the two was a tree in an intermediate state; now
+    // there is no write to restore from.
+    const dir = await project('check-nowrites', ZOD);
+    await run(['generate'], dir);
+
+    const target = path.join(dir, 'zod', 'users.zod.ts');
+    const edited = (await fs.readFile(target, 'utf8')).replace('z.string()', 'z.string().min(1)');
+    await fs.writeFile(target, edited, 'utf8');
+    const before = await tree(dir);
+
+    const r = await run(['generate', '--check'], dir);
+    expect(r.code).toBe(2);
+
+    const after = await tree(dir);
+    expect([...after.keys()].sort()).toEqual([...before.keys()].sort());
+    for (const [key, contents] of before) expect(after.get(key)).toBe(contents);
+  }, 240_000);
+
+  it('exits 0 and prints no diff on a tree that is up to date', async () => {
+    const dir = await project('check-clean', ZOD);
+    await run(['generate'], dir);
+    const r = await run(['generate', '--check'], dir);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toContain('up to date');
+    expect(r.stderr).not.toContain('@@');
+  }, 240_000);
+
+  it('keeps the drift list under --quiet and drops the diff', async () => {
+    // The list is the finding, which a `2` with nothing to read makes unusable. The diff is the
+    // explanation, which is what `--quiet` is asking to be spared.
+    const dir = await project('check-quiet', ZOD);
+    await run(['generate'], dir);
+    const target = path.join(dir, 'zod', 'users.zod.ts');
+    const original = await fs.readFile(target, 'utf8');
+    await fs.writeFile(target, original.replace('z.string()', 'z.string().min(1)'), 'utf8');
+
+    const r = await run(['generate', '--check', '--quiet'], dir);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('~ changed  ' + path.join('zod', 'users.zod.ts'));
+    expect(r.stderr).not.toContain('@@');
+  }, 240_000);
+
+  it('carries the diff and the cap in the --json document', async () => {
+    const dir = await project('check-json', ZOD);
+    await run(['generate'], dir);
+    const target = path.join(dir, 'zod', 'users.zod.ts');
+    const original = await fs.readFile(target, 'utf8');
+    await fs.writeFile(target, original.replace('z.string()', 'z.string().min(1)'), 'utf8');
+
+    const r = await run(['generate', '--check', '--json'], dir);
+    const doc = JSON.parse(r.stdout);
+    expect(doc.exitCode).toBe(2);
+    expect(doc.check.upToDate).toBe(false);
+    expect(doc.check.diffFileCap).toBeGreaterThan(0);
+    const entry = doc.check.drift[0];
+    expect(entry.file).toBe(path.join('zod', 'users.zod.ts'));
+    expect(entry.status).toBe('changed');
+    expect(entry.diff).toContain('@@');
+    expect(entry.diff).toContain('+  email: z.string(),');
+  }, 240_000);
+});
+
+describe('one analysis per run (item 82)', () => {
+  it('analyses once however many generators are configured', async () => {
+    // The plan item says "if it is not already shared", and it is: the analysis is built once in
+    // `generate` and handed to every generator's constructor. This is the guard that says so, so
+    // a future refactor that moved the analyzer inside the loop would fail here rather than
+    // quietly multiplying the cost by the number of generators.
+    const one = await project('shared-one', ZOD);
+    const many = await project(
+      'shared-many',
+      `${ZOD}, { kind: 'valibot', path: './valibot' }, { kind: 'arktype', path: './arktype' }, ` +
+        `{ kind: 'typebox', path: './typebox' }, { kind: 'effect', path: './effect' }`
+    );
+
+    const rOne = await run(['generate'], one);
+    const rMany = await run(['generate'], many);
+
+    const analyses = (text: string) => text.split('Analysis complete in').length - 1;
+    expect(analyses(rOne.stderr)).toBe(1);
+    expect(analyses(rMany.stderr)).toBe(1);
+    // Five generators really did run, so the single analysis is not a single generator.
+    expect(rMany.stderr.split('Generated (').length - 1).toBe(5);
+  }, 300_000);
+});

--- a/packages/cli/test/unified-diff.spec.ts
+++ b/packages/cli/test/unified-diff.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * The diff `generate --check` prints (plan item 81).
+ *
+ * The assertion that matters here is not that the output looks like a diff. A diff that looks
+ * right and is wrong is worse than no diff, because a reviewer acts on it: the whole point of
+ * printing one is that somebody decides whether the change is theirs or the generator's. So every
+ * case below is checked by *applying* the emitted patch to the "before" text and requiring the
+ * result to equal the "after" text exactly. `applyUnified` is deliberately a naive reader of the
+ * hunk headers rather than a second copy of the algorithm, so a bug in the diff cannot be
+ * cancelled out by the same bug in the check.
+ */
+import { describe, it, expect } from 'vitest';
+import { unifiedDiff, diffLines, DEFAULT_DIFF_LIMITS } from '../src/unified-diff';
+
+/**
+ * Apply a unified diff, reading the hunk headers and nothing else.
+ *
+ * Everything before the first hunk's start line is copied across, then each hunk is replayed:
+ * a space or `-` line consumes one line of the original, a space or `+` line emits one. If the
+ * headers are wrong, this desynchronises and the comparison fails, which is the point.
+ */
+function applyUnified(before: string, diff: string): string {
+  const src = before === '' ? [] : before.replace(/\n$/, '').split('\n');
+  const out: string[] = [];
+  let cursor = 0;
+  /** Whether the last line written to `out` was followed by the no-newline marker. */
+  let lastLineHadNoNewline = false;
+
+  const lines = diff.split('\n');
+  let i = 0;
+  while (i < lines.length && !lines[i].startsWith('@@')) i++;
+
+  while (i < lines.length) {
+    const header = /^@@ -(\d+),(\d+) \+(\d+),(\d+) @@/.exec(lines[i]);
+    if (!header) {
+      i++;
+      continue;
+    }
+    const aFrom = Number(header[1]);
+    const aCount = Number(header[2]);
+    const start = aCount === 0 ? aFrom : aFrom - 1;
+    while (cursor < start) {
+      out.push(src[cursor++]);
+      lastLineHadNoNewline = false;
+    }
+    i++;
+    for (; i < lines.length && !lines[i].startsWith('@@'); i++) {
+      const line = lines[i];
+      if (line === '') continue;
+      if (line.startsWith('\\')) {
+        // The marker describes the line just emitted, whichever side it came from. A `-` line
+        // carrying it is describing the original, so it says nothing about the result.
+        continue;
+      }
+      const nextIsMarker = lines[i + 1]?.startsWith('\\') ?? false;
+      if (line.startsWith(' ')) {
+        out.push(src[cursor++]);
+        lastLineHadNoNewline = nextIsMarker;
+      } else if (line.startsWith('-')) {
+        cursor++;
+      } else if (line.startsWith('+')) {
+        out.push(line.slice(1));
+        lastLineHadNoNewline = nextIsMarker;
+      }
+    }
+  }
+  while (cursor < src.length) {
+    out.push(src[cursor++]);
+    lastLineHadNoNewline = false;
+  }
+  if (!out.length) return '';
+  return out.join('\n') + (lastLineHadNoNewline ? '' : '\n');
+}
+
+const label = { fromLabel: 'a/x.ts', toLabel: 'b/x.ts' };
+
+describe('unifiedDiff', () => {
+  it('says nothing about two identical texts', () => {
+    expect(unifiedDiff('same\n', 'same\n', label)).toBe('');
+  });
+
+  it('names both sides in the header, so the file is identifiable in a log', () => {
+    const d = unifiedDiff('a\n', 'b\n', {
+      fromLabel: 'a/zod/users.zod.ts',
+      toLabel: 'b/zod/users.zod.ts',
+    });
+    expect(d).toContain('--- a/zod/users.zod.ts');
+    expect(d).toContain('+++ b/zod/users.zod.ts');
+  });
+
+  it('shows the changed line, and only the changed line, as - then +', () => {
+    const before = 'one\ntwo\nthree\n';
+    const after = 'one\nTWO\nthree\n';
+    const d = unifiedDiff(before, after, label);
+    expect(d).toContain('-two');
+    expect(d).toContain('+TWO');
+    expect(d).not.toContain('-one');
+    expect(d).not.toContain('+three');
+    expect(applyUnified(before, d)).toBe(after);
+  });
+
+  const cases: Array<[string, string, string]> = [
+    ['an inserted line', 'a\nb\n', 'a\nx\nb\n'],
+    ['a deleted line', 'a\nx\nb\n', 'a\nb\n'],
+    ['a replaced line', 'a\nx\nb\n', 'a\ny\nb\n'],
+    ['a file created from nothing', '', 'a\nb\n'],
+    ['a file emptied', 'a\nb\n', ''],
+    ['a change at the very start', 'a\nb\nc\n', 'z\nb\nc\n'],
+    ['a change at the very end', 'a\nb\nc\n', 'a\nb\nz\n'],
+    [
+      'two changes far apart, which must be two hunks',
+      tenLines('x'),
+      tenLines('x', { 0: 'first', 9: 'last' }),
+    ],
+    [
+      'two changes close together, which must merge into one hunk',
+      'a\nb\nc\nd\ne\n',
+      'a\nB\nc\nD\ne\n',
+    ],
+    ['no trailing newline on the right', 'a\nb\n', 'a\nb'],
+    ['no trailing newline on the left', 'a\nb', 'a\nb\n'],
+    ['a wholly different file', 'a\nb\nc\n', 'x\ny\nz\n'],
+    ['a repeated line, where a naive matcher picks the wrong one', 'x\nx\nx\n', 'x\nx\nx\nx\n'],
+  ];
+
+  for (const [name, before, after] of cases) {
+    it(`round-trips ${name}`, () => {
+      const d = unifiedDiff(before, after, label);
+      expect(d).not.toBe('');
+      expect(applyUnified(before, d)).toBe(after);
+    });
+  }
+
+  it('round-trips a generated-file-sized change', () => {
+    // The shape this is actually asked about: a long file with one field edited in the middle.
+    const before =
+      Array.from({ length: 800 }, (_, i) => `  field${i}: z.string(),`).join('\n') + '\n';
+    const after = before.replace('  field400: z.string(),', '  field400: z.string().max(50),');
+    const d = unifiedDiff(before, after, label);
+    expect(applyUnified(before, d)).toBe(after);
+    // Three lines of context each side, so a one-line change is a seven-line hunk and not 800.
+    expect(d.split('\n').length).toBeLessThan(15);
+  });
+
+  it('produces two hunks rather than one enormous one', () => {
+    const before = tenLines('x');
+    const after = tenLines('x', { 0: 'first', 9: 'last' });
+    const d = unifiedDiff(before, after, label);
+    expect(d.split('@@ ').length - 1).toBe(2);
+  });
+
+  it('marks a missing final newline the way diff does', () => {
+    const d = unifiedDiff('a\nb\n', 'a\nb', label);
+    expect(d).toContain('\\ No newline at end of file');
+  });
+});
+
+describe('the caps, which must be stated rather than silently applied', () => {
+  it('refuses a file longer than the line cap, and says how long it was', () => {
+    const big = Array.from({ length: 20 }, (_, i) => `line ${i}`).join('\n') + '\n';
+    const bigger = big.replace('line 3', 'line THREE');
+    const d = unifiedDiff(big, bigger, { ...label, limits: { maxLines: 5 } });
+    expect(d).toContain('no line diff');
+    expect(d).toContain('20 lines on disk');
+    expect(d).toContain('5-line cap');
+    // The header is still there, so the file is still identifiable.
+    expect(d).toContain('--- a/x.ts');
+  });
+
+  it('refuses a pair that differ by more than the edit cap, and says so', () => {
+    const before = Array.from({ length: 60 }, (_, i) => `a${i}`).join('\n') + '\n';
+    const after = Array.from({ length: 60 }, (_, i) => `b${i}`).join('\n') + '\n';
+    const d = unifiedDiff(before, after, { ...label, limits: { maxEdits: 4 } });
+    expect(d).toContain('no line diff');
+    expect(d).toContain('4-edit cap');
+  });
+
+  it('has caps at all by default', () => {
+    expect(DEFAULT_DIFF_LIMITS.maxLines).toBeGreaterThan(0);
+    expect(DEFAULT_DIFF_LIMITS.maxEdits).toBeGreaterThan(0);
+    expect(DEFAULT_DIFF_LIMITS.context).toBe(3);
+  });
+});
+
+describe('diffLines', () => {
+  it('returns null rather than grinding when the edit distance exceeds the cap', () => {
+    const a = Array.from({ length: 200 }, (_, i) => `a${i}`);
+    const b = Array.from({ length: 200 }, (_, i) => `b${i}`);
+    expect(diffLines(a, b, 10)).toBeNull();
+  });
+
+  it('finds the minimal edit script, not merely a correct one', () => {
+    // One insertion, so one non-equal operation. An implementation that rewrote the tail would
+    // return four, apply cleanly, and print a diff nobody can read.
+    const ops = diffLines(['a', 'b', 'c'], ['a', 'x', 'b', 'c'], 100);
+    expect(ops).not.toBeNull();
+    expect(ops!.filter((o) => o.kind !== 'equal')).toHaveLength(1);
+  });
+
+  it('costs a bounded number of edits for a one-line change in a long file', () => {
+    const a = Array.from({ length: 5000 }, (_, i) => `l${i}`);
+    const b = [...a];
+    b[2500] = 'changed';
+    // The prefix and suffix trim is what makes this finish: without it Myers would search a
+    // 5000-line space. With it there are two lines to compare.
+    const ops = diffLines(a, b, 4);
+    expect(ops).not.toBeNull();
+    expect(ops!.filter((o) => o.kind !== 'equal')).toHaveLength(2);
+  });
+});
+
+/** Ten numbered lines, with the given indices replaced. */
+function tenLines(prefix: string, overrides: Record<number, string> = {}): string {
+  return Array.from({ length: 10 }, (_, i) => overrides[i] ?? `${prefix}${i}`).join('\n') + '\n';
+}

--- a/packages/cli/test/watch-clear.e2e.spec.ts
+++ b/packages/cli/test/watch-clear.e2e.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * `drzl watch` and the terminal it is running in (plan item 75).
+ *
+ * The old behaviour was `if (!opts.json) console.clear()` at the top of every rebuild. Three
+ * things were wrong with it and only the first is what the plan item names:
+ *
+ *  - it was not optional, so every rebuild threw away the previous rebuild's errors and the
+ *    startup banner naming the watched directories
+ *  - it was decided from stdout's `isTTY` while everything a human reads is on stderr, so
+ *    `drzl watch > events.json` on a terminal cleared nothing, and the stream it was aimed at was
+ *    the one carrying the JSON
+ *  - the escape went to a stream a program may be parsing. Node's own `isTTY` check is what kept
+ *    that harmless, so the assertion below is on bytes rather than on the flag
+ *
+ * Every assertion is `indexOf(0x1b)` on a captured buffer, because a visual check of a terminal is
+ * exactly the check that cannot see an escape sequence: the terminal consumes it.
+ *
+ * Requires a build. CI builds before testing; locally, run `pnpm build` first.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn } from 'node:child_process';
+import { promises as fs, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const CLI = path.resolve(__dirname, '..', 'dist', 'cli.js');
+const ROOT = path.join(__dirname, '.tmp-watch-clear');
+const ESC = 0x1b;
+
+const SCHEMA = `
+import { pgTable, serial, text } from 'drizzle-orm/pg-core';
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+});
+`;
+
+async function project(name: string) {
+  const dir = path.join(ROOT, name);
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(path.join(dir, 'src', 'db'), { recursive: true });
+  await fs.writeFile(path.join(dir, 'src', 'db', 'schema.ts'), SCHEMA, 'utf8');
+  await fs.writeFile(
+    path.join(dir, 'drzl.config.ts'),
+    `export default { schema: './src/db/schema.ts', outDir: './out', generators: [{ kind: 'zod', path: './zod' }] };`,
+    'utf8'
+  );
+  return dir;
+}
+
+/**
+ * Start a watcher on ordinary pipes, let the startup build finish, then stop it.
+ *
+ * The watcher never exits on its own, so the run is bounded by the file it is waiting to produce
+ * rather than by a sleep: `zod/index.ts` appearing means one rebuild has completed.
+ */
+function watchOnPipes(args: string[], cwd: string) {
+  return new Promise<{ out: Buffer; err: Buffer }>((resolve, reject) => {
+    const env = { ...process.env, DRZL_HIDE_SPONSOR: '1' } as NodeJS.ProcessEnv;
+    // Removed rather than overridden: this shell exports FORCE_COLOR=3, which would turn an
+    // assertion about a pipe carrying no escapes into an assertion about that variable.
+    delete env.FORCE_COLOR;
+    delete env.NO_COLOR;
+    const child = spawn(process.execPath, [CLI, 'watch', '--poll', '--debounce', '50', ...args], {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout.on('data', (c: Buffer) => out.push(c));
+    child.stderr.on('data', (c: Buffer) => err.push(c));
+    child.on('error', reject);
+
+    const done = () => {
+      child.kill('SIGTERM');
+      setTimeout(() => resolve({ out: Buffer.concat(out), err: Buffer.concat(err) }), 200);
+    };
+    const deadline = Date.now() + 60_000;
+    const poll = setInterval(() => {
+      if (existsSync(path.join(cwd, 'zod', 'index.ts')) || Date.now() > deadline) {
+        clearInterval(poll);
+        // A moment more, so anything written just after the file lands is captured too.
+        setTimeout(done, 500);
+      }
+    }, 200);
+  });
+}
+
+/** Whether `script(1)` can give a command a real terminal. */
+async function hasScript(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn('script', ['--version'], { stdio: 'ignore' });
+    child.on('error', () => resolve(false));
+    child.on('close', (code) => resolve(code === 0));
+  });
+}
+
+/** Start a watcher under a pty, wait for one rebuild, and return everything it painted. */
+function watchOnTty(args: string[], cwd: string) {
+  return new Promise<string>((resolve, reject) => {
+    const env = { ...process.env, DRZL_HIDE_SPONSOR: '1' } as NodeJS.ProcessEnv;
+    delete env.FORCE_COLOR;
+    delete env.NO_COLOR;
+    const inner =
+      `stty rows 24 cols 80; ${JSON.stringify(process.execPath)} ${JSON.stringify(CLI)} ` +
+      ['watch', '--poll', '--debounce', '50', ...args].map((a) => JSON.stringify(a)).join(' ');
+    const child = spawn('script', ['-qec', inner, '/dev/null'], {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const chunks: Buffer[] = [];
+    child.stdout.on('data', (c: Buffer) => chunks.push(c));
+    child.stderr.on('data', (c: Buffer) => chunks.push(c));
+    child.on('error', reject);
+
+    const deadline = Date.now() + 60_000;
+    const poll = setInterval(() => {
+      if (existsSync(path.join(cwd, 'zod', 'index.ts')) || Date.now() > deadline) {
+        clearInterval(poll);
+        setTimeout(() => {
+          child.kill('SIGTERM');
+          setTimeout(() => resolve(Buffer.concat(chunks).toString('utf8')), 300);
+        }, 500);
+      }
+    }, 200);
+  });
+}
+
+/** The sequence `--clear` sends: erase display, erase scrollback, cursor home. */
+const CLEAR = '\u001b[2J\u001b[3J\u001b[H';
+
+/**
+ * Every way this file has ever cleared a screen, so "it did not clear" is a claim about the
+ * terminal rather than about one spelling.
+ *
+ * `console.clear()`, which is what ran here until now, is `cursorTo(0, 0)` followed by
+ * `clearScreenDown`. Measured under `script(1)` on Node 22.22 that is exactly `ESC [ 1 ; 1 H`
+ * then `ESC [ 0 J`, neither of which appears in the sequence `--clear` sends, so a test naming
+ * only the new spelling would pass against the old behaviour it exists to forbid.
+ */
+const ANY_CLEAR = ['\u001b[2J', '\u001b[3J', '\u001b[0J', '\u001b[1;1H'];
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.mkdir(ROOT, { recursive: true });
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+describe('drzl watch and the screen', () => {
+  it('does not clear when nothing asked it to', async () => {
+    const dir = await project('no-clear');
+    const r = await watchOnPipes([], dir);
+    expect(r.err.toString('utf8')).not.toContain(CLEAR);
+    expect(r.out.toString('utf8')).not.toContain(CLEAR);
+  }, 120_000);
+
+  it('sends no escape at all to a pipe, even with --clear', async () => {
+    // The item 77 defect, in the one place that still wrote an escape without asking a stream
+    // whether it was a terminal.
+    const dir = await project('clear-piped');
+    const r = await watchOnPipes(['--clear'], dir);
+    expect(r.err.indexOf(ESC)).toBe(-1);
+    expect(r.out.indexOf(ESC)).toBe(-1);
+  }, 120_000);
+
+  it('keeps stdout empty without --json, clear or no clear', async () => {
+    const dir = await project('clear-stdout');
+    const r = await watchOnPipes(['--clear'], dir);
+    expect(r.out.toString('utf8')).toBe('');
+  }, 120_000);
+
+  it('leaves the --json event stream alone', async () => {
+    const dir = await project('clear-json');
+    const r = await watchOnPipes(['--clear', '--json'], dir);
+    expect(r.out.indexOf(ESC)).toBe(-1);
+    // Still one JSON object per line, which is what a program reads it as.
+    for (const line of r.out.toString('utf8').split('\n').filter(Boolean)) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  }, 120_000);
+
+  it('clears a real terminal only when --clear is passed', async () => {
+    if (!(await hasScript())) return; // `script(1)` is what makes a pty available here.
+    const withFlag = await watchOnTty(['--clear'], await project('tty-clear'));
+    expect(withFlag).toContain(CLEAR);
+
+    const without = await watchOnTty([], await project('tty-plain'));
+    for (const sequence of ANY_CLEAR) expect(without).not.toContain(sequence);
+    // And the watcher really ran in both, so "no clear" is not "nothing happened".
+    expect(without).toContain('Watching:');
+  }, 180_000);
+});

--- a/packages/cli/test/watch-loop.spec.ts
+++ b/packages/cli/test/watch-loop.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * When `drzl watch` rebuilds, and how many rebuilds a burst becomes (plan item 75).
+ *
+ * The measurement that motivated this is in `watch-loop.ts`: against the shipped 4.22 build, six
+ * saves 700ms apart produced six rebuilds with four running at once, all writing the same output
+ * directory, because the debounce guarded the wait and nothing guarded the work. These are the
+ * tests that would have caught it, and the concurrency ones fail against a scheduler with the
+ * debounce alone.
+ *
+ * The clock is injected rather than real. A debounce test that sleeps is a test that is flaky on a
+ * loaded CI machine, and the thing under test is the ordering, not the milliseconds.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  createRebuildScheduler,
+  resolveDebounce,
+  DEFAULT_WATCH_DEBOUNCE_MS,
+} from '../src/watch-loop';
+
+/** A clock a test drives by hand. Only the last-scheduled callback can be pending, as in the CLI. */
+function fakeTimers() {
+  let next = 1;
+  const queued = new Map<number, { fn: () => void; at: number }>();
+  let now = 0;
+  return {
+    now: () => now,
+    timers: {
+      setTimeout(fn: () => void, ms: number) {
+        const id = next++;
+        queued.set(id, { fn, at: now + ms });
+        return id;
+      },
+      clearTimeout(handle: unknown) {
+        queued.delete(handle as number);
+      },
+    },
+    /** Move time on, firing everything due. */
+    advance(ms: number) {
+      now += ms;
+      for (const [id, t] of [...queued]) {
+        if (t.at <= now) {
+          queued.delete(id);
+          t.fn();
+        }
+      }
+    },
+    get pending() {
+      return queued.size;
+    },
+  };
+}
+
+/** A run that finishes only when the test says so, so overlap is observable. */
+function controllableRun() {
+  let starts = 0;
+  let finishes = 0;
+  let maxConcurrent = 0;
+  let concurrent = 0;
+  const waiting: Array<() => void> = [];
+  return {
+    get starts() {
+      return starts;
+    },
+    get finishes() {
+      return finishes;
+    },
+    get maxConcurrent() {
+      return maxConcurrent;
+    },
+    run: () =>
+      new Promise<void>((resolve) => {
+        starts++;
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        waiting.push(() => {
+          concurrent--;
+          finishes++;
+          resolve();
+        });
+      }),
+    /** Let the oldest in-flight run finish. */
+    finishOne() {
+      waiting.shift()?.();
+      // Two microtask turns: one for the `await run()` to resume, one for the trailing re-run it
+      // may start.
+      return Promise.resolve().then(() => Promise.resolve());
+    },
+  };
+}
+
+describe('the debounce', () => {
+  it('turns a burst of changes into one rebuild', async () => {
+    const clock = fakeTimers();
+    const runner = controllableRun();
+    const s = createRebuildScheduler({ run: runner.run, debounceMs: 200, timers: clock.timers });
+
+    // Five saves inside the window, which is what chokidar reports for a tool rewriting several
+    // files at once: the widest gap measured inside one burst was 9ms.
+    for (let i = 0; i < 5; i++) {
+      s.trigger();
+      clock.advance(9);
+    }
+    expect(runner.starts).toBe(0);
+    clock.advance(200);
+    expect(runner.starts).toBe(1);
+  });
+
+  it('rebuilds again for a change that arrives after the window', async () => {
+    const clock = fakeTimers();
+    const runner = controllableRun();
+    const s = createRebuildScheduler({ run: runner.run, debounceMs: 200, timers: clock.timers });
+
+    s.trigger();
+    clock.advance(200);
+    await runner.finishOne();
+    s.trigger();
+    clock.advance(200);
+    expect(runner.starts).toBe(2);
+  });
+});
+
+describe('one rebuild at a time', () => {
+  it('never runs two rebuilds at once, however many changes arrive during one', async () => {
+    const clock = fakeTimers();
+    const runner = controllableRun();
+    const s = createRebuildScheduler({ run: runner.run, debounceMs: 200, timers: clock.timers });
+
+    s.trigger();
+    clock.advance(200);
+    expect(runner.starts).toBe(1);
+
+    // Four more saves while that rebuild is still going, each far enough apart that the debounce
+    // cannot merge them. This is the case the shipped watcher started four rebuilds for.
+    for (let i = 0; i < 4; i++) {
+      s.trigger();
+      clock.advance(700);
+    }
+    expect(runner.starts).toBe(1);
+    expect(runner.maxConcurrent).toBe(1);
+  });
+
+  it('owes exactly one more rebuild, not one per change, when the first finishes', async () => {
+    const clock = fakeTimers();
+    const runner = controllableRun();
+    const s = createRebuildScheduler({ run: runner.run, debounceMs: 200, timers: clock.timers });
+
+    s.trigger();
+    clock.advance(200);
+    for (let i = 0; i < 4; i++) {
+      s.trigger();
+      clock.advance(700);
+    }
+
+    await runner.finishOne();
+    expect(runner.starts).toBe(2);
+    expect(runner.maxConcurrent).toBe(1);
+
+    await runner.finishOne();
+    expect(runner.starts).toBe(2);
+    expect(s.busy).toBe(false);
+  });
+
+  it('does not drop a change that arrives during a rebuild', async () => {
+    // The failure mode the other way: refusing a change while busy loses an edit, which is worse
+    // than the overlap it fixes.
+    const clock = fakeTimers();
+    const runner = controllableRun();
+    const s = createRebuildScheduler({ run: runner.run, debounceMs: 200, timers: clock.timers });
+
+    s.trigger();
+    clock.advance(200);
+    s.trigger();
+    clock.advance(200);
+    await runner.finishOne();
+    expect(runner.starts).toBe(2);
+  });
+
+  it('puts the startup build under the same guard', async () => {
+    const clock = fakeTimers();
+    const runner = controllableRun();
+    const s = createRebuildScheduler({ run: runner.run, debounceMs: 200, timers: clock.timers });
+
+    const startup = s.runNow();
+    s.trigger();
+    clock.advance(200);
+    expect(runner.starts).toBe(1);
+    await runner.finishOne();
+    await runner.finishOne();
+    await startup;
+    expect(runner.maxConcurrent).toBe(1);
+  });
+
+  it('forgets a pending debounce when cancelled', () => {
+    const clock = fakeTimers();
+    const runner = controllableRun();
+    const s = createRebuildScheduler({ run: runner.run, debounceMs: 200, timers: clock.timers });
+    s.trigger();
+    s.cancel();
+    clock.advance(1000);
+    expect(runner.starts).toBe(0);
+  });
+});
+
+describe('resolveDebounce', () => {
+  const swallow = () => {};
+
+  it('defaults to the measured interval', () => {
+    expect(resolveDebounce(undefined, swallow)).toBe(DEFAULT_WATCH_DEBOUNCE_MS);
+    expect(DEFAULT_WATCH_DEBOUNCE_MS).toBe(200);
+  });
+
+  it('takes a number, as a string, which is what commander hands over', () => {
+    expect(resolveDebounce('50', swallow)).toBe(50);
+  });
+
+  it('accepts zero, which `Number(x) || 200` silently turned into 200', () => {
+    expect(resolveDebounce('0', swallow)).toBe(0);
+  });
+
+  it('warns rather than silently substituting when the value is not a number', () => {
+    const warnings: string[] = [];
+    expect(resolveDebounce('banana', (w) => warnings.push(w))).toBe(DEFAULT_WATCH_DEBOUNCE_MS);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('banana');
+    expect(warnings[0]).toContain('200ms');
+  });
+
+  it('refuses a negative interval', () => {
+    const warnings: string[] = [];
+    expect(resolveDebounce('-5', (w) => warnings.push(w))).toBe(DEFAULT_WATCH_DEBOUNCE_MS);
+    expect(warnings).toHaveLength(1);
+  });
+});

--- a/packages/generator-arktype/src/index.ts
+++ b/packages/generator-arktype/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter } from '@drzl/validation-core';
 import type { Analysis, Table, Column } from '@drzl/analyzer';
 import type {
   CardinalityCheck,
@@ -1340,7 +1341,7 @@ export class ArkTypeGenerator implements ValidationRenderer<ArkTypeGenerateOptio
   constructor(private analysis: Analysis) {}
 
   async generate(opts: ArkTypeGenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outDir);
     const files: string[] = [];

--- a/packages/generator-effect/src/index.ts
+++ b/packages/generator-effect/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter } from '@drzl/validation-core';
 import type { Analysis, Table, Column } from '@drzl/analyzer';
 import type {
   ColumnCheck,
@@ -1073,7 +1074,7 @@ export class EffectGenerator implements ValidationRenderer<EffectGenerateOptions
   constructor(private analysis: Analysis) {}
 
   async generate(opts: EffectGenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outDir);
     const files: string[] = [];

--- a/packages/generator-express/src/index.ts
+++ b/packages/generator-express/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter, type FileSink } from '@drzl/validation-core';
 import type { Analysis, Column, Table } from '@drzl/analyzer';
 import type { AffixOptions, ImportExtension } from '@drzl/validation-core';
 import {
@@ -72,6 +73,16 @@ export interface GenerateOptions {
     schemaSuffix?: string;
     affix?: AffixOptions;
   };
+  /**
+   * Where the generated files go, when that is not the filesystem.
+   *
+   * Omitted, they go to disk exactly as before. Passed, every write and every `mkdir` is handed
+   * to the sink instead, which is what `drzl generate --dry-run` and `drzl generate --check`
+   * are built on: both need the content a run would produce without the run producing it. See
+   * `emit.ts` in @drzl/validation-core for why this is an option rather than an interception of
+   * `node:fs/promises`.
+   */
+  fileSink?: FileSink;
 }
 
 type Lib = NonNullable<NonNullable<GenerateOptions['validation']>['library']>;
@@ -359,7 +370,7 @@ export class ExpressGenerator {
   constructor(private analysis: Analysis) {}
 
   async generate(opts: GenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outputDir);
     const ctx: RenderContext = { out };

--- a/packages/generator-fastify/src/index.ts
+++ b/packages/generator-fastify/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter, type FileSink } from '@drzl/validation-core';
 import type { Analysis, Column, Table } from '@drzl/analyzer';
 import { tableSchemas, type Schema } from '@drzl/generator-json-schema';
 import type { ImportExtension } from '@drzl/validation-core';
@@ -149,6 +150,16 @@ export interface GenerateOptions {
    * `moduleResolution` without a compiler flag.
    */
   importExtension?: ImportExtension;
+  /**
+   * Where the generated files go, when that is not the filesystem.
+   *
+   * Omitted, they go to disk exactly as before. Passed, every write and every `mkdir` is handed
+   * to the sink instead, which is what `drzl generate --dry-run` and `drzl generate --check`
+   * are built on: both need the content a run would produce without the run producing it. See
+   * `emit.ts` in @drzl/validation-core for why this is an option rather than an interception of
+   * `node:fs/promises`.
+   */
+  fileSink?: FileSink;
 }
 
 /**
@@ -368,7 +379,7 @@ export class FastifyGenerator {
   constructor(private analysis: Analysis) {}
 
   async generate(opts: GenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outputDir);
     const ctx: RenderContext = { out };

--- a/packages/generator-graphql/src/index.ts
+++ b/packages/generator-graphql/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter, type FileSink } from '@drzl/validation-core';
 import type { Analysis, Column, Table } from '@drzl/analyzer';
 import type { ImportExtension } from '@drzl/validation-core';
 import {
@@ -78,6 +79,16 @@ export interface GenerateOptions {
    * `moduleResolution` without a compiler flag.
    */
   importExtension?: ImportExtension;
+  /**
+   * Where the generated files go, when that is not the filesystem.
+   *
+   * Omitted, they go to disk exactly as before. Passed, every write and every `mkdir` is handed
+   * to the sink instead, which is what `drzl generate --dry-run` and `drzl generate --check`
+   * are built on: both need the content a run would produce without the run producing it. See
+   * `emit.ts` in @drzl/validation-core for why this is an option rather than an interception of
+   * `node:fs/promises`.
+   */
+  fileSink?: FileSink;
 }
 
 const GRAPHQL_NAME = /^[_A-Za-z][_0-9A-Za-z]*$/;
@@ -834,7 +845,7 @@ export class GraphQLGenerator {
   constructor(private analysis: Analysis) {}
 
   async generate(opts: GenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outputDir);
     await fs.mkdir(out, { recursive: true });

--- a/packages/generator-hono/src/index.ts
+++ b/packages/generator-hono/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter, type FileSink } from '@drzl/validation-core';
 import type { Analysis, Column, Table } from '@drzl/analyzer';
 import type { AffixOptions, ImportExtension } from '@drzl/validation-core';
 import {
@@ -77,6 +78,16 @@ export interface GenerateOptions {
     schemaSuffix?: string;
     affix?: AffixOptions;
   };
+  /**
+   * Where the generated files go, when that is not the filesystem.
+   *
+   * Omitted, they go to disk exactly as before. Passed, every write and every `mkdir` is handed
+   * to the sink instead, which is what `drzl generate --dry-run` and `drzl generate --check`
+   * are built on: both need the content a run would produce without the run producing it. See
+   * `emit.ts` in @drzl/validation-core for why this is an option rather than an interception of
+   * `node:fs/promises`.
+   */
+  fileSink?: FileSink;
 }
 
 type Lib = NonNullable<NonNullable<GenerateOptions['validation']>['library']>;
@@ -391,7 +402,7 @@ export class HonoGenerator {
   constructor(private analysis: Analysis) {}
 
   async generate(opts: GenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outputDir);
     const ctx: RenderContext = { out };

--- a/packages/generator-json-schema/src/index.ts
+++ b/packages/generator-json-schema/src/index.ts
@@ -14,6 +14,7 @@
  *   components   `components.schemas` for an OpenAPI document, on `components: true`
  *   document     the whole OpenAPI document, paths and all, on `document: true`
  */
+import { fileWriter } from '@drzl/validation-core';
 import type { Analysis, Enum, Table } from '@drzl/analyzer';
 import type { ResolvedAffix, ValidationGenerateOptions } from '@drzl/validation-core';
 import {
@@ -132,7 +133,7 @@ export class JsonSchemaGenerator {
   constructor(private analysis: Analysis) {}
 
   async generate(opts: JsonSchemaGenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outDir);
     const files: string[] = [];

--- a/packages/generator-nestjs/src/index.ts
+++ b/packages/generator-nestjs/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter, type FileSink } from '@drzl/validation-core';
 import type { Analysis, Column, Table } from '@drzl/analyzer';
 import type { ImportExtension } from '@drzl/validation-core';
 import {
@@ -125,6 +126,16 @@ export interface GenerateOptions {
   validation?: {
     library?: 'zod' | 'valibot' | 'arktype';
   };
+  /**
+   * Where the generated files go, when that is not the filesystem.
+   *
+   * Omitted, they go to disk exactly as before. Passed, every write and every `mkdir` is handed
+   * to the sink instead, which is what `drzl generate --dry-run` and `drzl generate --check`
+   * are built on: both need the content a run would produce without the run producing it. See
+   * `emit.ts` in @drzl/validation-core for why this is an option rather than an interception of
+   * `node:fs/promises`.
+   */
+  fileSink?: FileSink;
 }
 
 type Lib = NonNullable<NonNullable<GenerateOptions['validation']>['library']>;
@@ -417,7 +428,7 @@ export class NestJSGenerator {
   constructor(private analysis: Analysis) {}
 
   async generate(opts: GenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outputDir);
     const ctx: RenderContext = { out };

--- a/packages/generator-orpc/src/index.ts
+++ b/packages/generator-orpc/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter, type FileSink } from '@drzl/validation-core';
 import type { Analysis, Column, Table } from '@drzl/analyzer';
 import { qualifiedTableName } from '@drzl/analyzer';
 import type { AffixOptions, ImportExtension } from '@drzl/validation-core';
@@ -57,6 +58,16 @@ export interface GenerateOptions {
     databaseTypeImport?: { name: string; from: string };
   };
   servicesDir?: string; // Path to services directory (e.g. 'src/services')
+  /**
+   * Where the generated files go, when that is not the filesystem.
+   *
+   * Omitted, they go to disk exactly as before. Passed, every write and every `mkdir` is handed
+   * to the sink instead, which is what `drzl generate --dry-run` and `drzl generate --check`
+   * are built on: both need the content a run would produce without the run producing it. See
+   * `emit.ts` in @drzl/validation-core for why this is an option rather than an interception of
+   * `node:fs/promises`.
+   */
+  fileSink?: FileSink;
 }
 
 export interface ProcedureSpec {
@@ -543,7 +554,7 @@ export class ORPCGenerator {
   }
 
   async generate(opts: GenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outputDir);
     await fs.mkdir(out, { recursive: true });

--- a/packages/generator-service/src/index.ts
+++ b/packages/generator-service/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter, type FileSink } from '@drzl/validation-core';
 import type { Analysis, Table, Column } from '@drzl/analyzer';
 import type { ImportExtension } from '@drzl/validation-core';
 import { formatCode, importSpecifier, resolveConfiguredImport } from '@drzl/validation-core';
@@ -27,6 +28,16 @@ export interface ServiceGenerateOptions {
     databaseType?: string; // Type annotation for injected database (e.g. 'DrizzleD1Database', 'Database' or 'import("../db").Database')
     databaseTypeImport?: { name: string; from: string }; // Optional: import type { name } from 'from'
   };
+  /**
+   * Where the generated files go, when that is not the filesystem.
+   *
+   * Omitted, they go to disk exactly as before. Passed, every write and every `mkdir` is handed
+   * to the sink instead, which is what `drzl generate --dry-run` and `drzl generate --check`
+   * are built on: both need the content a run would produce without the run producing it. See
+   * `emit.ts` in @drzl/validation-core for why this is an option rather than an interception of
+   * `node:fs/promises`.
+   */
+  fileSink?: FileSink;
 }
 
 function cap(s: string) {
@@ -483,7 +494,7 @@ export class ServiceGenerator {
   constructor(private analysis: Analysis) {}
 
   async generate(opts: ServiceGenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outDir);
     const typesDir = path.join(out, 'types');

--- a/packages/generator-trpc/src/index.ts
+++ b/packages/generator-trpc/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter, type FileSink } from '@drzl/validation-core';
 import type { Analysis, Column, Table } from '@drzl/analyzer';
 import type { AffixOptions, ImportExtension } from '@drzl/validation-core';
 import {
@@ -77,6 +78,16 @@ export interface GenerateOptions {
   };
   /** Where `@drzl/generator-service` is writing, for `template: 'service'`. */
   servicesDir?: string;
+  /**
+   * Where the generated files go, when that is not the filesystem.
+   *
+   * Omitted, they go to disk exactly as before. Passed, every write and every `mkdir` is handed
+   * to the sink instead, which is what `drzl generate --dry-run` and `drzl generate --check`
+   * are built on: both need the content a run would produce without the run producing it. See
+   * `emit.ts` in @drzl/validation-core for why this is an option rather than an interception of
+   * `node:fs/promises`.
+   */
+  fileSink?: FileSink;
 }
 
 /**
@@ -345,7 +356,7 @@ export class TRPCGenerator {
   constructor(private analysis: Analysis) {}
 
   async generate(opts: GenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outputDir);
     const ctx: RenderContext = {

--- a/packages/generator-typebox/src/index.ts
+++ b/packages/generator-typebox/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter } from '@drzl/validation-core';
 import type { Analysis, Table, Column } from '@drzl/analyzer';
 import type {
   ColumnCheck,
@@ -1505,7 +1506,7 @@ export class TypeBoxGenerator implements ValidationRenderer<TypeBoxGenerateOptio
   constructor(private analysis: Analysis) {}
 
   async generate(opts: TypeBoxGenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outDir);
     const files: string[] = [];

--- a/packages/generator-valibot/src/index.ts
+++ b/packages/generator-valibot/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter } from '@drzl/validation-core';
 import type { Analysis, Table, Column } from '@drzl/analyzer';
 import type {
   ResolvedAffix,
@@ -985,7 +986,7 @@ export class ValibotGenerator implements ValidationRenderer<ValibotGenerateOptio
   constructor(private analysis: Analysis) {}
 
   async generate(opts: ValibotGenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outDir);
     const files: string[] = [];

--- a/packages/generator-zod/src/index.ts
+++ b/packages/generator-zod/src/index.ts
@@ -1,3 +1,4 @@
+import { fileWriter } from '@drzl/validation-core';
 import type { Analysis, Column, Table } from '@drzl/analyzer';
 import type {
   ResolvedAffix,
@@ -1037,7 +1038,7 @@ export class ZodGenerator implements ValidationRenderer<ZodGenerateOptions> {
   constructor(private analysis: Analysis) {}
 
   async generate(opts: ZodGenerateOptions) {
-    const fs = await import('node:fs/promises');
+    const fs = fileWriter(opts.fileSink);
     const path = await import('node:path');
     const out = path.resolve(process.cwd(), opts.outDir);
     const files: string[] = [];

--- a/packages/validation-core/src/emit.ts
+++ b/packages/validation-core/src/emit.ts
@@ -1,0 +1,106 @@
+/**
+ * Where a generator's files go, so that "write it" and "tell me what you would write" are the same
+ * code path (plan items 68, 80, 81).
+ *
+ * Three requests turn out to be one mechanism. `--dry-run` needs to know what would be written
+ * without writing it, `generate` needs to say which files it created and which it changed rather
+ * than only how many it wrote, and `--check` needs to show a diff of the difference. All three are
+ * the same question asked per file: what content is about to land here, and what is here now. The
+ * only thing a generator has to give up for that is deciding, itself, that the answer goes to disk.
+ *
+ * ## Why an option and not an interception
+ *
+ * The tempting version is to leave every generator alone and patch `node:fs/promises` for the
+ * duration of the run, since each one reaches it through `await import('node:fs/promises')`. That
+ * was measured and rejected. Patching the CommonJS exports object is visible through a later
+ * dynamic import, but a module namespace that already exists is a snapshot and never changes:
+ *
+ *   const ns = await import('node:fs/promises');       // namespace built here
+ *   require('node:fs/promises').writeFile = spy;       // patch applied after
+ *   ns.writeFile === spy                               // false, measured on Node 22.22
+ *
+ * The CLI links `chokidar`, which imports `node:fs/promises` at module scope, so by the time any
+ * command body runs the namespace usually exists and the patch is invisible. A dry run built on
+ * that would write real files whenever an unrelated dependency happened to import first, which is
+ * the worst possible failure for this feature: silent, environmental, and destructive. An explicit
+ * option cannot fail that way, because a generator that never received a sink is a generator whose
+ * call site can be read.
+ *
+ * ## Shape
+ *
+ * `fileWriter` returns an object with the two methods every generator already calls on the
+ * `node:fs/promises` namespace, with the same signatures, so adopting it is one line per generator
+ * and no write site changes at all:
+ *
+ *   const fs = await import('node:fs/promises');   ->   const fs = fileWriter(opts.fileSink);
+ *
+ * That matters more than it looks. Fourteen generators write files, between one and six times
+ * each, and a change that touched every one of those sites would be fourteen chances to miss one
+ * and ship a dry run that writes.
+ */
+
+/**
+ * Somewhere for a generator's output to go that is not the filesystem.
+ *
+ * `mkdir` is part of it because a dry run that creates directories is not a dry run: run in an
+ * empty project, the honest answer leaves the directory empty, and `fs.mkdir(out, { recursive:
+ * true })` is the first thing every generator does.
+ */
+export interface FileSink {
+  mkdir(dir: string): void | Promise<void>;
+  writeFile(file: string, contents: string): void | Promise<void>;
+}
+
+/**
+ * The `node:fs/promises` subset generators use, narrowed to the two calls they actually make.
+ *
+ * Declared structurally rather than imported from `node:fs` so that the real namespace satisfies
+ * it without a cast and a sink can too. The `options` and `encoding` parameters are accepted and
+ * ignored by a sink: every call site in this repository passes `{ recursive: true }` and `'utf8'`,
+ * and a sink that took different arguments would make the swap a rewrite rather than a rename.
+ */
+export interface GeneratorFs {
+  mkdir(dir: string, options?: { recursive?: boolean }): Promise<unknown>;
+  writeFile(file: string, contents: string, encoding?: BufferEncoding): Promise<void>;
+}
+
+/**
+ * `node:fs/promises`, imported at most once per process.
+ *
+ * Lazily, because that is how every generator reached it before this file existed and a static
+ * import would put `node:fs` in the module graph of a package whose other exports are pure string
+ * work. Once, rather than per call, because the alternative is a dynamic import per written file
+ * and a generator emitting six hundred modules would perform six hundred of them for no reason.
+ */
+let realFs: Promise<typeof import('node:fs/promises')> | null = null;
+function nodeFs() {
+  return (realFs ??= import('node:fs/promises'));
+}
+
+/**
+ * The filesystem, or whatever was passed instead of it.
+ *
+ * Without a sink this is `node:fs/promises` itself, so a run with no sink performs the same calls
+ * in the same order as before this existed.
+ */
+export function fileWriter(sink?: FileSink): GeneratorFs {
+  if (!sink) {
+    return {
+      async mkdir(dir: string, options?: { recursive?: boolean }) {
+        return (await nodeFs()).mkdir(dir, options);
+      },
+      async writeFile(file: string, contents: string, encoding: BufferEncoding = 'utf8') {
+        return (await nodeFs()).writeFile(file, contents, encoding);
+      },
+    };
+  }
+  return {
+    async mkdir(dir: string) {
+      await sink.mkdir(dir);
+      return undefined;
+    },
+    async writeFile(file: string, contents: string) {
+      await sink.writeFile(file, contents);
+    },
+  };
+}

--- a/packages/validation-core/src/index.ts
+++ b/packages/validation-core/src/index.ts
@@ -6,12 +6,14 @@ import { pathToFileURL } from 'node:url';
 import type { Analysis, Column } from '@drzl/analyzer';
 import type { BrandingOption } from './branding.js';
 import { parseCheck } from './checks.js';
+import type { FileSink } from './emit.js';
 import type { ImportExtension } from './files.js';
 import type { AffixOptions } from './naming.js';
 
 export * from './branding.js';
 export * from './checks.js';
 export * from './constraints.js';
+export * from './emit.js';
 export * from './files.js';
 export * from './meta.js';
 export * from './naming.js';
@@ -168,6 +170,15 @@ export interface ValidationGenerateOptions {
     insert?: boolean;
     update?: boolean;
   };
+  /**
+   * Where the generated files go, when that is not the filesystem.
+   *
+   * Omitted, they go to disk exactly as before. Passed, every write and every `mkdir` is handed to
+   * the sink instead, which is what `drzl generate --dry-run` and `drzl generate --check` are
+   * built on: both need the content a run would produce without the run producing it. See
+   * `emit.ts` for why this is an option rather than an interception of `node:fs/promises`.
+   */
+  fileSink?: FileSink;
 }
 
 export interface ValidationRenderer<


### PR DESCRIPTION
Plan items 68, 80, 81, 75 and 82 as one change, built on the single observation that a dry run, a change report and a check diff all need the same per-file verdict.

## The mechanism

Generators no longer call `node:fs/promises` themselves; they take a `fileSink` shaped like the `fs` namespace they already used, so adoption was **one line per generator across fourteen packages** with no write site changed. The sink records `{file, before, after, verdict}` where verdict is created / changed / unchanged, and in plan mode records without writing. `--dry-run` stops there, `generate` reports from it, `--check` diffs from it.

**Interception was measured and rejected**, not assumed: patching a CommonJS exports object is visible to a later dynamic import, but an already-materialised module namespace is a snapshot, so with chokidar importing `node:fs/promises` at module scope, a dry run built that way would write real files whenever an unrelated dependency imported first. Silent, environmental, destructive.

## Proofs and decisions

- **No writes**: the directory is compared byte for byte, entries and contents, rather than by looking for generated files. Enforced at runtime as well, since generators are separately versioned and an older one would accept the option and ignore it: output dirs are snapshotted, anything written is restored, and the run fails with a named code.
- **Dry-run exit code is 0** whether or not anything would change: a run that computed its answer did what it was asked, and `2` is for a run that found what it was told to look for. A preview of a never-generated project would otherwise exit non-zero for being new.
- **Diff is unified, written in-house** (Myers with prefix/suffix trimming), because jsdiff resolves here only as a transitive devDependency of ts-node, so using it would rely on a hoist and promoting it costs a package on every CLI install for ~100 lines. It is validated by **applying its own output**: every case replays the emitted patch against the before text and requires the after text exactly, with a deliberately naive hunk reader so a bug cannot cancel itself out. Caps (20 files, 4000 lines, 1500 edits) are stated in the output; every drifted file is still named, only the explanation is capped.

## Two defects nobody had filed

- **`--check` was writing.** It regenerated over your tree and restored a snapshot, so the one command documented as never touching your tree rewrote every generated file on every CI run, with a window where a kill left it modified. Now it never writes. Accepted and documented consequence: `removed` drift is gone, because listing unrecognised files in an output directory would fail CI for any config whose `outDir` is `src`. Filed as **BY** with the manifest-based fix.
- **Watch ran rebuilds concurrently.** The debounce guards the wait, not the work, so a change arriving during a rebuild started another on top: measured on the shipped build with a 600-table schema, six saves 700ms apart produced **six rebuilds with four running concurrently**, all writing one output directory. Now five rebuilds, max concurrency 1.

## Measurements behind the smaller choices

The 200ms debounce is **kept but justified**: with the existing `awaitWriteFinish`, one save is already one event and the widest intra-burst gap was 9ms (without it: 5 events / 62ms for a chunked write, 3 / 101ms atomic, 2 / 121ms format-on-save). `--debounce 0` was read as absent by `Number(x) || 200`, as was `--debounce banana`. Clear-screen is now opt-in, on stderr and TTY-gated: `console.clear()` was mandatory (wiping the previous rebuild's errors) and decided from **stdout** while every human line goes to stderr, so `drzl watch > events.json` at a terminal cleared nothing.

**Item 82 closes as already-done with numbers**: one analysis per run across 1, 2, 3 and 5 generators at a constant 37ms on 200 tables, where four extra analyses would have added ~148ms against 2468ms of generator work. A test now pins "one analysis per run" so a refactor moving the analyzer into the loop fails loudly.

## Red-first

Reverting each fix in turn: watch concurrency 3 of 12 fail; clear-screen fails with `console.clear()` restored (the assertion covers `[2J`, `[3J`, `[0J` and `[1;1H`, because `console.clear()` emits `ESC[1;1H ESC[0J`, which a test naming only the new spelling would have passed); forcing the plan to write fails **12** tests including the runtime guard firing on `--check`. The diff tests were genuinely red twice during development.

Gates green (303 test files, CLI at 839 tests, verify-packed unmodified with no FAIL lines). One correction to my brief, worth recording: `verify-packed.sh` never runs `generate --check`; it runs plain `generate` and greps the generated files, not CLI output.

## Deliberate non-change

`generate` still rewrites byte-identical files even though the plan now knows they are unchanged. Making it idempotent would stop downstream watchers rebuilding for nothing, but no item asked for it and it is a side-effect change; filed in **BY** beside the manifest question, since both concern what `generate` owns on disk.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
