### PR TITLE
feat: drzl explain, and a gate stage that holds it to doctor (item 69)

### DIFF
--- a/.changeset/explain-command.md
+++ b/.changeset/explain-command.md
@@ -1,0 +1,46 @@
+---
+'@drzl/cli': minor
+---
+
+`drzl explain <table>`: what DRZL understood about one table
+
+When a generated schema is wrong, nothing said where it went wrong. `drzl analyze` prints the whole
+`Analysis` for the whole schema as JSON and points at nothing in it, and `drzl doctor` prints only
+the findings, across every table, and is silent about a table that is fine. Neither answers "did
+DRZL misread this column, drop this CHECK, or fail to follow this relation".
+
+`drzl explain users` prints, for one table: the resolved TypeScript type and the declared SQL type
+per column, with the array depth on the first (a `text[]` reads as `string[]`, not `string`);
+nullability, the key, the unique constraints, the foreign keys and the relations; and every measured
+fact the validation generators act on, which is the range, whether the values are whole, whether the
+column stores `NaN` and the infinities, the declared width or byte cap, the format, the enum
+members, the structured shape and the default.
+
+Two sections exist for the silent half. Every declared CHECK is shown **as parsed**, with the
+verdict a generated schema gives it and, where nothing enforces it, the shared parser's own reason.
+And a "Not understood" section collects, in one place, every CHECK clause nothing enforces, every
+column with no known type, and every relation the analyzer could not follow. All three produce a
+generated file that exists, compiles and checks less than the database does, with nothing anywhere
+saying so.
+
+A fact the generators deliberately do not state is marked and explained rather than listed as
+though it were enforced: a `varchar(32)` narrowed by `CHECK (label IN ('a','b'))` never reaches the
+schema as a width, and a `defaultNow()` makes the field optional on insert without any schema
+stating what it becomes. Those verdicts are read off `tableConstraints` in `@drzl/validation-core`,
+which is the same function the emitted constraint ledger is built from, so the report and the
+generated modules cannot disagree.
+
+A table is found by its database name, its schema-qualified name (`reporting.users`, and
+`public.users` for the default schema) or its TypeScript export name, exact first and then ignoring
+case. A name reaching two tables is refused with both of them named rather than resolved silently.
+A name reaching none lists the tables there are, with the near miss. A table your config's
+`include`/`exclude` removes is still found and still explained, with a line saying the config
+removes it, because that is the answer to "why is there no file for this table".
+
+With no table argument it prints one line per table with a count of what `explain` would report as
+not understood for each, which on a large schema is what says where to look.
+
+`--json` writes one document with the envelope merged in at the top level and the same information
+under stable keys, `--quiet` keeps the report and drops only the hints, and it exits `0` when it
+explained the table and `1` when the name reaches no table or more than one, or when there is no
+schema to read. It writes nothing, ever.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -56,6 +56,7 @@ export default {
           { text: 'Overview', link: '/cli' },
           { text: 'Init', link: '/cli/init' },
           { text: 'Analyze', link: '/cli/analyze' },
+          { text: 'Explain', link: '/cli/explain' },
           { text: 'Doctor', link: '/cli/doctor' },
           { text: 'Generate', link: '/cli/generate' },
           { text: 'Generate (oRPC)', link: '/cli/generate-orpc' },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,6 +31,7 @@ Jump to commands:
 
 - Init: set up a starter config → [/cli/init](/cli/init)
 - Analyze: inspect a schema → [/cli/analyze](/cli/analyze)
+- Explain: what DRZL understood about one table → [/cli/explain](/cli/explain)
 - Doctor: what DRZL cannot type or enforce → [/cli/doctor](/cli/doctor)
 - Generate: run configured generators → [/cli/generate](/cli/generate)
 - Generate (oRPC): quick oRPC without config → [/cli/generate-orpc](/cli/generate-orpc)
@@ -84,6 +85,43 @@ Options:
 
 Exits `1` when the schema could not be read at all, and `2` when it was read and `issues` holds an
 error-level entry. See [Exit codes](/cli/output#exit-codes).
+
+### explain
+
+Show what DRZL understood about one table: the type it resolved for every column, the facts the
+generators read off it, the constraints it will enforce, and the ones it read and could not use.
+
+::: code-group
+
+```bash [pnpm]
+pnpm dlx @drzl/cli explain <table> [--json] [-s src/db/schema.ts] [-c drzl.config.ts]
+```
+
+```bash [npm]
+npx @drzl/cli explain <table> [--json] [-s src/db/schema.ts] [-c drzl.config.ts]
+```
+
+```bash [yarn]
+yarn dlx @drzl/cli explain <table> [--json] [-s src/db/schema.ts] [-c drzl.config.ts]
+```
+
+```bash [bun]
+bunx @drzl/cli explain <table> [--json] [-s src/db/schema.ts] [-c drzl.config.ts]
+```
+
+:::
+
+Options:
+
+- `[table]`: the table, by database name, qualified name or export name. Omit it for the index.
+- `-s, --schema <path>`: the schema to read, overriding the config
+- `-c, --config <path>`: which config to read the schema path from
+- `--json`, `-q, --quiet`
+
+Writes nothing. Exits `0` when the table was explained, `1` when the name reaches no table or more
+than one, or when there is no schema to read.
+
+See [Explain](/cli/explain).
 
 ### doctor
 

--- a/docs/cli/analyze.md
+++ b/docs/cli/analyze.md
@@ -63,3 +63,9 @@ A failure is a document too, never prose on stdout:
 
 `1` and `2` were both `2` before. They are different events: the first means the document you
 asked for is not there, the second means it is there and something in it needs looking at.
+
+## See also
+
+This prints the whole `Analysis` and points at nothing in it. When the question is about one table,
+[`explain`](/cli/explain) reads the same analysis and says what DRZL made of that table, including
+which of its constraints reach the generated schemas and which do not.

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -205,5 +205,11 @@ validator check the value, which nothing can do for a `customType`, but it recov
 TypeScript type so the call site is still narrowed. See
 [Generators → Zod](/generators/zod#typedjson).
 
-See also: [Analyze](/cli/analyze) · [Generate](/cli/generate) ·
+See also: [Analyze](/cli/analyze) · [Explain](/cli/explain) · [Generate](/cli/generate) ·
 [Output & exit codes](/cli/output)
+
+`doctor` reports the findings across every table and says nothing about a table that is fine.
+[`explain`](/cli/explain) is the other direction: everything about one table, including the
+constraints it *does* enforce and the facts it read off each column, with the same silent failures
+called out at the bottom. Reach for `doctor` when the question is "what will not work in this
+schema", and for `explain` when it is "what did DRZL make of this table".

--- a/docs/cli/explain.md
+++ b/docs/cli/explain.md
@@ -1,0 +1,362 @@
+# Explain
+
+Show what DRZL understood about **one table**: the type it resolved for every column, the facts it
+measured, the constraints it will enforce, and the ones it read and could not use.
+
+Usage:
+
+::: code-group
+
+```bash [pnpm]
+pnpm dlx @drzl/cli explain <table> [--json] [-s src/db/schema.ts] [-c drzl.config.ts]
+```
+
+```bash [npm]
+npx @drzl/cli explain <table> [--json] [-s src/db/schema.ts] [-c drzl.config.ts]
+```
+
+```bash [yarn]
+yarn dlx @drzl/cli explain <table> [--json] [-s src/db/schema.ts] [-c drzl.config.ts]
+```
+
+```bash [bun]
+bunx @drzl/cli explain <table> [--json] [-s src/db/schema.ts] [-c drzl.config.ts]
+```
+
+:::
+
+Options:
+
+- `<table>`: the table to explain. Omit it for the index of every table; see
+  [The index](#the-index).
+- `-s, --schema <path>`: the schema to read. Overrides the config.
+- `-c, --config <path>`: which `drzl.config` to read the schema path from.
+- `--json`, `-q, --quiet`: as everywhere else, see [Output & exit codes](/cli/output).
+
+With neither flag it reads the `schema` path out of your `drzl.config.*`, then out of your
+drizzle-kit config, and failing both it looks for a schema in the usual places and confirms a
+candidate by importing it and finding Drizzle tables in it. So `drzl explain users` works in a
+checkout with nothing configured at all.
+
+It writes nothing, ever.
+
+## When to reach for it
+
+Your generated schema is wrong. Something about `users` validates a value the database refuses, or
+refuses one it accepts, and the question is **where** it went wrong: did DRZL misread the column
+type, drop the CHECK, fail to follow the relation, or read all three correctly?
+
+Nothing else answers that. [`analyze`](/cli/analyze) prints the whole `Analysis` for the whole
+schema as JSON and points at nothing in it. [`doctor`](/cli/doctor) prints only the findings, across
+every table, and says nothing about a table that is fine. This prints everything about one table,
+with the things it could not use called out at the bottom.
+
+## Example
+
+```bash
+npx @drzl/cli explain users
+```
+
+```
+users  src/db/schema.ts
+  postgres, table "users", export "users", 13 columns
+
+Columns
+  COLUMN     TS TYPE   SQL TYPE                  NULL
+  id         number    serial                    no    pk, has default
+  email      string    varchar(255)              no    unique
+  nickname   string    text                      yes   default 'anon'
+  role       string    role                      no    default 'member'
+  age        number    integer                   yes
+  balance    string    numeric(10, 2)            no
+  score      number    double precision          yes
+  followers  bigint    bigint                    no
+  visits     number    bigint                    no
+  ref        string    uuid                      no
+  tags       string[]  text[]                    yes
+  payload    any       jsonb                     yes
+  createdAt  Date      timestamp with time zone  no    has default
+
+What the generators read off each column
+  id         -2147483648 to 2147483647
+             whole numbers only
+             has a default
+             not stated by any generated schema: the value is produced at insert
+             time, by the database or by a Drizzle function, so the field is
+             optional on insert and no schema states what it becomes
+  email      at most 255 characters
+  nickname   defaults to 'anon'
+  role       one of 'admin', 'member', 'guest'
+             defaults to 'member'
+  age        -2147483648 to 2147483647
+             whole numbers only
+  score      fractions allowed
+             NaN is stored and returned
+             Infinity is stored and returned
+  followers  -9223372036854775808 to 9223372036854775807
+             whole numbers only
+  visits     -9007199254740991 to 9007199254740991
+             whole numbers only
+  ref        text in the uuid format the database parses
+  tags       an array of the type above
+  payload    any JSON value, checked recursively
+  createdAt  has a default
+             not stated by any generated schema: the value is produced at insert
+             time, by the database or by a Drizzle function, so the field is
+             optional on insert and no schema states what it becomes
+
+Keys
+  PRIMARY KEY (id)  filled in by the database
+  UNIQUE (email)
+  INDEX (id)
+
+Relations
+  memberships -> users  one
+  users -> memberships  many
+
+CHECK constraints, as DRZL parsed them
+  age_adult     CHECK (age >= 18)
+                enforced
+  nickname_len  CHECK (length(nickname) > 2)
+                enforced
+  email_shape   CHECK (email ~ '^[^@]+@[^@]+$')
+                not enforced by any generated schema
+                not a single comparison this version understands
+  tags_present  CHECK (cardinality(tags) > 0)
+                enforced
+
+Not understood  (1)
+  These are in your schema and are not in anything DRZL generates.
+
+  - email_shape: email ~ '^[^@]+@[^@]+$' is not enforced: not a single
+    comparison this version understands.
+    Your database still enforces it. Nothing DRZL generates does.
+```
+
+The whole report fits a terminal 80 columns wide.
+
+## What each section answers
+
+### Columns
+
+The **`TS TYPE`** is what the generated schema will accept and return, with the array depth on it:
+`text().array()` is `string[]` here, because Drizzle gives an array no column class of its own and
+reading the class alone is what once produced a schema for the element.
+
+The **`SQL TYPE`** is the type as the database declares it, taken from Drizzle's own
+`getSQLType()`. This is the wire, and it is the column to read first when a value round-trips
+wrongly: `bigint` in `{ mode: 'number' }` and in `{ mode: 'bigint' }` are the same SQL type and two
+different TypeScript ones, `int unsigned` is not `int`, and `varchar(255)` is not `text`.
+
+The last cell carries what the column is to the table: `pk`, `unique`, `fk -> users.id`,
+`generated`, and its default.
+
+### What the generators read off each column
+
+Every measured fact the validation generators act on: the range, whether it is whole, whether the
+column stores `NaN` and the infinities, the declared width or byte cap, a format the database
+parses, the enum members, the array depth, the structured shape, and the default.
+
+A fact printed **in yellow with a reason under it** is one nothing generated states. That is the
+line to read when your question is "why is my schema not checking this". There are two ways it
+happens:
+
+- **A default nobody can reproduce.** `defaultNow()`, `defaultRandom()`, `$defaultFn` and a
+  `serial`'s sequence all produce their value at insert time. The field is optional on insert and no
+  schema says what it becomes.
+- **A width the value space already states another way.** A `varchar(32)` narrowed by
+  `CHECK (label IN ('a','b'))`, an enum column, and a `uuid` or `numeric` column all state what they
+  hold by their members or their format, and the width is never written. This is measured off the
+  same guard the generators apply, not from a second copy of the rule, so the report and the emitted
+  module cannot disagree.
+
+### Keys, foreign keys, relations
+
+The primary key **whole**, composite included, with a note when it is composite: the service and
+router generators key `getById`, `update` and `delete` on its first column alone.
+
+### CHECK constraints, as DRZL parsed them
+
+Not the raw SQL. Each declared CHECK with the verdict a generated schema gives it, and where the
+verdict is "not enforced", the parser's own reason. `age >= 18` folds into a range, `length(x) > 2`
+becomes a predicate, `cardinality(tags) > 0` becomes an element count, and a regex or an
+`OR` across two branches is refused whole, because a validator enforcing a *guess* at your
+constraint rejects rows the database accepts.
+
+### Not understood
+
+Everything on this table that DRZL read and could not use, in one place:
+
+- a CHECK, or one clause of one, that nothing enforces
+- a column with no known type, whose validator will accept any value
+- a relation the analyzer could not follow
+- anything else the analyzer reported about this table
+
+When there is nothing, it says so: `Nothing about this table was dropped or left unrecognised.`
+
+## Finding the table by name
+
+A table is matched against three names: its **database name**, its **schema-qualified name**
+(`reporting.users`, and `public.users` for a table that declares no schema), and its **TypeScript
+export name**, since a reader looking at their own schema file may only know
+`export const orgMembers`.
+
+Exact first, over all three. Only when nothing matches exactly are they tried again ignoring case,
+and the report says so when that is how it matched.
+
+A name reaching **two** tables is refused rather than resolved, because answering a question about
+one table with facts about another is the one thing a diagnostic must not do:
+
+```
+$ drzl explain users
+"users" names 2 tables (DRZL_EXPLAIN_002): reporting.users (exported as reportingUsers),
+public.users (exported as users).
+Name one of them exactly, for example "reporting.users".
+```
+
+A name reaching **none** lists the tables there are, with the near miss where there is one:
+
+```
+$ drzl explain userz
+No table called "userz" (DRZL_EXPLAIN_001). This schema declares 3 tables: countries,
+memberships, users.
+Did you mean "users"?
+```
+
+## Your config's filters
+
+`explain` reads your `drzl.config`, and a table your `include`/`exclude` removes is still found and
+still explained, with a line saying the config removes it. That is the answer to "why is there no
+file for this table", and a command that could not find it would be answering a different question.
+Columns your `columns` filter removes are named the same way.
+
+## The index
+
+With no table argument it prints one line per table, with the number of things `explain` would
+report as not understood for each. On a schema with forty tables and one wrong file, this is what
+says which table to look at:
+
+```
+$ drzl explain
+src/db/schema.ts  postgres
+  3 tables
+
+  TABLE        EXPORT       COLUMNS
+  countries    countries    2
+  memberships  memberships  4
+  users        users        13       1 thing not understood
+
+  drzl explain <table>  for one of them in full
+```
+
+## `--json`
+
+One document, with the envelope merged in at the top level. See
+[Output & exit codes](/cli/output#json).
+
+```json
+{
+  "command": "explain",
+  "exitCode": 0,
+  "schema": "src/db/schema.ts",
+  "dialect": "postgres",
+  "table": {
+    "name": "memberships",
+    "tsName": "memberships",
+    "qualified": "memberships",
+    "addressable": "public.memberships",
+    "readOnly": false,
+    "matchedOn": "name",
+    "matchedExactly": true,
+    "columns": [
+      {
+        "name": "userId",
+        "tsType": "number",
+        "dbType": "INTEGER",
+        "sqlType": "integer",
+        "nullable": false,
+        "hasDefault": false,
+        "default": null,
+        "isGenerated": false,
+        "inPrimaryKey": true,
+        "unique": false,
+        "references": { "table": "users", "column": "id", "onDelete": "cascade" },
+        "facts": [
+          { "text": "-2147483648 to 2147483647", "stated": true },
+          { "text": "whole numbers only", "stated": true }
+        ]
+      }
+    ],
+    "primaryKey": { "columns": ["orgId", "userId"], "generated": false },
+    "unique": [{ "name": "membership_alt", "columns": ["userId", "joinedAt"] }],
+    "indexes": [{ "columns": ["orgId", "userId"] }],
+    "foreignKeys": [
+      {
+        "columns": ["userId"],
+        "references": { "table": "users", "columns": ["id"] },
+        "onDelete": "cascade"
+      }
+    ],
+    "relations": [{ "kind": "one", "from": "memberships", "to": "users", "outgoing": true }],
+    "constraints": [
+      {
+        "id": "memberships_userId_fkey",
+        "kind": "foreignKey",
+        "columns": ["userId"],
+        "rule": "FOREIGN KEY (userId) REFERENCES users (id) ON DELETE cascade",
+        "enforced": false,
+        "references": { "table": "users", "columns": ["id"], "onDelete": "cascade" }
+      }
+    ],
+    "gaps": []
+  }
+}
+```
+
+The keys, in the order they appear:
+
+| Key                       | Meaning                                                                    |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `schema`                  | the schema path, as it was resolved                                        |
+| `dialect`                 | the dialect the analyzer measured                                          |
+| `table`                   | the explanation. Present exactly when a table was named                    |
+| `table.qualified`         | `reporting.users`, or the bare name for the default schema                 |
+| `table.addressable`       | `public.users`: the spelling that reaches this table and no other          |
+| `table.matchedOn`         | `name`, `qualified` or `tsName`                                            |
+| `table.matchedExactly`    | `false` when the name matched only after case folding                      |
+| `table.excludedByConfig`  | present and `true` when this config's filters remove the table             |
+| `table.columnsRemovedByConfig` | present when this config's `columns` filter drops columns             |
+| `table.columns[].default` | `null`, or `{ kind: "literal", value }`, `{ kind: "expression", text }` or `{ kind: "runtime" }` |
+| `table.columns[].facts`   | `{ text, stated }`, plus `reason` where `stated` is `false`                |
+| `table.constraints`       | every constraint with `enforced`, and `unenforced` clauses with reasons     |
+| `table.gaps`              | what DRZL read and could not use: `{ kind, subject?, message, hint? }`      |
+
+`table.gaps[].kind` is `check`, `column`, `relation` or `analyzer`.
+
+With no table argument the document carries `tables` instead of `table`: one summary per table,
+`{ name, tsName, schema?, qualified, columns, checks, gaps }`.
+
+## Exit codes
+
+| Code | When                                                                                 |
+| ---- | ------------------------------------------------------------------------------------ |
+| `0`  | the table was explained, whatever the report says about it                           |
+| `1`  | no such table, an ambiguous name, or no schema DRZL could read                       |
+
+`2` is not used. A CHECK nothing enforces is a normal, usable schema, and a command that failed a
+pipeline for one would be switched off within a week. That is `doctor --strict`'s job; see
+[Exit codes](/cli/output#exit-codes).
+
+| Code              | Meaning                                        |
+| ----------------- | ---------------------------------------------- |
+| `DRZL_EXPLAIN_001` | There is no such table; the message lists the ones there are |
+| `DRZL_EXPLAIN_002` | The name reaches more than one table          |
+| `DRZL_SCHEMA_001` | The schema is missing, or the module would not import |
+| `DRZL_SCHEMA_002` | The schema imported cleanly and declares no tables |
+| `DRZL_CFG_001`    | There is no config, no drizzle-kit config and no schema to be found |
+
+## See also
+
+- [Doctor](/cli/doctor): the same silent failures, across every table, and nothing else
+- [Analyze](/cli/analyze): the whole `Analysis` as JSON
+- [Output & exit codes](/cli/output)

--- a/docs/cli/output.md
+++ b/docs/cli/output.md
@@ -10,6 +10,7 @@ to, whether it carries colour, what `--quiet` and `--json` do to it, and what th
 | Command                        | On stdout                                              |
 | ------------------------------ | ------------------------------------------------------ |
 | `analyze`                      | the analysis, as JSON                                  |
+| `explain`                      | the table report, as prose or as JSON                  |
 | `doctor`                       | the report, as prose or as JSON                        |
 | `generate`                     | the list of files written, one per line                |
 | `generate:orpc`, `generate:trpc` | the list of files written                            |
@@ -76,7 +77,7 @@ It does not remove:
   swallowed failure is worse off than one with no `--quiet` at all
 - **the exit code**, which means exactly what it means without the flag
 - **the answer** on stdout for the commands whose answer is text: `analyze` still prints the
-  analysis, `doctor` still prints the report
+  analysis, and `doctor` and `explain` still print their reports
 
 For `generate`, `generate:orpc`, `generate:trpc` and `init`, what the command produces is files on
 disk, so all of their text is a report about the work, and `--quiet` leaves them silent on success.
@@ -136,6 +137,8 @@ not produce its payload at all:
 | `DRZL_GEN_001`    | `generate` failed for any other reason                                 |
 | `DRZL_GEN_002`    | A generator threw, or is not installed                                 |
 | `DRZL_GEN_003`    | A generator wrote to disk during `--dry-run` or `--check`; see below   |
+| `DRZL_EXPLAIN_001`| `explain` was given a table name no table answers to                   |
+| `DRZL_EXPLAIN_002`| `explain` was given a name that reaches more than one table            |
 
 `DRZL_GEN_003` means an installed `@drzl/generator-*` package is older than the CLI and does not
 know how to report a file instead of writing it. Anything it wrote has been put back, and the fix
@@ -166,6 +169,19 @@ A schema that is missing or will not import is the one failure `analyze` reports
 document rather than through a failure envelope, because it still has one to give: the analysis
 comes back empty with the reason in `issues`, which says more than a one-line message would. The
 `exitCode` is `1` either way.
+
+### `explain --json`
+
+The explanation of one table, with the envelope merged in at the top level, so `.schema`,
+`.dialect` and `.table` sit beside `command` and `exitCode`. See
+[Explain](/cli/explain#json) for the shape of `.table`, key by key.
+
+```json
+{ "command": "explain", "exitCode": 0, "schema": "src/db/schema.ts", "dialect": "postgres", "table": {} }
+```
+
+With no table argument the document carries `tables`, an array of one summary per table, instead
+of `table`. Those are the only two shapes, and `.table` is present in exactly one of them.
 
 ### `doctor --json`
 
@@ -285,6 +301,7 @@ first and shows a diff or a report on the second.
 | Command                          | `0`                       | `1`                                                        | `2`                             |
 | -------------------------------- | ------------------------- | ---------------------------------------------------------- | ------------------------------- |
 | `analyze`                        | analysed                  | schema missing or could not be imported                    | analysed, with error-level issues |
+| `explain`                        | explained                 | no such table, an ambiguous name, or no schema to read      | not used                        |
 | `doctor`                         | reported                  | schema missing or could not be imported                    | findings **and** `--strict`     |
 | `generate`                       | generated                 | no config, invalid config, nothing to generate from, a generator threw | `--check` found drift |
 | `generate --dry-run`             | reported what it would write | as `generate`                                           | not used                        |
@@ -324,3 +341,7 @@ And two commands stopped reporting success when they had failed:
 
 `doctor`'s codes are unchanged: `0` when it read the schema, `1` when it could not, `2` with
 `--strict` and findings.
+
+`explain` arrived after this scheme and uses two of the three. A CHECK nothing enforces is a normal,
+usable schema, so a `2` there would fail a pipeline for a schema that is fine, which is the mistake
+`doctor` avoided by defaulting to `0`. `doctor --strict` is the command that exists to fail on that.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { SchemaAnalyzer } from '@drzl/analyzer';
+import { qualifiedTableName, SchemaAnalyzer } from '@drzl/analyzer';
 import { ORPCGenerator } from '@drzl/generator-orpc';
 import chokidar from 'chokidar';
 import { Command } from 'commander';
@@ -30,11 +30,22 @@ import {
 } from './config.js';
 import { ConfigValidationError } from './config-errors.js';
 import {
+  describeSchemaTarget,
   nothingToGenerate,
   schemaLoadFailure,
   type SchemaProblem,
 } from './schema-outcome.js';
 import { filterColumns } from './column-filter.js';
+import {
+  ambiguousTableProblem,
+  explainTable,
+  matchTable,
+  noSuchTableProblem,
+  renderExplanation,
+  renderIndex,
+  summarize,
+  type TableMatch,
+} from './explain.js';
 import {
   dialectMismatchWarning,
   resolveSchemaSource,
@@ -55,7 +66,7 @@ import {
 import { unifiedDiff } from './unified-diff.js';
 import { createRebuildScheduler, resolveDebounce } from './watch-loop.js';
 import { GeneratorNotInstalledError, loadGenerator } from './generator-loader.js';
-import { INIT_GENERATOR_CHOICES, runInit } from './init.js';
+import { detectSchema, INIT_GENERATOR_CHOICES, runInit } from './init.js';
 import { maybeShowSponsorMessage } from './sponsor.js';
 import { CLI_VERSION } from './version.js';
 
@@ -331,6 +342,172 @@ withOutputFlags(
       }
       process.exit(EXIT_FAILED);
     }
+  }
+});
+
+/**
+ * Where `drzl explain` reads the schema from, in the order the answers are trustworthy.
+ *
+ * `--schema` is what the caller said, so it wins outright. Then the config, through the same
+ * `resolveSchemaSource` every other command uses, so a drizzle-kit project needs no drzl config at
+ * all. Then item 66's loading-based detection, which is what makes `drzl explain users` work in a
+ * fresh checkout with nothing configured: a candidate is confirmed by importing it and finding
+ * Drizzle tables, not by its name.
+ *
+ * Never throws for want of a config. A diagnostic command that refuses to run until you have
+ * configured it is the one that gets reached for last.
+ */
+async function explainSchemaSource(
+  opts: { schema?: string; config?: string },
+  out: Output
+): Promise<
+  | { schema: string | string[]; label: string; note?: string; config?: DrzlConfig }
+  | undefined
+> {
+  // An explicit `--schema` reads no config at all, and so applies no filters. The flag says "look
+  // at this file", and narrowing it by a config that was written about a different one would
+  // report columns as removed that nothing removed.
+  if (opts.schema) return { schema: opts.schema, label: opts.schema };
+
+  const cfg = await loadConfig(opts.config, (w) => out.warn(w));
+  if (cfg) {
+    const source = await resolveSchemaSource(cfg);
+    for (const w of source.warnings) out.warn(w);
+    return {
+      schema: source.schema,
+      label: describeSchemaTarget(source.schema),
+      config: cfg,
+      ...(source.source === 'drizzle-kit' && source.drizzleKitConfigPath
+        ? { note: `Schema from ${path.relative(process.cwd(), source.drizzleKitConfigPath)}` }
+        : {}),
+    };
+  }
+
+  const detected = await detectSchema(process.cwd());
+  if (!detected.schema) return undefined;
+  return {
+    schema: detected.schema,
+    label: detected.schema,
+    note: detected.notes[detected.notes.length - 1],
+  };
+}
+
+withOutputFlags(
+  program
+    .command('explain')
+    .description('Show what DRZL understood about one table, and what it did not')
+    .argument(
+      '[table]',
+      'the table to explain, by database name, qualified name or export name; omit for the list'
+    )
+    .option('-c, --config <path>', 'path to drzl.config, read when --schema is not given')
+    .option('-s, --schema <path>', 'path to the schema, overriding the config')
+).action(async (tableName: string | undefined, opts: any) => {
+  const out = outputFor(opts);
+  /** Every failure this command has, reported the one way the output contract describes. */
+  const fail = (problem: { code: string; message: string; hint: string }): never => {
+    if (out.json) out.jsonData(jsonFailure('explain', problem.code, problem.message));
+    else {
+      out.error(problem.message);
+      out.hint(problem.hint);
+    }
+    process.exit(EXIT_FAILED);
+  };
+  try {
+    const source = await explainSchemaSource(opts, out);
+    if (!source) {
+      fail({
+        code: 'DRZL_CFG_001',
+        message:
+          'No schema found (DRZL_CFG_001). There is no drzl.config, no drizzle-kit config, and ' +
+          'no schema in the usual locations.',
+        hint: 'Pass --schema <path>, or run `drzl init` to write a config.',
+      });
+      return;
+    }
+    if (source.note) out.note(out.errStyle.gray(source.note));
+
+    const spinner = out.spinner('Reading the schema...');
+    const analysis = await new SchemaAnalyzer(source.schema).analyze({
+      // Both on, for the reason `doctor` turns both on: this command's job is to say everything
+      // that is known, and a relation that appears only under a flag is one a reader would be
+      // told is absent.
+      includeRelations: true,
+      validateConstraints: true,
+    });
+    spinner.stop();
+
+    // The analyzer's own verdict, not a guess from an empty table list: a module that would not
+    // import and a module that declares nothing are different mistakes in different files, and
+    // `schema-outcome.ts` is where that distinction already lives. Nothing about the sentence is
+    // reworded here beyond what did not happen, which for this command is never a file.
+    const problem =
+      schemaLoadFailure(analysis.issues, source.schema, 'There is nothing to explain.') ??
+      nothingToGenerate({
+        schema: source.schema,
+        analyzed: analysis.tables,
+        remaining: analysis.tables,
+        consequence: 'There is nothing to explain.',
+      });
+    if (problem) reportSchemaProblem(out, 'explain', problem);
+
+    const context = { schema: source.label, dialect: analysis.dialect };
+
+    if (!tableName) {
+      const tables = summarize(analysis);
+      if (out.json) out.jsonData({ command: 'explain', exitCode: EXIT_OK, ...context, tables });
+      else out.data(renderIndex(tables, context, out.outStyle));
+      process.exit(EXIT_OK);
+    }
+
+    const match = matchTable(analysis.tables, tableName);
+    if (match.kind === 'ambiguous') fail(ambiguousTableProblem(tableName, match.hits));
+    if (match.kind === 'none') {
+      fail(noSuchTableProblem(tableName, analysis.tables, match.suggestion));
+    }
+
+    // The filters are read but never applied to the search: a table this config excludes is
+    // exactly the one whose absence from the output needs explaining, and a command that could not
+    // find it would be answering "why is my table missing" with "there is no such table".
+    const cfg = source.config;
+    let keptTables: string[] | undefined;
+    let keptColumns: string[] | undefined;
+    if (cfg) {
+      keptTables = filterTables(analysis.tables, cfg).map((t) => qualifiedTableName(t));
+      try {
+        const narrowed = filterColumns(
+          [(match as Extract<TableMatch, { kind: 'found' }>).table],
+          cfg.columns
+        );
+        keptColumns = narrowed.tables[0]?.columns.map((c) => c.name);
+      } catch {
+        // A `columns` rule this config cannot honour is `generate`'s error to raise, and raising it
+        // here would leave a reader with no explanation at all of the table they asked about.
+        keptColumns = undefined;
+      }
+    }
+
+    const explanation = explainTable(
+      analysis,
+      match as Extract<TableMatch, { kind: 'found' }>,
+      { keptTables, keptColumns }
+    );
+    if (out.json) {
+      out.jsonData({ command: 'explain', exitCode: EXIT_OK, ...context, table: explanation });
+    } else {
+      out.data(renderExplanation(explanation, context, out.outStyle));
+    }
+    process.exit(EXIT_OK);
+  } catch (e: any) {
+    const msg = messageOf(e);
+    const code = drzlErrorCode(e, 'DRZL_CLI_EXPLAIN');
+    if (opts.json) out.jsonData(jsonFailure('explain', code, msg));
+    else if (e instanceof ConfigValidationError) out.error(msg);
+    else {
+      out.error('Explain failed (DRZL_CLI_EXPLAIN):', msg);
+      out.hint('Tip: run with --json for structured output.');
+    }
+    process.exit(EXIT_FAILED);
   }
 });
 

--- a/packages/cli/src/explain.ts
+++ b/packages/cli/src/explain.ts
@@ -1,0 +1,1006 @@
+/**
+ * `drzl explain <table>`: what DRZL understood about one table, and what it did not.
+ *
+ * The command exists for one moment: a generated schema is wrong, and the reader has no way to
+ * tell whether the analyzer misread the column, dropped the CHECK, failed to follow the relation,
+ * or read all three correctly and the generator is at fault. Today that question is answered by
+ * reading `drzl analyze --json` output, which is the whole analysis of the whole schema with
+ * nothing pointed out, or by reading the emitted validator and inferring backwards.
+ *
+ * Three sources are read, and none of them is re-derived here:
+ *
+ * - **The analyzer**, for the table itself: the resolved `tsType`, the declared `sqlType`,
+ *   nullability, defaults, keys, foreign keys, enum members and every measured fact
+ *   (`min`/`max`/`integer`/`allowsNaN`/`allowsInfinity`/`format`/`maxLength`/`maxBytes`).
+ * - **`tableConstraints` from `@drzl/validation-core`**, for whether a generated schema actually
+ *   checks each constraint. That function is what the emitted constraint ledger is built from, so
+ *   `explain` and the generated modules cannot disagree about what is enforced. It is also where
+ *   a CHECK's classification lives: a clause the shared parser declined comes back as an
+ *   `unenforced` entry with the parser's own reason, which is the sentence this command exists to
+ *   surface.
+ * - **The analysis's own `issues`**, filtered to this table, for a column type nobody has modelled
+ *   and a relation the analyzer could not follow.
+ *
+ * The two questions it deliberately answers together are "what is here" and "what is silently not
+ * here". A column DRZL cannot type still emits a validator, a CHECK the parser declines is simply
+ * absent from the output, and a `varchar(255)` on an enum column never reaches the schema as a
+ * width. All three produce a file that looks finished, and all three are named here.
+ *
+ * It writes nothing. `--dry-run` has no meaning for a command that has never had a write path.
+ */
+import type { Analysis, Column, Issue, Relation, Table } from '@drzl/analyzer';
+import { qualifiedForeignTable, qualifiedTableName } from '@drzl/analyzer';
+import { tableConstraints, type ConstraintFacts } from '@drzl/validation-core';
+import { Chalk, type ChalkInstance } from 'chalk';
+import { nearestKey } from './config-errors.js';
+import { addressableName, displayTableName, tableAliases } from './patterns.js';
+
+/**
+ * The styling used when a caller does not pass one.
+ *
+ * Level 0, so a caller who forgets gets plain text rather than escape sequences in a file. The
+ * decision belongs to `output.ts`, which asks it per stream; see the same constant in `doctor.ts`.
+ */
+const PLAIN: ChalkInstance = new Chalk({ level: 0 });
+
+/* ------------------------------------------------------------------------------------------ */
+/* Finding the table                                                                           */
+/* ------------------------------------------------------------------------------------------ */
+
+/** Which of a table's three names the query matched. */
+export type MatchedOn =
+  /** The bare database name, `users`. */
+  | 'name'
+  /** The qualified database name, `reporting.users`, or `public.users` for the default schema. */
+  | 'qualified'
+  /** The TypeScript export name, which is not always the database name. */
+  | 'tsName';
+
+export interface TableHit {
+  table: Table;
+  matchedOn: MatchedOn;
+}
+
+export type TableMatch =
+  | ({ kind: 'found'; exact: boolean } & TableHit)
+  /** Two or more tables answer to that name. Never resolved silently; see `matchTable`. */
+  | { kind: 'ambiguous'; exact: boolean; hits: TableHit[] }
+  | { kind: 'none'; suggestion?: string };
+
+/**
+ * Every name one table answers to, most specific first.
+ *
+ * `tableAliases` supplies the two database spellings, so `explain` and the config's `include`
+ * and `exclude` agree about what `public.users` means without either restating it. The export
+ * name is the third, because a reader looking at their own schema file knows
+ * `export const orgMembers` and may never have seen the string `organisation_members`.
+ *
+ * Order is the order a hit is reported in, and the qualified name is first: a table in a named
+ * SQL schema is identified by that spelling and by no other, so a query that used it should be
+ * reported as having used it.
+ */
+function namesOf(table: Table): Record<MatchedOn, string> {
+  const [bare, qualified] = tableAliases(table);
+  return { qualified, name: bare, tsName: table.tsName };
+}
+
+const MATCH_ORDER: MatchedOn[] = ['qualified', 'name', 'tsName'];
+
+/** What each of the three names is called in a sentence. */
+const MATCH_LABELS: Record<MatchedOn, string> = {
+  qualified: 'the schema-qualified name',
+  name: 'the database name',
+  tsName: 'the export name',
+};
+
+/** Every table whose names contain `query`, under the given case folding, one hit per table. */
+function hitsFor(tables: readonly Table[], query: string, fold: (s: string) => string): TableHit[] {
+  const wanted = fold(query);
+  const hits: TableHit[] = [];
+  for (const table of tables) {
+    const names = namesOf(table);
+    const matchedOn = MATCH_ORDER.find((key) => fold(names[key]) === wanted);
+    if (matchedOn) hits.push({ table, matchedOn });
+  }
+  return hits;
+}
+
+const same = (s: string) => s;
+const folded = (s: string) => s.toLowerCase();
+
+/**
+ * The table a query names, or why it names none.
+ *
+ * Exact before case-insensitive, and both over all three names at once. The two rounds are
+ * separate passes rather than one pass with a fallback comparison, because a schema holding both
+ * `users` and `Users` has an exact answer for each, and a single case-insensitive pass would call
+ * both of them ambiguous.
+ *
+ * Ambiguity is reported rather than resolved. It is reachable from an ordinary schema: two
+ * `pgSchema` tables share one bare name, and a table's export name can be another table's
+ * database name. Picking the first would answer a question about one table with facts about a
+ * different one, which is the single worst thing a command whose whole job is diagnosis can do.
+ *
+ * An ambiguous exact round stops there rather than falling through to the case-insensitive one.
+ * Loosening the comparison can only add hits, so the second round cannot resolve what the first
+ * could not.
+ */
+export function matchTable(tables: readonly Table[], query: string): TableMatch {
+  for (const [exact, fold] of [
+    [true, same],
+    [false, folded],
+  ] as const) {
+    const hits = hitsFor(tables, query, fold);
+    if (hits.length === 1) return { kind: 'found', exact, ...hits[0] };
+    if (hits.length > 1) return { kind: 'ambiguous', exact, hits };
+  }
+  // Only ever reached when nothing matched under either folding, so the suggestion is about a
+  // misspelling rather than about a case difference, which the second round has already forgiven.
+  const known = tables.flatMap((t) => {
+    const names = namesOf(t);
+    return t.tsName === names.name ? [names.name] : [names.name, names.tsName];
+  });
+  return { kind: 'none', suggestion: nearestKey(query, known) };
+}
+
+/* ------------------------------------------------------------------------------------------ */
+/* The explanation                                                                             */
+/* ------------------------------------------------------------------------------------------ */
+
+/** How a column's default arrives, which decides whether any generated schema can state it. */
+export type ExplainDefault =
+  /** `.default('GB')`: a literal a schema can reproduce. */
+  | { kind: 'literal'; value: unknown }
+  /** A `sql` default the analyzer rendered back to text. */
+  | { kind: 'expression'; text: string }
+  /**
+   * `defaultNow()`, `defaultRandom()`, `$defaultFn` and a `serial`'s sequence: the value exists
+   * only at insert time, so the field is optional on insert and no schema states what it becomes.
+   */
+  | { kind: 'runtime' };
+
+/**
+ * One measured fact about a column, and whether any generated schema says it.
+ *
+ * `stated` is not decided here. A width, a byte cap and a set of members are each read by every
+ * validation generator through the same guards `tableConstraints` applies, so the verdict comes
+ * off that function's output rather than from a second copy of the rule; see `capStated`.
+ */
+export interface ExplainFact {
+  text: string;
+  stated: boolean;
+  /** Why nothing states it, when nothing does. */
+  reason?: string;
+}
+
+export interface ExplainColumn {
+  name: string;
+  tsType: string;
+  /** The coarse family label, `TEXT` for every one of varchar, char and text. */
+  dbType: string;
+  /** The type as the database declares it, `varchar(255)`, absent where Drizzle would not say. */
+  sqlType?: string;
+  nullable: boolean;
+  hasDefault: boolean;
+  default: ExplainDefault | null;
+  isGenerated: boolean;
+  inPrimaryKey: boolean;
+  /** Named by a single-column UNIQUE constraint. A composite one is in `unique` instead. */
+  unique: boolean;
+  references?: {
+    table: string;
+    schema?: string;
+    column: string;
+    onDelete?: string;
+    onUpdate?: string;
+  };
+  enumValues?: string[];
+  arrayDimensions?: number;
+  shape?: Column['shape'];
+  facts: ExplainFact[];
+}
+
+/** A relation with this table at one end, in the direction the analysis recorded it. */
+export interface ExplainRelation extends Relation {
+  /** Whether this table is the `from` end. */
+  outgoing: boolean;
+}
+
+/**
+ * Something in this table that DRZL read and could not use.
+ *
+ * The section the command exists for. Every entry here is a place where the generated output is
+ * quietly narrower than the schema, and none of them is visible in the generated files.
+ */
+export interface ExplainGap {
+  kind:
+    /** A CHECK, or one clause of one, that no generated schema enforces. */
+    | 'check'
+    /** A column whose validator will accept any value. */
+    | 'column'
+    /** A relation the analyzer could not follow. */
+    | 'relation'
+    /** Anything else the analyzer said about this table. */
+    | 'analyzer';
+  /** The column or constraint it is about, where it is about one. */
+  subject?: string;
+  message: string;
+  hint?: string;
+}
+
+export interface TableExplanation {
+  /** The database table name, which is not always the export name. */
+  name: string;
+  /** The TypeScript export name. */
+  tsName: string;
+  /** The SQL schema, present only where the table declares one. */
+  schema?: string;
+  /** `reporting.users`, or the bare `users` for a table in the default schema. */
+  qualified: string;
+  /** `public.users`: the one spelling that addresses this table and no other. */
+  addressable: string;
+  /** Set for a materialized view, which takes no writes, so no insert or update schema is emitted. */
+  readOnly: boolean;
+  /** Which name the query matched, and whether it matched without case folding. */
+  matchedOn: MatchedOn;
+  matchedExactly: boolean;
+  /** True when this config's `include`/`exclude` removes the table, so no generator sees it. */
+  excludedByConfig?: boolean;
+  /** Columns this config's `columns` filter removes, in declaration order. */
+  columnsRemovedByConfig?: string[];
+  columns: ExplainColumn[];
+  primaryKey: { name?: string; columns: string[]; generated: boolean } | null;
+  unique: { name?: string; columns: string[] }[];
+  indexes: { name?: string; columns: string[] }[];
+  foreignKeys: {
+    name?: string;
+    columns: string[];
+    references: { table: string; columns: string[] };
+    onDelete?: string;
+    onUpdate?: string;
+  }[];
+  relations: ExplainRelation[];
+  /**
+   * Every constraint on the table with the verdict a generated schema gives it, verbatim from
+   * `tableConstraints`. The primary key, every UNIQUE, every foreign key, every CHECK and the
+   * declared widths, each with `enforced` and, where it is false, the reason per clause.
+   */
+  constraints: ConstraintFacts[];
+  /** What DRZL read and could not use. Empty when the whole table was understood. */
+  gaps: ExplainGap[];
+}
+
+/** One line of the index a bare `drzl explain` prints. */
+export interface TableSummary {
+  name: string;
+  tsName: string;
+  schema?: string;
+  qualified: string;
+  columns: number;
+  checks: number;
+  /** How many entries `drzl explain <this table>` would list under "Not understood". */
+  gaps: number;
+}
+
+/** The literal a `.default()` stored, as it would read in a schema file. */
+function renderLiteral(value: unknown): string {
+  if (typeof value === 'string') return `'${value.replace(/'/g, "\\'")}'`;
+  if (value === null) return 'null';
+  if (typeof value === 'bigint') return `${value}n`;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+/** How a column's default arrives, or nothing where it has none. */
+function defaultOf(column: Column): ExplainDefault | null {
+  if (column.defaultValue !== undefined) return { kind: 'literal', value: column.defaultValue };
+  if (column.defaultExpression) return { kind: 'expression', text: column.defaultExpression };
+  return column.hasDefault ? { kind: 'runtime' } : null;
+}
+
+/** A default in one cell of the column table. */
+function describeDefault(value: ExplainDefault | null): string {
+  if (!value) return '';
+  if (value.kind === 'literal') return `default ${renderLiteral(value.value)}`;
+  if (value.kind === 'expression') return `default ${value.text}`;
+  return 'has default';
+}
+
+/** What a `ColumnShape` is, in a sentence. Every kind has an arm, so a new one cannot go unnamed. */
+function describeShape(shape: NonNullable<Column['shape']>): string {
+  switch (shape.kind) {
+    case 'buffer':
+      return 'binary payload, carried as a Uint8Array';
+    case 'json':
+      return 'any JSON value, checked recursively';
+    case 'tuple':
+      return `tuple of ${shape.length} numbers`;
+    case 'numberObject':
+      return `object of numbers: ${shape.fields.join(', ')}`;
+    case 'numberVector':
+      return shape.length ? `numeric vector of ${shape.length}` : 'numeric vector';
+    case 'custom':
+      return shape.sqlType
+        ? `customType, declared ${shape.sqlType}, with no runtime shape to read`
+        : 'customType, with no runtime shape to read';
+    case 'bitstring':
+      if (shape.length === undefined) return 'string of 0 and 1';
+      return shape.exact
+        ? `string of ${shape.length} digits, each 0 or 1`
+        : `string of at most ${shape.length} digits, each 0 or 1`;
+    case 'byteString':
+      return shape.length ? `bytes, declared width ${shape.length}` : 'bytes';
+  }
+}
+
+/**
+ * Why a declared width never reaches the emitted schema.
+ *
+ * The branches of `statesCap` in `@drzl/validation-core`, in its order, so the sentence names the
+ * same reason the guard acted on. Whether it is stated is not decided here; that comes off
+ * `tableConstraints`, which calls the real guard. This only puts the reason into words, and the
+ * last arm is a generic sentence rather than a guess, so a branch added there is worded vaguely
+ * instead of wrongly.
+ */
+function capReason(column: Column, narrowedBySet: boolean): string {
+  if (column.shape)
+    return `"${column.name}" is a structured column, whose value space is not stated as a width`;
+  if (narrowedBySet)
+    return `a CHECK narrows "${column.name}" to a set of literals, which states its value space instead`;
+  if (column.enumValues?.length)
+    return `"${column.name}" is an enum, and its members state its value space instead`;
+  if (column.tsType !== 'string')
+    return `"${column.name}" does not arrive as a string, so there is nothing to measure`;
+  if (column.format)
+    return `the ${column.format} format replaces the width on "${column.name}" rather than adding to it`;
+  return `the generated schemas state "${column.name}" some other way`;
+}
+
+/**
+ * Everything measured about a column that a validator can act on, with the verdict beside it.
+ *
+ * The order is the order it reads: what the value is, then how wide, then what it may hold.
+ */
+function factsFor(
+  column: Column,
+  opts: { capStated: boolean; narrowedBySet: boolean }
+): ExplainFact[] {
+  const facts: ExplainFact[] = [];
+  const state = (text: string) => facts.push({ text, stated: true });
+
+  if (column.arrayDimensions) {
+    state(
+      column.arrayDimensions === 1
+        ? 'an array of the type above'
+        : `an array of ${column.arrayDimensions} dimensions`
+    );
+  }
+  if (column.shape) state(describeShape(column.shape));
+  if (column.enumValues?.length) {
+    state(`one of ${column.enumValues.map((v) => `'${v}'`).join(', ')}`);
+  }
+  if (column.format) state(`text in the ${column.format} format the database parses`);
+
+  if (column.min !== undefined && column.max !== undefined) {
+    state(`${column.min} to ${column.max}`);
+  } else if (column.min !== undefined) state(`at least ${column.min}`);
+  else if (column.max !== undefined) state(`at most ${column.max}`);
+  if (column.integer === true) state('whole numbers only');
+  if (column.integer === false) state('fractions allowed');
+
+  // A range cannot say either of these: `>=`/`<=` refuses an infinity whatever the two numbers
+  // are, and NaN compares false against both ends, so a bounded float column described by its
+  // range alone refuses values the database stores and hands back. The generators render them
+  // beside the range rather than as a wider one, which is why both are worth printing.
+  if (column.allowsNaN !== undefined) {
+    state(column.allowsNaN ? 'NaN is stored and returned' : 'NaN is refused');
+  }
+  if (column.allowsInfinity !== undefined) {
+    state(column.allowsInfinity ? 'Infinity is stored and returned' : 'Infinity is refused');
+  }
+
+  for (const [value, text] of [
+    [column.maxLength, `at most ${column.maxLength} characters`],
+    [column.maxBytes, `at most ${column.maxBytes} bytes`],
+  ] as const) {
+    if (value === undefined) continue;
+    facts.push(
+      opts.capStated
+        ? { text, stated: true }
+        : { text, stated: false, reason: capReason(column, opts.narrowedBySet) }
+    );
+  }
+
+  const value = defaultOf(column);
+  if (value?.kind === 'literal') state(`defaults to ${renderLiteral(value.value)}`);
+  else if (value?.kind === 'expression') state(`defaults to ${value.text}, evaluated by the database`);
+  else if (value?.kind === 'runtime') {
+    facts.push({
+      text: 'has a default',
+      stated: false,
+      reason:
+        'the value is produced at insert time, by the database or by a Drizzle function, so the ' +
+        'field is optional on insert and no schema states what it becomes',
+    });
+  }
+  if (column.isGenerated) {
+    state('generated by the database, so it is left out of insert and update schemas');
+  }
+  return facts;
+}
+
+/**
+ * Whether an analyzer issue is about this table.
+ *
+ * Matched against all three names, because the analyzer does not use one consistently and could
+ * not: a column warning is keyed on the export name, a relation warning on the qualified database
+ * name, and the extra-config warning on the table name. An issue about the schema as a whole
+ * carries no `path` at all and is not about any table, so it never lands here.
+ */
+function issueTouches(issue: Issue, table: Table): boolean {
+  if (!issue.path) return false;
+  const names = namesOf(table);
+  const own = [names.qualified, names.name, names.tsName, table.name];
+  if (own.includes(issue.path)) return true;
+  const dot = issue.path.lastIndexOf('.');
+  return dot > 0 && own.includes(issue.path.slice(0, dot));
+}
+
+/** The column half of a `table.column` issue path, when it has one. */
+function issueColumn(issue: Issue, table: Table): string | undefined {
+  const path = issue.path ?? '';
+  const names = namesOf(table);
+  for (const prefix of [names.qualified, names.tsName, names.name, table.name]) {
+    if (path.startsWith(`${prefix}.`)) {
+      const rest = path.slice(prefix.length + 1);
+      if (table.columns.some((c) => c.name === rest)) return rest;
+    }
+  }
+  return undefined;
+}
+
+/** Which analyzer codes are about a relation rather than about the table's own shape. */
+const RELATION_CODES = new Set(['DRZL_ANL_RELATIONS', 'DRZL_ANL_REL_V2']);
+
+/**
+ * Everything DRZL read and could not use, in the order it costs a reader most to not know.
+ *
+ * Constraints first, because a declined CHECK is the case where the generated file exists,
+ * compiles, validates, and enforces less than the database does with nothing anywhere saying so.
+ */
+function gapsFor(table: Table, constraints: ConstraintFacts[], issues: readonly Issue[]) {
+  const gaps: ExplainGap[] = [];
+
+  for (const constraint of constraints) {
+    for (const part of constraint.unenforced ?? []) {
+      gaps.push({
+        kind: 'check',
+        subject: constraint.name ?? constraint.id,
+        // `part.part` already carries the constraint name where the declaration had one, because
+        // that is the text an emitted schema would have attached. The renderer prefixes `subject`
+        // only when it is not already there, so a named CHECK is not announced twice.
+        message: `${part.part} is not enforced: ${part.reason}.`,
+        hint: 'Your database still enforces it. Nothing DRZL generates does.',
+      });
+    }
+  }
+
+  for (const issue of issues) {
+    if (issue.level === 'info') continue;
+    if (!issueTouches(issue, table)) continue;
+    const subject = issueColumn(issue, table);
+    gaps.push({
+      kind: RELATION_CODES.has(issue.code) ? 'relation' : subject ? 'column' : 'analyzer',
+      ...(subject ? { subject } : {}),
+      message: issue.message,
+      ...(issue.hint ? { hint: issue.hint } : {}),
+    });
+  }
+  return gaps;
+}
+
+export interface ExplainOptions {
+  /** Table names this config's `include`/`exclude` leaves in place, when a config was read. */
+  keptTables?: readonly string[];
+  /** Column names this config's `columns` filter leaves on this table, when one was read. */
+  keptColumns?: readonly string[];
+}
+
+/**
+ * Everything worth saying about one table.
+ *
+ * A pure function of the analysis and the match, so the renderer, the `--json` document and the
+ * tests all read one answer rather than three.
+ */
+export function explainTable(
+  analysis: Analysis,
+  match: Extract<TableMatch, { kind: 'found' }>,
+  options: ExplainOptions = {}
+): TableExplanation {
+  const table = match.table;
+  const qualified = qualifiedTableName(table);
+  const constraints = tableConstraints(table).constraints;
+
+  // Which columns a generated schema really caps, taken off the shared guard rather than from a
+  // second copy of it here: `tableConstraints` emits a `maxLength`/`maxBytes` constraint for a
+  // column exactly when the emitted schemas state one.
+  const capped = new Set(
+    constraints
+      .filter((c) => c.kind === 'maxLength' || c.kind === 'maxBytes')
+      .flatMap((c) => c.columns)
+  );
+  const narrowedBySet = new Set(
+    constraints.filter((c) => c.values).map((c) => c.values!.column)
+  );
+
+  const primaryKeyColumns = new Set(table.primaryKey?.columns ?? []);
+  const singleColumnUnique = new Set(
+    (table.unique ?? []).filter((u) => u.columns.length === 1).map((u) => u.columns[0])
+  );
+
+  const columns: ExplainColumn[] = table.columns.map((column) => ({
+    name: column.name,
+    tsType: column.tsType,
+    dbType: column.dbType,
+    ...(column.sqlType ? { sqlType: column.sqlType } : {}),
+    nullable: column.nullable,
+    hasDefault: column.hasDefault,
+    default: defaultOf(column),
+    isGenerated: column.isGenerated,
+    inPrimaryKey: primaryKeyColumns.has(column.name),
+    unique: singleColumnUnique.has(column.name),
+    ...(column.references ? { references: column.references } : {}),
+    ...(column.enumValues ? { enumValues: column.enumValues } : {}),
+    ...(column.arrayDimensions ? { arrayDimensions: column.arrayDimensions } : {}),
+    ...(column.shape ? { shape: column.shape } : {}),
+    facts: factsFor(column, {
+      capStated: capped.has(column.name),
+      narrowedBySet: narrowedBySet.has(column.name),
+    }),
+  }));
+
+  const relations: ExplainRelation[] = analysis.relations
+    .filter((r) => r.from === qualified || r.to === qualified || r.via === qualified)
+    .map((r) => ({ ...r, outgoing: r.from === qualified }));
+
+  // A key is "generated" when the database fills it in without being told, which is the question
+  // a reader has about an insert schema. `isGenerated` alone answers it for an identity column and
+  // not for a `serial`, whose sequence arrives as an ordinary default with nothing else naming it.
+  const keyColumns = table.columns.filter((c) => primaryKeyColumns.has(c.name));
+  const primaryKey = table.primaryKey?.columns.length
+    ? {
+        ...(table.primaryKey.name ? { name: table.primaryKey.name } : {}),
+        columns: [...table.primaryKey.columns],
+        generated: keyColumns.length > 0 && keyColumns.every((c) => c.isGenerated || c.hasDefault),
+      }
+    : null;
+
+  const removed = options.keptColumns
+    ? table.columns.map((c) => c.name).filter((name) => !options.keptColumns!.includes(name))
+    : [];
+
+  return {
+    name: table.name,
+    tsName: table.tsName,
+    ...(table.schema ? { schema: table.schema } : {}),
+    qualified,
+    addressable: addressableName(table),
+    readOnly: !!table.readOnly,
+    matchedOn: match.matchedOn,
+    matchedExactly: match.exact,
+    ...(options.keptTables && !options.keptTables.includes(qualified)
+      ? { excludedByConfig: true }
+      : {}),
+    ...(removed.length ? { columnsRemovedByConfig: removed } : {}),
+    columns,
+    primaryKey,
+    unique: (table.unique ?? []).map((u) => ({
+      ...(u.name ? { name: u.name } : {}),
+      columns: [...u.columns],
+    })),
+    indexes: (table.indexes ?? []).map((i) => ({
+      ...(i.name ? { name: i.name } : {}),
+      columns: [...i.columns],
+    })),
+    foreignKeys: (table.foreignKeys ?? []).map((fk) => ({
+      ...(fk.name ? { name: fk.name } : {}),
+      columns: [...fk.columns],
+      references: { table: qualifiedForeignTable(fk), columns: [...fk.foreignColumns] },
+      ...(fk.onDelete ? { onDelete: fk.onDelete } : {}),
+      ...(fk.onUpdate ? { onUpdate: fk.onUpdate } : {}),
+    })),
+    relations,
+    constraints,
+    gaps: gapsFor(table, constraints, analysis.issues),
+  };
+}
+
+/**
+ * One line per table, with the number of things DRZL did not understand about each.
+ *
+ * The last number is why this exists rather than being left to `analyze`, which prints the whole
+ * analysis as JSON and points at nothing in it. A reader with forty tables and one wrong file gets
+ * told which table to run `explain` on instead of reading forty.
+ */
+export function summarize(analysis: Analysis): TableSummary[] {
+  return analysis.tables.map((table) => ({
+    name: table.name,
+    tsName: table.tsName,
+    ...(table.schema ? { schema: table.schema } : {}),
+    qualified: qualifiedTableName(table),
+    columns: table.columns.length,
+    checks: table.checks?.length ?? 0,
+    gaps: gapsFor(table, tableConstraints(table).constraints, analysis.issues).length,
+  }));
+}
+
+/* ------------------------------------------------------------------------------------------ */
+/* Rendering                                                                                   */
+/* ------------------------------------------------------------------------------------------ */
+
+/**
+ * How wide the report lays itself out.
+ *
+ * 80 rather than the 96 `doctor` wraps its prose at, because this one prints aligned rows and a
+ * row that wraps is worse than a paragraph that does: the eye loses the column. Everything with a
+ * computed width is fitted inside this, and the only cells allowed past it are the last one on a
+ * line, where an overflow costs a soft wrap and nothing else.
+ */
+const WIDTH = 80;
+
+const pad = (text: string, width: number) => text + ' '.repeat(Math.max(0, width - text.length));
+
+/** The widest of a set of strings, which is the column width every row is padded to. */
+const widest = (values: string[]) => values.reduce((n, v) => Math.max(n, v.length), 0);
+
+/** Wrap a sentence under a fixed indent. Same shape as `doctor`'s, at this file's width. */
+function wrap(text: string, indent: string, first = indent): string {
+  const lines: string[] = [];
+  let line = '';
+  for (const word of String(text).split(/\s+/)) {
+    if (line && `${line} ${word}`.length + indent.length > WIDTH) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = line ? `${line} ${word}` : word;
+    }
+  }
+  if (line) lines.push(line);
+  return lines.map((l, i) => (i === 0 ? first : indent) + l).join('\n');
+}
+
+/**
+ * The TypeScript type as a reader of the generated schema would write it.
+ *
+ * `tsType` is the *element* type on an array column, because Drizzle gives an array no class of
+ * its own and the analyzer records the depth separately. Printing it bare said `string` for a
+ * `text[]`, which is the exact misreading that produced the array defect `arrayDimensions` was
+ * added to fix, so the suffix is put back here.
+ */
+function renderTsType(column: ExplainColumn): string {
+  return column.tsType + '[]'.repeat(column.arrayDimensions ?? 0);
+}
+
+/** The short markers beside a column: what it is to the table, rather than what it holds. */
+function columnNotes(column: ExplainColumn): string {
+  const notes: string[] = [];
+  if (column.inPrimaryKey) notes.push('pk');
+  if (column.unique) notes.push('unique');
+  if (column.references) {
+    notes.push(`fk -> ${column.references.table}.${column.references.column}`);
+  }
+  if (column.isGenerated) notes.push('generated');
+  const value = describeDefault(column.default);
+  if (value && !column.isGenerated) notes.push(value);
+  return notes.join(', ');
+}
+
+/** The rule and the verdict for one constraint, as the reader needs to read them: side by side. */
+function constraintLines(
+  constraint: ConstraintFacts,
+  style: ChalkInstance,
+  labelWidth: number
+): string[] {
+  const label = constraint.name ?? '';
+  const verdict = constraint.enforced
+    ? style.green('enforced')
+    : style.yellow('not enforced by any generated schema');
+  const out = [`  ${pad(label, labelWidth)}  ${constraint.rule}`];
+  out.push(`  ${' '.repeat(labelWidth)}  ${verdict}`);
+  for (const part of constraint.unenforced ?? []) {
+    out.push(style.dim(wrap(part.reason, ' '.repeat(labelWidth + 4))));
+  }
+  return out;
+}
+
+/**
+ * The human report.
+ *
+ * Grouped rather than one flat list, because the questions are different: "did DRZL read my column
+ * right" is answered by the first two sections and "is my constraint enforced" by the next three,
+ * and a reader arrives holding exactly one of them.
+ */
+export function renderExplanation(
+  explanation: TableExplanation,
+  context: { schema: string; dialect: string },
+  style: ChalkInstance = PLAIN
+): string {
+  const out: string[] = [];
+  const plural = (n: number, one: string) => `${n} ${one}${n === 1 ? '' : 's'}`;
+
+  out.push(style.bold(explanation.qualified) + style.dim(`  ${context.schema}`));
+  const identity = [
+    context.dialect,
+    `table "${explanation.name}"`,
+    `export "${explanation.tsName}"`,
+    plural(explanation.columns.length, 'column'),
+  ];
+  if (explanation.readOnly) identity.push('read-only, so no insert or update schema is emitted');
+  out.push(style.dim('  ' + identity.join(', ')));
+  if (!explanation.matchedExactly) {
+    // Said out loud, because a case-folded match is the one way this report can be about a table
+    // the reader did not think they were asking for.
+    out.push(style.dim(`  matched on ${MATCH_LABELS[explanation.matchedOn]}, ignoring case`));
+  }
+  if (explanation.excludedByConfig) {
+    out.push('');
+    out.push(style.yellow('  This config\'s include/exclude removes this table.'));
+    out.push(style.dim('  No generator sees it, so nothing below reaches any emitted file.'));
+  }
+  if (explanation.columnsRemovedByConfig?.length) {
+    out.push('');
+    out.push(
+      style.yellow(
+        `  This config's columns filter removes ${explanation.columnsRemovedByConfig.length} of ` +
+          `these columns: ${explanation.columnsRemovedByConfig.join(', ')}.`
+      )
+    );
+  }
+  out.push('');
+
+  // ---- columns -------------------------------------------------------------------------------
+  out.push(style.bold('Columns'));
+  const tsTypes = explanation.columns.map(renderTsType);
+  const nameWidth = widest(['COLUMN', ...explanation.columns.map((c) => c.name)]);
+  const tsWidth = widest(['TS TYPE', ...tsTypes]);
+  const sqlWidth = widest(['SQL TYPE', ...explanation.columns.map((c) => c.sqlType ?? c.dbType)]);
+  out.push(
+    style.dim(
+      `  ${pad('COLUMN', nameWidth)}  ${pad('TS TYPE', tsWidth)}  ` +
+        `${pad('SQL TYPE', sqlWidth)}  NULL`
+    )
+  );
+  explanation.columns.forEach((column, i) => {
+    // `sqlType` is what the database declares and is the answer a reader came for; `dbType` is a
+    // coarse family label and stands in only where Drizzle's builder would not answer at all.
+    const sql = column.sqlType ?? column.dbType;
+    const notes = columnNotes(column);
+    const nullable = column.nullable ? 'yes' : 'no';
+    out.push(
+      `  ${pad(column.name, nameWidth)}  ${pad(tsTypes[i], tsWidth)}  ` +
+        `${pad(sql, sqlWidth)}  ` +
+        // Padded only when something follows it: a trailing run of spaces on every second row is
+        // invisible in a terminal and is the first thing a test diff shows.
+        (notes ? `${pad(nullable, 4)}  ${style.dim(notes)}` : nullable)
+    );
+  });
+
+  // ---- the measured facts --------------------------------------------------------------------
+  const withFacts = explanation.columns.filter((c) => c.facts.length);
+  if (withFacts.length) {
+    out.push('');
+    out.push(style.bold('What the generators read off each column'));
+    const factWidth = widest(withFacts.map((c) => c.name));
+    for (const column of withFacts) {
+      let first = true;
+      for (const fact of column.facts) {
+        const label = first ? pad(column.name, factWidth) : ' '.repeat(factWidth);
+        first = false;
+        out.push(`  ${label}  ${fact.stated ? fact.text : style.yellow(fact.text)}`);
+        if (fact.stated) continue;
+        out.push(
+          style.dim(
+            wrap(
+              `not stated by any generated schema: ${fact.reason}`,
+              ' '.repeat(factWidth + 4)
+            )
+          )
+        );
+      }
+    }
+  }
+
+  // ---- keys, foreign keys, relations ---------------------------------------------------------
+  out.push('');
+  out.push(style.bold('Keys'));
+  if (explanation.primaryKey) {
+    const pk = explanation.primaryKey;
+    out.push(
+      `  PRIMARY KEY (${pk.columns.join(', ')})` +
+        (pk.generated ? style.dim('  filled in by the database') : '')
+    );
+    if (pk.columns.length > 1) {
+      out.push(
+        style.dim(
+          wrap(
+            'The service and router generators key getById, update and delete on ' +
+              `"${pk.columns[0]}" alone, so those operations match on part of this key.`,
+            '    '
+          )
+        )
+      );
+    }
+  } else {
+    out.push(style.yellow('  No primary key.'));
+    out.push(
+      style.dim(
+        wrap(
+          'The service and router generators fall back to a column named "id".',
+          '    '
+        )
+      )
+    );
+  }
+  for (const unique of explanation.unique) {
+    out.push(`  UNIQUE (${unique.columns.join(', ')})` + (unique.name ? style.dim(`  ${unique.name}`) : ''));
+  }
+  for (const index of explanation.indexes) {
+    out.push(style.dim(`  INDEX (${index.columns.join(', ')})${index.name ? `  ${index.name}` : ''}`));
+  }
+
+  if (explanation.foreignKeys.length) {
+    out.push('');
+    out.push(style.bold('Foreign keys'));
+    for (const fk of explanation.foreignKeys) {
+      const actions = [
+        fk.onDelete ? `ON DELETE ${fk.onDelete}` : '',
+        fk.onUpdate ? `ON UPDATE ${fk.onUpdate}` : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+      out.push(
+        `  (${fk.columns.join(', ')}) -> ${fk.references.table} ` +
+          `(${fk.references.columns.join(', ')})` +
+          (actions ? style.dim(`  ${actions}`) : '')
+      );
+    }
+  }
+
+  if (explanation.relations.length) {
+    out.push('');
+    out.push(style.bold('Relations'));
+    for (const relation of explanation.relations) {
+      const via = relation.via ? ` through ${relation.via}` : '';
+      out.push(
+        `  ${relation.from} -> ${relation.to}${via}` + style.dim(`  ${relation.kind}`)
+      );
+    }
+  }
+
+  // ---- constraints ---------------------------------------------------------------------------
+  const checks = explanation.constraints.filter((c) => c.kind === 'check');
+  if (checks.length) {
+    out.push('');
+    out.push(style.bold('CHECK constraints, as DRZL parsed them'));
+    const labelWidth = widest(checks.map((c) => c.name ?? ''));
+    for (const check of checks) out.push(...constraintLines(check, style, labelWidth));
+  }
+
+  // ---- what was not understood ---------------------------------------------------------------
+  out.push('');
+  if (!explanation.gaps.length) {
+    out.push(style.green('Nothing about this table was dropped or left unrecognised.'));
+    return out.join('\n');
+  }
+  out.push(style.yellow(`Not understood  (${explanation.gaps.length})`));
+  out.push(style.dim('  These are in your schema and are not in anything DRZL generates.'));
+  out.push('');
+  // One hint under the findings that share it, so the same sentence is not repeated under twenty
+  // columns. Same grouping as `doctor`, for the same reason.
+  const groups = new Map<string, ExplainGap[]>();
+  for (const gap of explanation.gaps) {
+    const key = gap.hint ?? '';
+    groups.set(key, [...(groups.get(key) ?? []), gap]);
+  }
+  for (const [hint, items] of groups) {
+    for (const gap of items) {
+      const named = gap.subject && !gap.message.startsWith(gap.subject);
+      out.push(wrap((named ? `${gap.subject}: ` : '') + gap.message, '    ', `  ${style.dim('-')} `));
+    }
+    if (hint) out.push(style.dim(wrap(hint, '    ')));
+    out.push('');
+  }
+  return out.join('\n').replace(/\n+$/, '');
+}
+
+/** The index a bare `drzl explain` prints. */
+export function renderIndex(
+  tables: TableSummary[],
+  context: { schema: string; dialect: string },
+  style: ChalkInstance = PLAIN
+): string {
+  const out: string[] = [];
+  const plural = (n: number, one: string) => `${n} ${one}${n === 1 ? '' : 's'}`;
+
+  out.push(style.bold(context.schema) + style.dim(`  ${context.dialect}`));
+  out.push(style.dim(`  ${plural(tables.length, 'table')}`));
+  out.push('');
+
+  const nameWidth = widest(['TABLE', ...tables.map((t) => t.qualified)]);
+  const tsWidth = widest(['EXPORT', ...tables.map((t) => t.tsName)]);
+  out.push(style.dim(`  ${pad('TABLE', nameWidth)}  ${pad('EXPORT', tsWidth)}  COLUMNS`));
+  for (const table of tables) {
+    const columns = String(table.columns);
+    out.push(
+      `  ${pad(table.qualified, nameWidth)}  ${pad(table.tsName, tsWidth)}  ` +
+        (table.gaps
+          ? `${pad(columns, 7)}  ` +
+            style.yellow(`${plural(table.gaps, 'thing')} not understood`)
+          : columns)
+    );
+  }
+  out.push('');
+  out.push(style.dim('  drzl explain <table>  for one of them in full'));
+  return out.join('\n');
+}
+
+/* ------------------------------------------------------------------------------------------ */
+/* The two ways a name fails                                                                   */
+/* ------------------------------------------------------------------------------------------ */
+
+/** No such table (DRZL_EXPLAIN_001), or the name reaches more than one (DRZL_EXPLAIN_002). */
+export const NO_SUCH_TABLE_CODE = 'DRZL_EXPLAIN_001';
+export const AMBIGUOUS_TABLE_CODE = 'DRZL_EXPLAIN_002';
+
+/** How many table names a failure message lists before it stops. */
+const NAME_CAP = 12;
+
+/**
+ * "There is no such table", with the tables there are.
+ *
+ * The list is the point. A reader who mistypes a name, or who is looking at the wrong schema file
+ * entirely, learns which from the same line, and the two are not otherwise distinguishable: an
+ * empty output and a wrong output look the same from outside.
+ */
+export function noSuchTableProblem(
+  query: string,
+  tables: readonly Table[],
+  suggestion: string | undefined
+): { code: string; message: string; hint: string } {
+  const names = tables.map((t) => displayTableName(t));
+  const shown = names.slice(0, NAME_CAP).join(', ');
+  const rest = names.length > NAME_CAP ? `, and ${names.length - NAME_CAP} more` : '';
+  return {
+    code: NO_SUCH_TABLE_CODE,
+    message:
+      `No table called "${query}" (${NO_SUCH_TABLE_CODE}). ` +
+      (names.length
+        ? `This schema declares ${names.length} table${names.length === 1 ? '' : 's'}: ${shown}${rest}.`
+        : 'This schema declares no tables.'),
+    hint: suggestion
+      ? `Did you mean "${suggestion}"?`
+      : 'A table is matched by its database name, by its schema-qualified name, or by the name it ' +
+        'is exported under, ignoring case where nothing matches exactly.',
+  };
+}
+
+/**
+ * "That name reaches more than one table", with both of them and the spelling that separates them.
+ *
+ * Reachable from an ordinary schema, and silently picking one would answer a question about one
+ * table with facts about another.
+ */
+export function ambiguousTableProblem(
+  query: string,
+  hits: readonly TableHit[]
+): { code: string; message: string; hint: string } {
+  const named = hits
+    .map((hit) => `${addressableName(hit.table)} (exported as ${hit.table.tsName})`)
+    .join(', ');
+  return {
+    code: AMBIGUOUS_TABLE_CODE,
+    message: `"${query}" names ${hits.length} tables (${AMBIGUOUS_TABLE_CODE}): ${named}.`,
+    hint: `Name one of them exactly, for example "${addressableName(hits[0].table)}".`,
+  };
+}

--- a/packages/cli/src/schema-outcome.ts
+++ b/packages/cli/src/schema-outcome.ts
@@ -44,6 +44,16 @@ export interface SchemaProblem {
   hint: string;
 }
 
+/**
+ * The clause that closes a hint by saying what did not happen because of this.
+ *
+ * A parameter rather than a constant, because these three problems are not `generate`'s alone any
+ * more: `drzl explain` reaches every one of them and has never written a file in its life, so
+ * "Nothing was generated." there is a sentence about a thing the command does not do. The default
+ * keeps every existing caller's text byte for byte.
+ */
+export const NOTHING_GENERATED = 'Nothing was generated.';
+
 /** The least this file needs to know about an analyzer issue. */
 export interface AnalyzerIssue {
   code?: string;
@@ -77,7 +87,8 @@ export function describeSchemaTarget(schema: string | readonly string[]): string
  */
 export function schemaLoadFailure(
   issues: readonly AnalyzerIssue[],
-  schema: string | readonly string[]
+  schema: string | readonly string[],
+  consequence: string = NOTHING_GENERATED
 ): SchemaProblem | undefined {
   const blocking = issues.filter(
     (issue) => issue.level === 'error' && issue.code && UNREADABLE_CODES.has(issue.code)
@@ -93,7 +104,9 @@ export function schemaLoadFailure(
     return {
       code: SCHEMA_UNREADABLE_CODE,
       message: `Schema file not found (${SCHEMA_UNREADABLE_CODE}): ${named}${more}`,
-      hint: 'Check the "schema" path in your drzl config, or point --config at another one. Nothing was generated.',
+      hint:
+        'Check the "schema" path in your drzl config, or point --config at another one. ' +
+        consequence,
     };
   }
 
@@ -108,8 +121,8 @@ export function schemaLoadFailure(
     code: SCHEMA_UNREADABLE_CODE,
     message,
     hint: single
-      ? `Fix that error and run again. \`drzl analyze ${single}\` prints it in full. Nothing was generated.`
-      : 'Fix that error and run again. Nothing was generated.',
+      ? `Fix that error and run again. \`drzl analyze ${single}\` prints it in full. ${consequence}`
+      : `Fix that error and run again. ${consequence}`,
   };
 }
 
@@ -133,9 +146,12 @@ export function nothingToGenerate(opts: {
   analyzed: readonly { name: string }[];
   /** The tables left for the generators. */
   remaining: readonly { name: string }[];
+  /** What did not happen because of this. See `NOTHING_GENERATED`. */
+  consequence?: string;
 }): SchemaProblem | undefined {
   if (opts.remaining.length > 0) return undefined;
   const target = describeSchemaTarget(opts.schema);
+  const consequence = opts.consequence ?? NOTHING_GENERATED;
 
   if (!opts.analyzed.length) {
     return {
@@ -144,7 +160,7 @@ export function nothingToGenerate(opts: {
       hint:
         'That module imported cleanly and exported no tables, so every generator would write an ' +
         'empty barrel. Export them from it, for example: export const users = pgTable(...). ' +
-        'Nothing was generated.',
+        consequence,
     };
   }
 
@@ -158,6 +174,7 @@ export function nothingToGenerate(opts: {
       `${target} declares ${names.length} table${names.length === 1 ? '' : 's'}: ${shown}${rest}.`,
     hint:
       'Check "include" and "exclude" in your drzl config. A pattern is matched against the whole ' +
-      'database table name, with * as the only metacharacter. Nothing was generated.',
+      'database table name, with * as the only metacharacter. ' +
+      consequence,
   };
 }

--- a/packages/cli/test/explain.e2e.spec.ts
+++ b/packages/cli/test/explain.e2e.spec.ts
@@ -1,0 +1,495 @@
+/**
+ * `drzl explain` against a real schema, spawned as a real process.
+ *
+ * The unit spec next door works over hand-built analyses, which is the right shape for the
+ * matching rules and the "nothing states this" verdicts. This one is here for the half that a
+ * hand-built analysis cannot prove: that the *analyzer* answers these questions the way the report
+ * claims. An unsigned MySQL `int` really coming back as `0 to 4294967295`, a `bigint({ mode:
+ * 'number' })` really carrying a different range from a `bigint({ mode: 'bigint' })`, and a regex
+ * CHECK really being the one the shared parser declines are each a fact about a package this file
+ * does not import, and each of them has been the subject of a defect in this repository.
+ *
+ * It also pins the process-level contract: which stream carries the report, the three exit codes,
+ * and the shape of the `--json` document.
+ *
+ * Requires a build. CI builds before testing; locally, run `pnpm build` first.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { existsSync, promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const CLI = path.resolve(__dirname, '..', 'dist', 'cli.js');
+const ROOT = path.join(__dirname, '.tmp-explain');
+
+interface Run {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Run the built CLI and keep both streams apart.
+ *
+ * Colour is forced off rather than left to the pipe's own answer, because a `FORCE_COLOR` exported
+ * by the developer's shell would otherwise put escapes through every assertion on the text. The
+ * separate colour spec is where the per-stream rules are tested; here they are noise.
+ */
+function run(args: string[], cwd = ROOT): Promise<Run> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [CLI, ...args],
+      { cwd, env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' }, maxBuffer: 20 * 1024 * 1024 },
+      (error: any, stdout, stderr) => {
+        if (error && typeof error.code !== 'number') return reject(error);
+        resolve({ code: error ? error.code : 0, stdout, stderr });
+      }
+    );
+  });
+}
+
+/**
+ * One schema carrying every case worth a line in this report.
+ *
+ * A composite key, a natural key, a declared enum, a nullable column with a literal default, both
+ * bigint modes, a foreign key with a relation over it, and four CHECK constraints: a bound the
+ * parser folds into a range, a count it translates, a cardinality on an array, and a regex it
+ * declines whole. The declined one is the case the whole command exists for.
+ */
+const PG_SCHEMA = `
+import { relations, sql } from 'drizzle-orm';
+import {
+  bigint, boolean, check, doublePrecision, integer, jsonb, numeric, pgEnum, pgTable,
+  primaryKey, serial, text, timestamp, unique, uuid, varchar,
+} from 'drizzle-orm/pg-core';
+
+export const role = pgEnum('role', ['admin', 'member', 'guest']);
+
+export const users = pgTable(
+  'users',
+  {
+    id: serial('id').primaryKey(),
+    email: varchar('email', { length: 255 }).notNull().unique(),
+    nickname: text('nickname').default('anon'),
+    role: role('role').notNull().default('member'),
+    age: integer('age'),
+    balance: numeric('balance', { precision: 10, scale: 2 }).notNull(),
+    score: doublePrecision('score'),
+    followers: bigint('followers', { mode: 'bigint' }).notNull(),
+    visits: bigint('visits', { mode: 'number' }).notNull(),
+    ref: uuid('ref').notNull(),
+    tags: text('tags').array(),
+    payload: jsonb('payload'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    check('age_adult', sql\`\${t.age} >= 18\`),
+    check('nickname_len', sql\`length(\${t.nickname}) > 2\`),
+    check('email_shape', sql\`\${t.email} ~ '^[^@]+@[^@]+$'\`),
+    check('tags_present', sql\`cardinality(\${t.tags}) > 0\`),
+  ]
+);
+
+export const memberships = pgTable(
+  'memberships',
+  {
+    orgId: integer('org_id').notNull(),
+    userId: integer('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    joinedAt: timestamp('joined_at').notNull(),
+    active: boolean('active').notNull().default(true),
+  },
+  (t) => [
+    primaryKey({ columns: [t.orgId, t.userId] }),
+    unique('membership_alt').on(t.userId, t.joinedAt),
+  ]
+);
+
+export const countries = pgTable('countries', {
+  code: text('code').primaryKey(),
+  name: text('name').notNull(),
+});
+
+export const usersRelations = relations(users, ({ many }) => ({
+  memberships: many(memberships),
+}));
+export const membershipsRelations = relations(memberships, ({ one }) => ({
+  user: one(users, { fields: [memberships.userId], references: [users.id] }),
+}));
+`;
+
+/**
+ * The MySQL half, because unsigned exists nowhere else and a schema has one dialect.
+ *
+ * `label` is the case where a declared width is real and no emitted schema writes it: the CHECK
+ * narrows the column to two literals, and a set states the value space instead of a cap.
+ */
+const MYSQL_SCHEMA = `
+import { sql } from 'drizzle-orm';
+import { bigint, check, int, mysqlTable, text, tinyint, varchar } from 'drizzle-orm/mysql-core';
+
+export const counters = mysqlTable(
+  'counters',
+  {
+    id: int('id', { unsigned: true }).primaryKey().autoincrement(),
+    hits: bigint('hits', { mode: 'bigint', unsigned: true }).notNull(),
+    small: tinyint('small', { unsigned: true }).notNull(),
+    label: varchar('label', { length: 32 }).notNull(),
+    body: text('body'),
+  },
+  (t) => [
+    check('label_set', sql\`\${t.label} IN ('a', 'b')\`),
+    check('odd', sql\`\${t.small} % 2 = 1\`),
+  ]
+);
+`;
+
+/** Two tables that share one database name, which is what makes a bare name ambiguous. */
+const TWO_SCHEMAS = `
+import { integer, pgSchema, pgTable, text } from 'drizzle-orm/pg-core';
+const reporting = pgSchema('reporting');
+export const users = pgTable('users', { id: integer('id').primaryKey() });
+export const reportingUsers = reporting.table('users', {
+  id: integer('id').primaryKey(),
+  note: text('note'),
+});
+`;
+
+beforeAll(async () => {
+  if (!existsSync(CLI)) {
+    throw new Error(`Built CLI not found at ${CLI}. Run \`pnpm build\` before \`pnpm test\`.`);
+  }
+  await fs.rm(ROOT, { recursive: true, force: true });
+  await fs.mkdir(path.join(ROOT, 'src', 'db'), { recursive: true });
+  await fs.writeFile(path.join(ROOT, 'src', 'db', 'schema.ts'), PG_SCHEMA, 'utf8');
+  await fs.writeFile(path.join(ROOT, 'src', 'db', 'mysql.ts'), MYSQL_SCHEMA, 'utf8');
+  await fs.writeFile(path.join(ROOT, 'src', 'db', 'two-schemas.ts'), TWO_SCHEMAS, 'utf8');
+  await fs.writeFile(path.join(ROOT, 'src', 'db', 'empty.ts'), 'export const x = 1;\n', 'utf8');
+}, 60_000);
+
+afterAll(async () => {
+  await fs.rm(ROOT, { recursive: true, force: true });
+});
+
+const pg = (...args: string[]) => run(['explain', ...args, '-s', 'src/db/schema.ts']);
+
+describe('drzl explain <table>', () => {
+  it('puts the report on stdout and nothing on stderr, and exits 0', async () => {
+    const r = await pg('users');
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('Columns');
+    expect(r.stderr).toBe('');
+  }, 60_000);
+
+  it('names the table, the export and the dialect in the header', async () => {
+    const { stdout } = await pg('users');
+    expect(stdout).toContain('postgres, table "users", export "users", 13 columns');
+  }, 60_000);
+
+  it('shows the declared SQL type per column, which is the wire the fixes turned on', async () => {
+    const { stdout } = await pg('users');
+    expect(stdout).toContain('varchar(255)');
+    expect(stdout).toContain('numeric(10, 2)');
+    expect(stdout).toContain('timestamp with time zone');
+    expect(stdout).toContain('text[]');
+  }, 60_000);
+
+  it('states the two bigint modes apart, by the range each really carries', async () => {
+    const { stdout } = await pg('users');
+    // `{ mode: 'bigint' }` is the full signed 64 bit range; `{ mode: 'number' }` stops at the
+    // safe-integer ceiling, because past it a JS number is not the value the driver returned.
+    expect(stdout).toContain('-9223372036854775808 to 9223372036854775807');
+    expect(stdout).toContain('-9007199254740991 to 9007199254740991');
+  }, 60_000);
+
+  it('lists the enum members', async () => {
+    expect((await pg('users')).stdout).toContain("one of 'admin', 'member', 'guest'");
+  }, 60_000);
+
+  it('states NaN and Infinity, which a range cannot say', async () => {
+    const { stdout } = await pg('users');
+    expect(stdout).toContain('NaN is stored and returned');
+    expect(stdout).toContain('Infinity is stored and returned');
+  }, 60_000);
+
+  it('reports a nullable column with a literal default as both', async () => {
+    const { stdout } = await pg('users');
+    expect(stdout).toMatch(/nickname\s+string\s+text\s+yes\s+default 'anon'/);
+  }, 60_000);
+
+  it('reports the three CHECK forms it translates as enforced', async () => {
+    const { stdout } = await pg('users');
+    for (const rule of [
+      'CHECK (age >= 18)',
+      'CHECK (length(nickname) > 2)',
+      'CHECK (cardinality(tags) > 0)',
+    ]) {
+      expect(stdout).toContain(rule);
+    }
+    expect(stdout.match(/^\s+enforced$/gm)?.length).toBe(3);
+  }, 60_000);
+
+  // The reason the command exists. The constraint is in the schema, the database enforces it, the
+  // generated validator does not, and nothing in the generated files says so.
+  it('names the CHECK the parser declines, with the reason, under Not understood', async () => {
+    const { stdout } = await pg('users');
+    expect(stdout).toContain('not enforced by any generated schema');
+    expect(stdout).toContain('not a single comparison this version understands');
+    expect(stdout).toContain('Not understood  (1)');
+  }, 60_000);
+
+  it('reports a composite key whole', async () => {
+    const { stdout } = await pg('memberships');
+    expect(stdout).toContain('PRIMARY KEY (orgId, userId)');
+    expect(stdout).toContain('UNIQUE (userId, joinedAt)');
+  }, 60_000);
+
+  it('reports the foreign key and the relations over it', async () => {
+    const { stdout } = await pg('memberships');
+    expect(stdout).toContain('(userId) -> users (id)');
+    expect(stdout).toContain('ON DELETE cascade');
+    expect(stdout).toContain('memberships -> users');
+  }, 60_000);
+
+  it('reports a natural key as the key it is', async () => {
+    const { stdout } = await pg('countries');
+    expect(stdout).toContain('PRIMARY KEY (code)');
+    expect(stdout).toContain('Nothing about this table was dropped or left unrecognised.');
+  }, 60_000);
+
+  it('fits a terminal 80 columns wide on every line', async () => {
+    for (const table of ['users', 'memberships', 'countries']) {
+      const { stdout } = await pg(table);
+      const wide = stdout.split('\n').filter((line) => line.length > 80);
+      expect(wide, `${table} has lines past 80 columns`).toEqual([]);
+    }
+  }, 120_000);
+});
+
+describe('the MySQL half', () => {
+  const mysql = (...args: string[]) => run(['explain', ...args, '-s', 'src/db/mysql.ts']);
+
+  it('gives an unsigned column the range it actually holds', async () => {
+    const { stdout } = await mysql('counters');
+    expect(stdout).toContain('int unsigned');
+    expect(stdout).toContain('0 to 4294967295');
+    expect(stdout).toContain('0 to 255');
+    expect(stdout).toContain('0 to 18446744073709551615');
+    // The signed answer this family used to give, which refused every value in the top half.
+    expect(stdout).not.toContain('-2147483648');
+  }, 60_000);
+
+  it('says a declared width is not stated when a CHECK narrows the column to a set', async () => {
+    const { stdout } = await mysql('counters');
+    expect(stdout).toContain('at most 32 characters');
+    expect(stdout.replace(/\s+/g, ' ')).toContain('a CHECK narrows "label" to a set of literals');
+  }, 60_000);
+
+  it('reports the byte budget a MySQL text column carries in its own type', async () => {
+    expect((await mysql('counters')).stdout).toContain('at most 65535 bytes');
+  }, 60_000);
+});
+
+describe('finding the table by name', () => {
+  it('matches the schema-qualified name', async () => {
+    const r = await run(['explain', 'reporting.users', '-s', 'src/db/two-schemas.ts']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('export "reportingUsers"');
+  }, 60_000);
+
+  it('matches the TypeScript export name', async () => {
+    const r = await run(['explain', 'reportingUsers', '-s', 'src/db/two-schemas.ts']);
+    expect(r.stdout).toContain('reporting.users');
+  }, 60_000);
+
+  it('refuses a bare name that reaches two schemas, and says how to separate them', async () => {
+    const r = await run(['explain', 'users', '-s', 'src/db/two-schemas.ts']);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('DRZL_EXPLAIN_002');
+    expect(r.stderr).toContain('reporting.users');
+    expect(r.stdout).toBe('');
+  }, 60_000);
+
+  it('names the tables there are, and suggests the near miss', async () => {
+    const r = await pg('userz');
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('DRZL_EXPLAIN_001');
+    expect(r.stderr).toContain('countries, memberships, users');
+    expect(r.stderr).toContain('Did you mean "users"?');
+  }, 60_000);
+});
+
+describe('a schema it cannot use', () => {
+  it('reports a missing file through the shared schema code, not a new message', async () => {
+    const r = await run(['explain', 'users', '-s', 'src/db/nope.ts']);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('Schema file not found (DRZL_SCHEMA_001)');
+    // The one thing that had to change: this command has never written a file.
+    expect(r.stderr).toContain('There is nothing to explain.');
+    expect(r.stderr).not.toContain('Nothing was generated.');
+  }, 60_000);
+
+  it('tells a module that declares no tables apart from one that would not import', async () => {
+    const r = await run(['explain', 'users', '-s', 'src/db/empty.ts']);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('DRZL_SCHEMA_002');
+  }, 60_000);
+
+  it('says there is no schema at all rather than failing to parse one', async () => {
+    const bare = path.join(ROOT, 'bare');
+    await fs.mkdir(bare, { recursive: true });
+    const r = await run(['explain', 'users'], bare);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('DRZL_CFG_001');
+    expect(r.stderr).toContain('--schema');
+  }, 60_000);
+});
+
+describe('the index a bare drzl explain prints', () => {
+  it('lists every table with the count of what was not understood', async () => {
+    const r = await run(['explain', '-s', 'src/db/schema.ts']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('3 tables');
+    expect(r.stdout).toContain('1 thing not understood');
+    expect(r.stdout).toContain('drzl explain <table>');
+  }, 60_000);
+});
+
+describe('--json', () => {
+  it('writes exactly one document to stdout and nothing to stderr', async () => {
+    const r = await pg('users', '--json');
+    expect(r.stderr).toBe('');
+    const doc = JSON.parse(r.stdout);
+    expect(doc.command).toBe('explain');
+    expect(doc.exitCode).toBe(0);
+    expect(doc.dialect).toBe('postgres');
+    expect(doc.schema).toBe('src/db/schema.ts');
+  }, 60_000);
+
+  it('pins the document shape', async () => {
+    const { stdout } = await pg('users', '--json');
+    const doc = JSON.parse(stdout);
+    expect(Object.keys(doc)).toEqual(['command', 'exitCode', 'schema', 'dialect', 'table']);
+    expect(Object.keys(doc.table)).toEqual([
+      'name',
+      'tsName',
+      'qualified',
+      'addressable',
+      'readOnly',
+      'matchedOn',
+      'matchedExactly',
+      'columns',
+      'primaryKey',
+      'unique',
+      'indexes',
+      'foreignKeys',
+      'relations',
+      'constraints',
+      'gaps',
+    ]);
+    const email = doc.table.columns.find((c: any) => c.name === 'email');
+    expect(email).toMatchObject({
+      name: 'email',
+      tsType: 'string',
+      dbType: 'TEXT',
+      sqlType: 'varchar(255)',
+      nullable: false,
+      hasDefault: false,
+      default: null,
+      isGenerated: false,
+      inPrimaryKey: false,
+      unique: true,
+    });
+    expect(email.facts).toContainEqual({ text: 'at most 255 characters', stated: true });
+    expect(doc.table.primaryKey).toEqual({ columns: ['id'], generated: true });
+    expect(doc.table.gaps).toEqual([
+      {
+        kind: 'check',
+        subject: 'email_shape',
+        message:
+          "email_shape: email ~ '^[^@]+@[^@]+$' is not enforced: not a single comparison this " +
+          'version understands.',
+        hint: 'Your database still enforces it. Nothing DRZL generates does.',
+      },
+    ]);
+  }, 60_000);
+
+  it('carries the enforcement verdict per constraint', async () => {
+    const { stdout } = await pg('users', '--json');
+    const byId = Object.fromEntries(
+      JSON.parse(stdout).table.constraints.map((c: any) => [c.id, c])
+    );
+    expect(byId.users_pkey.enforced).toBe(false);
+    expect(byId.age_adult.enforced).toBe(true);
+    expect(byId.email_shape.enforced).toBe(false);
+    expect(byId.email_shape.unenforced[0].reason).toContain('not a single comparison');
+  }, 60_000);
+
+  it('writes a failure document, with the same code the human run prints', async () => {
+    const r = await pg('userz', '--json');
+    expect(r.code).toBe(1);
+    expect(r.stderr).toBe('');
+    expect(JSON.parse(r.stdout)).toMatchObject({
+      ok: false,
+      command: 'explain',
+      code: 'DRZL_EXPLAIN_001',
+      exitCode: 1,
+    });
+  }, 60_000);
+
+  it('emits the index under --json when no table is named', async () => {
+    const { stdout } = await run(['explain', '-s', 'src/db/schema.ts', '--json']);
+    const doc = JSON.parse(stdout);
+    expect(Object.keys(doc)).toEqual(['command', 'exitCode', 'schema', 'dialect', 'tables']);
+    expect(doc.tables.map((t: any) => t.name).sort()).toEqual([
+      'countries',
+      'memberships',
+      'users',
+    ]);
+  }, 60_000);
+});
+
+describe('--quiet', () => {
+  it('keeps the report, because that is the answer rather than the narration', async () => {
+    const r = await pg('users', '--quiet');
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('Columns');
+    expect(r.stderr).toBe('');
+  }, 60_000);
+
+  it('keeps the failure, and drops only the hint under it', async () => {
+    const r = await pg('userz', '--quiet');
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('DRZL_EXPLAIN_001');
+    expect(r.stderr).not.toContain('Did you mean');
+  }, 60_000);
+});
+
+describe('the config', () => {
+  it('reads the schema path from drzl.config when none is given', async () => {
+    const dir = path.join(ROOT, 'configured');
+    await fs.mkdir(path.join(dir, 'src', 'db'), { recursive: true });
+    await fs.writeFile(path.join(dir, 'src', 'db', 'schema.ts'), PG_SCHEMA, 'utf8');
+    await fs.writeFile(
+      path.join(dir, 'drzl.config.ts'),
+      "export default { schema: 'src/db/schema.ts', outDir: 'out', exclude: ['countries'], " +
+        "columns: { users: { omit: ['payload'] } }, generators: [{ kind: 'zod' }] };\n",
+      'utf8'
+    );
+    const r = await run(['explain', 'users'], dir);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('export "users"');
+    // The filter narrows what the generators see, and saying so is the answer to "why is this
+    // column not in my validator".
+    expect(r.stdout).toContain('removes 1 of these columns: payload');
+  }, 60_000);
+
+  // A table the config excludes is exactly the one whose absence needs explaining, so it is still
+  // found. Reporting "there is no such table" would be the wrong answer to the right question.
+  it('still explains a table this config excludes, and says the config excludes it', async () => {
+    const dir = path.join(ROOT, 'configured');
+    const r = await run(['explain', 'countries'], dir);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('include/exclude removes this table');
+  }, 60_000);
+});

--- a/packages/cli/test/explain.spec.ts
+++ b/packages/cli/test/explain.spec.ts
@@ -1,0 +1,497 @@
+/**
+ * The parts of `drzl explain` that are a function of an analysis rather than of a process.
+ *
+ * Held apart from `explain.e2e.spec.ts`, which spawns the built CLI: the rules that decide which
+ * table a name reaches, and which facts about it a generated schema states, are worth exercising
+ * over inputs an analyzer cannot easily be made to produce. Two schemas holding one table name and
+ * a `varchar` that a CHECK narrows to a set are both a few lines here and a fixture tree there.
+ *
+ * No build required.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Analysis, Column, Table } from '@drzl/analyzer';
+import {
+  ambiguousTableProblem,
+  explainTable,
+  matchTable,
+  noSuchTableProblem,
+  renderExplanation,
+  renderIndex,
+  summarize,
+  type TableMatch,
+} from '../src/explain';
+
+/** A column with every field the analyzer leaves off by default already off. */
+function column(name: string, over: Partial<Column> = {}): Column {
+  return {
+    name,
+    tsType: 'string',
+    dbType: 'TEXT',
+    sqlType: 'text',
+    nullable: false,
+    hasDefault: false,
+    isGenerated: false,
+    ...over,
+  };
+}
+
+function table(over: Partial<Table> & { name: string }): Table {
+  return {
+    tsName: over.name,
+    columns: [],
+    unique: [],
+    indexes: [],
+    ...over,
+  } as Table;
+}
+
+function analysis(tables: Table[], over: Partial<Analysis> = {}): Analysis {
+  return { dialect: 'postgres', tables, enums: [], relations: [], issues: [], ...over };
+}
+
+/** The one call shape the CLI makes, so a test never has to narrow the union itself. */
+function explain(a: Analysis, query: string, options = {}) {
+  const match = matchTable(a.tables, query);
+  if (match.kind !== 'found') throw new Error(`expected a match for ${query}, got ${match.kind}`);
+  return explainTable(a, match as Extract<TableMatch, { kind: 'found' }>, options);
+}
+
+describe('matchTable', () => {
+  const users = table({ name: 'users', tsName: 'users' });
+  const orgMembers = table({ name: 'organisation_members', tsName: 'orgMembers' });
+  const reportingUsers = table({ name: 'users', tsName: 'reportingUsers', schema: 'reporting' });
+
+  it('matches the database name', () => {
+    const m = matchTable([users, orgMembers], 'users');
+    expect(m).toMatchObject({ kind: 'found', matchedOn: 'name', exact: true });
+  });
+
+  it('matches the TypeScript export name, which a reader may be the only one they know', () => {
+    const m = matchTable([users, orgMembers], 'orgMembers');
+    expect(m).toMatchObject({ kind: 'found', matchedOn: 'tsName', exact: true });
+    expect((m as any).table.name).toBe('organisation_members');
+  });
+
+  it('matches a qualified name, and reports that it was the qualified one', () => {
+    const m = matchTable([users, reportingUsers], 'reporting.users');
+    expect(m).toMatchObject({ kind: 'found', matchedOn: 'qualified', exact: true });
+    expect((m as any).table.tsName).toBe('reportingUsers');
+  });
+
+  it('matches the public. spelling of a table that declares no schema', () => {
+    const m = matchTable([users], 'public.users');
+    expect(m).toMatchObject({ kind: 'found', matchedOn: 'qualified', exact: true });
+  });
+
+  it('falls back to case-insensitive, and says it did', () => {
+    const m = matchTable([users, orgMembers], 'ORGMEMBERS');
+    expect(m).toMatchObject({ kind: 'found', matchedOn: 'tsName', exact: false });
+  });
+
+  it('prefers the exact match over a case-insensitive one on another table', () => {
+    const upper = table({ name: 'USERS', tsName: 'upperUsers' });
+    expect(matchTable([users, upper], 'USERS')).toMatchObject({
+      kind: 'found',
+      exact: true,
+      table: { tsName: 'upperUsers' },
+    });
+    expect(matchTable([users, upper], 'users')).toMatchObject({
+      kind: 'found',
+      exact: true,
+      table: { tsName: 'users' },
+    });
+  });
+
+  // Reachable from an ordinary schema, and the one answer this command must never give silently:
+  // facts about a table the reader did not ask about are worse than no answer at all.
+  it('refuses to choose when a bare name reaches two schemas', () => {
+    const m = matchTable([users, reportingUsers], 'users');
+    expect(m.kind).toBe('ambiguous');
+    expect((m as any).hits).toHaveLength(2);
+  });
+
+  it('refuses to choose when one table export name is another table database name', () => {
+    const shadow = table({ name: 'accounts', tsName: 'users' });
+    expect(matchTable([users, shadow], 'users').kind).toBe('ambiguous');
+  });
+
+  it('does not fall through to case folding after an ambiguous exact round', () => {
+    const m = matchTable([users, reportingUsers], 'users');
+    expect(m).toMatchObject({ kind: 'ambiguous', exact: true });
+  });
+
+  it('suggests the nearest name when nothing matches', () => {
+    expect(matchTable([users, orgMembers], 'userz')).toEqual({
+      kind: 'none',
+      suggestion: 'users',
+    });
+  });
+
+  it('offers no suggestion for a name that is not a typo of anything', () => {
+    expect(matchTable([users, orgMembers], 'invoices')).toEqual({ kind: 'none' });
+  });
+});
+
+describe('the failure messages', () => {
+  it('names the table that was asked for and the tables there are', () => {
+    const problem = noSuchTableProblem(
+      'userz',
+      [table({ name: 'users' }), table({ name: 'posts' })],
+      'users'
+    );
+    expect(problem.code).toBe('DRZL_EXPLAIN_001');
+    expect(problem.message).toContain('"userz"');
+    expect(problem.message).toContain('users, posts');
+    expect(problem.hint).toContain('users');
+  });
+
+  it('caps the list rather than printing a hundred names', () => {
+    const many = Array.from({ length: 30 }, (_, i) => table({ name: `t${i}` }));
+    const problem = noSuchTableProblem('nope', many, undefined);
+    expect(problem.message).toContain('and 18 more');
+  });
+
+  it('hands back a spelling that separates two ambiguous tables', () => {
+    const hits = [
+      { table: table({ name: 'users', schema: 'reporting', tsName: 'r' }), matchedOn: 'name' as const },
+      { table: table({ name: 'users', tsName: 'users' }), matchedOn: 'name' as const },
+    ];
+    const problem = ambiguousTableProblem('users', hits);
+    expect(problem.code).toBe('DRZL_EXPLAIN_002');
+    expect(problem.message).toContain('reporting.users');
+    expect(problem.message).toContain('public.users');
+    expect(problem.hint).toContain('"reporting.users"');
+  });
+});
+
+describe('explainTable', () => {
+  it('states the array depth in the TypeScript type it reports', () => {
+    const a = analysis([
+      table({ name: 'posts', columns: [column('tags', { arrayDimensions: 1, sqlType: 'text[]' })] }),
+    ]);
+    const rendered = renderExplanation(explain(a, 'posts'), { schema: 's.ts', dialect: 'postgres' });
+    // `tsType` is the element type on an array column, because Drizzle gives an array no class of
+    // its own. Printing it bare says `string` for a `text[]`, which is the exact misreading that
+    // made every array schema reject every row the database returned.
+    expect(rendered).toContain('string[]');
+  });
+
+  it('separates the three ways a default arrives', () => {
+    const a = analysis([
+      table({
+        name: 'rows',
+        columns: [
+          column('a', { hasDefault: true, defaultValue: 'GB' }),
+          column('b', { hasDefault: true, defaultExpression: 'now()' }),
+          column('c', { hasDefault: true }),
+        ],
+      }),
+    ]);
+    const columns = explain(a, 'rows').columns;
+    expect(columns[0].default).toEqual({ kind: 'literal', value: 'GB' });
+    expect(columns[1].default).toEqual({ kind: 'expression', text: 'now()' });
+    expect(columns[2].default).toEqual({ kind: 'runtime' });
+  });
+
+  // The point of the "stated" flag: a default nothing can reproduce makes the field optional and
+  // states no value, and a reader asking "why does my schema not check this" gets the reason.
+  it('reports a runtime default as a fact no generated schema states', () => {
+    const a = analysis([table({ name: 'rows', columns: [column('c', { hasDefault: true })] })]);
+    const fact = explain(a, 'rows').columns[0].facts.find((f) => f.text === 'has a default');
+    expect(fact?.stated).toBe(false);
+    expect(fact?.reason).toContain('optional on insert');
+  });
+
+  it('reports a declared width as stated on an ordinary string column', () => {
+    const a = analysis([
+      table({ name: 'rows', columns: [column('email', { maxLength: 255, sqlType: 'varchar(255)' })] }),
+    ]);
+    const fact = explain(a, 'rows').columns[0].facts.find((f) => f.text.includes('255 characters'));
+    expect(fact).toEqual({ text: 'at most 255 characters', stated: true });
+  });
+
+  // Each of these is a width the column really declares and that no emitted schema ever writes,
+  // because the value space is stated some other way. That is exactly the case the command exists
+  // to explain, and the verdict is read off `tableConstraints` rather than re-derived here.
+  it.each([
+    [
+      'a CHECK narrowing it to a set',
+      { maxLength: 32, sqlType: 'varchar(32)' } as Partial<Column>,
+      [{ name: 'set', expression: "label IN ('a', 'b')" }],
+      'set of literals',
+    ],
+    [
+      'an enum',
+      { maxLength: 32, enumValues: ['a', 'b'] } as Partial<Column>,
+      [],
+      'is an enum',
+    ],
+    [
+      'a uuid format',
+      { maxLength: 36, format: 'uuid' } as Partial<Column>,
+      [],
+      'uuid format replaces the width',
+    ],
+  ])('reports a width nothing states when the column has %s', (_why, over, checks, reason) => {
+    const a = analysis([
+      table({ name: 'rows', columns: [column('label', over)], checks: checks as any }),
+    ]);
+    const fact = explain(a, 'rows').columns[0].facts.find((f) => f.text.includes('at most'));
+    expect(fact?.stated).toBe(false);
+    expect(fact?.reason).toContain(reason);
+  });
+
+  it('carries the measured facts a range cannot state', () => {
+    const a = analysis([
+      table({
+        name: 'rows',
+        columns: [
+          column('score', {
+            tsType: 'number',
+            dbType: 'DOUBLE',
+            sqlType: 'double precision',
+            integer: false,
+            allowsNaN: true,
+            allowsInfinity: true,
+          }),
+        ],
+      }),
+    ]);
+    const texts = explain(a, 'rows').columns[0].facts.map((f) => f.text);
+    expect(texts).toContain('NaN is stored and returned');
+    expect(texts).toContain('Infinity is stored and returned');
+  });
+
+  it('reports a composite primary key whole, and says which column the generators key on', () => {
+    const a = analysis([
+      table({
+        name: 'memberships',
+        columns: [column('orgId'), column('userId')],
+        primaryKey: { columns: ['orgId', 'userId'] },
+      }),
+    ]);
+    const explanation = explain(a, 'memberships');
+    expect(explanation.primaryKey).toEqual({ columns: ['orgId', 'userId'], generated: false });
+    const rendered = renderExplanation(explanation, { schema: 's.ts', dialect: 'postgres' });
+    expect(rendered).toContain('PRIMARY KEY (orgId, userId)');
+    // Collapsed, because the sentence is wrapped to the width and the assertion is about the
+    // sentence rather than about where the wrap fell.
+    expect(rendered.replace(/\s+/g, ' ')).toContain('"orgId" alone');
+  });
+
+  it('calls a key generated when the database fills it in, serial included', () => {
+    const a = analysis([
+      table({
+        name: 'users',
+        columns: [column('id', { tsType: 'number', dbType: 'SERIAL', hasDefault: true })],
+        primaryKey: { columns: ['id'] },
+      }),
+    ]);
+    expect(explain(a, 'users').primaryKey?.generated).toBe(true);
+  });
+
+  it('says a table has no primary key rather than leaving the section empty', () => {
+    const a = analysis([table({ name: 'logs', columns: [column('line')] })]);
+    expect(explain(a, 'logs').primaryKey).toBeNull();
+    const rendered = renderExplanation(explain(a, 'logs'), { schema: 's.ts', dialect: 'postgres' });
+    expect(rendered).toContain('No primary key');
+  });
+
+  it('keeps only the relations with this table at one end', () => {
+    const a = analysis([table({ name: 'users' }), table({ name: 'posts' }), table({ name: 'tags' })], {
+      relations: [
+        { kind: 'many', from: 'users', to: 'posts' },
+        { kind: 'one', from: 'posts', to: 'users' },
+        { kind: 'many', from: 'posts', to: 'tags' },
+      ],
+    });
+    const relations = explain(a, 'users').relations;
+    expect(relations).toHaveLength(2);
+    expect(relations.map((r) => r.outgoing)).toEqual([true, false]);
+  });
+});
+
+describe('what was dropped or left unrecognised', () => {
+  it('names a CHECK the shared parser could not classify, with the parser own reason', () => {
+    const a = analysis([
+      table({
+        name: 'users',
+        columns: [column('email')],
+        checks: [{ name: 'email_shape', expression: "email ~ '^x'" }],
+      }),
+    ]);
+    const gaps = explain(a, 'users').gaps;
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]).toMatchObject({ kind: 'check', subject: 'email_shape' });
+    expect(gaps[0].message).toContain('is not enforced:');
+  });
+
+  // The label lives inside the clause text already, because that is the message an emitted schema
+  // would attach. Prefixing the subject as well printed `email_shape: email_shape: ...`.
+  it('does not print the constraint name twice', () => {
+    const a = analysis([
+      table({
+        name: 'users',
+        columns: [column('email')],
+        checks: [{ name: 'email_shape', expression: "email ~ '^x'" }],
+      }),
+    ]);
+    const rendered = renderExplanation(explain(a, 'users'), { schema: 's.ts', dialect: 'postgres' });
+    expect(rendered).not.toContain('email_shape: email_shape');
+  });
+
+  it('names a CHECK on a column the table does not have', () => {
+    const a = analysis([
+      table({
+        name: 'users',
+        columns: [column('email')],
+        checks: [{ name: 'wrong', expression: 'nickname >= 3' }],
+      }),
+    ]);
+    expect(explain(a, 'users').gaps[0].message).toContain('not a column of that table');
+  });
+
+  it('passes through a column the analyzer could not type', () => {
+    const a = analysis([table({ name: 'users', columns: [column('weird', { tsType: 'unknown' })] })], {
+      issues: [
+        {
+          code: 'DRZL_ANL_UNKNOWN_COLUMN',
+          level: 'warn',
+          message: 'Column "weird" on table "users" has no known type, so its validator will accept any value.',
+          path: 'users.weird',
+          hint: 'Open an issue naming the column type.',
+        },
+      ],
+    });
+    const gaps = explain(a, 'users').gaps;
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]).toMatchObject({ kind: 'column', subject: 'weird' });
+  });
+
+  it('passes through a relation the analyzer could not follow', () => {
+    const a = analysis([table({ name: 'users' })], {
+      issues: [
+        {
+          code: 'DRZL_ANL_REL_V2',
+          level: 'warn',
+          message: 'Relation "posts" on "users" names no target table and was skipped.',
+          path: 'users',
+        },
+      ],
+    });
+    expect(explain(a, 'users').gaps[0]).toMatchObject({ kind: 'relation' });
+  });
+
+  it('leaves out an issue about another table', () => {
+    const a = analysis([table({ name: 'users' }), table({ name: 'posts' })], {
+      issues: [{ code: 'DRZL_ANL_UNKNOWN_COLUMN', level: 'warn', message: 'x', path: 'posts.body' }],
+    });
+    expect(explain(a, 'users').gaps).toEqual([]);
+  });
+
+  it('leaves out an issue about the schema as a whole, which names no table', () => {
+    const a = analysis([table({ name: 'users' })], {
+      issues: [{ code: 'DRZL_ANL_DIALECT', level: 'warn', message: 'no dialect' }],
+    });
+    expect(explain(a, 'users').gaps).toEqual([]);
+  });
+
+  it('says so plainly when the whole table was understood', () => {
+    const a = analysis([table({ name: 'users', columns: [column('id')] })]);
+    expect(explain(a, 'users').gaps).toEqual([]);
+    const rendered = renderExplanation(explain(a, 'users'), { schema: 's.ts', dialect: 'postgres' });
+    expect(rendered).toContain('Nothing about this table was dropped');
+  });
+});
+
+describe('the config filters', () => {
+  const a = analysis([
+    table({ name: 'users', columns: [column('id'), column('secret')] }),
+    table({ name: 'posts' }),
+  ]);
+
+  it('says when this config removes the table, rather than failing to find it', () => {
+    const explanation = explain(a, 'users', { keptTables: ['posts'] });
+    expect(explanation.excludedByConfig).toBe(true);
+    const rendered = renderExplanation(explanation, { schema: 's.ts', dialect: 'postgres' });
+    expect(rendered).toContain('include/exclude removes this table');
+  });
+
+  it('names the columns this config removes', () => {
+    const explanation = explain(a, 'users', { keptTables: ['users', 'posts'], keptColumns: ['id'] });
+    expect(explanation.columnsRemovedByConfig).toEqual(['secret']);
+    expect(explanation.excludedByConfig).toBeUndefined();
+  });
+});
+
+describe('the rendered report', () => {
+  const a = analysis([
+    table({
+      name: 'users',
+      columns: [
+        column('id', { tsType: 'number', dbType: 'SERIAL', sqlType: 'serial', hasDefault: true }),
+        column('email', { maxLength: 255, sqlType: 'varchar(255)' }),
+        // A column with nothing in the last cell, so the trailing-whitespace assertion below has
+        // a row that can carry any. Every other column here is a key, a default or a unique, and
+        // a padded cell with content after it never shows the defect.
+        column('nickname', { nullable: true }),
+        column('createdAt', { tsType: 'Date', sqlType: 'timestamp with time zone', hasDefault: true }),
+      ],
+      primaryKey: { columns: ['id'] },
+      unique: [{ columns: ['email'] }],
+      checks: [{ name: 'shape', expression: "email ~ '^x'" }],
+    }),
+  ]);
+  const rendered = renderExplanation(explain(a, 'users'), {
+    schema: 'src/db/schema.ts',
+    dialect: 'postgres',
+  });
+
+  it('fits a terminal 80 columns wide', () => {
+    const tooWide = rendered.split('\n').filter((line) => line.length > 80);
+    expect(tooWide).toEqual([]);
+  });
+
+  // A run of spaces at the end of a line is invisible in a terminal and is the first thing a
+  // reviewer sees in a diff, so the padding stops where the content does.
+  it('leaves no trailing whitespace on any line', () => {
+    const trailing = rendered.split('\n').filter((line) => /\s$/.test(line));
+    expect(trailing).toEqual([]);
+  });
+
+  it('carries no escape sequences when the caller passes no styling', () => {
+    expect(rendered).not.toContain('');
+  });
+
+  it('shows the declared SQL type beside the TypeScript one', () => {
+    expect(rendered).toContain('varchar(255)');
+    expect(rendered).toContain('timestamp with time zone');
+  });
+});
+
+describe('the index a bare drzl explain prints', () => {
+  const a = analysis([
+    table({ name: 'users', columns: [column('id')] }),
+    table({
+      name: 'posts',
+      tsName: 'blogPosts',
+      columns: [column('body')],
+      checks: [{ name: 'shape', expression: "body ~ '^x'" }],
+    }),
+  ]);
+
+  it('counts what explain would report as not understood, per table', () => {
+    expect(summarize(a)).toEqual([
+      { name: 'users', tsName: 'users', qualified: 'users', columns: 1, checks: 0, gaps: 0 },
+      { name: 'posts', tsName: 'blogPosts', qualified: 'posts', columns: 1, checks: 1, gaps: 1 },
+    ]);
+  });
+
+  it('prints both names, because either is what a reader knows', () => {
+    const rendered = renderIndex(summarize(a), { schema: 's.ts', dialect: 'postgres' });
+    expect(rendered).toContain('posts');
+    expect(rendered).toContain('blogPosts');
+    expect(rendered).toContain('1 thing not understood');
+    expect(rendered.split('\n').filter((l) => /\s$/.test(l))).toEqual([]);
+  });
+});

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -571,6 +571,93 @@ if [ "$got_missing" != 1 ]; then
   exit 1
 fi
 echo "    exit codes: 0 on a readable schema, 1 on one it cannot read"
+
+# ---------------------------------------------------------------------------------------------
+# `drzl explain`, against the `drzl doctor` that reports the same silences.
+#
+# The two commands answer the same question from opposite ends and share none of the code that
+# answers it: `doctor` calls `parseCheck` itself and filters the analyzer's issues, while `explain`
+# reads `tableConstraints`, which is what the emitted constraint ledger is built from. So a drift
+# in either one is a drift between them, and this is the only place the two are compared.
+#
+# The assertion is not that `explain` prints something. It is that the things it lists as not
+# understood about `invoices` are exactly the things `doctor` reports about `invoices`: the same
+# untypeable column, and the same CHECK that no generator translates. `explain` going quiet about
+# either is the silence both commands exist to prevent, and a green run would not otherwise say so.
+echo "==> explain and doctor agree about what is not understood"
+npx drzl explain invoices -s src/db/doctor-fixture.ts --json > "$WORK/explain.json"
+
+node --input-type=module -e "
+import { readFile } from 'node:fs/promises';
+const report = JSON.parse(await readFile('$WORK/doctor.json', 'utf8'));
+const doc = JSON.parse(await readFile('$WORK/explain.json', 'utf8'));
+
+// No backticks anywhere in this block. It reaches node inside a double-quoted -e argument, so
+// bash reads one as command substitution; see the doctor stage above for what that cost once.
+const gaps = doc.table.gaps ?? [];
+const columns = new Set(gaps.filter((g) => g.kind === 'column').map((g) => g.subject));
+const checks = new Set(gaps.filter((g) => g.kind === 'check').map((g) => g.subject));
+
+const mine = (kind) => (report.findings ?? []).filter((f) => f.kind === kind && f.table === 'invoices');
+const doctorColumns = new Set(mine('unknown-column').map((f) => f.column));
+const doctorChecks = new Set(mine('check-declined').map((f) => f.constraint));
+
+// Sets rather than lists: doctor reports one finding per declined clause and explain one gap per
+// unenforced part, so the two can differ in count for one constraint while naming the same one.
+// The question here is which constraints and columns each names, and that has one answer.
+const differ = (a, b) => a.size !== b.size || [...a].some((x) => !b.has(x));
+if (differ(columns, doctorColumns) || differ(checks, doctorChecks)) {
+  console.error('    FAIL: doctor and explain disagree about the invoices table.');
+  console.error('      doctor columns: ' + JSON.stringify([...doctorColumns]));
+  console.error('      explain columns: ' + JSON.stringify([...columns]));
+  console.error('      doctor checks: ' + JSON.stringify([...doctorChecks]));
+  console.error('      explain checks: ' + JSON.stringify([...checks]));
+  process.exit(1);
+}
+// Both empty compares equal, so the equality above is satisfied by a fixture with nothing wrong
+// and by an explain that reports nothing whatever it is given. The fixture guarantees one of each.
+if (!columns.size || !checks.size) {
+  console.error('    FAIL: the fixture produced no untypeable column or no declined CHECK, so the');
+  console.error('          comparison above compared empty sets and proved nothing.');
+  process.exit(1);
+}
+// A verdict with no reason under it is a report that says a constraint is missing and leaves the
+// reader no way to act. The reason comes off the shared parser, so an empty one here means explain
+// has stopped carrying what that parser said rather than that the parser has stopped saying it.
+const unreasoned = (doc.table.constraints ?? [])
+  .flatMap((c) => (c.unenforced ?? []).map((u) => [c.id, u.reason]))
+  .filter(([, reason]) => !reason || !String(reason).trim());
+if (unreasoned.length) {
+  console.error('    FAIL: explain reported these constraints as unenforced and gave no reason:');
+  for (const [id] of unreasoned) console.error('      ' + id);
+  process.exit(1);
+}
+console.log(
+  '    ' + columns.size + ' untypeable column(s) and ' + checks.size +
+    ' unenforced CHECK(s), named identically by doctor and explain'
+);
+" || { echo "FAIL: explain and doctor disagree about what DRZL could not use." >&2; exit 1; }
+
+# The exit codes are what a script reads. A table that is there, a table that is not, and a name
+# that reaches two tables are three different answers, and only the packed artifact can be asked.
+cat > src/db/two-schemas.ts <<'TWO_SCHEMAS'
+import { integer, pgSchema, pgTable } from 'drizzle-orm/pg-core';
+const reporting = pgSchema('reporting');
+export const users = pgTable('users', { id: integer('id').primaryKey() });
+export const reportingUsers = reporting.table('users', { id: integer('id').primaryKey() });
+TWO_SCHEMAS
+
+explain_code() { npx drzl explain "$@" >/dev/null 2>&1; echo $?; }
+got_found=$(explain_code invoices -s src/db/doctor-fixture.ts)
+got_missing=$(explain_code no_such_table -s src/db/doctor-fixture.ts)
+got_ambiguous=$(explain_code users -s src/db/two-schemas.ts)
+if [ "$got_found" != 0 ] || [ "$got_missing" != 1 ] || [ "$got_ambiguous" != 1 ]; then
+  echo "FAIL: drzl explain exited $got_found on a table that exists, $got_missing on one that" >&2
+  echo "      does not, and $got_ambiguous on a name reaching two tables. Expected 0, 1, 1." >&2
+  exit 1
+fi
+echo "    exit codes: 0 explained, 1 no such table, 1 ambiguous name"
+rm -f src/db/two-schemas.ts
 rm -f src/db/doctor-fixture.ts
 
 BARREL="src/generated/zod/index.ts"


### PR DESCRIPTION
Plan item 69, the last item in the CLI tier: `drzl explain <table>`, plus the gate stage that keeps it honest.

## Where the answers come from

Three sources, none re-derived: the analyzer's `Column`/`Table` for facts (resolved `tsType` with array depth restored, the declared `sqlType` from Drizzle's own `getSQLType()`, nullability, the three kinds of default, keys, foreign keys, enum members, and every measured fact the generators act on), **`tableConstraints` from `@drzl/validation-core`** for the enforcement verdict, and `analysis.issues` filtered to the table for untypeable columns and unfollowable relations.

Using `tableConstraints` is the load-bearing choice: it is the function the emitted constraint ledger is built from, so `explain` and the generated modules cannot disagree, and each declined clause comes back carrying the shared parser's own reason rather than a second copy of the rule.

## What it says is not there

Facts the generators deliberately do not state are marked with their reason: a `varchar(32)` narrowed by a `CHECK ... IN (...)` never reaches the schema as a width, nor does one on an enum or a `uuid`/`numeric` column, and a `defaultNow()` makes the field optional on insert with no schema stating what it becomes. A `Not understood` section lists CHECKs the parser declined, columns it could not type, and relations it could not follow, which are exactly the cases where someone's output is wrong today and the reason is invisible.

Bare `drzl explain` earns its place: `analyze` prints the whole `Analysis` as JSON and points at nothing, and there is no human table listing anywhere in the CLI. The index prints one line per table **with the count of things `explain` would report as not understood**, which is what tells you where to look in a forty-table schema.

## Matching, and the case that matters

Exact over all three names at once (database name, qualified name including the `public.` alias, TS export name), then the same three case-insensitively with the looser match reported. An ambiguous name is **refused** with both tables named and the spelling that separates them, not resolved silently, and an ambiguous exact round does not fall through since loosening can only add hits. A table removed by the config's `include`/`exclude` is still found and still explained, with a line saying the config removes it, because a command that could not find it would answer "why is my table missing" with "there is no such table".

Deliberately left out, with reasons: `Table.meta` (a re-rendering of facts already shown), the raw CHECK SQL as the only representation (it is carried, but the classification is the point), and a `--strict`-style exit 2, since a declined CHECK is a normal usable schema and `doctor --strict` is that command.

## The gate stage (controller-applied here)

`explain` and `doctor` answer the same question from opposite ends and **share none of the code that answers it** (`doctor` calls `parseCheck` itself and filters issues; `explain` reads `tableConstraints`), so a drift in either is a drift between them, and nothing else in the file compares them. The stage asserts the sets of not-understood columns and CHECKs for one table are identical between the two commands, then **refuses two empty sets** (both-empty compares equal, so the comparison would otherwise pass against a command that reports nothing whatever it is given), refuses an unenforced verdict with no reason under it, and pins exit codes 0 / 1 / 1 for found, missing and ambiguous. Four sabotages were run against it and all four fire: dropping the check gap, dropping the column gap, blanking the reasons, renaming the constraint. It reuses the doctor fixture and the JSON that stage already writes, so it costs one extra CLI invocation.

## Verification

The command is new, so red-first was inverted deliberately: the specs passed on the first run, so each fix was reverted in turn and the spec re-run (array suffix, two padding bugs, a duplicated constraint label, ambiguity refusal replaced by "pick the first", and the consequence clause), each reverting cleanly to red and back. 75 new tests, CLI package at 914.

Gates green including `pnpm verify:packed`. Recorded from the agent: no stage in the gate enumerates commands, so there was no command list to add to; the doc extractor ignores `docs/cli/explain.md` since it has no runnable config block.

One small shared change: `schema-outcome.ts` gained an optional consequence clause, with the default keeping every existing caller's text byte for byte, because "Nothing was generated." is false for a command with no write path.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
