### PR TITLE
ci: check three documented blocks, after the run has finished printing

### DIFF
--- a/docs/guide/comparison.md
+++ b/docs/guide/comparison.md
@@ -108,7 +108,8 @@ accept a parseable date string or an epoch number where the first-party modules 
 ## Where DRZL is worse
 
 **Six columns on drizzle-orm 0.45.2 where the first-party validator is right and DRZL is not.**
-Filed rather than fixed, and printed by name on every run:
+Filed rather than fixed, and carried by name in the gate's own defect ledger, which fails the
+run if any of them stops reproducing:
 
 ```
       mysql/m_year: DRZL emits an unbounded integer, official emits an integer within 1901..2155 [new]

--- a/docs/guide/verification.md
+++ b/docs/guide/verification.md
@@ -207,7 +207,6 @@ local MySQL 8.4.11 on utf8mb4 in strict mode.
     32 CHECK probes against a real SQLite (10 constrained columns)
     37 probes against a real MySQL
     9 defaulted columns, 9 reproduced by applyDefaults
-    10 line(s) of docs/guide/benchmarks.md matched this run's output, 0 not compared
     117 columns and 11 tables compared, drizzle-orm 0.45.2 against 1.0.0-rc.4
     drizzle-orm 0.45.2 against drizzle-zod 0.8.3, drizzle-valibot 0.4.2, drizzle-arktype 0.1.3, drizzle-typebox 0.3.3
     1500 column comparisons across 72 pairings

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -6431,37 +6431,56 @@ fi
 # "three actual databases" makes the extraction return nothing, and the count guard below exits 1
 # rather than reporting that everything matched.
 echo "==> the numbers the documentation quotes, against this run"
-DOC_BENCH="$ROOT/docs/guide/benchmarks.md"
+# Each entry is <file>|<phrase>: the first fenced block after <phrase> in that file is compared.
+# The phrase is matched with awk's index() rather than as a pattern, so a phrase carrying
+# punctuation cannot quietly become a regex that matches somewhere else.
+DOC_BLOCKS=(
+  "docs/guide/benchmarks.md|three real databases"
+  "docs/guide/verification.md|Lines from the run behind this page"
+  "docs/guide/comparison.md|the run behind this page printed"
+  "docs/guide/comparison.md|printed by name on every run"
+)
 doc_missing=0
 doc_checked=0
 doc_skipped=0
-while IFS= read -r doc_line; do
-  doc_trim="$(printf '%s' "$doc_line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
-  [ -z "$doc_trim" ] && continue
-  if [ -z "${MYSQL_URL:-}" ] && printf '%s' "$doc_trim" | grep -q 'MySQL'; then
-    doc_skipped=$((doc_skipped + 1))
-    echo "    not compared, that stage did not run without MYSQL_URL: $doc_trim"
-    continue
-  fi
-  doc_checked=$((doc_checked + 1))
-  if ! grep -Fq -- "$doc_trim" "$WORK/printed.log"; then
-    if [ "$doc_missing" -eq 0 ]; then
-      echo "    FAIL: docs/guide/benchmarks.md quotes this script's output, and this run did not"
-      echo "          print these lines. Paste what the run printed, or say what changed:"
+for doc_entry in "${DOC_BLOCKS[@]}"; do
+  doc_rel="${doc_entry%%|*}"
+  doc_phrase="${doc_entry#*|}"
+  doc_seen=0
+  while IFS= read -r doc_line; do
+    doc_trim="$(printf '%s' "$doc_line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ -z "$doc_trim" ] && continue
+    doc_seen=$((doc_seen + 1))
+    if [ -z "${MYSQL_URL:-}" ] && printf '%s' "$doc_trim" | grep -q 'MySQL'; then
+      doc_skipped=$((doc_skipped + 1))
+      echo "    not compared, that stage did not run without MYSQL_URL: $doc_trim"
+      continue
     fi
-    echo "      $doc_trim"
-    doc_missing=$((doc_missing + 1))
+    doc_checked=$((doc_checked + 1))
+    if ! grep -Fq -- "$doc_trim" "$WORK/printed.log"; then
+      if [ "$doc_missing" -eq 0 ]; then
+        echo "    FAIL: the documentation quotes this script's output, and this run did not"
+        echo "          print these lines. Paste what the run printed, or say what changed:"
+      fi
+      echo "      $doc_rel: $doc_trim"
+      doc_missing=$((doc_missing + 1))
+    fi
+  done < <(awk -v p="$doc_phrase" 'index($0,p)>0{found=1} found && /^```$/{n++; next} found && n==1' "$ROOT/$doc_rel")
+  # Per block, not once at the end. A dead anchor in one file would otherwise hide behind another
+  # file's matches and the run would report that everything matched. Counted on lines extracted
+  # rather than lines compared, so a block that is entirely MySQL lines does not read as dead on a
+  # run without MYSQL_URL.
+  if [ "$doc_seen" -eq 0 ]; then
+    echo "    FAIL: found no quoted lines in $doc_rel after the phrase \"$doc_phrase\", so this" >&2
+    echo "          check measured nothing there. The prose above the block was probably edited." >&2
+    exit 1
   fi
-done < <(awk '/three real databases/{found=1} found && /^```$/{n++; next} found && n==1' "$DOC_BENCH")
-if [ "$doc_checked" -eq 0 ]; then
-  echo "    FAIL: found no quoted lines to compare, so this check measured nothing." >&2
-  exit 1
-fi
+done
 if [ "$doc_missing" -gt 0 ]; then
   echo "FAIL: the documentation quotes numbers this run did not produce." >&2
   exit 1
 fi
-echo "    $doc_checked line(s) of docs/guide/benchmarks.md matched this run's output, $doc_skipped not compared"
+echo "    $doc_checked line(s) across ${#DOC_BLOCKS[@]} documented block(s) matched this run's output, $doc_skipped not compared"
 
 cd "$APP"
 

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -4575,7 +4575,7 @@ report_size src/gen/pg/typebox  typebox  490  || size_fail=1
 # tree can carry it.
 [ "$size_fail" = 0 ] || exit 1
 
-if ! npx tsx src/parity.ts; then
+if ! npx tsx src/parity.ts | tee -a "$WORK/printed.log"; then
   echo "FAIL: DRZL's generated schemas diverge from the official drizzle-orm validators." >&2
   exit 1
 fi
@@ -6404,84 +6404,6 @@ if ! npx tsx --disable-warning=ExperimentalWarning src/sqlite-truth.ts | tee -a 
   exit 1
 fi
 
-# ---------------------------------------------------------------------------------------------
-# The numbers the published documentation quotes, against the run that produced them.
-#
-# Until this existed nothing in the project checked a number in the documentation. Measured rather
-# than assumed: `9.9999999999999999e42` substituted for the float4 bound in the shipped TypeBox
-# page left `pnpm lint`, `pnpm typecheck`, every package test, `pnpm -C docs build` and
-# `scripts/extract-doc-configs.mjs` all at exit 0, and that last one is the only docs-aware stage
-# in the whole gate: it reads runnable config blocks and cannot see a table or a paragraph.
-#
-# It is not a documentation test framework, and it does not try to be. It covers exactly one
-# thing, the block in benchmarks.md that quotes this script's own output, which is the only prose
-# in the docs whose numbers this run also computes. That block was stale when this check was
-# written: it claimed `DRZL 1007, drizzle-orm 979` and `closer on 28` for a run that had been
-# printing 1012 and 33 since the commit that changed the float bounds, and five rounds of review
-# had read the same branch without noticing. Every other number in the docs is still unchecked and
-# still has nothing behind it.
-#
-# The comparison is line by line and literal, so a fabricated digit fails rather than a fabricated
-# sentence. Lines about MySQL are skipped, by name and out loud, when no MYSQL_URL is set: that
-# stage did not run, so this run has nothing to compare them with.
-#
-# Both controls were run against a captured run log before this shipped. `DRZL 1048` changed to
-# `DRZL 9999` in the page exits 1 naming that line. The vacuity control matters more, because this
-# check finds its block by a phrase in the prose above it: editing "three real databases" to
-# "three actual databases" makes the extraction return nothing, and the count guard below exits 1
-# rather than reporting that everything matched.
-echo "==> the numbers the documentation quotes, against this run"
-# Each entry is <file>|<phrase>: the first fenced block after <phrase> in that file is compared.
-# The phrase is matched with awk's index() rather than as a pattern, so a phrase carrying
-# punctuation cannot quietly become a regex that matches somewhere else.
-DOC_BLOCKS=(
-  "docs/guide/benchmarks.md|three real databases"
-  "docs/guide/verification.md|Lines from the run behind this page"
-  "docs/guide/comparison.md|the run behind this page printed"
-  "docs/guide/comparison.md|printed by name on every run"
-)
-doc_missing=0
-doc_checked=0
-doc_skipped=0
-for doc_entry in "${DOC_BLOCKS[@]}"; do
-  doc_rel="${doc_entry%%|*}"
-  doc_phrase="${doc_entry#*|}"
-  doc_seen=0
-  while IFS= read -r doc_line; do
-    doc_trim="$(printf '%s' "$doc_line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
-    [ -z "$doc_trim" ] && continue
-    doc_seen=$((doc_seen + 1))
-    if [ -z "${MYSQL_URL:-}" ] && printf '%s' "$doc_trim" | grep -q 'MySQL'; then
-      doc_skipped=$((doc_skipped + 1))
-      echo "    not compared, that stage did not run without MYSQL_URL: $doc_trim"
-      continue
-    fi
-    doc_checked=$((doc_checked + 1))
-    if ! grep -Fq -- "$doc_trim" "$WORK/printed.log"; then
-      if [ "$doc_missing" -eq 0 ]; then
-        echo "    FAIL: the documentation quotes this script's output, and this run did not"
-        echo "          print these lines. Paste what the run printed, or say what changed:"
-      fi
-      echo "      $doc_rel: $doc_trim"
-      doc_missing=$((doc_missing + 1))
-    fi
-  done < <(awk -v p="$doc_phrase" 'index($0,p)>0{found=1} found && /^```$/{n++; next} found && n==1' "$ROOT/$doc_rel")
-  # Per block, not once at the end. A dead anchor in one file would otherwise hide behind another
-  # file's matches and the run would report that everything matched. Counted on lines extracted
-  # rather than lines compared, so a block that is entirely MySQL lines does not read as dead on a
-  # run without MYSQL_URL.
-  if [ "$doc_seen" -eq 0 ]; then
-    echo "    FAIL: found no quoted lines in $doc_rel after the phrase \"$doc_phrase\", so this" >&2
-    echo "          check measured nothing there. The prose above the block was probably edited." >&2
-    exit 1
-  fi
-done
-if [ "$doc_missing" -gt 0 ]; then
-  echo "FAIL: the documentation quotes numbers this run did not produce." >&2
-  exit 1
-fi
-echo "    $doc_checked line(s) across ${#DOC_BLOCKS[@]} documented block(s) matched this run's output, $doc_skipped not compared"
-
 cd "$APP"
 
 # ---------------------------------------------------------------------------------------------
@@ -7193,7 +7115,7 @@ if (capBroken.length) {
 if (diffs.length || dead.length || capBroken.length || !capChecked.length) process.exit(1);
 CROSS
 
-OLD_JSON="$WORK/cols-0.4x.json" NEW_JSON="$WORK/cols-v1.json" npx tsx cross-major.ts || {
+OLD_JSON="$WORK/cols-0.4x.json" NEW_JSON="$WORK/cols-v1.json" npx tsx cross-major.ts | tee -a "$WORK/printed.log" || {
   echo "FAIL: the analyzer is not consistent across drizzle-orm majors." >&2
   exit 1
 }
@@ -9326,7 +9248,7 @@ async function main() {
 }
 PARITY_0_4X
 
-if ! npx tsx parity-0-4x.ts; then
+if ! npx tsx parity-0-4x.ts | tee -a "$WORK/printed.log"; then
   echo "FAIL: DRZL's generated validators do not match the official ones on drizzle-orm 0.4x." >&2
   exit 1
 fi
@@ -9535,6 +9457,92 @@ if ! node "$WORK/check-provenance.mjs" "$(npm config get registry)" $names; then
   exit 1
 fi
 cd "$APP"
+
+# ---------------------------------------------------------------------------------------------
+# The numbers the published documentation quotes, against the run that produced them.
+#
+# Until this existed nothing in the project checked a number in the documentation. Measured rather
+# than assumed: `9.9999999999999999e42` substituted for the float4 bound in the shipped TypeBox
+# page left `pnpm lint`, `pnpm typecheck`, every package test, `pnpm -C docs build` and
+# `scripts/extract-doc-configs.mjs` all at exit 0, and that last one is the only docs-aware stage
+# in the whole gate: it reads runnable config blocks and cannot see a table or a paragraph.
+#
+# It is not a documentation test framework, and it does not try to be. It covers exactly one
+# thing, the block in benchmarks.md that quotes this script's own output, which is the only prose
+# in the docs whose numbers this run also computes. That block was stale when this check was
+# written: it claimed `DRZL 1007, drizzle-orm 979` and `closer on 28` for a run that had been
+# printing 1012 and 33 since the commit that changed the float bounds, and five rounds of review
+# had read the same branch without noticing. Every other number in the docs is still unchecked and
+# still has nothing behind it.
+#
+# The comparison is line by line and literal, so a fabricated digit fails rather than a fabricated
+# sentence. Lines about MySQL are skipped, by name and out loud, when no MYSQL_URL is set: that
+# stage did not run, so this run has nothing to compare them with.
+#
+# Both controls were run against a captured run log before this shipped. `DRZL 1048` changed to
+# `DRZL 9999` in the page exits 1 naming that line. The vacuity control matters more, because this
+# check finds its block by a phrase in the prose above it: editing "three real databases" to
+# "three actual databases" makes the extraction return nothing, and the count guard below exits 1
+# rather than reporting that everything matched.
+echo "==> the numbers the documentation quotes, against this run"
+# The corpus is $WORK/printed.log, which every stage a documented page may quote appends to: the
+# six database-truth harnesses, both parity passes and the cross-major pass. A page quoting a line
+# from a stage that does not append there cannot be checked, and the per-block guard below would
+# report it as a dead anchor rather than as an unquotable line, so keep the two in step.
+# Each entry is <file>|<phrase>: the first fenced block after <phrase> in that file is compared.
+# The phrase is matched with awk's index() rather than as a pattern, so a phrase carrying
+# punctuation cannot quietly become a regex that matches somewhere else.
+DOC_BLOCKS=(
+  "docs/guide/benchmarks.md|three real databases"
+  "docs/guide/verification.md|Lines from the run behind this page"
+  "docs/guide/comparison.md|the run behind this page printed"
+)
+# The defect table further down comparison.md is deliberately not here. It is assembled from this
+# script's own DEFECTS ledger rather than quoted from output: the run prints the counts and stays
+# silent about the columns themselves, because a ledgered defect reproducing is the quiet case.
+# Listing it here would fail every run over lines no run ever prints.
+doc_missing=0
+doc_checked=0
+doc_skipped=0
+for doc_entry in "${DOC_BLOCKS[@]}"; do
+  doc_rel="${doc_entry%%|*}"
+  doc_phrase="${doc_entry#*|}"
+  doc_seen=0
+  while IFS= read -r doc_line; do
+    doc_trim="$(printf '%s' "$doc_line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ -z "$doc_trim" ] && continue
+    doc_seen=$((doc_seen + 1))
+    if [ -z "${MYSQL_URL:-}" ] && printf '%s' "$doc_trim" | grep -q 'MySQL'; then
+      doc_skipped=$((doc_skipped + 1))
+      echo "    not compared, that stage did not run without MYSQL_URL: $doc_trim"
+      continue
+    fi
+    doc_checked=$((doc_checked + 1))
+    if ! grep -Fq -- "$doc_trim" "$WORK/printed.log"; then
+      if [ "$doc_missing" -eq 0 ]; then
+        echo "    FAIL: the documentation quotes this script's output, and this run did not"
+        echo "          print these lines. Paste what the run printed, or say what changed:"
+      fi
+      echo "      $doc_rel: $doc_trim"
+      doc_missing=$((doc_missing + 1))
+    fi
+  done < <(awk -v p="$doc_phrase" 'index($0,p)>0{found=1} found && /^```$/{n++; next} found && n==1' "$ROOT/$doc_rel")
+  # Per block, not once at the end. A dead anchor in one file would otherwise hide behind another
+  # file's matches and the run would report that everything matched. Counted on lines extracted
+  # rather than lines compared, so a block that is entirely MySQL lines does not read as dead on a
+  # run without MYSQL_URL.
+  if [ "$doc_seen" -eq 0 ]; then
+    echo "    FAIL: found no quoted lines in $doc_rel after the phrase \"$doc_phrase\", so this" >&2
+    echo "          check measured nothing there. The prose above the block was probably edited." >&2
+    exit 1
+  fi
+done
+if [ "$doc_missing" -gt 0 ]; then
+  echo "FAIL: the documentation quotes numbers this run did not produce." >&2
+  exit 1
+fi
+echo "    $doc_checked line(s) across ${#DOC_BLOCKS[@]} documented block(s) matched this run's output, $doc_skipped not compared"
+
 
 echo "OK: $count packages packed, installed into an empty project, generated, and the output"
 echo "    typechecks under bundler, node16 and nodenext, and is compared column by column and value"

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -20,6 +20,13 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK="$(mktemp -d)"
+
+# Lines a documentation page quotes are recorded here as well as printed, so the stage at the end
+# of this file can compare them against what the run actually said. The six database-truth
+# harnesses and both parity passes pipe their whole output into this file; a plain echo the docs
+# quote has to say so itself, which is what this is for. If a page starts quoting a line that does
+# not go through here, that stage fails naming the line rather than passing quietly.
+quoted() { printf '%s\n' "$1" | tee -a "$WORK/printed.log"; }
 trap 'rm -rf "$WORK"' EXIT
 
 TARS="$WORK/tars"
@@ -208,7 +215,7 @@ for dir in "$ROOT"/packages/*/; do
   (cd "$dir" && pnpm pack --pack-destination "$TARS" >/dev/null)
   count=$((count + 1))
 done
-echo "    packed $count package(s)"
+quoted "    packed $count package(s)"
 if [ "$count" -eq 0 ]; then
   echo "FAIL: nothing was packed. A build that emits nothing must not pass silently." >&2
   exit 1
@@ -751,7 +758,7 @@ EOF
     echo "FAIL: emitted output does not typecheck under moduleResolution=$mr" >&2
     exit 1
   fi
-  echo "    $mr ok"
+  quoted "    $mr ok"
 done
 
 
@@ -1013,7 +1020,7 @@ if [ "$doc_failed" -ne 0 ]; then
   echo "      A config a reader can copy has to produce code that compiles." >&2
   exit 1
 fi
-echo "    all $doc_total documented configs generate and typecheck"
+quoted "    all $doc_total documented configs generate and typecheck"
 
 # ---------------------------------------------------------------------------------------------
 # duplicateFinder must cover the primary key.


### PR DESCRIPTION
Widens the docs-numbers stage from one quoted block to three, so the pages added in PR #195 are held to the run the way `benchmarks.md` is. The first attempt at this failed the gate, and everything below is what that failure taught.

## Why these pages need it

The stage exists because the benchmarks block **was stale when the check was written** (its own comment records claiming `DRZL 1007` for a run that had been printing 1012, with five review rounds reading past it). The new pages quote real run output for the same reason and drift the same way.

## Three things a reading could not have found

- **The corpus was too small, in two rounds.** `printed.log` is appended to by the six database-truth harnesses and nothing else. First the parity and cross-major summaries the pages quote could not be found in it however correct they were; then, with those teed in, five plain script echoes the same page quotes could not either (`packed N package(s)`, the three moduleResolution `ok` lines, and the documented-configs count). Both parity passes and the cross-major pass now append, and a named `quoted()` helper records the handful of echoes a page quotes as it prints them, so the intent is stated once rather than teed ad hoc.
- **The stage ran too early.** It sat at line 6434 while the 0.4x parity pass it needs runs at 9329, so a page quoting the second major was compared against a corpus that could not yet contain it. A check about the whole run now runs after the whole run, immediately before the closing banner.
- **One quoted block was not a quote.** `comparison.md` lists six columns where official is right and DRZL is not, claiming they are "printed by name on every run". Measured against a real run: **none of the six are printed**. They live in the DEFECTS ledger, and a ledgered defect reproducing is the quiet case, so the run prints counts and stays silent about the columns. The page's claim is corrected to say where they actually live, and the block stays out of the gated set with a comment explaining why, since gating it would fail every run over lines no run ever prints.

Also removed: `verification.md` quoted this stage's own summary line back at it, which is circular by construction and broke the instant the summary changed wording.

## Guard changes from the original proposal

The vacuity check fires **per block** rather than once at the end, since a dead anchor in one file would otherwise hide behind another file's matches and the run would report that everything matched, which is the exact failure the original vacuity control was added to prevent. And it counts lines **extracted** rather than compared, so a block consisting of MySQL lines does not read as a dead anchor on a run without `MYSQL_URL`.

## Validation

The stage was extracted into a harness built from its own text and run against a corpus rebuilt from a real run's output: clean run passes; a fabricated digit fails and names both files that quote the line; a dead anchor in one page fails while the others match; without `MYSQL_URL` it passes with lines reported as not compared.

The fabricated-digit control took three attempts to construct honestly, which is worth recording because the first two looked like passes: the first corrupted one copy of a line that appears in two blocks, so the surviving copy satisfied the check; the second substituted a number the file does not contain, so it changed nothing at all. Only the third falsified the claim.

The ship's own full `verify:packed` run is the integration proof on top of that, and it is the check that caught the ordering and corpus problems in the first place.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
