### PR TITLE
docs: upgrading and the two drizzle majors (items 85, 86, 88)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -37,6 +37,8 @@ export default {
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Configuration', link: '/guide/configuration' },
           { text: 'Bun and Deno', link: '/guide/runtimes' },
+          { text: 'drizzle-orm 0.4x and v1', link: '/guide/drizzle-majors' },
+          { text: 'Upgrade notes', link: '/guide/upgrading' },
           { text: 'How it is verified', link: '/guide/verification' },
           { text: 'Compared with drizzle-orm', link: '/guide/comparison' },
           { text: 'Benchmarks', link: '/guide/benchmarks' },

--- a/docs/guide/comparison.md
+++ b/docs/guide/comparison.md
@@ -164,3 +164,6 @@ None of the above is a claim you have to take on trust. `pnpm verify:packed` pri
 quoted here, and the ledgers that record each divergence live in `scripts/verify-packed.sh` beside
 the measurement that settled it. An entry that stops being true fails the run just as loudly as a
 difference nobody declared. See [How it is verified](/guide/verification).
+
+The rows above that name a drizzle-orm major are covered in full, with what each one emits, on
+[drizzle-orm 0.4x and v1](/guide/drizzle-majors).

--- a/docs/guide/drizzle-majors.md
+++ b/docs/guide/drizzle-majors.md
@@ -1,0 +1,248 @@
+# drizzle-orm 0.4x and v1
+
+DRZL reads your schema by importing it, so the drizzle-orm that decides what your columns are is the
+one in **your** project, not one DRZL ships. Every DRZL package declares `drizzle-orm` as a dev
+dependency only.
+
+The two majors do not describe the same schema the same way. Where they differ, DRZL reports what
+drizzle actually built, so the same source line can produce different generated output on either
+side. This page is the list of those differences that reach emitted files, with a check you can run
+for each.
+
+## The versions
+
+| Tag      | Version      | What it is                                     |
+| -------- | ------------ | ---------------------------------------------- |
+| `latest` | `0.45.2`     | what `npm install drizzle-orm` gives you today |
+| `rc`     | `1.0.0-rc.4` | the v1 release candidate                       |
+
+Both are analyzed on every CI run, over the same fixtures, and every difference between them either
+fails the run or is named in a ledger with the reason. See
+[How it is verified](/guide/verification#both-drizzle-orm-majors) for what that stage prints.
+
+## Running both side by side
+
+Every check on this page uses the same setup: install the other major under an alias, so one project
+can import both.
+
+```bash
+npm install --save-dev drizzle-orm-v1@npm:drizzle-orm@1.0.0-rc.4
+```
+
+Write the column twice, once from each, and ask the analyzer:
+
+```js
+// probe.mjs, run as: node probe.mjs src/db/schema.ts
+import { SchemaAnalyzer } from '@drzl/analyzer';
+
+const a = await new SchemaAnalyzer(process.argv[2]).analyze({});
+for (const c of a.tables[0].columns) {
+  console.log(c.name, JSON.stringify({ tsType: c.tsType, sqlType: c.sqlType, dbType: c.dbType }));
+}
+```
+
+Changing `from 'drizzle-orm/pg-core'` to `from 'drizzle-orm-v1/pg-core'` in the schema file is the
+whole difference between the two runs. [`drzl explain`](/cli/explain) answers the same question with
+more of the picture, and takes the schema path on `-s`.
+
+## Differences that reach your generated output
+
+### `bigint({ mode: 'string' })` exists only on v1, and 0.4x does not complain
+
+0.45.2 spells the config as `'number' | 'bigint'`, so `mode: 'string'` is a type error there. At
+runtime it is not an error at all: the branch tests only for `'number'`, so it falls through and
+builds the **bigint-mode** column, whose driver mapping really does return a bigint. Nothing throws
+and nothing warns.
+
+DRZL describes what was built, so one source line produces two different validators:
+
+```ts
+bigint('n', { mode: 'string' }).notNull();
+```
+
+```ts
+// drizzle-orm 0.45.2
+"n": z.bigint().gte(-9223372036854775808n).lte(9223372036854775807n),
+
+// drizzle-orm 1.0.0-rc.4
+"n": z.string().regex(new RegExp("^\\s*[+-]?(\\d(_?\\d)*|0[xX]_?[\\da-fA-F](_?[\\da-fA-F])*|0[oO]_?[0-7](_?[0-7])*|0[bB]_?[01](_?[01])*)\\s*$")),
+```
+
+This is the difference to know about if you are moving a schema **down** from v1 to 0.4x, because
+the type error is the only signal and a `// @ts-expect-error` or a cast removes it. The pattern on
+the v1 side is the input syntax that dialect's server parses, and it differs between Postgres and
+MySQL; a bare string accepted 14 values Postgres rejects.
+
+### A `.array().array()` is two dimensions on 0.4x and one on v1
+
+v1's `array()` takes its depth as a string, so `.array('[][]')` is the two-dimensional spelling and
+chaining `.array()` stays at one however often you repeat it. v1 infers `string[]` for the column
+below; 0.45.2 infers `string[][]`.
+
+```ts
+text('n').array().array();
+```
+
+```ts
+// drizzle-orm 0.45.2
+"n": z.array(z.array(z.string())).nullable().optional(),
+
+// drizzle-orm 1.0.0-rc.4
+"n": z.array(z.string()).nullable().optional(),
+```
+
+Both are right about their own major. Checked against each major's own first-party validator on this
+exact column: `drizzle-zod` 0.8.3 on 0.45.2 accepts `[['a']]` and rejects `['a']`, and
+`drizzle-orm/zod` on 1.0.0-rc.4 does the opposite.
+
+### A bare `blob()` on SQLite is a different column
+
+The two explicit modes agree across the majors. A bare `blob()` does not: 0.45.2 builds the buffer
+column and 1.0.0-rc.4 builds the JSON one.
+
+```ts
+// drizzle-orm 0.45.2
+"n": z.instanceof(Uint8Array).nullable().optional(),
+
+// drizzle-orm 1.0.0-rc.4
+"n": z.json().nullable().optional(),
+```
+
+### `numeric` and `decimal` carry their format only on v1
+
+On 0.45.2 the column reports no format, so the emitted schema is a bare string and accepts
+`'hello'`. This one is **DRZL's defect rather than a difference to live with**: it is in the gate's
+`DEFECTS` ledger, named on every run, and filed rather than fixed.
+
+```ts
+numeric('n', { precision: 10, scale: 2 });
+```
+
+```ts
+// drizzle-orm 0.45.2
+"n": z.string().nullable().optional(),
+
+// drizzle-orm 1.0.0-rc.4
+"n": z.string().regex(new RegExp("^\\s*([+-]?(0[xX][0-9a-fA-F]...")).nullable().optional(),
+```
+
+### MySQL's `TEXT` family carries a character cap only on v1
+
+v1 states a `length` equal to the type's own cap; 0.45.2 leaves it undefined. Both majors get the
+**byte** cap, which DRZL derives from the SQL type rather than from drizzle:
+
+```
+drizzle-orm 0.45.2      body {"maxBytes":255,"sqlType":"tinytext"}
+drizzle-orm 1.0.0-rc.4  body {"maxLength":255,"maxBytes":255,"sqlType":"tinytext"}
+```
+
+UTF-8 spends at least one byte per code point, so the byte cap is never the looser of the two, and
+the character cap v1 adds can never be the deciding check. What changes is the **error report**: on
+256 ascii characters into a `tinytext`, Zod and Valibot report one issue on 0.45.2 and two on
+1.0.0-rc.4, ArkType names the byte cap on one major and the character cap on the other, and TypeBox
+reports two errors against three. Anything that renders validation messages sees a difference. The
+JSON Schema output is byte-identical on both majors: it carries `maxLength: 255` with a description
+saying the real budget is bytes, which JSON Schema has no keyword for.
+
+This one is in the `DEFECTS` ledger, and DRZL on 0.4x is **looser than the first-party validator for
+0.4x**: `drizzle-zod` 0.8.3 emits the cap off its own text-subtype table rather than off `length`.
+
+### Types 0.4x does not export at all
+
+Not a difference in description, a difference in what compiles. A schema using any of these cannot be
+imported under 0.45.2:
+
+| Export                                                                     | 0.45.2       | 1.0.0-rc.4 |
+| -------------------------------------------------------------------------- | ------------ | ---------- |
+| `bytea` from `drizzle-orm/pg-core`                                         | not exported | function   |
+| `blob`, `tinyblob`, `mediumblob`, `longblob` from `drizzle-orm/mysql-core` | not exported | function   |
+| `tinytext`, `text`, `mediumtext`, `longtext` from `drizzle-orm/mysql-core` | function     | function   |
+
+### The first-party TypeBox module on v1
+
+If you are comparing DRZL's TypeBox output against drizzle's own on 1.0.0-rc.4: `drizzle-orm/typebox`
+targets the newer `typebox` package rather than `@sinclair/typebox`, and fails on import against the
+released one. `drizzle-orm/typebox-legacy` is the same module built for `@sinclair/typebox`, which is
+what DRZL's TypeBox generator emits for, and it imports cleanly. The gate's parity stage uses
+`typebox-legacy` for exactly this reason.
+
+## Differences that used to reach your output and no longer do
+
+Listed with the version boundary, because a lockfile older than one of these still has it.
+
+| What                                                                 | Fixed in                                |
+| -------------------------------------------------------------------- | --------------------------------------- |
+| Every array column came back `unknown` on 0.4x                       | `@drzl/analyzer` 1.13.0                 |
+| An enum column came back `unknown` on 0.4x                           | `@drzl/analyzer` 1.13.0                 |
+| A view produced no schemas at all on 0.x                             | `@drzl/analyzer` 1.16.0                 |
+| Unsigned integer columns got the signed range, differently per major | on `master`, not in a published release |
+
+**Views** are the one worth checking a lockfile over. On every 0.x release a view answers `undefined`
+to `drizzle:Columns`, `drizzle:Name` and `drizzle:Schema`, and its columns live only under
+`Symbol.for('drizzle:ViewBaseConfig')`. The analyzer identified a table-like export by asking for
+`drizzle:Columns`, so on 0.x it skipped every view and said nothing about it, while generating for
+the same view normally on v1. Probed on 0.29.5, 0.33.0, 0.36.4, 0.39.3, 0.44.7, 0.45.0 and 0.45.2,
+invisible on all of them, and on 1.0.0-beta.1, beta.24, rc.1 and rc.4, visible on all of them.
+`pgView`, `pgMaterializedView`, `mysqlView` and `sqliteView` were all affected, in their
+query-builder, explicit-column-list, `.existing()` and schema-qualified forms alike.
+
+**Unsigned integers** were wrong on both majors and in different ways, which is why the fix is listed
+here rather than as a difference: 0.4x gave every unsigned width the signed range and gave `serial`
+no range at all, while v1 dropped `uint16`, `uint24` and `uint32` into an implicit-decimal path and
+returned nothing for `uint64`. Both majors now answer with the type's own range, and the gate proves
+they agree. The fix is on `master` and has not yet been published, so a released version still has
+the old behaviour:
+
+```ts
+int('u', { unsigned: true });
+// both majors: {"tsType":"number","sqlType":"int unsigned","min":"0","max":"4294967295"}
+```
+
+## Where DRZL is still wrong on 0.4x
+
+Every one of these is in a ledger in `scripts/verify-packed.sh`, counted and named on every run, and
+an entry that stops reproducing fails the run as loudly as an unledgered difference.
+
+- **17 columns get a coarser `dbType` label**, because 0.4x carries no codec: `varchar`, `char` and
+  `smallint` fold to `TEXT` or `INTEGER`, `date` to `TIMESTAMP`, `inet`, `cidr` and `macaddr` to
+  `TEXT`. Setting all seventeen to the v1 value and regenerating produced 29 byte-identical files, so
+  this label does not reach emitted output.
+- **`numeric` and `decimal` accept any string**, on 3 columns. See above.
+- **MySQL `TEXT` carries no character cap**, on 4 columns. See above.
+
+A second group comes from the other direction, where the first-party validator **for 0.45.2** is
+right and DRZL is not: MySQL `year`, SQLite `integer()` and SQLite `blob({ mode: 'bigint' })`, plus
+their nullable twins, six columns in all. None of the six reproduces on 1.0.0-rc.4.
+[Compared with the first-party validators](/guide/comparison#where-drzl-is-worse) lists them with
+what each side emits. `integer()` is the one to know the shape of, because the two majors also
+disagree about it:
+
+```ts
+// drizzle-orm 0.45.2
+"n": z.number().int().gte(-9223372036854775808).lte(9223372036854775807).nullable().optional(),
+
+// drizzle-orm 1.0.0-rc.4
+"n": z.number().int().gte(-9007199254740991).lte(9007199254740991).nullable().optional(),
+```
+
+The emitted bound differs in all four libraries, but the **verdict** differs in three of them: zod's
+own `.int()` refuses a number outside the safe-integer range without being asked, so the zod output
+reaches the right answer despite the wrong bound.
+
+## What is not measured
+
+- **The cross-major comparison covers Postgres and the MySQL text family.** SQLite is compared
+  against the first-party 0.4x validators but is not in the cross-major diff, so a difference that
+  shows up only between the two majors on SQLite would not be caught there. The `integer()` bound
+  above is one such difference, and it is caught by the parity pass instead.
+- **Views are outside the diff's field guard**, deliberately: `pgMaterializedView` answers on
+  1.0.0-rc.4 and returns undefined on 0.45.2, so the stage would report a whole table as v1-only.
+  They are covered by the analyzer's own tests instead.
+- **Nothing on this page is a claim about drizzle-orm's intent.** These are measurements of what each
+  major builds, taken by importing it.
+
+## See also
+
+- [Upgrade notes](/guide/upgrading), for changes that came from a DRZL release rather than the ORM
+- [How it is verified](/guide/verification)
+- [Analyzer](/packages/analyzer), for the per-type facts the generators read

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -1,0 +1,388 @@
+# Upgrade notes
+
+Changes that altered what generated output **means**, rather than what it can do. Each one names the
+version it landed in, shows the emitted code on both sides, and ends with a check you can run
+against your own repository.
+
+Both notes on this page shipped in the same release, published 2026-08-02.
+
+| Package                   | Last version with the old behaviour | First version with the new |
+| ------------------------- | ----------------------------------- | -------------------------- |
+| `@drzl/analyzer`          | 1.13.0                              | **1.14.0**                 |
+| `@drzl/validation-core`   | 3.13.0                              | **3.14.0**                 |
+| `@drzl/generator-zod`     | 3.14.1                              | **3.15.0**                 |
+| `@drzl/generator-valibot` | 3.13.0                              | **3.14.0**                 |
+| `@drzl/generator-arktype` | 3.9.0                               | **3.10.0**                 |
+| `@drzl/generator-typebox` | 0.7.0                               | **0.8.0**                  |
+| `@drzl/cli`               | 4.13.1                              | **4.14.0**                 |
+
+## Read the analyzer's version, not the CLI's
+
+`@drzl/cli` **imports** `@drzl/analyzer` rather than bundling it, at a caret range, so the analyzer
+your CLI loaded is whichever version your lockfile resolved. `drzl --version` prints the CLI's own
+version and nothing else, and two packages whose output was affected by the first note below,
+`@drzl/generator-service` and `@drzl/generator-orpc`, did not change version across the fix at all:
+both sat at 2.1.2 and 2.5.0 on either side of it, because the defect was never in their code.
+
+So a version number is the wrong instrument here. Read the resolved analyzer:
+
+```bash
+npm ls @drzl/analyzer
+```
+
+and then use the behavioural checks below, which do not depend on getting that arithmetic right.
+
+## A table-level `unique()` was read as the primary key
+
+**Affected:** `@drzl/analyzer` 1.4.0 through 1.13.0. **Fixed in 1.14.0.**
+
+### Whether this reaches you at all
+
+Only a table that declares a constraint with the table-level `unique(...)` builder, in the
+extra-config callback:
+
+```ts
+export const users = pgTable(
+  'users',
+  {
+    id: serial('id').primaryKey(),
+    org: integer('org').notNull(),
+    handle: text('handle').notNull(),
+  },
+  (t) => [unique('org_handle').on(t.org, t.handle)] // this line
+);
+```
+
+A `.unique()` **on a column** builds a different object and was never affected. Measured on both
+sides of the fix: a schema whose only uniqueness is `text('email').notNull().unique()` gets
+`primaryKey: { columns: ['id'] }` from 1.13.0 and from 1.20.1 alike.
+
+### What went wrong
+
+Drizzle's extra-config callback hands back builder objects, and the analyzer told them apart by
+their shape. An index builder keeps its data under `.config` and carries a `unique` flag; a primary
+key builder keeps `columns` on the instance and has no such flag. The rule was therefore "no
+`unique` flag means this is the primary key".
+
+`UniqueConstraintBuilder` also keeps `columns` on the instance, and also has no `unique` flag. You
+can see the collision without any DRZL code, against drizzle-orm 0.45.2:
+
+```ts
+import { pgTable, serial, text, integer, unique, primaryKey } from 'drizzle-orm/pg-core';
+
+const t = pgTable('users', {
+  id: serial('id').primaryKey(),
+  org: integer('org').notNull(),
+  handle: text('handle').notNull(),
+});
+
+for (const e of [
+  unique('org_handle').on(t.org, t.handle),
+  primaryKey({ columns: [t.org, t.handle] }),
+]) {
+  const kind = String(e?.constructor?.[Symbol.for('drizzle:entityKind')]);
+  const cfg = e?.config ?? e;
+  console.log(kind, 'cfg.unique =', cfg?.unique);
+}
+```
+
+```
+PgUniqueConstraintBuilder cfg.unique = undefined
+PgPrimaryKeyBuilder       cfg.unique = undefined
+```
+
+Worse than losing the constraint: the branch **replaced** the key it had already found. Builders are
+told apart by `drizzle:entityKind` now, matched on the suffix because the dialect prefix varies and
+the symbol survives minification.
+
+### What your generated files look like
+
+The same schema, analyzed by both versions:
+
+```
+@drzl/analyzer 1.13.0
+  primaryKey: {"columns":["org","handle"]}
+  unique:     []
+
+@drzl/analyzer 1.14.0 and later
+  primaryKey: {"columns":["id"]}
+  unique:     [{"columns":["org","handle"],"name":"org_handle"}]
+```
+
+`@drzl/generator-service` reads `primaryKey` to build its lookups, so every addressing method
+filtered on the wrong column. This is the file it wrote:
+
+```ts
+// @drzl/generator-service 2.1.2, on @drzl/analyzer 1.13.0
+type Updateusers = Partial<Omit<typeof users.$inferInsert, 'org'>>;
+
+export class UserService {
+  static async getById(id: number): Promise<Selectusers | null> {
+    const rows = await db.select().from(users).where(eq(users.org, id)).limit(1);
+    return rows[0] ?? null;
+  }
+  static async update(id: number, data: Updateusers): Promise<Selectusers> {
+    const rows = await db.update(users).set(data).where(eq(users.org, id)).returning();
+    return rows[0];
+  }
+  static async delete(id: number): Promise<boolean> {
+    await db.delete(users).where(eq(users.org, id));
+    return true;
+  }
+}
+```
+
+and this is the same file today:
+
+```ts
+// @drzl/generator-service 2.4.0, on @drzl/analyzer 1.20.1
+type Updateusers = Partial<Omit<typeof users.$inferInsert, 'id'>>;
+
+export class UserService {
+  static async getById(id: number): Promise<Selectusers | null> {
+    const rows = await db.select().from(users).where(eq(users.id, id)).limit(1);
+    return rows[0] ?? null;
+  }
+  static async update(id: number, data: Updateusers): Promise<Selectusers> {
+    const rows = await db.update(users).set(data).where(eq(users.id, id)).returning();
+    return rows[0];
+  }
+  static async delete(id: number): Promise<boolean> {
+    await db.delete(users).where(eq(users.id, id));
+    return true;
+  }
+}
+```
+
+`eq(users.org, id)` **compiles**, because `org` is an integer column and `id` is a number. Nothing
+fails at build time. `getById` returns some row from the org; `update` and `delete` reach **every
+row sharing that value**, silently, at runtime.
+
+The stub emission (no `dataAccess: 'drizzle'`) has no WHERE clause and was never wrong in this way.
+The row types were, in both modes: the columns mistaken for the key were dropped from the insert and
+update interfaces, and the real key was added to them.
+
+```ts
+// on @drzl/analyzer 1.13.0
+export interface Insertusers {
+  id?: number;
+}
+```
+
+```ts
+// on @drzl/analyzer 1.14.0 and later
+export interface Insertusers {
+  org: number;
+  handle: string;
+}
+```
+
+The four validation generators read `primaryKey` through `@drzl/validation-core` when they build
+**update** schemas, so an update schema dropped the wrong columns and kept the real key.
+
+`@drzl/generator-orpc` did not read `primaryKey` at all when this shipped, so its routes were not
+reached by this defect. The release note for the fix says "the service and router generators build
+their lookups from that", which was true of the service generator and forward-looking about the
+routers: oRPC only started addressing rows by the table's real key later, and until that landed it
+addressed every table by a hardcoded `id`.
+
+### Three ways to check your own repository
+
+**Read the service you already have.** No install, no upgrade. Open your generated service and look
+at what `getById` filters on:
+
+```bash
+grep -n 'where(eq(' src/services/*.ts
+```
+
+If the column named there is not that table's primary key, that file was generated by an affected
+version and is wrong.
+
+**Ask the CLI what the key is.** [`drzl explain`](/cli/explain) prints a `Keys` block, and needs no
+config: it finds the schema itself.
+
+```bash
+npx @drzl/cli explain users
+```
+
+```
+Keys
+  PRIMARY KEY (id)  filled in by the database
+  UNIQUE (org, handle)  org_handle
+  INDEX (id)
+```
+
+A table whose `PRIMARY KEY` line names the columns you wrote a `unique(...)` over, with no `UNIQUE`
+line beside it, is the shape of the defect. `drzl explain users --json` carries the same two facts as
+`table.primaryKey` and `table.unique` if you would rather assert on them in a script.
+
+**Regenerate and see whether anything moves.** [`drzl generate --check`](/cli/generate) rewrites
+nothing and exits 2 with a unified diff when the committed output differs from what the current
+version produces.
+
+```bash
+npx @drzl/cli generate --check
+```
+
+### If you were hit
+
+Update `@drzl/analyzer` to 1.14.0 or later (`npm install @drzl/analyzer@latest`, or refresh the
+lockfile entry), regenerate, and read the diff. A diff that moves `getById`, `update` and `delete`
+onto a different column is this defect, and any call site that passed a non-key value as `id` was
+addressing rows by a column that does not identify one.
+
+## `varchar(n)` counts characters, and MySQL `TEXT` counts bytes
+
+**Affected:** `@drzl/generator-typebox` 0.7.0 and earlier, `@drzl/generator-arktype` 3.9.0 and
+earlier. **New shape in 0.8.0 and 3.10.0.** The Zod and Valibot output already counted code points
+and did not change shape.
+
+Two facts about the databases, neither of which the old output matched:
+
+- `varchar(10)` counts **characters** in Postgres and in MySQL. Ten astral characters are a valid
+  row. `Type.String({ maxLength: 10 })` and `"string <= 10"` both count UTF-16 code units, so both
+  **refused a row the database accepts**.
+- MySQL's `TEXT` family counts **bytes**. `tinytext` holds 255 ascii characters and 63 thumbs-up
+  ones, and refuses the 64th at 256 bytes. Nothing counted bytes, so the emitted schema **accepted
+  rows MySQL refuses**.
+
+A character cap and a byte cap are now separate facts on the column, `maxLength` and `maxBytes`, and
+a MySQL `TEXT` column carries both. See [Analyzer](/packages/analyzer) for the per-type table.
+
+### TypeBox
+
+Same column, `varchar('title', { length: 10 })`:
+
+```ts
+// @drzl/generator-typebox 0.7.0
+import { Type } from '@sinclair/typebox';
+
+export const InsertnotesSchema = Type.Object({
+  title: Type.String({ maxLength: 10 }),
+});
+```
+
+```ts
+// @drzl/generator-typebox 0.8.0 and later
+import { Type, Kind, TypeRegistry } from '@sinclair/typebox';
+
+TypeRegistry.Set('DrzlRowCheck', (schema: any, value: any) => schema.assert(value));
+
+export const InsertnotesSchema = Type.Object({
+  title: Type.Intersect([
+    Type.String(),
+    Type.Unsafe<unknown>({
+      [Kind]: 'DrzlRowCheck',
+      description: 'at most 10 characters',
+      assert: (v: any) => typeof v !== 'string' || [...v].length <= 10,
+    }),
+  ]),
+});
+```
+
+A MySQL `tinytext` column emits the same shape with the byte counter in it:
+
+```ts
+      description: 'at most 255 bytes',
+      assert: (v: any) => typeof v !== 'string' || new TextEncoder().encode(v).length <= 255,
+```
+
+Three consequences, each measured:
+
+**The verdict changed in both directions.** Ten thumbs-up characters into `varchar(10)`: refused by
+0.7.0, accepted from 0.8.0, which is what both databases do. Sixty-four thumbs-up characters into a
+MySQL `tinytext`, 256 bytes: accepted by 0.7.0, refused from 0.8.0, which is again what MySQL does.
+Eleven ascii characters into `varchar(10)` are refused by both, and 255 ascii into `tinytext` are
+accepted by both.
+
+**The cap no longer survives `JSON.stringify`.** It is a `Kind`-registered `Type.Unsafe`, and a
+registered kind is a function, so serialising the schema keeps only its description:
+
+```
+0.7.0 : {"maxLength":10,"type":"string"}
+0.8.0+: {"allOf":[{"type":"string"},{"description":"at most 10 characters"}]}
+```
+
+If you were feeding DRZL's TypeBox output to AJV, to Fastify's schema compiler or into an OpenAPI
+document, the width is not in the serialised form any more. TypeBox's own `Value.Check` and the
+`Static<>` type are unaffected, and the emitted module still validates the cap when you run it. Use
+the [JSON Schema generator](/generators/json-schema) where you need the cap as a keyword.
+
+**The module gained a top-level side effect.** A file with any capped column now imports `Kind` and
+`TypeRegistry` and calls `TypeRegistry.Set('DrzlRowCheck', ...)` when it loads.
+
+### ArkType
+
+```ts
+// @drzl/generator-arktype 3.9.0
+export const InsertnotesSchema = type({
+  title: 'string <= 10',
+});
+
+export const UpdatenotesSchema = type({
+  title: 'string <= 10?',
+});
+```
+
+```ts
+// @drzl/generator-arktype 3.10.0 and later
+export const InsertnotesSchema = type({
+  title: type('string').narrow(
+    (v, ctx) => v == null || [...v].length <= 10 || ctx.mustBe('at most 10 characters')
+  ),
+});
+
+export const UpdatenotesSchema = type({
+  'title?': type('string').narrow(
+    (v, ctx) => v == null || [...v].length <= 10 || ctx.mustBe('at most 10 characters')
+  ),
+});
+```
+
+The verdicts changed the same way TypeBox's did. Two shape changes matter beyond that:
+
+- A capped field's value is a `Type` instance now, not a DSL string. Anything reading, rewriting or
+  string-matching the emitted source will not find `string <= 10` any more.
+- **The optional marker moved from the value to the key.** `"title": "string <= 10?"` became
+  `"title?": type(...)`, because a `?` cannot be appended to a narrowed type. Both accept a missing
+  `title`, so the behaviour is the same, but the emitted text is not.
+
+### Three later changes on the same feature
+
+If you are moving further than 0.8.0 or 3.10.0, these moved again:
+
+- **`@drzl/generator-arktype` 3.11.0.** An array column's cap moved from the element to the whole
+  value: `type('string[]').narrow((v, ctx) => ... v.every((e1) => ...))`.
+- **`@drzl/generator-typebox` 0.12.0.** The predicate's guard changed from `v == null` to
+  `typeof v !== 'string'`.
+- **`@drzl/generator-json-schema` 0.4.1.** This generator ignored `maxBytes` entirely until then, so
+  0.3.0 and 0.4.0 emitted no byte cap for a MySQL `TEXT` column. It now emits the cap as a
+  `maxLength` with a description saying the real budget is bytes, which JSON Schema has no keyword
+  for.
+
+### The check
+
+The caps are read off the column, so ask the analyzer what it sees before comparing any emitted
+file. This needs no config:
+
+```bash
+npx @drzl/cli explain notes
+```
+
+The **What the generators read off each column** section names each cap in the units it is counted
+in, `at most 10 characters` or `at most 255 bytes`, and marks a cap that nothing states with the
+reason. Then regenerate:
+
+```bash
+npx @drzl/cli generate --check
+```
+
+Every capped string column in TypeBox or ArkType output will appear in that diff. That is expected,
+and the diff is the whole migration: there is nothing to hand-edit.
+
+## See also
+
+- [drizzle-orm 0.4x and v1](/guide/drizzle-majors), for differences that come from the ORM rather
+  than from a DRZL release
+- [How it is verified](/guide/verification), for what the gate measures on every run
+- [Compared with the first-party validators](/guide/comparison), including where DRZL is still wrong

--- a/docs/guide/verification.md
+++ b/docs/guide/verification.md
@@ -114,6 +114,9 @@ exists because the v1 side used to be the consumer tree, whose `drizzle-orm` is 
 unpinned, and `latest` is 0.45.2: this stage compared 0.45.2 with 0.45.2 for months and passed for
 the same reason a diff of a file against itself passes.
 
+The differences these two stages measure, and what each one does to your generated files, are on
+[drizzle-orm 0.4x and v1](/guide/drizzle-majors).
+
 ## A ledger fails when a defect stops reproducing
 
 Every ledger in the gate is asserted **in both directions**, and that is the part that makes them

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -7141,8 +7141,9 @@ import { SchemaAnalyzer } from '@drzl/analyzer';
 
 /**
  * Columns 0.4x cannot name today. Filed, not tolerated: naming one makes its entry dead and
- * fails this check, so a fix cannot land quietly. The same three columns carry entries in the
- * DEFECTS map above, which is the relative half of the same finding.
+ * fails this check, so a fix cannot land quietly. When this map had entries, each carried one in
+ * the DEFECTS map above too, which is the relative half of the same finding. It is empty now, and
+ * the closing summary of this script no longer claims otherwise.
  */
 const KNOWN_UNNAMED: Record<string, string> = {
   // Empty, and that is a result rather than a reason to delete this check. Every Postgres class the
@@ -9566,7 +9567,7 @@ echo "    The four generators are cross-checked against each other on every dial
 echo "    checked against a real Postgres, a real SQLite and, where MYSQL_URL is set, a real"
 echo "    MySQL, with applyDefaults compared against what the database writes, and described the"
 echo "    same way by the analyzer under both drizzle-orm majors, bar the differences that stage"
-echo "    names one at a time, three of which are columns 0.4x leaves unnamed. The same column by"
+echo "    names one at a time. The same column by"
 echo "    column comparison runs a second time against the first-party validators for 0.45.2,"
 echo "    where the columns known to differ are counted and named above, each with what DRZL"
 echo "    emits, what official emits and which filing it is. Where an official validator crashes"


### PR DESCRIPTION
Plan items 85, 86 and 88 as two pages, both built from git history and from running the old code rather than from the plan's one-line descriptions.

## Item 85, the unique() primary-key bug

Introducing commit, fixing commit and the exact affected range are named (`@drzl/analyzer` 1.4.0 through 1.13.0, fixed in 1.14.0). The mechanism: the analyzer told drizzle's extra-config builders apart by shape, treating "no `unique` flag" as a primary key, and a `UniqueConstraintBuilder` satisfies that too, confirmed by probing real 0.45.2 builders where both report `cfg.unique === undefined`. Worse than losing the constraint, the branch spliced over the key it had already found.

Before and after are **emitted output**, from bundling the pre-fix analyzer and generator out of git and running them: `primaryKey: {"columns":["org","handle"]}, unique: []` against `primaryKey: {"columns":["id"]}, unique: [...]`, and a service addressing rows by `eq(users.org, id)` on `getById`, `update` and `delete`. **It compiles**, so nothing failed at build time while update and delete hit every row sharing that value.

Two corrections to the obvious story, both of which change the advice: the CLI **does not bundle** the analyzer (it imports at a caret range, three sites in `dist/cli.js`), and `@drzl/generator-service` and `@drzl/generator-orpc` **never changed version** across the fix. Version arithmetic therefore cannot tell a reader whether they were affected, which is what makes a behavioural self-test necessary rather than a nicety. Three are given, cheapest first: a `grep` over service files already on disk (no install, and the only one that works for the affected versions since `drzl explain` did not exist then), then `drzl explain <table>` whose Keys block was verified to print the primary key beside the unique constraint, then `generate --check`, verified to exit 2 with a diff.

## Item 86, the varchar cap

Same method: both pre-change generators plus the pre-change analyzer and validation-core built from git and run against one fixture, so the shapes on the page are emitted rather than reconstructed, then both schemas executed. TypeBox `Type.String({ maxLength: 10 })` becomes the registered-kind intersect; ArkType `"string <= 10"` becomes `type('string').narrow(...)` with the optional marker moving from value to key. Behavioural consequences measured: 10 astral characters refused before and accepted now, 64 emoji into a `tinytext` accepted before and refused now, and **`JSON.stringify` drops the cap**, which is the one that silently breaks AJV, Fastify and OpenAPI consumers.

## Item 88, the two majors

Every difference is measured live rather than quoted from the ledger, which caught four claims that are **no longer true**: unsigned handling agrees since `cf19c30` (this session's own PR #179, marked as unpublished on the page), enums and arrays agree since analyzer 1.13.0, the JSON Schema documents are now byte-identical across majors, and `drizzle-orm/typebox` at rc.4 is importable with `typebox-legacy` rather than unimportable. What remains live is on the page with its measurement: `bigint({mode:'string'})`, array dimensions, bare SQLite `blob()`, `numeric` unchecked on 0.4x, the MySQL TEXT character cap, and the missing `bytea`/`blob` exports.

## The controller edit in this PR

The gate's closing summary claimed "three of which are columns 0.4x leaves unnamed". `KNOWN_UNNAMED` is **empty**, and has been since the last arm landed, which the map's own comment already says. Both the summary and that comment are corrected here, so the script stops asserting something its own data contradicts. This is the same class as the false sentence PR #196 caught on the comparison page, found the same way: by someone going to check.

## Gating note

Nothing on the new pages is gateable: the docs-numbers stage compares against `$WORK/printed.log`, and these pages quote analyzer facts, emitted generator source and `drzl explain` output, none of which any stage prints. The agent deliberately did **not** re-quote the cross-major run lines already gated in `verification.md`, since a second ungated copy is precisely the staleness that stage exists to prevent; both pages link there instead.

Docs build and full test suite green; the three gated blocks were checked with the gate's own awk after every edit and extract identically. Docs-only, no changeset.

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
