### PR TITLE
ci: name what failed, run nightly against the registry, state the policy (items 98, 99, 100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,11 @@
 name: ci
+concurrency:
+  # Superseded runs on the same pull request are cancelled; pushes to master are not, because the
+  # release workflow starts from the same push and a cancelled CI run there would leave the only
+  # record of that commit's gate incomplete.
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     paths-ignore:
@@ -93,9 +100,32 @@ jobs:
           node-version: 22
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm verify:packed
+      - name: Verify the packed artefacts
+        id: verify
         env:
           MYSQL_URL: mysql://root:root@127.0.0.1:3306/drzl
+        run: |
+          set -o pipefail
+          pnpm verify:packed 2>&1 | tee /tmp/verify-packed.log
+
+      # The gate has 62 exit sites and 159 FAIL lines, and none of them reach the checks page: a
+      # failed step shows "Process completed with exit code 1" and the authored FAIL line sits
+      # somewhere inside about 670 lines of output. This lifts that line, and the stage heading
+      # above it, onto the annotation and the job summary, so a reader learns which stage died
+      # without opening the log.
+      - name: Name what failed
+        if: failure() && steps.verify.outcome == 'failure'
+        run: |
+          stage=$(awk '$1 == "==>" { sub(/^[[:space:]]*==>[[:space:]]*/, ""); s = $0 } END { print s }' /tmp/verify-packed.log)
+          fail=$(awk '{ t = $0; sub(/^[[:space:]]+/, "", t); if (index(t, "FAIL") == 1) s = t } END { print s }' /tmp/verify-packed.log)
+          echo "::error title=verify-packed: ${stage:-unknown stage}::${fail:-the gate exited non-zero without printing a FAIL line}"
+          {
+            echo "### verify-packed failed"
+            echo
+            echo "Stage: **${stage:-unknown}**"
+            echo
+            echo "> ${fail:-no FAIL line was printed, so the gate died on an unguarded command}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   changeset-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,264 @@
+name: nightly
+
+# Everything in ci.yml pins the versions it measures, deliberately, so a claim in the docs is
+# exactly true of a named version. The cost of that trade is that an upstream release is invisible
+# until somebody opens a pull request, and then it lands on that pull request instead of on its
+# own. This workflow is the other side of the trade: it runs the same gates against what the
+# registry serves today, on a schedule, and it opens exactly one issue when they break.
+on:
+  schedule:
+    # 03:20 UTC rather than the top of an hour. GitHub queues scheduled runs and drops them under
+    # load, and :00 is the busiest minute of every hour by a wide margin.
+    - cron: '20 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Cheap, always runs, and it is the only job that answers "did upstream move at all". It stays
+  # useful even on a day when the two expensive jobs below cannot run.
+  pins:
+    if: github.repository == 'use-drzl/drzl'
+    runs-on: ubuntu-latest
+    outputs:
+      latest: ${{ steps.resolve.outputs.latest }}
+      rc: ${{ steps.resolve.outputs.rc }}
+      pinned_0_4x: ${{ steps.resolve.outputs.pinned_0_4x }}
+      pinned_v1: ${{ steps.resolve.outputs.pinned_v1 }}
+      drifted: ${{ steps.resolve.outputs.drifted }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - id: resolve
+        name: What the registry serves against what the gate pins
+        run: |
+          set -o pipefail
+          latest=$(npm view drizzle-orm dist-tags.latest)
+          rc=$(npm view drizzle-orm dist-tags.rc)
+          read -r pinned_0_4x pinned_v1 < <(bash scripts/verify-packed.sh --print-pins)
+
+          {
+            echo "| tag | registry | gate pins |"
+            echo "| --- | --- | --- |"
+            echo "| latest | $latest | $pinned_0_4x |"
+            echo "| rc | $rc | $pinned_v1 |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          drifted=no
+          [ "$latest" = "$pinned_0_4x" ] && [ "$rc" = "$pinned_v1" ] || drifted=yes
+
+          # A patch move is ordinary and is reported in the summary above and nowhere else. A minor
+          # or major move on the `latest` tag is different: the majors page, the comparison page
+          # and the verification page all state what 0.4x does, and a new minor can falsify any of
+          # them. That one is worth waking somebody for, whether or not the gate goes red.
+          pinned_line=${pinned_0_4x%.*}
+          latest_line=${latest%.*}
+          if [ "$pinned_line" != "$latest_line" ]; then
+            echo "the latest tag moved off $pinned_line to $latest" >> "$GITHUB_STEP_SUMMARY"
+            echo "FAIL: drizzle-orm latest moved from $pinned_0_4x to $latest, a new minor line."
+            exit 1
+          fi
+
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          echo "pinned_0_4x=$pinned_0_4x" >> "$GITHUB_OUTPUT"
+          echo "pinned_v1=$pinned_v1" >> "$GITHUB_OUTPUT"
+          echo "drifted=$drifted" >> "$GITHUB_OUTPUT"
+
+      # The trigger in the deprecation policy, printed rather than argued. Both readings come from
+      # the registry's own per-version download counts, so nobody has to estimate the split.
+      - name: The 0.4x share, which the deprecation policy keys on
+        run: |
+          set -o pipefail
+          curl -sS --fail https://api.npmjs.org/versions/drizzle-orm/last-week > /tmp/dl.json
+          node -e "
+            const d = JSON.parse(require('fs').readFileSync('/tmp/dl.json', 'utf8')).downloads;
+            let total = 0, v1 = 0, v04 = 0, older = 0;
+            for (const [v, n] of Object.entries(d)) {
+              total += n;
+              if (v.startsWith('1.')) v1 += n;
+              else if (v.startsWith('0.4')) v04 += n;
+              else older += n;
+            }
+            const pct = (x) => (100 * x / total).toFixed(2);
+            const rows = [
+              ['drizzle-orm 1.x', v1, pct(v1)],
+              ['drizzle-orm 0.4x', v04, pct(v04)],
+              ['drizzle-orm below 0.4', older, pct(older)],
+            ];
+            const out = ['| line | last week | share |', '| --- | ---: | ---: |']
+              .concat(rows.map(([a, b, c]) => '| ' + a + ' | ' + b.toLocaleString() + ' | ' + c + '% |'))
+              .join('\n');
+            require('fs').appendFileSync(process.env.GITHUB_STEP_SUMMARY, out + '\n');
+            console.log(out);
+          "
+
+  # The gate itself, against the versions the registry serves rather than the versions it pins.
+  # Identical to the verify-packed job in ci.yml except for the two overrides and the service
+  # container being the same one, so a failure here means the new upstream release broke something
+  # this project claims.
+  gate-on-published:
+    if: github.repository == 'use-drzl/drzl'
+    needs: pins
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: drzl
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -uroot -proot"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Verify the packed artefacts against the published versions
+        id: verify
+        env:
+          MYSQL_URL: mysql://root:root@127.0.0.1:3306/drzl
+          DRIZZLE_0_4X: ${{ needs.pins.outputs.latest }}
+          DRIZZLE_V1: ${{ needs.pins.outputs.rc }}
+        run: |
+          set -o pipefail
+          pnpm verify:packed 2>&1 | tee /tmp/verify-packed.log
+      - name: Name what failed
+        if: failure() && steps.verify.outcome == 'failure'
+        run: |
+          stage=$(awk '$1 == "==>" { sub(/^[[:space:]]*==>[[:space:]]*/, ""); s = $0 } END { print s }' /tmp/verify-packed.log)
+          fail=$(awk '{ t = $0; sub(/^[[:space:]]+/, "", t); if (index(t, "FAIL") == 1) s = t } END { print s }' /tmp/verify-packed.log)
+          echo "::error title=nightly gate: ${stage:-unknown stage}::${fail:-the gate exited non-zero without printing a FAIL line}"
+          {
+            echo "### the gate failed against published versions"
+            echo
+            echo "drizzle-orm 0.4x: ${DRIZZLE_0_4X}, v1: ${DRIZZLE_V1}"
+            echo
+            echo "Stage: **${stage:-unknown}**"
+            echo
+            echo "> ${fail:-no FAIL line}"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          DRIZZLE_0_4X: ${{ needs.pins.outputs.latest }}
+          DRIZZLE_V1: ${{ needs.pins.outputs.rc }}
+
+  # The other half of the same trade. ci.yml pins Bun and Deno to the versions docs/guide/runtimes.md
+  # names, so the page is exactly true and an upstream runtime regression is invisible. This runs the
+  # same script on whatever each project ships today.
+  runtimes-latest:
+    if: github.repository == 'use-drzl/drzl'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: vx.x.x
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build:packages
+      - name: Bun and Deno, at whatever they ship today
+        run: |
+          set -o pipefail
+          bash scripts/runtime-compat.sh 2>&1 | tee /tmp/runtime-compat.log
+      - name: Record the versions this run actually measured
+        if: always()
+        run: |
+          awk '$1 == "==>" { on = ($2 == "runtimes"); next } on && NF { print "    " $0 }' \
+            /tmp/runtime-compat.log >> "$GITHUB_STEP_SUMMARY"
+
+  # A nightly that opens nothing is a cron job that turns red in a tab nobody opens. One issue,
+  # reused rather than duplicated, assigned, and closed by the run that goes green again.
+  report:
+    if: always() && github.repository == 'use-drzl/drzl'
+    needs: [pins, gate-on-published, runtimes-latest]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const TITLE = 'Nightly: upstream drizzle-orm or runtime check is failing';
+            const LABEL = 'nightly';
+            const ASSIGNEE = 'omar-dulaimi';
+            const results = {
+              pins: '${{ needs.pins.result }}',
+              'gate-on-published': '${{ needs.gate-on-published.result }}',
+              'runtimes-latest': '${{ needs.runtimes-latest.result }}',
+            };
+            const failed = Object.entries(results).filter(([, r]) => r === 'failure');
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const { data: open } = await github.rest.issues.listForRepo({
+              ...context.repo,
+              state: 'open',
+              labels: LABEL,
+              per_page: 100,
+            });
+            const existing = open.find((i) => i.title === TITLE);
+
+            if (failed.length === 0) {
+              if (existing) {
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: existing.number,
+                  body: `Green again on ${run}. Closing; the next failure reopens this issue.`,
+                });
+                await github.rest.issues.update({
+                  ...context.repo,
+                  issue_number: existing.number,
+                  state: 'closed',
+                });
+              }
+              return;
+            }
+
+            const body = [
+              `Failed jobs: ${failed.map(([j]) => j).join(', ')}.`,
+              '',
+              `Run: ${run}`,
+              '',
+              'What the gate pins today:',
+              `- drizzle-orm 0.4x: \`${{ needs.pins.outputs.pinned_0_4x }}\``,
+              `- drizzle-orm v1: \`${{ needs.pins.outputs.pinned_v1 }}\``,
+              '',
+              'What the registry serves today:',
+              `- \`latest\`: \`${{ needs.pins.outputs.latest }}\``,
+              `- \`rc\`: \`${{ needs.pins.outputs.rc }}\``,
+              '',
+              'The failing job summary names the stage and quotes its FAIL line.',
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                ...context.repo,
+                title: TITLE,
+                labels: [LABEL],
+                assignees: [ASSIGNEE],
+                body,
+              });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,9 @@ Thanks for your interest in contributing! This guide explains how to set up your
     it column by column against the official `drizzle-orm` validators, and runs it against a real
     Postgres (PGlite) and a real SQLite (`node:sqlite`). Set `MYSQL_URL` to include MySQL, which
     CI provides as a service container; without it that stage skips and says so.
-  - It takes a couple of minutes and it is the only thing here that exercises what a consumer
+  - It takes about three minutes locally (160s measured on a 16-core laptop, and it barely
+    responds to cores because it is dominated by npm installs) and it is the only thing here that
+    exercises what a consumer
     actually gets. Everything else imports from source.
 
 ## Repo Structure (packages/)

--- a/docs/guide/drizzle-majors.md
+++ b/docs/guide/drizzle-majors.md
@@ -241,6 +241,36 @@ reaches the right answer despite the wrong bound.
 - **Nothing on this page is a claim about drizzle-orm's intent.** These are measurements of what each
   major builds, taken by importing it.
 
+## How long 0.4x is supported
+
+Supporting both majors is not free, and the cost is countable: about 11 percent of the gate's
+runtime, 81 of its roughly 150 ledger entries, one analyzer file carrying the whole 0.4x class map,
+six test files that exist only for it, and this page. It has also paid for itself repeatedly. Every
+array column, and every enum column, came back untyped on 0.4x while the gate was green; `point`
+and `line` were typed as strings, so the emitted schema rejected every real row; and six columns
+are still wrong on 0.45.2 and right on 1.0.0-rc.4.
+
+So the policy is staged, and every trigger is a number anyone can check rather than a date:
+
+| Stage | Trigger | What changes |
+| --- | --- | --- |
+| Both majors gated | in force today | every check on this page runs on every pull request under both majors |
+| 0.4x frozen | the `latest` dist-tag moves off the 0.4x line, so `npm install drizzle-orm` serves 1.x | the gate keeps the 0.4x version pinned that day and stops following new 0.4x releases. This page names that version |
+| 0.4x nightly only | 1.x reaches half of drizzle-orm's last-week downloads | the 0.4x stages move out of the per-pull-request gate into the nightly. `drzl generate` and `drzl doctor` print one line when the resolved drizzle-orm is 0.4x |
+| 0.4x removed | 0.4x falls below a tenth of last-week downloads | the 0.4x class map and its ledger entries are deleted, in a major of `@drzl/analyzer` and `@drzl/cli`. This page becomes history and says so |
+
+The trigger is checkable at `https://api.npmjs.org/versions/drizzle-orm/last-week`, which reports
+downloads per published version, so the split is counted rather than estimated. Read on 2026-08-09,
+over 18,085,669 downloads: **1.x at 5.24 percent**, **0.4x at 85.88 percent** (with 0.45.2 alone at
+69.33), and older releases at 8.88. On those numbers stage one holds, and there is no argument for
+anything else: the version most of the ecosystem installs is the version DRZL was silently broken
+on twice.
+
+Each transition is a deliberate release rather than an automatic one, so a single day's reading
+cannot trigger it, and each is a changeset, so it reaches the changelog and the release notes. From
+the third stage the CLI itself says so, which is the only channel that reaches someone who never
+opens the docs, and the removal is a major, so no caret range delivers it by accident.
+
 ## See also
 
 - [Upgrade notes](/guide/upgrading), for changes that came from a DRZL release rather than the ORM

--- a/docs/guide/runtimes.md
+++ b/docs/guide/runtimes.md
@@ -157,3 +157,10 @@ Windows or macOS, on Bun or Deno canary, or against Deno Deploy, Cloudflare Work
 hosted runtime; a worker runtime is a different environment from the Deno CLI and this page does not
 speak for it. `drzl watch`, which is long-lived and filesystem-event driven, was not exercised under
 Bun or Deno.
+
+## Newer runtimes than these
+
+The CI job that keeps this page true pins Bun and Deno to the versions named above, so the page is
+exactly true rather than approximately true. A nightly workflow runs the same script against
+whatever each project ships that day and records the versions it actually measured, so a regression
+in a newer runtime is caught on its own schedule instead of on the next pull request.

--- a/docs/guide/verification.md
+++ b/docs/guide/verification.md
@@ -196,6 +196,28 @@ The same discipline applies to the fixtures. Adding a value to the probe pool is
 changed something: an enum column whose members were absent from the pool was rejected by both
 sides for every value, so the comparison agreed while measuring nothing.
 
+## A failure names its own stage
+
+The gate has 62 places it can exit and 159 lines that can carry a FAIL, and none of them used to
+reach GitHub's checks page: a failed step showed `Process completed with exit code 1`, and the line
+that said what went wrong sat somewhere inside about 670 lines of output. CI now lifts the stage
+heading and the FAIL line onto the failure annotation and the job summary, so the first thing a
+reader sees names the stage that died.
+
+## Nightly, against what the registry serves
+
+Everything above pins the versions it measures, on purpose, so a claim on these pages is exactly
+true of a named version. The cost is that an upstream release is invisible until somebody opens a
+pull request, and then it lands on that pull request rather than on its own. A nightly workflow is
+the other half of that trade: it resolves drizzle-orm's `latest` and `rc` tags, runs the same gate
+against them, runs the runtime checks against whatever Bun and Deno ship that day, and prints the
+per-version download split the deprecation policy keys on.
+
+When it breaks it opens one issue, assigned, and a later failure comments on that issue rather than
+opening a second. The run that goes green again closes it, so the issue's state is the current
+state rather than a history. The gate itself is unchanged by any of this: with no overrides it runs
+the pinned versions, which is what every number on this site was measured against.
+
 ## What one run printed
 
 Lines from the run behind this page, verbatim: commit `74def57`, Node 22.22.0, `MYSQL_URL` set to a

--- a/scripts/verify-packed.sh
+++ b/scripts/verify-packed.sh
@@ -30,6 +30,23 @@ quoted() { printf '%s\n' "$1" | tee -a "$WORK/printed.log"; }
 trap 'rm -rf "$WORK"' EXIT
 
 TARS="$WORK/tars"
+
+# The two drizzle-orm versions this gate measures. The defaults are the pinned ones, which is what
+# every claim in docs/guide/drizzle-majors.md and docs/guide/comparison.md is stated against. The
+# nightly overrides them with whatever `latest` and `rc` serve that day, which is the only way an
+# upstream release gets caught on its own schedule rather than on the next pull request.
+DRIZZLE_PINS_OVERRIDDEN=0
+{ [ -z "${DRIZZLE_0_4X:-}" ] && [ -z "${DRIZZLE_V1:-}" ]; } || DRIZZLE_PINS_OVERRIDDEN=1
+DRIZZLE_0_4X="${DRIZZLE_0_4X:-0.45.2}"
+DRIZZLE_V1="${DRIZZLE_V1:-1.0.0-rc.4}"
+
+# Answering this without running anything is what lets the nightly compare the pins against the
+# registry in one cheap job.
+if [ "${1:-}" = "--print-pins" ]; then
+  printf '%s %s\n' "$DRIZZLE_0_4X" "$DRIZZLE_V1"
+  exit 0
+fi
+
 APP="$WORK/consumer"
 mkdir -p "$TARS" "$APP/src/db"
 
@@ -3987,7 +4004,7 @@ PARITY_HARNESS
 # explicit root dependency on this line, so peer auto-install has nothing left to add and the
 # flag only removes the walk-order sensitivity.
 npm install --no-audit --no-fund --loglevel=error --legacy-peer-deps \
-  "$TARS"/*.tgz drizzle-orm@1.0.0-rc.4 zod valibot arktype @sinclair/typebox tsx typescript \
+  "$TARS"/*.tgz drizzle-orm@"$DRIZZLE_V1" zod valibot arktype @sinclair/typebox tsx typescript \
   ajv@^8.17.1 ajv-formats@^3.0.1 @seriousme/openapi-schema-validator@^2.9.1 \
   @electric-sql/pglite >/dev/null
 
@@ -6439,7 +6456,7 @@ rm -rf "$OLD" "$NEW"; mkdir -p "$OLD/src" "$NEW/src"
 cd "$OLD"
 npm init -y >/dev/null 2>&1
 npm install --no-audit --no-fund --loglevel=error \
-  "$TARS"/*.tgz drizzle-orm@0.45.2 zod tsx >/dev/null
+  "$TARS"/*.tgz drizzle-orm@"$DRIZZLE_0_4X" zod tsx >/dev/null
 
 # The same tarballs and the other major. `zod` because the generate step below runs in the 0.4x
 # tree; this one only analyzes, and installing the same set keeps the two trees differing in
@@ -6447,7 +6464,7 @@ npm install --no-audit --no-fund --loglevel=error \
 # --legacy-peer-deps for the same reason as the parity install above: this tree also holds the
 # generator-effect tarball beside drizzle rc.4, whose optional effect peers are disjoint.
 ( cd "$NEW" && npm init -y >/dev/null 2>&1 && npm install --no-audit --no-fund --loglevel=error --legacy-peer-deps \
-  "$TARS"/*.tgz drizzle-orm@1.0.0-rc.4 zod tsx >/dev/null )
+  "$TARS"/*.tgz drizzle-orm@"$DRIZZLE_V1" zod tsx >/dev/null )
 
 # Written once and analyzed under both majors, so the comparison below is about the analyzer
 # rather than about two schemas that happen to differ. Every type here exists in both.
@@ -9523,6 +9540,11 @@ for doc_entry in "${DOC_BLOCKS[@]}"; do
     if [ -z "${MYSQL_URL:-}" ] && printf '%s' "$doc_trim" | grep -q 'MySQL'; then
       doc_skipped=$((doc_skipped + 1))
       echo "    not compared, that stage did not run without MYSQL_URL: $doc_trim"
+      continue
+    fi
+    if [ "$DRIZZLE_PINS_OVERRIDDEN" = 1 ] && printf '%s' "$doc_trim" | grep -q 'drizzle-orm'; then
+      doc_skipped=$((doc_skipped + 1))
+      echo "    not compared, this run overrode the drizzle-orm pins: $doc_trim"
       continue
     fi
     doc_checked=$((doc_checked + 1))


### PR DESCRIPTION
Plan items 98, 99 and 100. Item 97 is deliberately not here: it is a large mechanical refactor and goes last so it does not collide.

## Item 98: the split is measured and rejected; the failure-naming half ships

Two facts settle it. **All four CI jobs already run in parallel**, so wall clock is the longest job rather than a sum. And **the gate barely responds to cores**: 160.8s on 16 vCPU against 177.2s on 4, a factor of 1.10, because it is dominated by npm installs and single-process `tsx` runs rather than by anything parallelisable (`pnpm -r test`, by contrast, moves 1.55x).

Modelled from the measured pieces, an n-way split needs per-job fixed cost below roughly **20 to 25 seconds** to break even, which is optimistic once checkout, two setup actions and a pnpm store restore that materialises 752 MB are counted. Worse, every extra job pays a **cold** npm cache: the consumer install set is **37.5s cold against 9.4s warm**, so a split converts one cold install into n of them. It would also diverge from `release.yml`, which runs the gate as a single step and must keep doing so.

Two narrower splits were priced and rejected too: a matrix over dialects saves at most 6s of a 9.5s comparison while costing two extra cold installs, and a shared pack job serialises 28s ahead of two jobs that currently pack in parallel.

**What ships instead** is item 98's other stated goal. The gate has 62 exit sites and 159 FAIL lines, and none of them reach the checks page: a failed step shows `Process completed with exit code 1` while the authored line sits inside about 670 lines of output. CI now lifts the last stage heading and the last FAIL line onto the failure annotation and the job summary. The extraction was validated against two real failing logs and returns empty on a green run. A concurrency group also lands, cancelling superseded pull-request runs but never master, since `release.yml` starts from the same push.

## Item 99: the nightly

Two axes, one workflow, four jobs. Tags were checked rather than assumed: `latest` is 0.45.2, `rc` is 1.0.0-rc.4, and there is **no `next` tag**. A cheap `pins` job resolves both against what the gate pins and fails on its own when `latest` moves to a **new minor line**, because three docs pages state what 0.4x does and a new minor can falsify any of them. `gate-on-published` runs the same gate against the resolved versions; `runtimes-latest` runs the runtime script against whatever Bun and Deno ship that day and records the versions it actually measured.

**The failure path is concrete**, because a nightly that notifies nobody is a tab that turns red: one assigned issue with a fixed title, a repeat failure **comments on it** rather than opening a second, and the run that goes green again closes it, so the issue's state is the current state. Every job is guarded so a fork cannot file issues on its own copy, and the cron is off the hour because GitHub queues and drops scheduled runs.

The gate gains exactly what the nightly needs: the two versions become env-overridable with the pinned values as defaults, `--print-pins` answers what it pins without running anything (verified, including with overrides), and the doc-numbers stage skips lines naming drizzle-orm when the pins are overridden, since two documented lines name the versions verbatim and would otherwise make every nightly red for a reason that is not a defect.

## Item 100: a staged policy with triggers, not dates

Argued from what both majors actually cost: **11 percent of gate runtime**, **81 of about 150 ledger entries**, one analyzer file carrying the whole 0.4x class map, six test files, and a docs page. And from what it has bought, which is the other half of the argument: every array column and every enum column came back untyped on 0.4x while the gate was green, `point` and `line` were typed as strings so the emitted schema rejected every real row, and six columns are still wrong on 0.45.2 and right on rc.4.

Four stages, each keyed to a number anyone can check at `api.npmjs.org/versions/drizzle-orm/last-week`: both majors gated (today), 0.4x frozen when `latest` moves off the 0.4x line, 0.4x nightly-only when 1.x reaches half of last-week downloads, 0.4x removed below a tenth. On the counted split today (**0.4x 85.88%, 1.x 5.24%**, with 0.45.2 alone at 69.33%) stage one holds and nothing else is arguable: the version most of the ecosystem installs is the version DRZL was silently broken on twice. Each transition is a deliberate release, and from stage three the CLI itself says so, which is the only channel reaching someone who never opens the docs.

## Deferred to item 97, filed as CE

Both measured, both touching what item 97 restructures: **parallelising the documented-configs stage** (29.2s, the largest single segment, every iteration independent except for a shared probe directory; replicated at 26.4s / 8.4s / 4.6s for 1 / 4 / 8 workers with all 36 configs ok at every setting) and **extracting the two registry stages** (20.1s, network only, no build or pack or install), which needs the stage selector item 97 will build. Also recorded there: **the stage headings do not bound the work they name**, so a parity failure is annotated with the wrong stage today, proved by running a scratch copy twice.

Docs updated to match, since all of it is true at merge: the verification page gains the failure-naming and nightly sections, the runtimes page points at the nightly instead of `ci.yml`'s promise of one, the majors page carries the support policy with its counted split, and CONTRIBUTING states the measured gate time rather than "a couple of minutes".

https://claude.ai/code/session_01BtBa5BxE2Q6CyYCSd8d4m4
